### PR TITLE
Speed up Travis builds by building debug and dropping Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
         allow_failures:
           - rust: nightly
         fast_finish: true
-
       before_script:
         - rustup component add clippy
         - rustup component add rustfmt
@@ -26,11 +25,9 @@ matrix:
 
     - language: rust
       name: "Reveal viewer"
-
       install:
         # Install NVM and Node
         - sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
-        - nvm install 10
         - nvm install 12
         # Install wasm-pack for Rust
         - rm -rf $HOME/.cargo/bin/wasm-pack
@@ -39,25 +36,35 @@ matrix:
         - npm install -g codecov
       script:
         - cd $TRAVIS_BUILD_DIR/viewer
-        - nvm use 10
+        - nvm use 12
         - npm install
-        - npm run release
+        - npm run build
         - npm run coverage
-        - cd $TRAVIS_BUILD_DIR//examples
+        - cd $TRAVIS_BUILD_DIR/examples
         - npm install
-        - npm run release
+        - npm run build
+      after_script:
+        - codecov
 
+    - language: rust
+      name: "Reveal viewer release"
+      if: branch =~ /^release/
+      install:
+        # Install NVM and Node
+        - sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+        - nvm install 12
+        # Install wasm-pack for Rust
+        - rm -rf $HOME/.cargo/bin/wasm-pack
+        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      script:
         - cd $TRAVIS_BUILD_DIR/viewer
         - nvm use 12
         - npm install
         - npm run release
-        - npm run coverage
         - cd $TRAVIS_BUILD_DIR/examples
         - npm install
         - npm run release
 
-      after_script:
-        - codecov
 branches:
   only:
     - master


### PR DESCRIPTION
Unless we are building for a release branch, we will only make debug
builds, which are significantly faster than release builds. In addition,
we will only target Node 10 to reduce build times.