### PR TITLE
Keep running tsc from putting files in the dist folder

### DIFF
--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "esnext",
     "declaration": true,
     "declarationDir": "dist",
-    "outDir": "dist",
+    "outDir": "dist-ts",
     "rootDir": "src",
     "esModuleInterop": true,
     "downlevelIteration": true,


### PR DESCRIPTION
This avoids the error message

    Uncaught SyntaxError: Cannot use import statement outside a module

which was caused by parser.worker.js being placed under dist/workers and
then copied into the examples.