### PR TITLE
ts(viewer): export PotreePointColorType as public

### DIFF
--- a/viewer/src/index.ts
+++ b/viewer/src/index.ts
@@ -11,6 +11,8 @@ export { Color, Cognite3DViewerOptions, AddModelOptions, SupportedModelTypes } f
 export { CadLoadingHints } from './datamodels/cad/CadLoadingHints';
 export { BoundingBoxClipper } from './utilities';
 
+export { PotreePointColorType } from './datamodels/pointcloud/types';
+
 // Export ThreeJS to enable easy import for our users
 import * as THREE from 'three';
 export { THREE };


### PR DESCRIPTION
Need that type for the console, to be able to setup colortype picker.