### PR TITLE
Add spinner for pointcloud; fix spinner styles

### DIFF
--- a/examples/src/pages/SimplePointcloud.tsx
+++ b/examples/src/pages/SimplePointcloud.tsx
@@ -2,8 +2,8 @@
  * Copyright 2020 Cognite AS
  */
 
-import React, { useEffect, useRef } from 'react';
-import { CanvasWrapper } from '../components/styled';
+import React, { useEffect, useRef, useState } from 'react'
+import { CanvasWrapper, Loader } from '../components/styled'
 
 import * as THREE from 'three';
 import * as reveal from '@cognite/reveal/experimental';
@@ -61,7 +61,12 @@ function initializeGui(
 
 export function SimplePointcloud() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
   useEffect(() => {
+    if (!canvasRef.current) {
+      return
+    }
     const gui = new dat.GUI();
 
     async function main() {
@@ -100,6 +105,7 @@ export function SimplePointcloud() {
       ) {
         await client.authenticate();
         model = await revealManager.addModel('pointcloud', modelRevision);
+        revealManager.on('loadingStateChanged', setIsLoading);
       } else {
         throw new Error(
           'Need to provide either project & model OR modelUrl as query parameters'
@@ -182,9 +188,13 @@ export function SimplePointcloud() {
     return () => {
       gui.destroy();
     };
-  });
+  }, []);
+
   return (
     <CanvasWrapper>
+      <Loader isLoading={isLoading} style={{ position: 'absolute' }}>
+        Loading...
+      </Loader>
       <canvas ref={canvasRef} />
     </CanvasWrapper>
   );

--- a/viewer/src/__tests__/viewer/public/RevealManagerBase.test.ts
+++ b/viewer/src/__tests__/viewer/public/RevealManagerBase.test.ts
@@ -25,7 +25,8 @@ describe('RevealManagerBase', () => {
   const mockPointCloudManager: Omit<PointCloudManager<number>, ''> = {
     addModel: jest.fn(),
     needsRedraw: false,
-    updateCamera: jest.fn()
+    updateCamera: jest.fn(),
+    getLoadingStateObserver: jest.fn()
   };
   const pointCloudManager = mockPointCloudManager as PointCloudManager<number>;
   const materialManager = new MaterialManager();

--- a/viewer/src/datamodels/pointcloud/PointCloudManager.ts
+++ b/viewer/src/datamodels/pointcloud/PointCloudManager.ts
@@ -7,12 +7,14 @@ import { PointCloudFactory } from './PointCloudFactory';
 import { PointCloudMetadataRepository } from './PointCloudMetadataRepository';
 import { PotreeGroupWrapper } from './PotreeGroupWrapper';
 import { PotreeNodeWrapper } from './PotreeNodeWrapper';
+import { PotreeLoadHandler } from './PotreeLoadHandler';
 
 export class PointCloudManager<TModelIdentifier> {
   private readonly _pointCloudMetadataRepository: PointCloudMetadataRepository<TModelIdentifier>;
   private readonly _pointCloudFactory: PointCloudFactory;
 
   private _pointCloudGroupWrapper?: PotreeGroupWrapper;
+  private _potreeLoadHandler: PotreeLoadHandler;
 
   constructor(
     cadModelMetadataRepository: PointCloudMetadataRepository<TModelIdentifier>,
@@ -20,10 +22,15 @@ export class PointCloudManager<TModelIdentifier> {
   ) {
     this._pointCloudMetadataRepository = cadModelMetadataRepository;
     this._pointCloudFactory = cadModelFactory;
+    this._potreeLoadHandler = new PotreeLoadHandler();
   }
 
   get needsRedraw(): boolean {
     return this._pointCloudGroupWrapper ? this._pointCloudGroupWrapper.needsRedraw : false;
+  }
+
+  getLoadingStateObserver() {
+    return this._potreeLoadHandler.observer();
   }
 
   updateCamera(_camera: THREE.PerspectiveCamera) {}

--- a/viewer/src/datamodels/pointcloud/PotreeLoadHandler.ts
+++ b/viewer/src/datamodels/pointcloud/PotreeLoadHandler.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2020 Cognite AS
+ */
+import * as Potree from '@cognite/potree-core';
+import { Observable, interval } from 'rxjs';
+import { map, share, distinctUntilChanged, startWith } from 'rxjs/operators';
+
+export class PotreeLoadHandler {
+  private static isLoading(): boolean {
+    return Potree.Global.numNodesLoading > 0;
+  }
+
+  private readonly _potreeLoadObservable: Observable<boolean>;
+  constructor(intervalMillis: number = 1000) {
+    this._potreeLoadObservable = interval(intervalMillis).pipe(map(_ => PotreeLoadHandler.isLoading()));
+  }
+
+  observer(): Observable<boolean> {
+    return this._potreeLoadObservable.pipe(share(), startWith(PotreeLoadHandler.isLoading()), distinctUntilChanged());
+  }
+}

--- a/viewer/src/utilities/Spinner.ts
+++ b/viewer/src/utilities/Spinner.ts
@@ -25,6 +25,8 @@ export class Spinner {
     this.el = document.createElement('div');
     this.el.title = 'Loading...';
     this.el.style.position = 'absolute';
+    this.el.style.top = '0';
+    this.el.style.left = '0';
     this.el.style.display = 'none';
 
     const spinner = document.createElement('div');


### PR DESCRIPTION
* fix spinner styles
* implement loading state logic for pointCloudManager

Now the spinner should always be here for Cognite3dViewer and play well with `revealManager.on('loadingStateChange', ...`