### PR TITLE
Route CDF requests through webpack-dev-server proxy

### DIFF
--- a/examples/src/filtering.ts
+++ b/examples/src/filtering.ts
@@ -13,6 +13,7 @@ CameraControls.install({ THREE });
 async function main() {
   const urlParams = new URL(location.href).searchParams;
   const modelId = createModelIdentifierFromUrlParams(urlParams, '/primitives');
+  const apiKey = urlParams.get('apiKey');
 
   let shadingNeedsUpdate = false;
   let visibleIndices = new Set([1, 2, 8, 12]);
@@ -42,7 +43,7 @@ async function main() {
   });
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId));
+  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId, apiKey));
   const cadNode = new CadNode(cadModel, { nodeAppearance });
   let modelNeedsUpdate = false;
   cadNode.addEventListener('update', () => {

--- a/examples/src/picking.ts
+++ b/examples/src/picking.ts
@@ -18,6 +18,7 @@ function createSphere(point: THREE.Vector3, color: string): THREE.Mesh {
 async function main() {
   const urlParams = new URL(location.href).searchParams;
   const modelId = createModelIdentifierFromUrlParams(urlParams, '/primitives');
+  const apiKey = urlParams.get('apiKey');
 
   const pickedNodes: Set<number> = new Set();
   const pickedObjects: Set<THREE.Mesh> = new Set();
@@ -33,7 +34,7 @@ async function main() {
   const scene = new THREE.Scene();
 
   // Add some data for Reveal
-  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId));
+  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId, apiKey));
   const cadNode = new CadNode(cadModel, { nodeAppearance });
   let modelNeedsUpdate = false;
   cadNode.addEventListener('update', () => {

--- a/examples/src/post-processing-effects.ts
+++ b/examples/src/post-processing-effects.ts
@@ -15,6 +15,7 @@ CameraControls.install({ THREE });
 async function main() {
   const urlParams = new URL(location.href).searchParams;
   const modelId = createModelIdentifierFromUrlParams(urlParams, '/primitives');
+  const apiKey = urlParams.get('apiKey');
 
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
@@ -23,7 +24,7 @@ async function main() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
 
-  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId));
+  const cadModel = await loadCadModelFromCdfOrUrl(modelId, await createClientIfNecessary(modelId, apiKey));
   const cadModelNode = new reveal_threejs.CadNode(cadModel);
   let modelNeedsUpdate = false;
   cadModelNode.addEventListener('update', () => {

--- a/examples/src/sector-with-pointcloud.ts
+++ b/examples/src/sector-with-pointcloud.ts
@@ -32,6 +32,7 @@ async function main() {
     modelIdParameterName: 'pointcloud',
     modelUrlParameterName: 'pointcloudUrl'
   });
+  const apiKey = urlParams.get('apiKey');
 
   const scene = new THREE.Scene();
   const renderer = new THREE.WebGLRenderer();
@@ -43,7 +44,7 @@ async function main() {
 
   const cadModel = await loadCadModelFromCdfOrUrl(
     cadModelIdentifier,
-    await createClientIfNecessary(cadModelIdentifier)
+    await createClientIfNecessary(cadModelIdentifier, apiKey)
   );
   const cadNode = new reveal_threejs.CadNode(cadModel);
   let modelNeedsUpdate = false;

--- a/examples/src/simple.ts
+++ b/examples/src/simple.ts
@@ -12,9 +12,13 @@ CameraControls.install({ THREE });
 async function main() {
   const urlParams = new URL(location.href).searchParams;
   const modelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
+  const apiKey = urlParams.get('apiKey');
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier, await createClientIfNecessary(modelIdentifier));
+  const cadModel = await loadCadModelFromCdfOrUrl(
+    modelIdentifier,
+    await createClientIfNecessary(modelIdentifier, apiKey)
+  );
   const cadNode = new reveal_threejs.CadNode(cadModel);
   let sectorsNeedUpdate = true;
   cadNode.addEventListener('update', () => {

--- a/examples/src/ssao.ts
+++ b/examples/src/ssao.ts
@@ -13,9 +13,13 @@ CameraControls.install({ THREE });
 async function main() {
   const urlParams = new URL(location.href).searchParams;
   const modelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
+  const apiKey = urlParams.get('apiKey');
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier, await createClientIfNecessary(modelIdentifier));
+  const cadModel = await loadCadModelFromCdfOrUrl(
+    modelIdentifier,
+    await createClientIfNecessary(modelIdentifier, apiKey)
+  );
   const cadNode = new CadNode(cadModel);
   let modelNeedsUpdate = false;
   cadNode.addEventListener('update', () => {

--- a/examples/src/utils/loaders.ts
+++ b/examples/src/utils/loaders.ts
@@ -63,15 +63,22 @@ export async function loadCadModelFromCdfOrUrl(
   return reveal.loadCadModelFromCdf(client, model.modelId);
 }
 
-export async function createClientIfNecessary(modelId: ModelIdentifier): Promise<CogniteClient | undefined> {
+export async function createClientIfNecessary(
+  modelId: ModelIdentifier,
+  apiKey: string | null
+): Promise<CogniteClient | undefined> {
   if (isUrlModelIdentifier(modelId)) {
     // Model is not on CDF
     return undefined;
   }
 
-  const client = new CogniteClient({ appId: 'cognite.reveal.example' });
-  client.loginWithOAuth({ project: modelId.project });
-  await client.authenticate();
+  const client = new CogniteClient({ baseUrl: '/cdf', appId: 'cognite.reveal.example' });
+  if (apiKey) {
+    client.loginWithApiKey({ project: modelId.project, apiKey });
+  } else {
+    client.loginWithOAuth({ project: modelId.project });
+    await client.authenticate();
+  }
   return client;
 }
 

--- a/examples/src/world-to-screen.ts
+++ b/examples/src/world-to-screen.ts
@@ -13,9 +13,13 @@ CameraControls.install({ THREE });
 async function main() {
   const urlParams = new URL(location.href).searchParams;
   const modelIdentifier = createModelIdentifierFromUrlParams(urlParams, '/primitives');
+  const apiKey = urlParams.get('apiKey');
 
   const scene = new THREE.Scene();
-  const cadModel = await loadCadModelFromCdfOrUrl(modelIdentifier, await createClientIfNecessary(modelIdentifier));
+  const cadModel = await loadCadModelFromCdfOrUrl(
+    modelIdentifier,
+    await createClientIfNecessary(modelIdentifier, apiKey)
+  );
 
   let pickingNeedsUpdate = false;
   let pickedNode: number | undefined;

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -230,6 +230,18 @@ module.exports = env => {
         resolve('public/'),
         resolve('dist/'),
       ],
+
+      proxy: {
+       // Setup a proxy to allow requests from LAN to access API without CORS issues
+       '/cdf': {
+            target: 'https://api.cognitedata.com',
+            changeOrigin: true,
+            secure: true,
+            pathRewrite: {
+              '^/cdf': ''
+            }
+        },
+      },
       writeToDisk: true,
     },
     optimization: {


### PR DESCRIPTION
Route all requests through CDF through a webpack-dev-server proxy to work around CORS issues accessing CDF from LAN (i.e. when not using localhost, such as from phones/tables)