### PR TITLE
Disable prefer-for-of

### DIFF
--- a/examples/tslint.json
+++ b/examples/tslint.json
@@ -16,6 +16,7 @@
           "enforce-trailing-newline": false
         }
       ],
-      "no-return-await": true
+      "no-return-await": true,
+      "prefer-for-of": false
     }
 }

--- a/viewer/tslint.json
+++ b/viewer/tslint.json
@@ -17,6 +17,7 @@
         }
       ],
       "no-return-await": true,
-      "no-unbound-method": true
+      "no-unbound-method": true,
+      "prefer-for-of": false
     }
 }


### PR DESCRIPTION
Disable perfer-for-of tslint rule that encourages `for (const element of ...)` over `for (let i = 0; ...)` since `for (let i=0; ...)` is [a lot faster](https://www.incredible-web.com/blog/performance-of-for-loops-with-javascript/).