### PR TITLE
Share color and tree index arrays between meshes

### DIFF
--- a/viewer/src/models/cad/parseSectorData.ts
+++ b/viewer/src/models/cad/parseSectorData.ts
@@ -118,14 +118,14 @@ export async function createParser(
           const fileTriangleCounts = meshIndices.map(i => triangleCounts[i]);
           const offsets = createOffsetsArray(fileTriangleCounts);
           // Load CTM (geometry)
-          const ctm = await loadCtmGeometryCache.request(fileId);
+          const {
+            indices,
+            vertices,
+            normals,
+            colors: sharedColors,
+            treeIndices: sharedTreeIndices
+          } = await loadCtmGeometryCache.request(fileId);
 
-          const indices: Uint32Array = ctm.indices;
-          const vertices: Float32Array = ctm.vertices;
-          const normals: Float32Array = ctm.normals;
-          const expandedTreeIndices = new Float32Array(indices.length);
-
-          const colorsBuffer = new Float32Array((3 * vertices.length) / 3);
           for (let i = 0; i < meshIndices.length; i++) {
             const meshIdx = meshIndices[i];
             const treeIndex = treeIndices[meshIdx];
@@ -133,22 +133,22 @@ export async function createParser(
             const triCount = fileTriangleCounts[i];
             const [r, g, b] = readColorToFloat32s(colors, meshIdx);
 
-            expandedTreeIndices.fill(treeIndex, triOffset, triOffset + triCount);
+            sharedTreeIndices.fill(treeIndex, triOffset, triOffset + triCount);
             for (let triIdx = triOffset; triIdx < triOffset + triCount; triIdx++) {
               for (let j = 0; j < 3; j++) {
                 const vIdx = indices[3 * triIdx + j];
 
-                colorsBuffer[3 * vIdx] = r;
-                colorsBuffer[3 * vIdx + 1] = g;
-                colorsBuffer[3 * vIdx + 2] = b;
+                sharedColors[3 * vIdx] = r;
+                sharedColors[3 * vIdx + 1] = g;
+                sharedColors[3 * vIdx + 2] = b;
               }
             }
           }
 
           const mesh: TriangleMesh = {
-            colors: colorsBuffer,
+            colors: sharedColors,
             fileId,
-            treeIndices: expandedTreeIndices,
+            treeIndices: sharedTreeIndices,
             indices,
             vertices,
             normals

--- a/viewer/src/workers/parser.worker.ts
+++ b/viewer/src/workers/parser.worker.ts
@@ -121,10 +121,15 @@ export class ParserWorker {
     const rust = await rustModule;
     // TODO handle parsing failure
     const ctm = rust.parse_ctm(buffer);
+    const indices = ctm.indices();
+    const vertices = ctm.vertices();
+    const normals = ctm.normals();
     const result = {
-      indices: ctm.indices(),
-      vertices: ctm.vertices(),
-      normals: ctm.normals()
+      indices,
+      vertices,
+      normals,
+      colors: new Float32Array(indices.length),
+      treeIndices: new Float32Array(indices.length)
     };
     ctm.free();
     return result;

--- a/viewer/src/workers/types/parser.types.ts
+++ b/viewer/src/workers/types/parser.types.ts
@@ -68,6 +68,8 @@ export interface ParseCtmResult {
   indices: Uint32Array;
   vertices: Float32Array;
   normals: Float32Array | undefined;
+  colors: Float32Array;
+  treeIndices: Float32Array;
 }
 
 export interface ParseQuadsArguments {


### PR DESCRIPTION
Previously, we would allocate arrays large enough to contain color and tree index information about all other meshes for each mesh.