### PR TITLE
chore(examples): link the same sdk viewer uses, to avoid version conflicts

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@cognite/sdk": "^2.32.0",
+    "@cognite/sdk": "link:../viewer/node_modules/@cognite/sdk",
     "camera-controls": "^1.22.1",
     "@cognite/potree-core": "^1.1.3",
     "@cognite/reveal": "link:../viewer/dist",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1155,15 +1155,9 @@
   version "0.0.0"
   uid ""
 
-"@cognite/sdk@^2.32.0":
-  version "2.32.0"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk/-/sdk-2.32.0.tgz#4942e7ad21c93804d9be2a65bdc9f0196d1a0f18"
-  integrity sha512-uQivhbRNxwkWyxC9ugckMyi0zFv1OQYSZDcSowH6HTfzPGw+d3w/kE6Kc3Fx8fi1/DisKywWtH21gw1zkH2SQw==
-  dependencies:
-    cross-fetch "^3.0.4"
-    lodash "^4.17.11"
-    query-string "^5.1.1"
-    url "^0.11.0"
+"@cognite/sdk@link:../viewer/node_modules/@cognite/sdk":
+  version "0.0.0"
+  uid ""
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
I just realized that in the same way we link local viewer in examples, we might have a link on the viewer's installed cognite/sdk. That allows us to forget about different versions.