### PR TITLE
Make dependabot push changes to unprotected branch

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,38 +1,43 @@
 version: 1
 update_configs:
   # NPM deps
-  - package_manager: "javascript"
+  - target_branch: dependency-updates
+    package_manager: "javascript"
     directory: "/examples"
-    update_schedule: weekly
+    update_schedule: live
     automerged_updates:
       - match:
           dependency_name: "*"
           update_type: "all"
-  - package_manager: "javascript"
+  - target_branch: dependency-updates
+    package_manager: "javascript"
     directory: "/viewer"
-    update_schedule: weekly
+    update_schedule: live
     automerged_updates:
       - match:
           dependency_name: "*"
           update_type: "all"
   # Rust deps
-  - package_manager: "rust:cargo"
+  - target_branch: dependency-updates
+    package_manager: "rust:cargo"
     directory: "/f3df"
-    update_schedule: weekly
+    update_schedule: live
     automerged_updates:
       - match:
           dependency_name: "*"
           update_type: "all"
-  - package_manager: rust:cargo
+  - target_branch: dependency-updates
+    package_manager: rust:cargo
     directory: "/i3df"
-    update_schedule: weekly
+    update_schedule: live
     automerged_updates:
       - match:
           dependency_name: "*"
           update_type: "all"
-  - package_manager: "rust:cargo"
+  - target_branch: dependency-updates
+    package_manager: "rust:cargo"
     directory: "/viewer"
-    update_schedule: weekly
+    update_schedule: live
     automerged_updates:
       - match:
           dependency_name: "*"


### PR DESCRIPTION
This should keep dependabot from creating a large number of PRs that take
forever to merge into master because they need to be rebuilt every time
another PR has been merged. Instead, we ask dependabot to pull all these
updates into a new branch, called dependency-updates and merge them
immediately because this branch has no protection.

We will then need to manually create a PR from this branch into master
once a week.