### PR TITLE
Add support for getting intersection from click in migration wrapper

### DIFF
--- a/examples/src/migration.ts
+++ b/examples/src/migration.ts
@@ -61,6 +61,20 @@ async function main() {
     const revisionId = Number.parseInt(revisionIdStr, 10);
     addModel({ modelId, revisionId });
   }
+  viewer.on('click', function(event) {
+    const { offsetX, offsetY } = event;
+    console.log('2D coordinates', event);
+    const intersection = viewer.getIntersectionFromPixel(offsetX, offsetY);
+    if (intersection !== null) {
+      const { nodeId, point, model } = intersection;
+      console.log(`Clicked node ${nodeId} at`, point);
+      // highlight the object
+      model.setNodeColor(nodeId, 0, 255, 0);
+      // TODO make the camera zoom to the object
+      //const boundingBox = model.getBoundingBox(nodeId);
+      //viewer.fitCameraToBoundingBox(boundingBox, 2000); // 2 sec
+    }
+  });
 }
 
 main();

--- a/examples/template-single-canvas.ejs
+++ b/examples/template-single-canvas.ejs
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-    <div id="canvas-container" style="vertical-align: top; position: fixed; width: 800px; height: 600px;"/>
+    <div id="canvas-container" style="padding: 50px; vertical-align: top; position: fixed; width: 800px; height: 600px;"/>
     <script type="text/javascript" src="<%= script %>"></script>
 </body>
 

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1037,6 +1037,11 @@
         "pretty-format": "^25.1.0"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -67,10 +67,12 @@
     "@cognite/sdk": "^2.25.0",
     "@cognite/three-combo-controls": "^1.4.1",
     "@tweenjs/tween.js": "^18.5.0",
+    "@types/lodash": "^4.14.149",
     "comlink": "^4.1.0",
     "gl-matrix": "^3.2.1",
     "glslify": "^7.0.0",
     "glslify-import": "^3.1.0",
+    "lodash": "^4.17.15",
     "rxjs": "^6.5.4",
     "three": "^0.114.0"
   }

--- a/viewer/src/views/threejs/cad/CadNode.ts
+++ b/viewer/src/views/threejs/cad/CadNode.ts
@@ -107,6 +107,7 @@ export class CadNode extends THREE.Object3D {
 
   requestNodeUpdate(treeIndices: number[]) {
     this._materialManager.updateNodes(treeIndices);
+    this.dispatchEvent({ type: 'update' });
   }
 
   set renderMode(mode: RenderMode) {


### PR DESCRIPTION
This implements the same API as in the original viewer for click events
and sets the color of a clicked node in the migration example.

Also, offset the canvas a little more to make sure we detect offset bugs
while testing.