### PR TITLE
Actually fill the entire array of visibility

### DIFF
--- a/viewer/src/views/threejs/cad/materials.ts
+++ b/viewer/src/views/threejs/cad/materials.ts
@@ -35,7 +35,7 @@ export function createMaterials(): Materials {
 
   const colors = new Uint8Array(4 * colorCount);
   const visibility = new Uint8Array(4 * visibilityCount);
-  for (let i = 0; i < visibilityCount; i++) {
+  for (let i = 0; i < 4 * visibilityCount; i++) {
     visibility[i] = 255;
   }
   const overrideColorPerTreeIndex = new THREE.DataTexture(colors, pixelCount, pixelCount);


### PR DESCRIPTION
Previously, the wrong number of elements were initialized to 255,
which lead the all nodes above a certain tree index number to be
initialized as hidden. This change ensures all nodes are visible by
default.