### PR TITLE
Disable proxy in webpack dev server as it caused eternal login loops.

### DIFF
--- a/examples/src/utils/loaders.ts
+++ b/examples/src/utils/loaders.ts
@@ -72,7 +72,7 @@ export async function createClientIfNecessary(
     return undefined;
   }
 
-  const client = new CogniteClient({ baseUrl: '/cdf', appId: 'cognite.reveal.example' });
+  const client = new CogniteClient({ appId: 'cognite.reveal.example' });
   if (apiKey) {
     client.loginWithApiKey({ project: modelId.project, apiKey });
   } else {

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -237,17 +237,6 @@ module.exports = env => {
         resolve('dist/'),
       ],
 
-      proxy: {
-       // Setup a proxy to allow requests from LAN to access API without CORS issues
-       '/cdf': {
-            target: 'https://api.cognitedata.com',
-            changeOrigin: true,
-            secure: true,
-            pathRewrite: {
-              '^/cdf': ''
-            }
-        },
-      },
       writeToDisk: true,
     },
     optimization: {


### PR DESCRIPTION
Fixes an issue where the user was sent in eternal login loop when opening examples that loaded data from CDF.