### PR TITLE
Reduce the use of unwrap to avoid panics in the workers

### DIFF
--- a/i3df/src/renderables.rs
+++ b/i3df/src/renderables.rs
@@ -51,14 +51,17 @@ impl Scene {
     pub fn sector_id(&self, index: usize) -> usize {
         self.sectors[index].id
     }
-    pub fn sector_parent_id(&self, index: usize) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.sectors[index].parent_id).unwrap()
+    pub fn sector_parent_id(&self, index: usize) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.sectors[index].parent_id)
+            .map_err(|e| e.to_string().into())
     }
-    pub fn sector_bbox_min(&self, index: usize) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.sectors[index].bbox_min).unwrap()
+    pub fn sector_bbox_min(&self, index: usize) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.sectors[index].bbox_min)
+            .map_err(|e| e.to_string().into())
     }
-    pub fn sector_bbox_max(&self, index: usize) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.sectors[index].bbox_max).unwrap()
+    pub fn sector_bbox_max(&self, index: usize) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.sectors[index].bbox_max)
+            .map_err(|e| e.to_string().into())
     }
     pub fn sector(&mut self, index: usize) -> Sector {
         // NOTE the user can only get the sector once
@@ -337,12 +340,12 @@ macro_rules! new_geometry_types {
                 self.primitive_collections.instanced_mesh_collection.clone()
             }
 
-            pub fn tree_index_to_node_id_map(&self) -> Map {
-                Map::from(serde_wasm_bindgen::to_value(&self.primitive_collections.tree_index_to_node_id_map).unwrap())
+            pub fn tree_index_to_node_id_map(&self) -> Result<Map, JsValue> {
+                Ok(Map::from(serde_wasm_bindgen::to_value(&self.primitive_collections.tree_index_to_node_id_map).map_err(|e| e.to_string())?))
             }
 
-            pub fn node_id_to_tree_index_map(&self) -> Map {
-                Map::from(serde_wasm_bindgen::to_value(&self.primitive_collections.node_id_to_tree_index_map).unwrap())
+            pub fn node_id_to_tree_index_map(&self) -> Result<Map, JsValue> {
+                Ok(Map::from(serde_wasm_bindgen::to_value(&self.primitive_collections.node_id_to_tree_index_map).map_err(|e| e.to_string())?))
             }
 
             pub fn statistics(&self) -> SectorStatistics {

--- a/viewer/rust/lib.rs
+++ b/viewer/rust/lib.rs
@@ -49,7 +49,7 @@ pub fn parse_ctm(input: &[u8]) -> Result<CtmResult, JsValue> {
     panic::set_hook(Box::new(console_error_panic_hook::hook));
 
     let cursor = std::io::Cursor::new(input);
-    let file = openctm::parse(cursor).unwrap();
+    let file = openctm::parse(cursor).map_err(|e| e.to_string())?;
 
     let result = CtmResult { file };
 
@@ -127,12 +127,12 @@ pub fn parse_and_convert_f3df(input: &[u8]) -> Result<SimpleSectorData, JsValue>
 
     Ok(SimpleSectorData {
         faces: faces_as_float_32_array,
-        node_id_to_tree_index_map: Map::from(
-            serde_wasm_bindgen::to_value(&renderable_sector.node_id_to_tree_index_map).unwrap(),
-        ),
-        tree_index_to_node_id_map: Map::from(
-            serde_wasm_bindgen::to_value(&renderable_sector.tree_index_to_node_id_map).unwrap(),
-        ),
+        node_id_to_tree_index_map: Map::from(serde_wasm_bindgen::to_value(
+            &renderable_sector.node_id_to_tree_index_map,
+        )?),
+        tree_index_to_node_id_map: Map::from(serde_wasm_bindgen::to_value(
+            &renderable_sector.tree_index_to_node_id_map,
+        )?),
     })
 }
 


### PR DESCRIPTION
There are still some unwrap calls in the primitive modules (for rotate_between), but I'm not sure how recoverable they are in that code and bubbling them up to JS would require a lot of refactoring.