### PR TITLE
chore: check for unused vars and ts errors on lint

### DIFF
--- a/viewer/.eslintrc.js
+++ b/viewer/.eslintrc.js
@@ -4,6 +4,9 @@
 
 module.exports = {
   root: true,
+  env: {
+    browser: true
+  },
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   parserOptions: {
     project: './tsconfig.json',
@@ -11,7 +14,7 @@ module.exports = {
     ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module' // Allows for the use of imports
   },
-  plugins: ['header'],
+  plugins: ['header', '@typescript-eslint'],
   extends: [
     'plugin:@typescript-eslint/recommended',
 
@@ -46,12 +49,6 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars-expiremental': [
-      'off',
-      {
-        ignoredNamesRegex: '^_'
-      }
-    ],
 
     // TODO: maksnester 26-06-2020 we need to fix our codebase to play well with these rules
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -24,8 +24,9 @@
     "clean": "rimraf -rf dist/ ../target pkg/",
     "test": "jest",
     "coverage": "jest --coverage",
-    "lint": "eslint . --ext .ts,.js --max-warnings 0",
+    "lint": "eslint . --ext .ts,.js --max-warnings 0 && yarn run tsc",
     "lint:fix": "yarn run lint --fix",
+    "tsc": "tsc --noEmit --incremental false --skipLibCheck true",
     "prepublishscript": "yarn run coverage && yarn run clean && yarn run release"
   },
   "author": "Lars Moastuen <lars.moastuen@cognite.com>",
@@ -101,7 +102,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged -q"
+      "pre-commit": "lint-staged -q && yarn run tsc"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
I decided to just run tsc on lint to check for various ts errors uncaught by the linter, and specifically, for unused vars. 

If I enable eslint rule for unused vars it works poorly with our `(_unused, args) => ...`. And in general, there is some mess with unused vars and typescript in eslint. Hopefully, it will be resolved someday, but for now, I think running tsc is a good thing. 

See [related issue ](https://github.com/typescript-eslint/typescript-eslint/issues/1856):

> This is never something we invested much time into for a number of reasons like:
> * most of the rules that use the scope manager are either infrequently used, or have analogous checks/options in the TypeScript itself,
> * we wanted to be careful that we wouldn't implement something that would get outdated by changes to the underlying TS language,