### PR TITLE
Initialize CogniteClient once in examples that load multiple models

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -54,7 +54,6 @@
         "gl-matrix": "^3.2.1",
         "glslify": "^7.0.0",
         "glslify-import": "^3.1.0",
-        "rxjs": "^6.5.4",
         "three": "^0.114.0"
       }
     },

--- a/examples/src/filtering.ts
+++ b/examples/src/filtering.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import CameraControls from 'camera-controls';
 import * as reveal_threejs from '@cognite/reveal/threejs';
 import dat from 'dat.gui';
-import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams } from './utils/loaders';
+import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams, createClientIfNecessary } from './utils/loaders';
 
 CameraControls.install({ THREE });
 
@@ -42,7 +42,7 @@ async function main() {
   });
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelId);
+  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId));
   const cadNode = new reveal_threejs.CadNode(cadModel, { shading });
 
   scene.add(cadNode);

--- a/examples/src/picking.ts
+++ b/examples/src/picking.ts
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import CameraControls from 'camera-controls';
 import * as reveal_threejs from '@cognite/reveal/threejs';
-import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams } from './utils/loaders';
+import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams, createClientIfNecessary } from './utils/loaders';
 
 CameraControls.install({ THREE });
 
@@ -33,7 +33,7 @@ async function main() {
   const scene = new THREE.Scene();
 
   // Add some data for Reveal
-  const cadModel = await loadCadModelFromCdfOrUrl(modelId);
+  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId));
   const cadNode = new reveal_threejs.CadNode(cadModel, { shading });
   scene.add(cadNode);
 

--- a/examples/src/post-processing-effects.ts
+++ b/examples/src/post-processing-effects.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import * as reveal_threejs from '@cognite/reveal/threejs';
 
 import CameraControls from 'camera-controls';
-import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams } from './utils/loaders';
+import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams, createClientIfNecessary } from './utils/loaders';
 
 const postprocessing = require('postprocessing');
 
@@ -23,7 +23,7 @@ async function main() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
 
-  const cadModel = await loadCadModelFromCdfOrUrl(modelId);
+  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId));
   const cadModelNode = new reveal_threejs.CadNode(cadModel);
   scene.add(cadModelNode);
 

--- a/examples/src/sector-with-pointcloud.ts
+++ b/examples/src/sector-with-pointcloud.ts
@@ -19,7 +19,8 @@ import {
 import {
   loadCadModelFromCdfOrUrl,
   loadPointCloudModelFromCdfOrUrl,
-  createModelIdentifierFromUrlParams
+  createModelIdentifierFromUrlParams,
+  createClientIfNecessary
 } from './utils/loaders';
 
 CameraControls.install({ THREE });
@@ -40,7 +41,10 @@ async function main() {
 
   Potree.XHRFactory.config.customHeaders.push({ header: 'MyDummyHeader', value: 'MyDummyValue' });
 
-  const cadModel = await loadCadModelFromCdfOrUrl(cadModelIdentifier);
+  const cadModel = await loadCadModelFromCdfOrUrl(
+    cadModelIdentifier,
+    await createClientIfNecessary(cadModelIdentifier)
+  );
   const cadNode = new reveal_threejs.CadNode(cadModel);
   const cadModelOffsetRoot = new THREE.Group();
   cadModelOffsetRoot.name = 'Sector model offset root';

--- a/examples/src/sector-with-pointcloud.ts
+++ b/examples/src/sector-with-pointcloud.ts
@@ -27,13 +27,10 @@ CameraControls.install({ THREE });
 async function main() {
   const urlParams = new URL(location.href).searchParams;
   const cadModelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
-  const pointCloudModelIdentifier = createModelIdentifierFromUrlParams(
-    urlParams,
-    '/transformer',
-    'pointcloud',
-    'project',
-    'pointcloudUrl'
-  );
+  const pointCloudModelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/transformer', {
+    modelIdParameterName: 'pointcloud',
+    modelUrlParameterName: 'pointcloudUrl'
+  }3);
 
   const scene = new THREE.Scene();
   const renderer = new THREE.WebGLRenderer();

--- a/examples/src/sector-with-pointcloud.ts
+++ b/examples/src/sector-with-pointcloud.ts
@@ -30,7 +30,7 @@ async function main() {
   const pointCloudModelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/transformer', {
     modelIdParameterName: 'pointcloud',
     modelUrlParameterName: 'pointcloudUrl'
-  }3);
+  });
 
   const scene = new THREE.Scene();
   const renderer = new THREE.WebGLRenderer();

--- a/examples/src/side-by-side.ts
+++ b/examples/src/side-by-side.ts
@@ -15,6 +15,7 @@ import {
   RenderOptions
 } from './utils/renderer-debug-widget';
 import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams } from './utils/loaders';
+import { CogniteClient } from '@cognite/sdk';
 
 CameraControls.install({ THREE });
 
@@ -48,14 +49,15 @@ function initializeModel(
 
 async function main() {
   const params = new URL(location.href).searchParams;
-  const modelIdentifier1 = createModelIdentifierFromUrlParams(params, '/primitives', 'model1', 'project', 'modelUrl1');
-  const modelIdentifier2 = createModelIdentifierFromUrlParams(
-    params,
-    modelIdentifier1,
-    'model2',
-    'project',
-    'modelUrl2'
-  );
+  const project = params.get('project');
+  const modelIdentifier1 = createModelIdentifierFromUrlParams(params, '/primitives', {
+    modelIdParameterName: 'model1',
+    modelUrlParameterName: 'modelUrl1'
+  });
+  const modelIdentifier2 = createModelIdentifierFromUrlParams(params, modelIdentifier1, {
+    modelIdParameterName: 'model2',
+    modelUrlParameterName: 'modelUrl2'
+  });
   const modelHeader1 = params.get('modelUrl1') || `${params.get('model1')}@${params.get('project')}`;
   const modelHeader2 = params.get('modelUrl2') || `${params.get('model2')}@${params.get('project')}`;
 
@@ -69,9 +71,16 @@ async function main() {
   const leftCanvas = document.getElementById('leftCanvas')! as HTMLCanvasElement;
   const rightCanvas = document.getElementById('rightCanvas')! as HTMLCanvasElement;
 
+  // Initialize CogniteClient (if loading model from CDF)
+  let client: CogniteClient | undefined;
+  if (project) {
+    client = new CogniteClient({ appId: 'cognite.reveal.examples' });
+    await client.loginWithOAuth({ project });
+  }
+
   // Initialize models
-  const model1 = await loadCadModelFromCdfOrUrl(modelIdentifier1);
-  const model2 = await loadCadModelFromCdfOrUrl(modelIdentifier2);
+  const model1 = await loadCadModelFromCdfOrUrl(modelIdentifier1, client);
+  const model2 = await loadCadModelFromCdfOrUrl(modelIdentifier2, client);
   const [renderer1, scene1, modelNode1, options1] = initializeModel(model1, leftCanvas, gui1);
   const [renderer2, scene2, modelNode2, options2] = initializeModel(model2, rightCanvas, gui2);
 

--- a/examples/src/simple.ts
+++ b/examples/src/simple.ts
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import CameraControls from 'camera-controls';
 import * as reveal_threejs from '@cognite/reveal/threejs';
-import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams } from './utils/loaders';
+import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams, createClientIfNecessary } from './utils/loaders';
 
 CameraControls.install({ THREE });
 
@@ -14,7 +14,7 @@ async function main() {
   const modelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier);
+  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier, await createClientIfNecessary(modelIdentifier));
   const cadNode = new reveal_threejs.CadNode(cadModel);
   let sectorsNeedUpdate = true;
   cadNode.addEventListener('update', () => {

--- a/examples/src/ssao.ts
+++ b/examples/src/ssao.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import CameraControls from 'camera-controls';
 import { CadNode, SsaoEffect, SsaoPassType } from '@cognite/reveal/threejs';
 import dat from 'dat.gui';
-import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams } from './utils/loaders';
+import { loadCadModelFromCdfOrUrl, createModelIdentifierFromUrlParams, createClientIfNecessary } from './utils/loaders';
 
 CameraControls.install({ THREE });
 
@@ -15,7 +15,7 @@ async function main() {
   const modelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier);
+  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier, await createClientIfNecessary(modelIdentifier));
   const cadNode = new CadNode(cadModel);
 
   scene.add(cadNode);

--- a/examples/src/utils/loaders.ts
+++ b/examples/src/utils/loaders.ts
@@ -51,17 +51,28 @@ export function createModelIdentifierFromUrlParams(
  * @param model Model identifier. If a number, the model is assumed to be stored in CDF.
  * @param project If model is a number (i.e. model ID), project must be provided.
  */
-export async function loadCadModelFromCdfOrUrl(model: ModelIdentifier, client?: CogniteClient): Promise<reveal.CadModel> {
+export async function loadCadModelFromCdfOrUrl(
+  model: ModelIdentifier,
+  client?: CogniteClient
+): Promise<reveal.CadModel> {
   if (isUrlModelIdentifier(model)) {
     return reveal.loadCadModelByUrl(model.modelUrl);
-  } else {
-    if (!client) {
-      client = new CogniteClient({ appId: 'cognite.reveal.example' });
-      client.loginWithOAuth({ project: model.project });
-      await client.authenticate();
-    }
-    return reveal.loadCadModelFromCdf(client, model.modelId);
+  } else if (!client) {
+    throw new Error('Must provide a SDK client');
   }
+  return reveal.loadCadModelFromCdf(client, model.modelId);
+}
+
+export async function createClientIfNecessary(modelId: ModelIdentifier): Promise<CogniteClient | undefined> {
+  if (isUrlModelIdentifier(modelId)) {
+    // Model is not on CDF
+    return undefined;
+  }
+
+  const client = new CogniteClient({ appId: 'cognite.reveal.example' });
+  client.loginWithOAuth({ project: modelId.project });
+  await client.authenticate();
+  return client;
 }
 
 /**

--- a/examples/src/utils/loaders.ts
+++ b/examples/src/utils/loaders.ts
@@ -16,13 +16,23 @@ function isUrlModelIdentifier(model: ModelIdentifier): model is UrlModelIdentifi
 export function createModelIdentifierFromUrlParams(
   urlParams: URLSearchParams,
   fallbackModel: ModelIdentifier | string,
-  modelIdParameterName: string = 'model',
-  projectParameterName: string = 'project',
-  modelUrlParameterName: string = 'modelUrl'
+  options?: {
+    modelIdParameterName?: string;
+    projectParameterName?: string;
+    modelUrlParameterName?: string;
+  }
 ): ModelIdentifier {
-  const modelId = urlParams.get(modelIdParameterName);
-  const modelUrl = urlParams.get(modelUrlParameterName);
-  const project = urlParams.get(projectParameterName);
+  const opts = {
+    ...{
+      modelIdParameterName: 'model',
+      projectParameterName: 'project',
+      modelUrlParameterName: 'modelUrl'
+    },
+    ...options
+  };
+  const modelId = urlParams.get(opts.modelIdParameterName);
+  const modelUrl = urlParams.get(opts.modelUrlParameterName);
+  const project = urlParams.get(opts.projectParameterName);
   const fallbackModelIdentifier = typeof fallbackModel === 'string' ? { modelUrl: fallbackModel } : fallbackModel;
 
   if (modelUrl) {
@@ -41,13 +51,15 @@ export function createModelIdentifierFromUrlParams(
  * @param model Model identifier. If a number, the model is assumed to be stored in CDF.
  * @param project If model is a number (i.e. model ID), project must be provided.
  */
-export async function loadCadModelFromCdfOrUrl(model: ModelIdentifier): Promise<reveal.CadModel> {
+export async function loadCadModelFromCdfOrUrl(model: ModelIdentifier, client?: CogniteClient): Promise<reveal.CadModel> {
   if (isUrlModelIdentifier(model)) {
     return reveal.loadCadModelByUrl(model.modelUrl);
   } else {
-    const client = new CogniteClient({ appId: 'cognite.reveal.example' });
-    client.loginWithOAuth({ project: model.project });
-    await client.authenticate();
+    if (!client) {
+      client = new CogniteClient({ appId: 'cognite.reveal.example' });
+      client.loginWithOAuth({ project: model.project });
+      await client.authenticate();
+    }
     return reveal.loadCadModelFromCdf(client, model.modelId);
   }
 }

--- a/examples/src/world-to-screen.ts
+++ b/examples/src/world-to-screen.ts
@@ -6,17 +6,17 @@ import * as THREE from 'three';
 import CameraControls from 'camera-controls';
 import * as reveal_threejs from '@cognite/reveal/threejs';
 import { CadNode } from '@cognite/reveal/threejs';
-import { createModelIdentifierFromUrlParams, loadCadModelFromCdfOrUrl } from './utils/loaders';
+import { createModelIdentifierFromUrlParams, loadCadModelFromCdfOrUrl, createClientIfNecessary } from './utils/loaders';
 import { MOUSE } from 'three';
 
 CameraControls.install({ THREE });
 
 async function main() {
   const urlParams = new URL(location.href).searchParams;
-  const modelIndentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
+  const modelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelIndentifier);
+  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier, await createClientIfNecessary(modelIdentifier));
 
   const { htmlElement, updateHtmlElements } = createHtmlElements();
   document.body.appendChild(htmlElement);


### PR DESCRIPTION
Resolves an issue where user was sent in an infinite login loop.