### PR TITLE
Improve camera suggestion and fix Box3 center

### DIFF
--- a/viewer/src/examples/threejs/simple.ts
+++ b/viewer/src/examples/threejs/simple.ts
@@ -7,7 +7,7 @@ import CameraControls from 'camera-controls';
 import { createThreeJsSectorNode } from '../../views/threejs/sector/createThreeJsSectorNode';
 import { createLocalSectorModel } from '../..';
 import { getUrlParameter } from '../../utils/urlUtils';
-import { suggestCameraLookAt } from '../../utils/cameraUtils';
+import { suggestCameraConfig } from '../../utils/cameraUtils';
 import { FetchSectorMetadataDelegate } from '../../models/sector/delegates';
 import { vec3 } from 'gl-matrix';
 import { toThreeVector3 } from '../../views/threejs/utilities';
@@ -23,17 +23,16 @@ async function main() {
   scene.add(sectorModelNode);
 
   const fetchMetadata: FetchSectorMetadataDelegate = sectorModel[0];
-  const [metaData, modelTransform] = await fetchMetadata();
+  const [rootSectorMetadata, modelTransform] = await fetchMetadata();
 
   const renderer = new THREE.WebGLRenderer();
   renderer.setClearColor('#444');
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
-  const [pos, target] = suggestCameraLookAt(metaData.bounds);
-  const far = 3 * vec3.distance(target, pos);
+  const { position, target, near, far } = suggestCameraConfig(rootSectorMetadata);
   const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.2, far);
   const controls = new CameraControls(camera, renderer.domElement);
-  const threePos = toThreeVector3(pos, sectorModelNode.modelTransformation);
+  const threePos = toThreeVector3(position, sectorModelNode.modelTransformation);
   const threeTarget = toThreeVector3(target, sectorModelNode.modelTransformation);
   controls.setLookAt(threePos.x, threePos.y, threePos.z, threeTarget.x, threeTarget.y, threeTarget.z);
   controls.update(0.0);

--- a/viewer/src/utils/Box3.ts
+++ b/viewer/src/utils/Box3.ts
@@ -9,7 +9,9 @@ export class Box3 {
   public readonly max: vec3;
 
   public get center(): vec3 {
-    return vec3.scaleAndAdd(vec3.create(), this.min, this.max, 0.5);
+    const result = vec3.create();
+    const sum = vec3.add(result, this.min, this.max);
+    return vec3.scale(result, sum, 0.5);
   }
 
   constructor(points: vec3[]) {

--- a/viewer/src/utils/cameraUtils.ts
+++ b/viewer/src/utils/cameraUtils.ts
@@ -4,12 +4,44 @@
 
 import { vec3, mat4 } from 'gl-matrix';
 import { Box3 } from './Box3';
+import { SectorMetadata } from '../models/sector/types';
+import { traverseDepthFirst } from './traversal';
 
-export function suggestCameraLookAt(bounds: Box3): [vec3, vec3] {
-  // TODO 2019-12-08 larsmoa: Make something more decent
+export interface SuggestedCameraConfig {
+  position: vec3;
+  target: vec3;
+  near: number;
+  far: number;
+}
+
+export function suggestCameraConfig(rootSector: SectorMetadata): SuggestedCameraConfig {
+  const averageMin = vec3.create();
+  const averageMax = vec3.create();
+  let count = 0;
+
+  traverseDepthFirst(rootSector, node => {
+    vec3.add(averageMin, averageMin, node.bounds.min);
+    vec3.add(averageMax, averageMax, node.bounds.max);
+    count += 1;
+    return true;
+  });
+
+  vec3.scale(averageMin, averageMin, 1.0 / count);
+  vec3.scale(averageMax, averageMax, 1.0 / count);
+
+  const bounds = new Box3([averageMin, averageMax]);
   const target = bounds.center;
   const extent = vec3.subtract(vec3.create(), bounds.max, bounds.min);
   const d = Math.max(extent[0], extent[1], extent[2]);
-  const pos = vec3.add(vec3.create(), target, vec3.fromValues(-1.0 * extent[0], -1.0 * extent[1], 2.0 * extent[2]));
-  return [pos, target];
+  const position = vec3.add(
+    vec3.create(),
+    target,
+    vec3.fromValues(-2.0 * extent[0], -2.0 * extent[1], 2.0 * extent[2])
+  );
+  return {
+    position,
+    target,
+    near: 0.1,
+    far: vec3.distance(position, target) * 6
+  };
 }


### PR DESCRIPTION
Previously Box3.center() would scale only the max value by 0.5 and not
the sum of the max and min value.