### PR TITLE
Do not create model twice in migration examples

### DIFF
--- a/examples/src/migration.ts
+++ b/examples/src/migration.ts
@@ -23,8 +23,7 @@ async function main() {
   (window as any).viewer = viewer;
 
   async function addModel(modelId: number, revisionId: number) {
-    const model = await reveal_migration.createCognite3DModel(modelId, revisionId, client);
-    await viewer.addModel(model);
+    const model = await viewer.addModel({modelId, revisionId});
     viewer.fitCameraToModel(model);
     models.push(model);
   }


### PR DESCRIPTION
The model will created inside `addModel` anyways and the `model` reference was to an unused object.