### PR TITLE
feat(Cognite3DViewer): add model now returns any supported model type

### DIFF
--- a/documentation/docs/migration-guide.md
+++ b/documentation/docs/migration-guide.md
@@ -15,4 +15,5 @@ because streaming is used.
 <!--- notes:
 * Cognite3DViewer.getIntersectionFromPixel doesn't have the model param
 * Cognite3DViewer.clearCache is not supported
+* Cognite3DViewer.addModel now can return any supported model type, not only cad. For cad use addCadModel
 --->

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -11,7 +11,6 @@ import {
   AddModelOptions,
   Cognite3DViewer,
   Cognite3DModel,
-  SupportedModelTypes,
   BoundingBoxClipper,
 } from '@cognite/reveal';
 
@@ -68,22 +67,15 @@ export function Migration() {
       (window as any).viewer = viewer;
 
       async function addModel(options: AddModelOptions) {
-        switch (
-        await viewer.determineModelType(options.modelId, options.revisionId)
-        ) {
-          case SupportedModelTypes.CAD:
-            const model = await viewer.addModel(options);
-            viewer.fitCameraToModel(model);
+        try {
+          const model = await viewer.addModel(options);
+          viewer.fitCameraToModel(model);
+          if (model instanceof Cognite3DModel) {
             cadModels.push(model);
-            break;
-
-          case SupportedModelTypes.PointCloud:
-            const pointCloud = await viewer.addPointCloudModel(options);
-            viewer.fitCameraToModel(pointCloud);
-            break;
-
-          default:
-            alert(`Model ID is invalid or is not supported`);
+          }
+        } catch (e) {
+          console.error(e);
+          alert(`Model ID is invalid or is not supported`);
         }
       }
 

--- a/viewer/src/__tests__/migration/Cognite3DViewer.test.ts
+++ b/viewer/src/__tests__/migration/Cognite3DViewer.test.ts
@@ -89,6 +89,7 @@ describe('Cognite3DViewer', () => {
     nock(/.*/)
       .defaultReplyHeaders({ 'access-control-allow-origin': '*', 'access-control-allow-credentials': 'true' })
       .get(/.*\/outputs/)
+      .twice() // the first one goes to determine model type
       .reply(200, outputs);
     nock(/.*/)
       .defaultReplyHeaders({ 'access-control-allow-origin': '*', 'access-control-allow-credentials': 'true' })


### PR DESCRIPTION
It should a bit simplify the usage of Cognite3DViewer when type doesn't really matter. Also, now `addModel` truly adds any model and we have explicitly declared addCadModel as we have for addPointCloudModel. 

I actually think that the reveal manager should have the same API instead of an overloading addModel. 