### PR TITLE
feat(Cognite3dViewer): add `forceRerender(): void`

### DIFF
--- a/viewer/src/__tests__/viewer/public/RevealManagerBase.test.ts
+++ b/viewer/src/__tests__/viewer/public/RevealManagerBase.test.ts
@@ -12,6 +12,7 @@ import { PointCloudManager } from '@/datamodels/pointcloud/PointCloudManager';
 describe('RevealManagerBase', () => {
   const mockCadManager: Omit<CadManager<number>, ''> = {
     addModel: jest.fn(),
+    requestRedraw: jest.fn(),
     resetRedraw: jest.fn(),
     needsRedraw: false,
     updateCamera: jest.fn(),
@@ -26,7 +27,8 @@ describe('RevealManagerBase', () => {
     addModel: jest.fn(),
     needsRedraw: false,
     updateCamera: jest.fn(),
-    getLoadingStateObserver: jest.fn()
+    getLoadingStateObserver: jest.fn(),
+    requestRedraw: jest.fn()
   };
   const pointCloudManager = mockPointCloudManager as PointCloudManager<number>;
   const materialManager = new MaterialManager();

--- a/viewer/src/datamodels/cad/CadManager.ts
+++ b/viewer/src/datamodels/cad/CadManager.ts
@@ -70,6 +70,10 @@ export class CadManager<TModelIdentifier> {
     this._subscription.unsubscribe();
   }
 
+  requestRedraw(): void {
+    this._needsRedraw = true;
+  }
+
   resetRedraw(): void {
     this._needsRedraw = false;
   }

--- a/viewer/src/datamodels/pointcloud/PointCloudManager.ts
+++ b/viewer/src/datamodels/pointcloud/PointCloudManager.ts
@@ -25,6 +25,12 @@ export class PointCloudManager<TModelIdentifier> {
     this._potreeLoadHandler = new PotreeLoadHandler();
   }
 
+  requestRedraw(): void {
+    if (this._pointCloudGroupWrapper) {
+      this._pointCloudGroupWrapper.requestRedraw();
+    }
+  }
+
   get needsRedraw(): boolean {
     return this._pointCloudGroupWrapper ? this._pointCloudGroupWrapper.needsRedraw : false;
   }

--- a/viewer/src/datamodels/pointcloud/PotreeGroupWrapper.ts
+++ b/viewer/src/datamodels/pointcloud/PotreeGroupWrapper.ts
@@ -13,8 +13,11 @@ import { PotreeNodeWrapper } from './PotreeNodeWrapper';
  * basic functionality.
  */
 export class PotreeGroupWrapper extends THREE.Object3D {
+  private _needsRedraw: boolean = true;
+
   get needsRedraw(): boolean {
     return (
+      this._needsRedraw ||
       Potree.Global.numNodesLoading !== this.numNodesLoadingAfterLastRedraw ||
       this.numChildrenAfterLastRedraw !== this.potreeGroup.children.length ||
       this.nodes.some(n => n.needsRedraw)
@@ -47,6 +50,10 @@ export class PotreeGroupWrapper extends THREE.Object3D {
     for (const child of this.potreeGroup.children) {
       yield new PotreeNodeWrapper(child as Potree.PointCloudOcttree);
     }
+  }
+
+  requestRedraw() {
+    this._needsRedraw = true;
   }
 
   private resetNeedsRedraw() {

--- a/viewer/src/public/RevealManagerBase.ts
+++ b/viewer/src/public/RevealManagerBase.ts
@@ -44,6 +44,11 @@ export class RevealManagerBase<TModelIdentifier> implements RenderManager {
     this.isDisposed = true;
   }
 
+  public requestRedraw(): void {
+    this._cadManager.requestRedraw();
+    this._pointCloudManager.requestRedraw();
+  }
+
   public resetRedraw(): void {
     this._cadManager.resetRedraw();
   }

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -17,6 +17,7 @@ import { SectorGeometry } from '@/datamodels/cad/sector/types';
 import { SectorQuads } from '@/datamodels/cad/rendering/types';
 import { vec3 } from 'gl-matrix';
 import { NodeAppearanceProvider, DefaultNodeAppearance } from '@/datamodels/cad/NodeAppearance';
+import { Matrix4 } from 'three';
 
 const mapCoordinatesBuffers = {
   v: vec3.create()
@@ -132,6 +133,11 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
 
   getModelBoundingBox(): THREE.Box3 {
     return this.getBoundingBox();
+  }
+
+  updateTransformation(matrix: Matrix4): void {
+    this.cadNode.applyMatrix4(matrix);
+    this.cadNode.updateMatrixWorld(false);
   }
 
   updateNodeIdMaps(sector: { lod: string; data: SectorGeometry | SectorQuads }) {

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -80,7 +80,7 @@ export class Cognite3DViewer {
   private readonly models: CogniteModelBase[] = [];
 
   private isDisposed = false;
-  private readonly forceRendering = false; // For future support
+  private forceRendering = false; // For future support
 
   private readonly renderController: RenderController;
   private latestRequestId: number = -1;
@@ -404,6 +404,10 @@ export class Cognite3DViewer {
     this.moveCameraTo(position, target, duration);
   }
 
+  forceRerender(): void {
+    this.revealManager.requestRedraw();
+  }
+
   enableKeyboardNavigation(): void {
     this.controls.enableKeyboardNavigation = true;
   }
@@ -593,6 +597,7 @@ export class Cognite3DViewer {
       this.controls.update(this.clock.getDelta());
       renderController.update();
       this.revealManager.update(this.camera);
+
       if (
         renderController.needsRedraw ||
         this.forceRendering ||

--- a/viewer/src/public/migration/CogniteModelBase.ts
+++ b/viewer/src/public/migration/CogniteModelBase.ts
@@ -8,4 +8,5 @@ export interface CogniteModelBase {
   readonly type: SupportedModelTypes;
   dispose(): void;
   getModelBoundingBox(): THREE.Box3;
+  updateTransformation(matrix: THREE.Matrix4): void;
 }

--- a/viewer/src/public/migration/CognitePointCloudModel.ts
+++ b/viewer/src/public/migration/CognitePointCloudModel.ts
@@ -9,6 +9,7 @@ import { toThreeJsBox3 } from '@/utilities';
 import { PotreeNodeWrapper } from '@/datamodels/pointcloud/PotreeNodeWrapper';
 import { PotreeGroupWrapper } from '@/datamodels/pointcloud/PotreeGroupWrapper';
 import { PotreePointColorType } from '@/datamodels/pointcloud/types';
+import { Matrix4 } from 'three';
 
 export class CognitePointCloudModel extends THREE.Object3D implements CogniteModelBase {
   public readonly type: SupportedModelTypes = SupportedModelTypes.PointCloud;
@@ -30,6 +31,11 @@ export class CognitePointCloudModel extends THREE.Object3D implements CogniteMod
 
   getModelBoundingBox(): THREE.Box3 {
     return toThreeJsBox3(new THREE.Box3(), this.potreeNode.boundingBox);
+  }
+
+  updateTransformation(matrix: Matrix4): void {
+    this.applyMatrix4(matrix);
+    this.updateMatrixWorld(false);
   }
 
   get pointBudget(): number {


### PR DESCRIPTION
This works for me to implement edit rotation in the console. So I can do the following:

```ts
model.updateTransformation(rotationMatrix);
viewer.forceRerender();
```

An alternative implementation I think would be to have render trigger right in `updateTransformation` function. Which in turn should do something like

```ts
// for CognitePointCloudModel
  updateTransformation(matrix: Matrix4): void {
    this.applyMatrix4(matrix);
    this.updateMatrixWorld(false);
    this.potreeNode.requestRedraw()
  }

// for Cognite3dModel
  updateTransformation(matrix: Matrix4): void {
    this.cadNode.applyMatrix4(matrix);
    this.cadNode.updateMatrixWorld(false);
   this.cadNode.requestRedraw()
  }
```

But I just thought maybe it would be convenient to have that forceRedraw fn for some other cases. So left like that.