### PR TITLE
Draw all meshes double sided

### DIFF
--- a/viewer/src/views/threejs/sector/instancedMeshes.ts
+++ b/viewer/src/views/threejs/sector/instancedMeshes.ts
@@ -11,6 +11,7 @@ const instancedMeshMaterial = new THREE.ShaderMaterial({
   extensions: {
     derivatives: true
   },
+  side: THREE.DoubleSide,
   fragmentShader: sectorShaders.instancedMesh.fragment,
   vertexShader: sectorShaders.instancedMesh.vertex
 });

--- a/viewer/src/views/threejs/sector/triangleMeshes.ts
+++ b/viewer/src/views/threejs/sector/triangleMeshes.ts
@@ -35,6 +35,7 @@ export function createTriangleMeshes(triangleMeshes: TriangleMesh[], bounds: THR
       extensions: {
         derivatives: true
       },
+      side: THREE.DoubleSide,
       fragmentShader: sectorShaders.detailedMesh.fragment,
       vertexShader: sectorShaders.detailedMesh.vertex
     });


### PR DESCRIPTION
We cannot assume that the data in the original model has proper face
culling set up and need to draw both sides.