### PR TITLE
Post rendering effects (e.g. highlighting) now works with the Cognite3dViewer.getScreenshot()

### DIFF
--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -431,6 +431,7 @@ export class Cognite3DViewer {
 
     this.renderer.setSize(width, height);
     this.renderer.render(this.scene, screenshotCamera);
+    addPostRenderEffects(this.materialManager, this.renderer, screenshotCamera, this.scene);
     const url = this.renderer.domElement.toDataURL();
 
     this.renderer.setSize(originalWidth, originalHeight);


### PR DESCRIPTION
Fixes an issue causing e.g. highlighted objects which should be rendered in front of other objects to be rendered like 'regular objects'