### PR TITLE
Initial OpenCTM MG2 compression support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.rs]
+indent_size = 4

--- a/openctm/src/bin/dump.rs
+++ b/openctm/src/bin/dump.rs
@@ -1,8 +1,9 @@
 use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
 use std::fs::File;
-use std::io::stdout;
+use std::io::{stdout, SeekFrom, Seek, Read, Cursor};
 use structopt::StructOpt;
+use std::{time, fs};
 
 #[derive(StructOpt)]
 struct Options {
@@ -13,6 +14,8 @@ struct Options {
     compact: bool,
     #[structopt(short, long)]
     stats: bool,
+    #[structopt(short, long)]
+    benchmark: bool,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -31,24 +34,40 @@ enum Output {
         normals: Option<usize>,
         uv_maps: Vec<UvMapStats>,
     },
+    Benchmark {
+        runs: usize,
+        avg_time_micros: u64,
+        best_time: u64,
+    },
+}
+
+fn get_file_as_byte_vec(filename: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    let mut f = File::open(&filename)?;
+    let metadata = fs::metadata(&filename)?;
+    let mut buffer = vec![0; metadata.len() as usize];
+    f.read_exact(&mut buffer)?;
+
+    Ok(buffer)
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::from_args();
 
-    let reader = Box::new(File::open(options.file)?);
+    let file_bytes = get_file_as_byte_vec(&options.file)?;
+    let cursor = Cursor::new(file_bytes);
+    let mut buf_reader = std::io::BufReader::new(cursor);
 
-    let file = openctm::parse(std::io::BufReader::new(reader))?;
+    let parsed_file = openctm::parse(&mut buf_reader)?;
 
     let output = if options.stats {
         Output::FileStats {
-            indices: file.indices.len(),
-            vertices: file.vertices.len(),
-            normals: match file.normals {
+            indices: parsed_file.indices.len(),
+            vertices: parsed_file.vertices.len(),
+            normals: match parsed_file.normals {
                 Some(x) => Some(x.len()),
                 None => None,
             },
-            uv_maps: file
+            uv_maps: parsed_file
                 .uv_maps
                 .into_iter()
                 .map(|x| UvMapStats {
@@ -58,8 +77,27 @@ fn main() -> Result<(), Box<dyn Error>> {
                 })
                 .collect(),
         }
+    } else if options.benchmark {
+        let runs = 1000;
+        let mut times = vec![0; runs];
+        for time in times.iter_mut().take(runs) {
+            buf_reader.seek(SeekFrom::Start(0))?;
+            let t1 = time::Instant::now();
+            openctm::parse(&mut buf_reader)?;
+            let t2 = time::Instant::now();
+            *time = t2.duration_since(t1).as_micros() as u64;
+        }
+        let total_time: u64 = times.iter().sum();
+        let avg_time = total_time / runs as u64;
+        let best_time = *times.iter().min().unwrap();
+
+        Output::Benchmark {
+            runs,
+            avg_time_micros: avg_time,
+            best_time,
+        }
     } else {
-        Output::File(file)
+        Output::File(parsed_file)
     };
 
     if options.compact {

--- a/openctm/src/bin/dump.rs
+++ b/openctm/src/bin/dump.rs
@@ -1,9 +1,9 @@
 use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
 use std::fs::File;
-use std::io::{stdout, SeekFrom, Seek, Read, Cursor};
+use std::io::{stdout, Cursor, Read, Seek, SeekFrom};
+use std::{fs, time};
 use structopt::StructOpt;
-use std::{time, fs};
 
 #[derive(StructOpt)]
 struct Options {

--- a/openctm/src/lib.rs
+++ b/openctm/src/lib.rs
@@ -41,13 +41,6 @@ pub enum CompressionMethod {
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct Triangle {
-    pub a: u32,
-    pub b: u32,
-    pub c: u32,
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct Normal {
     pub x: f32,
     pub y: f32,
@@ -272,14 +265,6 @@ fn parse_triangle_indices(mut input: impl io::BufRead, triangle_count: u32) -> R
     let mut indices = input.read_packed_u32s(index_count, 3 * 4)?;
     restore_indices(&mut indices);
 
-    let mut triangles = vec![Default::default(); triangle_count];
-    for i in 0..triangle_count {
-        triangles[i] = Triangle {
-            a: indices[3 * i],
-            b: indices[3 * i + 1],
-            c: indices[3 * i + 2],
-        }
-    }
     Ok(indices)
 }
 

--- a/openctm/src/lib.rs
+++ b/openctm/src/lib.rs
@@ -213,12 +213,11 @@ pub trait ReadExt: io::Read {
         if magic_bytes == &bytes {
             Ok(bytes)
         } else {
-            Err(Error::new(
-                format!("Expected magic bytes {} but got {}",
-                        std::str::from_utf8(magic_bytes)?,
-                        std::str::from_utf8(&bytes)?
-                )
-            ))
+            Err(Error::new(format!(
+                "Expected magic bytes {} but got {}",
+                std::str::from_utf8(magic_bytes)?,
+                std::str::from_utf8(&bytes)?
+            )))
         }
     }
 }
@@ -259,7 +258,10 @@ fn restore_indices(indices: &mut Vec<u32>) {
     }
 }
 
-fn parse_triangle_indices(mut input: impl io::BufRead, triangle_count: u32) -> Result<Vec<u32>, Error> {
+fn parse_triangle_indices(
+    mut input: impl io::BufRead,
+    triangle_count: u32,
+) -> Result<Vec<u32>, Error> {
     input.read_magic_bytes(b"INDX")?;
 
     let triangle_count = triangle_count as usize;
@@ -358,7 +360,12 @@ fn restore_grid_indices(grid_indices: &mut Vec<u32>) {
     }
 }
 
-fn restore_vertices(vertex_components: &[u32], vertex_count: usize, grid_indices: &[u32], mg2_header: &MG2Header) -> Vec<Vertex> {
+fn restore_vertices(
+    vertex_components: &[u32],
+    vertex_count: usize,
+    grid_indices: &[u32],
+    mg2_header: &MG2Header,
+) -> Vec<Vertex> {
     let vertex_precision = mg2_header.vertex_precision;
     let y_div = mg2_header.div_x;
     let z_div = y_div * mg2_header.div_y;
@@ -384,7 +391,6 @@ fn restore_vertices(vertex_components: &[u32], vertex_count: usize, grid_indices
         let grid_x = x as f32 * size_x + lower_bound.x;
         let grid_y = y as f32 * size_y + lower_bound.y;
         let grid_z = z as f32 * size_z + lower_bound.z;
-
 
         let j = 3 * i;
         let mut delta_x = vertex_components[j];
@@ -474,7 +480,7 @@ pub fn parse(mut input: impl io::BufRead) -> Result<File, Error> {
             file_format
         ));
     }
-    let compression_method: CompressionMethod = match num::FromPrimitive::from_i32(input.read_i32::<LittleEndian>()?) {
+    let compression_method = match num::FromPrimitive::from_i32(input.read_i32::<LittleEndian>()?) {
         Some(x) => x,
         None => return Err(error!("Unknown OpenCTM compression method")),
     };

--- a/openctm/src/lib.rs
+++ b/openctm/src/lib.rs
@@ -372,7 +372,6 @@ fn restore_vertices(vertex_components: &[u32], vertex_count: usize, grid_indices
 
     let mut vertices: Vec<Vertex> = vec![Default::default(); vertex_count];
     for (i, vertex) in vertices.iter_mut().enumerate() {
-        let j = 3 * i;
         let grid_index = grid_indices[i];
 
         let mut x = grid_index as f32;
@@ -381,6 +380,7 @@ fn restore_vertices(vertex_components: &[u32], vertex_count: usize, grid_indices
         let y = x / y_div;
         x -= y * y_div;
 
+        let j = 3 * i;
         let mut delta_x = vertex_components[j];
         if grid_index == prev_grid_index {
             delta_x += prev_delta_x;

--- a/openctm/src/lib.rs
+++ b/openctm/src/lib.rs
@@ -358,7 +358,7 @@ fn restore_grid_indices(grid_indices: &mut Vec<u32>) {
     }
 }
 
-fn restore_vertices(vertex_components: &Vec<u32>, vertex_count: usize, grid_indices: &Vec<u32>, mg2_header: &MG2Header) -> Vec<Vertex> {
+fn restore_vertices(vertex_components: &[u32], vertex_count: usize, grid_indices: &[u32], mg2_header: &MG2Header) -> Vec<Vertex> {
     let precision = mg2_header.vertex_precision;
     let y_div = mg2_header.div_x as f32;
     let z_div = y_div * mg2_header.div_y as f32;
@@ -505,7 +505,7 @@ pub fn parse(mut input: impl io::BufRead) -> Result<File, Error> {
     match num::FromPrimitive::from_i32(compression_method) {
         Some(CompressionMethod::MG1) => parse_mg1(&header, input),
         Some(CompressionMethod::MG2) => parse_mg2(&header, input),
-        Some(CompressionMethod::RAW) => return Err(error!("RAW compression method not yet implemented")), // TODO replace with Result
-        None => return Err(error!("Unknown compression method")), // TODO replace with Result
+        Some(CompressionMethod::RAW) => Err(error!("RAW compression method not yet implemented")), // TODO replace with Result
+        None => Err(error!("Unknown compression method")), // TODO replace with Result
     }
 }

--- a/openctm/tests/box.rs
+++ b/openctm/tests/box.rs
@@ -12,8 +12,7 @@ mod tests {
     fn box_ctm() {
         let reader = parse(std::io::BufReader::new(
             std::fs::File::open("tests/box.ctm").unwrap(),
-        ))
-        .unwrap();
+        )).unwrap();
 
         let vertices = vec![
             Vertex {

--- a/openctm/tests/box.rs
+++ b/openctm/tests/box.rs
@@ -12,7 +12,8 @@ mod tests {
     fn box_ctm() {
         let reader = parse(std::io::BufReader::new(
             std::fs::File::open("tests/box.ctm").unwrap(),
-        )).unwrap();
+        ))
+        .unwrap();
 
         let vertices = vec![
             Vertex {

--- a/viewer/rust/lib.rs
+++ b/viewer/rust/lib.rs
@@ -6,7 +6,6 @@ use wasm_bindgen::JsValue;
 #[macro_use]
 pub mod error;
 
-
 #[wasm_bindgen]
 pub struct CtmResult {
     file: openctm::File,

--- a/viewer/rust/lib.rs
+++ b/viewer/rust/lib.rs
@@ -1,5 +1,4 @@
 use js_sys::{Float32Array, Map, Uint32Array};
-use serde::{Deserialize, Serialize};
 use std::panic;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -7,28 +6,6 @@ use wasm_bindgen::JsValue;
 #[macro_use]
 pub mod error;
 
-#[derive(Deserialize, Serialize)]
-struct UvMap {
-    //pub name: String,
-    //pub filename: String,
-    #[serde(with = "serde_bytes")]
-    pub uv: Vec<u8>, // actually u32
-}
-
-#[derive(Deserialize, Serialize)]
-struct Body {
-    #[serde(with = "serde_bytes")]
-    pub indices: Vec<u8>, // actually u32
-    #[serde(with = "serde_bytes")]
-    pub vertices: Vec<u8>, // actually f32
-    pub normals: Vec<u8>, // actually f32
-    pub uv_maps: Vec<UvMap>,
-}
-
-#[derive(Deserialize, Serialize)]
-struct Ctm {
-    pub body: Body,
-}
 
 #[wasm_bindgen]
 pub struct CtmResult {


### PR DESCRIPTION
Implemented the features we actually use for MG2 encoded OpenCTM files. It doesn't work flawlessly with the way we reference ctm files from i3d files (at the moment). The colors are stored in the i3d file and dependent on the vertex ordering in the ctm file, which isn't preserved with MG2 compression.

MG1 compressed ctm files with colors from i3d file:
![Screenshot 2020-07-16 at 13 30 27](https://user-images.githubusercontent.com/7214852/87666232-87608f80-c768-11ea-867d-df5ac37c9d73.png)

MG2 compressed:
![Screenshot 2020-07-16 at 13 30 07](https://user-images.githubusercontent.com/7214852/87666202-79ab0a00-c768-11ea-82ac-861511bee6b5.png)

Even though it doesn't work that great with i3d, the parsing logic checks out. Making it work with colors is a large undertaking involving changing the i3d format, new finalize logic, and optimizer changes.