### PR TITLE
fix(Spinner): specify top-left position explicitly

### DIFF
--- a/viewer/src/utilities/Spinner.ts
+++ b/viewer/src/utilities/Spinner.ts
@@ -25,6 +25,8 @@ export class Spinner {
     this.el = document.createElement('div');
     this.el.title = 'Loading...';
     this.el.style.position = 'absolute';
+    this.el.style.top = '0';
+    this.el.style.left = '0';
     this.el.style.display = 'none';
 
     const spinner = document.createElement('div');


### PR DESCRIPTION
If parent doesn't have `display: flex` it doesn't work the same way with defaults.