### PR TITLE
Update README to reflect new location of the serve script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,16 @@ You can either run the same command as in Windows, or install it faster through 
 
 ## Getting started ##
 
-To test the viewer, you need to build the viewer first and then the examples:
+To test the viewer, you need to build the viewer and then the serve script will handle dependencies for examples:
 
 ```
 cd viewer
 npm install
 npm run build
-cd ..
-
-cd examples
-npm install
 npm run serve
 ```
 
-If you now navigate to [localhost:8080](https://localhost:8080), you will see a list of examples
+If you now navigate to [localhost:3000](https://localhost:3000), you will see a list of examples
 that can be explored in the browser.
 
 ## Publishing Viewer (Dev only)


### PR DESCRIPTION
Port is also changed from 8080 to 3000. I see port 8080 is specified in `examples/.env.example`, but the server as started by `npm run serve` starts at port 3000. Is this a bug?