### PR TITLE
Introduce a limit on number of elements in the cache

### DIFF
--- a/viewer/src/cache/MemoryRequestCache.ts
+++ b/viewer/src/cache/MemoryRequestCache.ts
@@ -4,25 +4,71 @@
 
 import { RequestCache, RequestDelegate } from './RequestCache';
 
-export class MemoryRequestCache<Key, Data, Result> implements RequestCache<Key, Data, Result> {
-  private readonly _results: Map<Key, Result>;
-  private readonly _request: RequestDelegate<Key, Data, Result>;
-  constructor(request: RequestDelegate<Key, Data, Result>) {
-    this._results = new Map();
-    this._request = request;
+class TimestampedContainer<T> {
+  private _lastAccessTime: number;
+  private readonly _value: T;
+
+  constructor(value: T) {
+    this._value = value;
+    this._lastAccessTime = Date.now();
   }
 
-  request(id: Key, data: Data) {
+  get value() {
+    this.touch();
+    return this._value;
+  }
+
+  get lastAccessTime() {
+    return this._lastAccessTime;
+  }
+
+  private touch() {
+    this._lastAccessTime = Date.now();
+  }
+}
+
+export class MemoryRequestCache<Key, Data, Result> implements RequestCache<Key, Data, Result> {
+  private readonly _maxElementsInCache: number;
+  private readonly _results: Map<Key, TimestampedContainer<Result>>;
+  private readonly _request: RequestDelegate<Key, Data, Result>;
+
+  constructor(request: RequestDelegate<Key, Data, Result>, maxElementsInCache: number = 50) {
+    this._results = new Map();
+    this._request = request;
+    this._maxElementsInCache = maxElementsInCache;
+  }
+
+  request(id: Key, data: Data): Result {
     const existing = this._results.get(id);
     if (existing) {
-      return existing;
+      return existing.value;
     }
-    const result: Result = this._request(id, data);
+
+    this.cleanupCache();
+    const value = ;
+    const result = new TimestampedContainer<Result>(this._request(id, data));
     this._results.set(id, result);
-    return result;
+    return result.value;
   }
 
   clearCache() {
     this._results.clear();
+  }
+
+  private cleanupCache() {
+    const maxCacheSize = this._maxElementsInCache;
+    if (this._results.size > maxCacheSize) {
+      const allResults = Array.from(this._results.entries());
+      allResults.sort((left, right) => {
+        return right[1].lastAccessTime - left[1].lastAccessTime;
+      });
+
+      // Remove least recent access items
+      let index = 0;
+      while (this._results.size > maxCacheSize) {
+        const toRemove = allResults[index++];
+        this._results.delete(toRemove[0]);
+      }
+    }
   }
 }

--- a/viewer/src/cache/MemoryRequestCache.ts
+++ b/viewer/src/cache/MemoryRequestCache.ts
@@ -45,7 +45,6 @@ export class MemoryRequestCache<Key, Data, Result> implements RequestCache<Key, 
     }
 
     this.cleanupCache();
-    const value = ;
     const result = new TimestampedContainer<Result>(this._request(id, data));
     this._results.set(id, result);
     return result.value;

--- a/viewer/src/cache/RequestCache.ts
+++ b/viewer/src/cache/RequestCache.ts
@@ -5,6 +5,6 @@
 export type RequestDelegate<Key, Data, Result> = (id: Key, data: Data) => Result;
 
 export interface RequestCache<Key, Data, Result> {
-  request: RequestDelegate<Key, Data, Result>;
-  clearCache: () => void;
+  request(id: Key, data: Data): Result;
+  clearCache(): void;
 }


### PR DESCRIPTION
Keep a maximum number of elements in the cache and evict based on last accessed. Attempt to reduce memory footprint.