### PR TITLE
Enable cargo cache in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - nvm install 10
         - nvm install 12
         # Install wasm-pack for Rust
-        - cargo install wasm-pack
+        - cargo install --force wasm-pack
       before_script: 
         - cd viewer
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ matrix:
     - language: rust
       name: "Reveal viewer"
       cache:
-        cargo:
+        cargo: true
+        npm: true
         directories: 
           - "viewer/node_modules"
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - nvm install 10
         - nvm install 12
         # Install wasm-pack for Rust
-        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        - cargo install wasm-pack
       before_script: 
         - cd viewer
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ matrix:
         - nvm install 10
         - nvm install 12
         # Install wasm-pack for Rust
-        - cargo install wasm-pack
+        - rm -rf $HOME/.cargo/bin/wasm-pack
+        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       before_script: 
         - cd viewer
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - nvm install 10
         - nvm install 12
         # Install wasm-pack for Rust
-        - cargo install --force wasm-pack
+        - cargo install wasm-pack
       before_script: 
         - cd viewer
       script:


### PR DESCRIPTION
Fix a typo in .travis.yml to enable the cargo cache and delete wasm-pack binary before installation. Otherwise, the build will be stalled while the wasm-pack installer is waiting for user input to allow overwriting the binary. Also set npm cache to true.