### PR TITLE
Cognite3DViewer: implement basic addObject3D/removeObject3D + minor examples fix

### DIFF
--- a/examples/src/pages/DistanceMeasurement.tsx
+++ b/examples/src/pages/DistanceMeasurement.tsx
@@ -76,7 +76,11 @@ export function DistanceMeasurement() {
 
       const scene = new THREE.Scene();
       let isRenderRequired = true;
-      const revealManager = createRenderManager('local', client);
+
+      const revealManager = createRenderManager(
+        modelRevision !== undefined ? 'cdf' : 'local',
+        client
+      );
 
       let model: CadNode;
       if (

--- a/viewer/src/__tests__/migration/Cognite3DViewer.test.ts
+++ b/viewer/src/__tests__/migration/Cognite3DViewer.test.ts
@@ -103,4 +103,16 @@ describe('Cognite3DViewer', () => {
     expect(viewer.getCameraTarget()).toEqual(bbox.getCenter(new THREE.Vector3()));
     expect(bSphere.containsPoint(viewer.getCameraPosition())).toBeTrue();
   });
+
+  test('viewer can add/remove Object3d on scene', () => {
+    const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
+    const scene = viewer.getScene();
+    const obj = new THREE.Mesh(new THREE.SphereBufferGeometry(), new THREE.MeshBasicMaterial());
+
+    viewer.addObject3D(obj);
+    expect(scene.getObjectById(obj.id)).toEqual(obj);
+
+    viewer.removeObject3D(obj);
+    expect(scene.getObjectById(obj.id)).toBeFalsy();
+  });
 });

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -277,11 +277,20 @@ export class Cognite3DViewer {
     return SupportedModelTypes.NotSupported;
   }
 
-  addObject3D(_object: THREE.Object3D): void {
-    throw new NotSupportedInMigrationWrapperError();
+  addObject3D(object: THREE.Object3D): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.scene.add(object);
+    this.renderController.redraw();
   }
-  removeObject3D(_object: THREE.Object3D): void {
-    throw new NotSupportedInMigrationWrapperError();
+
+  removeObject3D(object: THREE.Object3D): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.scene.remove(object);
+    this.renderController.redraw();
   }
 
   setSlicingPlanes(slicingPlanes: THREE.Plane[]): void {


### PR DESCRIPTION
* add methods from old 3d viewer to add/remove Object3D on scene
* Fixed hardcoded local reveal manager in distance measurement example.

~Part of code with `additionalObjects` isn't used for now, so I kept it but commented out.~ 