### PR TITLE
Accept 'requires' dependencies in package-log.json in addition to 'dependencies'

### DIFF
--- a/scripts/verify-package-lock.sh
+++ b/scripts/verify-package-lock.sh
@@ -2,7 +2,9 @@
 
 cd examples
 REVEAL_DEPS=$(cat package-lock.json | jq '.["dependencies"] | .["@cognite/reveal"] | .dependencies | length')
-if (( REVEAL_DEPS == 0)); then
+REVEAL_REQS=$(cat package-lock.json | jq '.["dependencies"] | .["@cognite/reveal"] | .requires | length')
+REVEAL_TOTAL_DEPENDENCIES_COUNT=sum=$(( $REVEAL_DEPS + $REVEAL_REQS ))
+if (( REVEAL_TOTAL_DEPENDENCIES_COUNT == 0)); then
     echo "ERROR: examples/package-lock.json has no dependencies under @cognite/reveal."
     echo "This happens if you run npm install in examples before running it in viewer."
     echo "Please re-run npm install and push your PR again."


### PR DESCRIPTION
dependencies' was replaced with 'requires' after npm install. See https://stackoverflow.com/questions/52926922/package-lock-json-requires-vs-dependencies