### PR TITLE
chore(.gitignore): add examples/public with exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ examples/coverage
 examples/npm-debug.log*
 examples/yarn-debug.log*
 examples/yarn-error.log*
+# Public is also used for temorary local models so ignore everything
+examples/public/
+!examples/public/index.html
+!examples/public/favicon.ico
+!examples/public/manifest.json
 
 # Typescript
 tsconfig.tsbuildinfo

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,23 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app)
 and extended with [react-app-rewired](https://github.com/timarney/react-app-rewired) to copy reveal/viewer workers and wasm files to output folder.
 
+## Getting started 
+
+You need to build the viewer first and then the examples:
+
+```bash
+cd ./viewer
+npm install
+npm run build
+
+cd ../examples
+yarn install
+yarn start
+```
+
+Examples are not bounded to specific viewer release, but use the latest code from master branch.
+
+
 ## [Environment files](https://create-react-app.dev/docs/adding-custom-environment-variables/)
 
 Create a copy of `.env.example` file and rename it to `.env`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,14 @@ yarn start
 
 Examples are not bounded to specific viewer release, but use the latest code from master branch.
 
+### Viewer development
+
+In case if you want to get live changes from viewer in examples you need to link viewer with yarn link. It's already addressed in `serve` script in `viewer/package.json`, so you can do:
+
+```bash
+cd ./viewer
+npm run serve
+```
 
 ## [Environment files](https://create-react-app.dev/docs/adding-custom-environment-variables/)
 

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "0.1.1",
+  "version": "1.0.0-alpha-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "release": "npm run mkdist && webpack",
     "build": "npm run mkdist && webpack --env.development",
+    "build:watch": "npm run build -- --watch",
     "mkdist": "run-script-os",
     "mkdist:win32": "@powershell $(if(-not(Test-Path dist -PathType Container)) { mkdir dist;$? } else { $true;$? }) -and $(Copy-Item -Path package.json, README.md -Destination dist;$?)",
     "mkdist:linux:darwin": "mkdir -p dist && cp package.json README.md dist",
@@ -21,7 +22,7 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "lint": "tslint --project .",
-    "serve": "npm install && npm link && cd examples && npm install && npm link @cognite/reveal && npm run serve",
+    "serve": "npm install && yarn link && cd ../examples && yarn && yarn link @cognite/reveal && yarn start",
     "prepublishscript": "npm run release && npm run coverage",
     "publishscript": "node script/copyPackage.js",
     "postpublishscript": "cd dist && npm publish"


### PR DESCRIPTION
Since examples/public is also used to store local models - ignore it.
Also, fixed viewer `npm run serve` script for local development.
Updated examples/readme.md