### PR TITLE
fix(RevealManager): add dispose() method

### DIFF
--- a/examples/src/pages/Simple.tsx
+++ b/examples/src/pages/Simple.tsx
@@ -21,6 +21,8 @@ export function Simple() {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    let revealManager: reveal.RevealManager | reveal.LocalHostRevealManager;
+
     async function main() {
       if (!canvas.current) {
         return;
@@ -33,7 +35,7 @@ export function Simple() {
       client.loginWithOAuth({ project });
 
       const scene = new THREE.Scene();
-      const revealManager: reveal.RenderManager = createRenderManager(
+      revealManager = createRenderManager(
         modelRevision !== undefined ? 'cdf' : 'local',
         client
       );
@@ -121,6 +123,10 @@ export function Simple() {
     }
 
     main();
+
+    return () => {
+      revealManager?.dispose();
+    };
   }, []);
   return (
     <CanvasWrapper>

--- a/viewer/src/datamodels/cad/sector/CachedRepository.ts
+++ b/viewer/src/datamodels/cad/sector/CachedRepository.ts
@@ -54,6 +54,8 @@ export class CachedRepository implements Repository {
     data: SectorGeometry | SectorQuads;
   }> = new Subject();
 
+  private isDisposed = false;
+
   constructor(
     modelSectorProvider: CadSectorProvider,
     modelDataParser: CadSectorParser,
@@ -66,6 +68,16 @@ export class CachedRepository implements Repository {
 
   clearSemaphore() {
     this._rateLimiter.clearPendingRequests();
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+    this._isLoadingSubject.complete();
+    this.clearSemaphore();
+    this.clearCache();
   }
 
   // TODO j-bjorne 16-04-2020: Should look into ways of not sending in discarded sectors,

--- a/viewer/src/public/LocalHostRevealManager.ts
+++ b/viewer/src/public/LocalHostRevealManager.ts
@@ -25,6 +25,8 @@ import { DefaultPointCloudTransformation } from '@/datamodels/pointcloud/Default
 type LocalModelIdentifier = { fileName: string };
 
 export class LocalHostRevealManager extends RevealManagerBase<LocalModelIdentifier> {
+  private readonly sectorRepository: CachedRepository;
+
   constructor(options?: RevealOptions) {
     const modelDataParser: CadSectorParser = new CadSectorParser();
     const materialManager: MaterialManager = new MaterialManager();
@@ -57,6 +59,8 @@ export class LocalHostRevealManager extends RevealManagerBase<LocalModelIdentifi
       pointCloudFactory
     );
     super(cadManager, materialManager, pointCloudManager);
+
+    this.sectorRepository = sectorRepository;
   }
 
   public addModel(type: 'cad', fileName: string, modelNodeAppearance?: ModelNodeAppearance): Promise<CadNode>;
@@ -74,5 +78,13 @@ export class LocalHostRevealManager extends RevealManagerBase<LocalModelIdentifi
       default:
         throw new Error(`case: ${type} not handled`);
     }
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.sectorRepository.dispose();
+    super.dispose();
   }
 }

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -28,6 +28,7 @@ type LoadingStateChangeListener = (isLoading: boolean) => any;
 
 export class RevealManager extends RevealManagerBase<CdfModelIdentifier> {
   private readonly eventListeners: { loadingStateChanged: LoadingStateChangeListener[] };
+  private readonly sectorRepository: CachedRepository;
 
   constructor(client: CogniteClient, options?: RevealOptions) {
     const modelDataParser: CadSectorParser = new CadSectorParser();
@@ -62,6 +63,7 @@ export class RevealManager extends RevealManagerBase<CdfModelIdentifier> {
 
     super(cadManager, materialManager, pointCloudManager);
 
+    this.sectorRepository = sectorRepository;
     this.eventListeners = {
       loadingStateChanged: new Array<LoadingStateChangeListener>()
     };
@@ -109,6 +111,14 @@ export class RevealManager extends RevealManagerBase<CdfModelIdentifier> {
       throw new Error(`Unsupported event "${event}"`);
     }
     this.eventListeners[event] = this.eventListeners[event].filter(fn => fn !== listener);
+  }
+
+  public dispose() {
+    if (this.isDisposed) {
+      return;
+    }
+    this.eventListeners.loadingStateChanged.splice(0);
+    this.sectorRepository.dispose();
   }
 
   private notifyLoadingStateListeners(isLoaded: boolean) {

--- a/viewer/src/public/RevealManagerBase.ts
+++ b/viewer/src/public/RevealManagerBase.ts
@@ -25,6 +25,8 @@ export interface RevealOptions {
 export type OnDataUpdated = () => void;
 
 export class RevealManagerBase<TModelIdentifier> implements RenderManager {
+  protected isDisposed = false;
+
   // CAD
   protected readonly _cadManager: CadManager<TModelIdentifier>;
   protected readonly _materialManager: MaterialManager;
@@ -46,6 +48,13 @@ export class RevealManagerBase<TModelIdentifier> implements RenderManager {
     this._cadManager = cadManager;
     this._materialManager = materialManager;
     this._pointCloudManager = pointCloudManager;
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
   }
 
   public resetRedraw(): void {

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -177,6 +177,8 @@ export class Cognite3DViewer {
       cancelAnimationFrame(this.latestRequestId);
     }
 
+    this.sectorRepository.dispose();
+    this.revealManager.dispose();
     this.domElement.removeChild(this.canvas);
     this.renderer.dispose();
     this.scene.dispose();


### PR DESCRIPTION
I noticed that after example is left and everything is unmounted, reveal still requesting stuff in the queue and that's not necessary. 