### PR TITLE
Remove unnecessary struct wrapping and double entry into wasm when parsing an i3d sector

### DIFF
--- a/viewer/rust/lib.rs
+++ b/viewer/rust/lib.rs
@@ -81,13 +81,7 @@ pub fn parse_ctm(input: &[u8]) -> Result<CtmResult, JsValue> {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct SectorHandle {
-    sector: i3df::Sector,
-}
-
-#[wasm_bindgen]
-pub fn parse_sector(input: &[u8]) -> Result<SectorHandle, JsValue> {
+pub fn parse_and_convert_sector(input: &[u8]) -> Result<i3df::renderables::Sector, JsValue> {
     // TODO read https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/building-your-project.html
     // and see if this can be moved to one common place
     panic::set_hook(Box::new(console_error_panic_hook::hook));
@@ -95,16 +89,10 @@ pub fn parse_sector(input: &[u8]) -> Result<SectorHandle, JsValue> {
     let cursor = std::io::Cursor::new(input);
 
     // TODO see if it is possible to simplify this so we can use the ? operator instead
-    let sector = match i3df::parse_sector(cursor) {
-        Ok(x) => x,
-        Err(e) => return Err(JsValue::from(error::ParserError::from(e))),
-    };
-    Ok(SectorHandle { sector })
-}
-
-#[wasm_bindgen]
-pub fn convert_sector(sector: &SectorHandle) -> i3df::renderables::Sector {
-    i3df::renderables::convert_sector(&sector.sector)
+    match i3df::parse_sector(cursor) {
+        Ok(x) => Ok(i3df::renderables::convert_sector(&x)),
+        Err(e) => return Err(JsValue::from(error::ParserError::from(e)))
+    }
 }
 
 #[wasm_bindgen]

--- a/viewer/rust/lib.rs
+++ b/viewer/rust/lib.rs
@@ -91,7 +91,7 @@ pub fn parse_and_convert_sector(input: &[u8]) -> Result<i3df::renderables::Secto
     // TODO see if it is possible to simplify this so we can use the ? operator instead
     match i3df::parse_sector(cursor) {
         Ok(x) => Ok(i3df::renderables::convert_sector(&x)),
-        Err(e) => Err(JsValue::from(error::ParserError::from(e)))
+        Err(e) => Err(JsValue::from(error::ParserError::from(e))),
     }
 }
 

--- a/viewer/rust/lib.rs
+++ b/viewer/rust/lib.rs
@@ -91,7 +91,7 @@ pub fn parse_and_convert_sector(input: &[u8]) -> Result<i3df::renderables::Secto
     // TODO see if it is possible to simplify this so we can use the ? operator instead
     match i3df::parse_sector(cursor) {
         Ok(x) => Ok(i3df::renderables::convert_sector(&x)),
-        Err(e) => return Err(JsValue::from(error::ParserError::from(e)))
+        Err(e) => Err(JsValue::from(error::ParserError::from(e)))
     }
 }
 

--- a/viewer/src/utilities/workers/parser.worker.ts
+++ b/viewer/src/utilities/workers/parser.worker.ts
@@ -16,9 +16,7 @@ const rustModule = import('../../../pkg');
 export class ParserWorker {
   public async parseSector(buffer: Uint8Array): Promise<ParseSectorResult> {
     const rust = await rustModule;
-    // TODO dragly 2020-04-22 could this be just one call that returns renderables?
-    const sectorDataHandle = rust.parse_sector(buffer);
-    const sectorData = rust.convert_sector(sectorDataHandle);
+    const sectorData = rust.parse_and_convert_sector(buffer);
 
     const instanceMeshes = this.extractInstanceMeshes(sectorData);
 
@@ -35,7 +33,6 @@ export class ParserWorker {
     };
 
     sectorData.free();
-    sectorDataHandle.free();
 
     return parseResult;
   }


### PR DESCRIPTION
I'm not expecting (or measuring..) a significant performance gain, but it's a nice simplification that removes a struct type and removes a function call in ts, in addition to having more consistent naming with f3d.