### PR TITLE
Remove warning spam from ThreeJS in tests

### DIFF
--- a/viewer/src/__tests__/setupJest.ts
+++ b/viewer/src/__tests__/setupJest.ts
@@ -17,3 +17,14 @@ class StubWorker {
   public postMessage(_: any) {}
 }
 (window as any).Worker = StubWorker;
+
+// Filter away warning from ThreeJS about "THREE.WebGLRenderer: EXT_xxx extension not supported."
+// which is caused by using a mock WebGL implementation for unit testing
+// tslint:disable-next-line: no-console
+const consoleWarn = console.warn.bind(console);
+(console as any).warn = (message?: any, ...optionalParams: any[]) => {
+  const messageStr = message + '';
+  if (!messageStr.match(/THREE\.WebGLRenderer: .* extension not supported\./)) {
+    consoleWarn(message, ...optionalParams);
+  }
+};

--- a/viewer/src/__tests__/views/threejs/cad/picking.test.ts
+++ b/viewer/src/__tests__/views/threejs/cad/picking.test.ts
@@ -27,9 +27,7 @@ describe('intersectCadNodes', () => {
     renderer,
     camera
   };
-  const cadNode: CadNode = {
-    add: jest.fn()
-  } as any;
+  const cadNode: CadNode = new THREE.Object3D() as any;
 
   test('no nodes, returns empty array', () => {
     const intersections = intersectCadNodes([], input);

--- a/viewer/src/utilities/networking/types.ts
+++ b/viewer/src/utilities/networking/types.ts
@@ -11,5 +11,5 @@ export interface BlobOutputMetadata {
 }
 
 export interface ModelUrlProvider<TModelIdentifier> {
-  getModelUrl(params: TModelIdentifier): Promise<string>;
+  getModelUrl(identifier: TModelIdentifier): Promise<string>;
 }


### PR DESCRIPTION
Get rid of warning from initialization of THREE.WebGLRenderer about missing extensions during unit testing.