### PR TITLE
feat(Cognite3DViewer): add loading spinner; add `getLoadingStateObserver` for RevealManager

### DIFF
--- a/examples/src/components/styled.ts
+++ b/examples/src/components/styled.ts
@@ -18,3 +18,9 @@ export const CanvasWrapper = styled(Container)`
     max-height: 100vh;
   }
 `;
+
+export const Loader = styled.div<{ isLoading: boolean }>`
+  background: black;
+  color: white;
+  display: ${(props) => (props.isLoading ? 'block' : 'none')};
+`;

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -19,6 +19,7 @@ export function Migration() {
   const canvasWrapperRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const gui = new dat.GUI();
+    let viewer: Cognite3DViewer
 
     async function main() {
       const urlParams = new URL(window.location.href).searchParams;
@@ -60,7 +61,7 @@ export function Migration() {
       await client.authenticate();
 
       // Prepare viewer
-      const viewer = new Cognite3DViewer({
+      viewer = new Cognite3DViewer({
         sdk: client,
         domElement: canvasWrapperRef.current!,
       });
@@ -226,6 +227,7 @@ export function Migration() {
 
     return () => {
       gui.destroy();
+      viewer.dispose();
     };
   });
   return <CanvasWrapper ref={canvasWrapperRef} />;

--- a/examples/src/pages/Simple.tsx
+++ b/examples/src/pages/Simple.tsx
@@ -10,14 +10,15 @@ import {
 } from '../utils/example-helpers';
 import { CogniteClient } from '@cognite/sdk';
 import * as reveal from '@cognite/reveal/experimental';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { WebGLRenderer } from 'three';
-import { CanvasWrapper } from '../components/styled';
+import { CanvasWrapper, Loader } from '../components/styled';
 
 CameraControls.install({ THREE });
 
 export function Simple() {
   const canvas = useRef<HTMLCanvasElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     async function main() {
@@ -48,6 +49,7 @@ export function Simple() {
         modelRevision !== undefined
       ) {
         model = await revealManager.addModel('cad', modelRevision);
+        revealManager.getLoadingStateObserver().subscribe(setIsLoading);
       } else {
         throw new Error(
           'Need to provide either project & model OR modelUrl as query parameters'
@@ -119,9 +121,12 @@ export function Simple() {
     }
 
     main();
-  });
+  }, []);
   return (
     <CanvasWrapper>
+      <Loader isLoading={isLoading} style={{ position: 'absolute' }}>
+        Loading...
+      </Loader>
       <canvas ref={canvas} />
     </CanvasWrapper>
   );

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -22,9 +22,12 @@ import { PointCloudMetadataRepository } from '@/datamodels/pointcloud/PointCloud
 import { PointCloudFactory } from '@/datamodels/pointcloud/PointCloudFactory';
 import { PointCloudManager } from '@/datamodels/pointcloud/PointCloudManager';
 import { DefaultPointCloudTransformation } from '@/datamodels/pointcloud/DefaultPointCloudTransformation';
+import { Observable } from 'rxjs';
 
 type CdfModelIdentifier = { modelRevision: IdEither; format: File3dFormat };
 export class RevealManager extends RevealManagerBase<CdfModelIdentifier> {
+  private readonly loadingStateObserver: Observable<boolean>;
+
   constructor(client: CogniteClient, options?: RevealOptions) {
     const modelDataParser: CadSectorParser = new CadSectorParser();
     const materialManager: MaterialManager = new MaterialManager();
@@ -57,6 +60,8 @@ export class RevealManager extends RevealManagerBase<CdfModelIdentifier> {
     );
 
     super(cadManager, materialManager, pointCloudManager);
+
+    this.loadingStateObserver = sectorRepository.getLoadingStateObserver();
   }
 
   public addModel(
@@ -87,6 +92,10 @@ export class RevealManager extends RevealManagerBase<CdfModelIdentifier> {
       default:
         throw new Error(`case: ${type} not handled`);
     }
+  }
+
+  public getLoadingStateObserver(): Observable<boolean> {
+    return this.loadingStateObserver;
   }
 
   private createModelIdentifier(id: string | number): IdEither {

--- a/viewer/src/utilities/Spinner.ts
+++ b/viewer/src/utilities/Spinner.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Cognite AS
+ */
+
+// @ts-ignore
+import css from 'raw-loader!./spinnerStyles.css';
+
+export class Spinner {
+  private static readonly stylesId = 'reveal-viewer-spinner-styles';
+  private static readonly cssClass = 'reveal-viewer-spinner';
+
+  private static loadStyles() {
+    if (document.getElementById(Spinner.stylesId)) {
+      return;
+    }
+    const style = document.createElement('style');
+    style.id = Spinner.stylesId;
+    style.appendChild(document.createTextNode(css));
+    document.head.appendChild(style);
+  }
+
+  private el: HTMLElement;
+
+  constructor(parent: HTMLElement) {
+    Spinner.loadStyles();
+    this.el = document.createElement('div');
+    this.el.title = 'Loading...';
+    this.el.style.position = 'absolute';
+    this.el.style.display = 'none';
+
+    const spinner = document.createElement('div');
+    spinner.className = Spinner.cssClass;
+    this.el.appendChild(spinner);
+
+    parent.style.position = 'relative';
+    parent.appendChild(this.el);
+  }
+
+  show() {
+    this.el.style.display = 'block';
+  }
+
+  hide() {
+    this.el.style.display = 'none';
+  }
+
+  dispose() {
+    const styleTag = document.getElementById(Spinner.stylesId);
+    if (styleTag) {
+      styleTag.remove();
+    }
+  }
+}

--- a/viewer/src/utilities/spinnerStyles.css
+++ b/viewer/src/utilities/spinnerStyles.css
@@ -1,0 +1,37 @@
+.reveal-viewer-spinner,
+.reveal-viewer-spinner:after {
+    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+}
+.reveal-viewer-spinner {
+    margin: 10px;
+    position: relative;
+    border: 5px solid rgba(255, 255, 255, 0.22);
+    border-left: 5px solid #ffffff;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation: reveal-spinner-animation 0.7s infinite linear;
+    animation: reveal-spinner-animation 0.7s infinite linear;
+}
+@-webkit-keyframes reveal-spinner-animation {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+@keyframes reveal-spinner-animation {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}


### PR DESCRIPTION
Looks like this:

![image](https://user-images.githubusercontent.com/4989157/84046900-f9e09180-a9aa-11ea-8da4-17504ea37714.png)

And for the RevealManager I just exposed a public method to have a loading state as in viewer.