### PR TITLE
Fix issues causing viewer not to work on iOS

### DIFF
--- a/f3df/src/bin/dump.rs
+++ b/f3df/src/bin/dump.rs
@@ -1,5 +1,4 @@
 use serde_derive::Serialize;
-use serde_yaml;
 use std::error::Error;
 use std::fs::File;
 use std::io::{stdout, BufReader};

--- a/f3df/src/bin/dump.rs
+++ b/f3df/src/bin/dump.rs
@@ -1,12 +1,9 @@
 use serde_derive::Serialize;
-use serde_json;
 use serde_yaml;
 use std::error::Error;
 use std::fs::File;
 use std::io::{stdout, BufReader};
 use structopt::StructOpt;
-
-use f3df;
 
 #[derive(StructOpt)]
 struct Options {

--- a/f3df/src/renderables.rs
+++ b/f3df/src/renderables.rs
@@ -1,4 +1,3 @@
-use nalgebra;
 use serde_derive::Serialize;
 use std::collections::HashMap;
 use std::f32::consts::{FRAC_PI_2, PI};

--- a/f3df/tests/integration.rs
+++ b/f3df/tests/integration.rs
@@ -1,5 +1,3 @@
-use f3df;
-
 #[test]
 fn parse_file() {
     let file = std::fs::File::open("tests/files/test.f3d").unwrap();

--- a/i3df/build.rs
+++ b/i3df/build.rs
@@ -329,7 +329,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
         pub struct Texture {
             // TODO generate from YAML
-            pub file_id: u32,
+            pub file_id: f64,
             pub width: u16,
             pub height: u16,
         }

--- a/i3df/build.rs
+++ b/i3df/build.rs
@@ -329,7 +329,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
         pub struct Texture {
             // TODO generate from YAML
-            pub file_id: u64,
+            pub file_id: u32,
             pub width: u16,
             pub height: u16,
         }

--- a/i3df/build.rs
+++ b/i3df/build.rs
@@ -1,8 +1,6 @@
 use heck::CamelCase;
-use i3df_specification;
 use indexmap::IndexMap;
 use quote::{format_ident, quote};
-use serde_yaml;
 use std::collections::HashMap;
 use std::env;
 use std::error::Error;

--- a/i3df/src/bin/dump.rs
+++ b/i3df/src/bin/dump.rs
@@ -3,8 +3,6 @@ use std::io::{stdout, BufReader};
 use structopt::StructOpt;
 
 use serde_derive::{Deserialize, Serialize};
-use serde_json;
-use serde_yaml;
 
 #[derive(StructOpt)]
 struct Options {

--- a/i3df/src/lib.rs
+++ b/i3df/src/lib.rs
@@ -269,7 +269,7 @@ pub fn decode_array_texture(mut reader: impl Read) -> Result<Vec<Texture>, Error
     let mut array = Vec::new();
 
     for _ in 0..item_count {
-        let file_id = reader.read_u64::<LittleEndian>()? as u32;
+        let file_id = reader.read_u64::<LittleEndian>()? as f64;
         let width = reader.read_u16::<LittleEndian>()?;
         let height = reader.read_u16::<LittleEndian>()?;
         let _reserved = reader.read_u32::<LittleEndian>()?;

--- a/i3df/src/lib.rs
+++ b/i3df/src/lib.rs
@@ -2,7 +2,6 @@ use std::io::{self, BufRead, BufReader, Cursor, Read};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
-use nalgebra;
 use serde_derive::{Deserialize, Serialize};
 
 use wasm_bindgen::prelude::*;

--- a/i3df/src/lib.rs
+++ b/i3df/src/lib.rs
@@ -269,7 +269,7 @@ pub fn decode_array_texture(mut reader: impl Read) -> Result<Vec<Texture>, Error
     let mut array = Vec::new();
 
     for _ in 0..item_count {
-        let file_id = reader.read_u64::<LittleEndian>()?;
+        let file_id = reader.read_u64::<LittleEndian>()? as u32;
         let width = reader.read_u16::<LittleEndian>()?;
         let height = reader.read_u16::<LittleEndian>()?;
         let _reserved = reader.read_u32::<LittleEndian>()?;

--- a/i3df/src/renderables.rs
+++ b/i3df/src/renderables.rs
@@ -5,7 +5,6 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::f32::consts::PI;
 
-use serde_wasm_bindgen;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 

--- a/viewer/rust/lib.rs
+++ b/viewer/rust/lib.rs
@@ -1,16 +1,8 @@
-use console_error_panic_hook;
 use js_sys::{Float32Array, Map, Uint32Array};
 use serde::{Deserialize, Serialize};
 use std::panic;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
-
-// From reveal-rs
-use f3df;
-use i3df;
-use openctm;
-use serde;
-use serde_bytes;
 
 #[macro_use]
 pub mod error;

--- a/viewer/src/glsl/base/updateFragmentDepth.glsl
+++ b/viewer/src/glsl/base/updateFragmentDepth.glsl
@@ -1,6 +1,4 @@
-#ifdef GL_EXT_frag_depth
-
-void updateFragmentDepth(vec3 p,mat4 projectionMatrix){
+float computeFragmentDepth(vec3 p, mat4 projectionMatrix) {
   // Anders Hafreager comments:
   // Depth value can be calculated by transforming the z-component of the intersection point to projection space.
   // The w-component is also needed to scale projection space into clip space.
@@ -10,14 +8,21 @@ void updateFragmentDepth(vec3 p,mat4 projectionMatrix){
   // If we want to use orthographic camera, the full w-component is found as
   float projected_intersection_w=projectionMatrix[0][3]*p.x+projectionMatrix[1][3]*p.y+projectionMatrix[2][3]*p.z+projectionMatrix[3][3];
   // float projected_intersection_w = projectionMatrix[2][3]*newPoint.z; // Optimized for perspective camera
-  gl_FragDepthEXT = ((gl_DepthRange.diff * (projected_intersection_z / projected_intersection_w)) + gl_DepthRange.near + gl_DepthRange.far) * .5;
+  return ((gl_DepthRange.diff * (projected_intersection_z / projected_intersection_w)) + gl_DepthRange.near + gl_DepthRange.far) * .5;
+}
+
+#ifdef GL_EXT_frag_depth
+
+float updateFragmentDepth(vec3 p,mat4 projectionMatrix) {
+  gl_FragDepthEXT = computeFragmentDepth(p, projectionMatrix);
+  return gl_FragDepthEXT;
 }
 
 #else
 
-void updateFragmentDepth(vec3 p,mat4 projectionMatrix){
+float updateFragmentDepth(vec3 p, mat4 projectionMatrix){
   // Extension not available - not much we can do.
-  gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+  return computeFragmentDepth(p, projectionMatrix);
 }
 
 #endif

--- a/viewer/src/glsl/sector/primitives/cone.frag
+++ b/viewer/src/glsl/sector/primitives/cone.frag
@@ -152,6 +152,6 @@ void main() {
   #endif
 
 
-    updateFragmentDepth(p, projectionMatrix);
-    updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragDepthEXT, matCapTexture);
+    float fragDepth = updateFragmentDepth(p, projectionMatrix);
+    updateFragmentColor(renderMode, color, v_treeIndex, normal, fragDepth, matCapTexture);
 }

--- a/viewer/src/glsl/sector/primitives/eccentricCone.frag
+++ b/viewer/src/glsl/sector/primitives/eccentricCone.frag
@@ -137,6 +137,6 @@ void main() {
     normal = normalize(cross(A, B));
 #endif
 
-    updateFragmentDepth(p, projectionMatrix);
-    updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragDepthEXT, matCapTexture);
+    float fragDepth = updateFragmentDepth(p, projectionMatrix);
+    updateFragmentColor(renderMode, color, v_treeIndex, normal, fragDepth, matCapTexture);
 }

--- a/viewer/src/glsl/sector/primitives/ellipsoidSegment.frag
+++ b/viewer/src/glsl/sector/primitives/ellipsoidSegment.frag
@@ -104,6 +104,6 @@ void main() {
     }
 #endif
 
-  updateFragmentDepth(p, projectionMatrix);
-  updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragDepthEXT, matCapTexture);
+  float fragDepth = updateFragmentDepth(p, projectionMatrix);
+  updateFragmentColor(renderMode, color, v_treeIndex, normal, fragDepth, matCapTexture);
 }

--- a/viewer/src/glsl/sector/primitives/generalCylinder.frag
+++ b/viewer/src/glsl/sector/primitives/generalCylinder.frag
@@ -133,6 +133,6 @@ void main() {
     normal = normalize(p_local - W.xyz * dot(p_local, W.xyz));
 #endif
 
-    updateFragmentDepth(p, projectionMatrix);
-    updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragDepthEXT, matCapTexture);
+    float fragDepth = updateFragmentDepth(p, projectionMatrix);
+    updateFragmentColor(renderMode, color, v_treeIndex, normal, fragDepth, matCapTexture);
 }

--- a/viewer/src/glsl/sector/primitives/sphericalSegment.frag
+++ b/viewer/src/glsl/sector/primitives/sphericalSegment.frag
@@ -102,6 +102,6 @@ void main() {
     }
 #endif
 
-  updateFragmentDepth(p, projectionMatrix);
-  updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragDepthEXT, matCapTexture);
+  float fragDepth = updateFragmentDepth(p, projectionMatrix);
+  updateFragmentColor(renderMode, color, v_treeIndex, normal, fragDepth, matCapTexture);
 }

--- a/viewer/src/views/threejs/cad/materials.ts
+++ b/viewer/src/views/threejs/cad/materials.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import { sectorShaders, shaderDefines } from './shaders';
 import { RenderMode } from '../materials';
 import { determinePowerOfTwoDimensions } from '../../../utils/determinePowerOfTwoDimensions';
-import  matCapTextureImage  from './matCapTextureData';
+import matCapTextureImage from './matCapTextureData';
 
 export interface Materials {
   // Materials
@@ -40,7 +40,7 @@ export function createMaterials(treeIndexCount: number): Materials {
   visibility.fill(255);
   const overrideColorPerTreeIndex = new THREE.DataTexture(colors, textureDims.width, textureDims.height);
   const overrideVisibilityPerTreeIndex = new THREE.DataTexture(visibility, textureDims.width, textureDims.height);
-  
+
   const matCapTexture = new THREE.Texture(matCapTextureImage);
   matCapTexture.needsUpdate = true;
 
@@ -222,7 +222,13 @@ export function createMaterials(treeIndexCount: number): Materials {
     simple: simpleMaterial
   };
   for (const material of Object.values(allMaterials)) {
-    updateDefinesAndUniforms(material, dataTextureSize, overrideColorPerTreeIndex, overrideVisibilityPerTreeIndex, matCapTexture);
+    updateDefinesAndUniforms(
+      material,
+      dataTextureSize,
+      overrideColorPerTreeIndex,
+      overrideVisibilityPerTreeIndex,
+      matCapTexture
+    );
   }
 
   return { ...allMaterials, overrideColorPerTreeIndex, overrideVisibilityPerTreeIndex };
@@ -252,7 +258,7 @@ function updateDefinesAndUniforms(
       dataTextureSize: {
         value: dataTextureSize
       },
-      matCapTexture:{
+      matCapTexture: {
         value: matCapTexture
       }
     }


### PR DESCRIPTION
This PR fixes two issues:
1. BigUInt64Array is not supported on Safari/iOS - use u32 over u64 structs exposed by Rust
2. Avoid using gl_FragDepthEXT when WebGL extension is unavailable.