### PR TITLE
refactor(SupportedModelTypes): use type union, remove NotSupported

### DIFF
--- a/viewer/src/datamodels/base/SupportedModelTypes.ts
+++ b/viewer/src/datamodels/base/SupportedModelTypes.ts
@@ -1,0 +1,4 @@
+/*!
+ * Copyright 2020 Cognite AS
+ */
+export type SupportedModelTypes = 'pointcloud' | 'cad';

--- a/viewer/src/datamodels/base/index.ts
+++ b/viewer/src/datamodels/base/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { MetadataRepository } from './MetadataRepository';
+export * from './SupportedModelTypes';

--- a/viewer/src/datamodels/cad/CadManager.ts
+++ b/viewer/src/datamodels/cad/CadManager.ts
@@ -129,9 +129,9 @@ export class CadManager<TModelIdentifier> {
     this._materialManager.setRenderMode(renderMode);
   }
 
-  async addModel(modelIdentifier: TModelIdentifier, nodeApperanceProvider?: NodeAppearanceProvider): Promise<CadNode> {
+  async addModel(modelIdentifier: TModelIdentifier, nodeAppearanceProvider?: NodeAppearanceProvider): Promise<CadNode> {
     const metadata = await this._cadModelMetadataRepository.loadData(modelIdentifier);
-    const model = this._cadModelFactory.createModel(metadata, nodeApperanceProvider);
+    const model = this._cadModelFactory.createModel(metadata, nodeAppearanceProvider);
     model.addEventListener('update', () => {
       this._needsRedraw = true;
     });

--- a/viewer/src/datamodels/cad/CadModelFactory.ts
+++ b/viewer/src/datamodels/cad/CadModelFactory.ts
@@ -12,13 +12,13 @@ export class CadModelFactory {
     this._materialManager = materialManager;
   }
 
-  createModel(modelMetadata: CadModelMetadata, nodeApperanceProvider?: NodeAppearanceProvider): CadNode {
+  createModel(modelMetadata: CadModelMetadata, nodeAppearanceProvider?: NodeAppearanceProvider): CadNode {
     const { blobUrl, scene } = modelMetadata;
     const cadModel = new CadNode(modelMetadata, this._materialManager);
     this._materialManager.addModelMaterials(blobUrl, scene.maxTreeIndex);
 
-    if (nodeApperanceProvider) {
-      this._materialManager.setNodeAppearanceProvider(blobUrl, nodeApperanceProvider);
+    if (nodeAppearanceProvider) {
+      this._materialManager.setNodeAppearanceProvider(blobUrl, nodeAppearanceProvider);
     }
 
     this._materialManager.updateModelNodes(blobUrl, [...Array(scene.maxTreeIndex + 1).keys()]);

--- a/viewer/src/index.ts
+++ b/viewer/src/index.ts
@@ -7,7 +7,7 @@ export { Cognite3DModel } from './public/migration/Cognite3DModel';
 export { CognitePointCloudModel } from './public/migration/CognitePointCloudModel';
 export { Cognite3DViewer } from './public/migration/Cognite3DViewer';
 export { Intersection } from './public/migration/intersection';
-export { Color, Cognite3DViewerOptions, AddModelOptions, SupportedModelTypes } from './public/migration/types';
+export { Color, Cognite3DViewerOptions, AddModelOptions } from './public/migration/types';
 export { CadLoadingHints } from './datamodels/cad/CadLoadingHints';
 export { BoundingBoxClipper } from './utilities';
 
@@ -16,3 +16,4 @@ export { PotreePointColorType } from './datamodels/pointcloud/types';
 // Export ThreeJS to enable easy import for our users
 import * as THREE from 'three';
 export { THREE };
+export { SupportedModelTypes } from '@/datamodels/base/SupportedModelTypes';

--- a/viewer/src/migration.ts
+++ b/viewer/src/migration.ts
@@ -7,4 +7,5 @@ export { Cognite3DModel } from './public/migration/Cognite3DModel';
 export { CognitePointCloudModel } from './public/migration/CognitePointCloudModel';
 export { Cognite3DViewer } from './public/migration/Cognite3DViewer';
 export { Intersection } from './public/migration/intersection';
-export { Color, Cognite3DViewerOptions, AddModelOptions, SupportedModelTypes } from './public/migration/types';
+export { Color, Cognite3DViewerOptions, AddModelOptions } from './public/migration/types';
+export { SupportedModelTypes } from '@/datamodels/base/SupportedModelTypes';

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -19,6 +19,7 @@ import { PotreeGroupWrapper } from '@/datamodels/pointcloud/PotreeGroupWrapper';
 import { PotreeNodeWrapper } from '@/datamodels/pointcloud/PotreeNodeWrapper';
 import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
 import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderManager';
+import { SupportedModelTypes } from '@/public/migration/types';
 
 export class RevealManager<TModelIdentifier> {
   private readonly _cadManager: CadManager<TModelIdentifier>;
@@ -161,7 +162,7 @@ export class RevealManager<TModelIdentifier> {
     modelIdentifier: TModelIdentifier
   ): Promise<[PotreeGroupWrapper, PotreeNodeWrapper]>;
   public async addModel(
-    type: 'cad' | 'pointcloud',
+    type: SupportedModelTypes,
     modelIdentifier: TModelIdentifier,
     nodeApperanceProvider?: NodeAppearanceProvider
   ): Promise<[PotreeGroupWrapper, PotreeNodeWrapper] | CadNode> {

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -155,7 +155,7 @@ export class RevealManager<TModelIdentifier> {
   public addModel(
     type: 'cad',
     modelIdentifier: TModelIdentifier,
-    nodeApperanceProvider?: NodeAppearanceProvider
+    nodeAppearanceProvider?: NodeAppearanceProvider
   ): Promise<CadNode>;
   public addModel(
     type: 'pointcloud',
@@ -164,20 +164,20 @@ export class RevealManager<TModelIdentifier> {
   public async addModel(
     type: SupportedModelTypes,
     modelIdentifier: TModelIdentifier,
-    nodeApperanceProvider?: NodeAppearanceProvider
+    nodeAppearanceProvider?: NodeAppearanceProvider
   ): Promise<[PotreeGroupWrapper, PotreeNodeWrapper] | CadNode> {
     trackLoadModel(
       {
         moduleName: 'RevealManager',
         methodName: 'addModel',
-        options: { nodeApperanceProvider }
+        options: { nodeAppearanceProvider }
       },
       modelIdentifier
     );
 
     switch (type) {
       case 'cad': {
-        const cadNode = await this._cadManager.addModel(modelIdentifier, nodeApperanceProvider);
+        const cadNode = await this._cadManager.addModel(modelIdentifier, nodeAppearanceProvider);
         this._subscriptions.add(
           this._cadManager
             .getParsedData()

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -19,7 +19,7 @@ import { PotreeGroupWrapper } from '@/datamodels/pointcloud/PotreeGroupWrapper';
 import { PotreeNodeWrapper } from '@/datamodels/pointcloud/PotreeNodeWrapper';
 import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
 import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderManager';
-import { SupportedModelTypes } from '@/public/migration/types';
+import { SupportedModelTypes } from '@/datamodels/base';
 
 export class RevealManager<TModelIdentifier> {
   private readonly _cadManager: CadManager<TModelIdentifier>;

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -7,7 +7,7 @@ import { CogniteClient } from '@cognite/sdk';
 import { vec3 } from 'gl-matrix';
 
 import { NodeIdAndTreeIndexMaps } from './NodeIdAndTreeIndexMaps';
-import { Color, SupportedModelTypes } from './types';
+import { Color } from './types';
 import { CogniteModelBase } from './CogniteModelBase';
 import { NotSupportedInMigrationWrapperError } from './NotSupportedInMigrationWrapperError';
 import { toThreeJsBox3, toThreeMatrix4, toThreeVector3, fromThreeVector3 } from '@/utilities';
@@ -16,6 +16,7 @@ import { CadLoadingHints } from '@/datamodels/cad/CadLoadingHints';
 import { CadModelMetadata } from '@/datamodels/cad/CadModelMetadata';
 import { NodeAppearanceProvider, DefaultNodeAppearance } from '@/datamodels/cad/NodeAppearance';
 import { trackError } from '@/utilities/metrics';
+import { SupportedModelTypes } from '@/datamodels/base';
 
 const mapCoordinatesBuffers = {
   v: vec3.create()

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -22,7 +22,7 @@ const mapCoordinatesBuffers = {
 };
 
 export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
-  public readonly type: SupportedModelTypes = SupportedModelTypes.CAD;
+  public readonly type: SupportedModelTypes = 'cad';
 
   get renderHints(): CadRenderHints {
     return this.cadNode.renderHints;

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -318,9 +318,9 @@ export class Cognite3DViewer {
   async addModel(options: AddModelOptions): Promise<Cognite3DModel | CognitePointCloudModel> {
     const type = await this.determineModelType(options.modelId, options.revisionId);
     switch (type) {
-      case SupportedModelTypes.CAD:
+      case 'cad':
         return this.addCadModel(options);
-      case SupportedModelTypes.PointCloud:
+      case 'pointcloud':
         return this.addPointCloudModel(options);
       default:
         throw new Error('Model is not supported');
@@ -345,7 +345,7 @@ export class Cognite3DViewer {
     trackLoadModel(
       {
         options: omit(options, ['modelId', 'revisionId']),
-        type: SupportedModelTypes.CAD,
+        type: 'cad',
         moduleName: 'Cognite3DViewer',
         methodName: 'addCadModel'
       },
@@ -406,7 +406,7 @@ export class Cognite3DViewer {
     trackLoadModel(
       {
         options: omit(options, ['modelId', 'revisionId']),
-        type: SupportedModelTypes.PointCloud,
+        type: 'pointcloud',
         moduleName: 'Cognite3DViewer',
         methodName: 'addPointCloudModel'
       },
@@ -446,16 +446,17 @@ export class Cognite3DViewer {
    * @param modelId the model's id
    * @param revisionId the model's revision id
    *
+   * @returns empty string if type is not supported
    * @example
    * ```typescript
    * const viewer = new Cognite3DViewer(...);
    * const type = await viewer.determineModelType(options.modelId, options.revisionId)
    * let model: Cognite3DModel | CognitePointCloudModel
    * switch (type) {
-   *   case SupportedModelTypes.CAD:
+   *   case 'cad':
    *     model = await viewer.addCadModel(options);
    *     break;
-   *   case SupportedModelTypes.PointCloud:
+   *   case 'pointcloud':
    *     model = await viewer.addPointCloudModel(options);
    *     break;
    *   default:
@@ -464,15 +465,15 @@ export class Cognite3DViewer {
    * viewer.fitCameraToModel(model);
    * ```
    */
-  async determineModelType(modelId: number, revisionId: number): Promise<SupportedModelTypes> {
+  async determineModelType(modelId: number, revisionId: number): Promise<SupportedModelTypes | ''> {
     const clientExt = new CdfModelDataClient(this.sdkClient);
     const outputs = await clientExt.getOutputs({ modelId, revisionId, format: File3dFormat.AnyFormat });
     if (outputs.findMostRecentOutput(File3dFormat.RevealCadModel) !== undefined) {
-      return SupportedModelTypes.CAD;
+      return 'cad';
     } else if (outputs.findMostRecentOutput(File3dFormat.EptPointCloud) !== undefined) {
-      return SupportedModelTypes.PointCloud;
+      return 'pointcloud';
     }
-    return SupportedModelTypes.NotSupported;
+    return '';
   }
 
   /**
@@ -833,7 +834,7 @@ export class Cognite3DViewer {
    * ```
    */
   getIntersectionFromPixel(offsetX: number, offsetY: number): null | Intersection {
-    const cadModels = this.getModels(SupportedModelTypes.CAD);
+    const cadModels = this.getModels('cad');
     const nodes = cadModels.map(x => x.cadNode);
 
     const coords = {
@@ -872,8 +873,8 @@ export class Cognite3DViewer {
     throw new NotSupportedInMigrationWrapperError('Cache is not supported');
   }
 
-  private getModels(type: SupportedModelTypes.CAD): Cognite3DModel[];
-  private getModels(type: SupportedModelTypes.PointCloud): CognitePointCloudModel[];
+  private getModels(type: 'cad'): Cognite3DModel[];
+  private getModels(type: 'pointcloud'): CognitePointCloudModel[];
   private getModels(type: SupportedModelTypes): CogniteModelBase[] {
     return this.models.filter(x => x.type === type);
   }

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -14,7 +14,7 @@ import { merge, Subject, Subscription, fromEventPattern } from 'rxjs';
 import { from3DPositionToRelativeViewportCoordinates } from '@/utilities/worldToViewport';
 import { intersectCadNodes } from '@/datamodels/cad/picking';
 
-import { AddModelOptions, Cognite3DViewerOptions, GeometryFilter, SupportedModelTypes } from './types';
+import { AddModelOptions, Cognite3DViewerOptions, GeometryFilter } from './types';
 import { NotSupportedInMigrationWrapperError } from './NotSupportedInMigrationWrapperError';
 import { Intersection } from './intersection';
 import RenderController from './RenderController';
@@ -30,6 +30,7 @@ import { RevealManager } from '../RevealManager';
 import { createCdfRevealManager } from '../createRevealManager';
 import { CdfModelIdentifier } from '@/utilities/networking/types';
 import { RevealOptions, SectorNodeIdToTreeIndexMapLoadedEvent } from '../types';
+import { SupportedModelTypes } from '@/datamodels/base';
 
 export type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
 export type CameraChangeDelegate = (position: THREE.Vector3, target: THREE.Vector3) => void;

--- a/viewer/src/public/migration/CogniteModelBase.ts
+++ b/viewer/src/public/migration/CogniteModelBase.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { SupportedModelTypes } from './types';
+import { SupportedModelTypes } from '@/datamodels/base';
 
 export interface CogniteModelBase {
   readonly type: SupportedModelTypes;

--- a/viewer/src/public/migration/CognitePointCloudModel.ts
+++ b/viewer/src/public/migration/CognitePointCloudModel.ts
@@ -4,12 +4,12 @@
 
 import * as THREE from 'three';
 import { CogniteModelBase } from './CogniteModelBase';
-import { SupportedModelTypes } from './types';
 import { toThreeJsBox3 } from '@/utilities';
 import { PotreeNodeWrapper } from '@/datamodels/pointcloud/PotreeNodeWrapper';
 import { PotreeGroupWrapper } from '@/datamodels/pointcloud/PotreeGroupWrapper';
 import { PotreePointColorType } from '@/datamodels/pointcloud/types';
 import { Matrix4 } from 'three';
+import { SupportedModelTypes } from '@/datamodels/base';
 
 export class CognitePointCloudModel extends THREE.Object3D implements CogniteModelBase {
   public readonly type: SupportedModelTypes = 'pointcloud';

--- a/viewer/src/public/migration/CognitePointCloudModel.ts
+++ b/viewer/src/public/migration/CognitePointCloudModel.ts
@@ -12,7 +12,7 @@ import { PotreePointColorType } from '@/datamodels/pointcloud/types';
 import { Matrix4 } from 'three';
 
 export class CognitePointCloudModel extends THREE.Object3D implements CogniteModelBase {
-  public readonly type: SupportedModelTypes = SupportedModelTypes.PointCloud;
+  public readonly type: SupportedModelTypes = 'pointcloud';
   public readonly modelId: number;
   public readonly revisionId: number;
   private readonly potreeNode: PotreeNodeWrapper;

--- a/viewer/src/public/migration/types.ts
+++ b/viewer/src/public/migration/types.ts
@@ -57,5 +57,3 @@ export interface AddModelOptions {
   orthographicCamera?: boolean;
   onComplete?: () => void;
 }
-
-export type SupportedModelTypes = 'pointcloud' | 'cad';

--- a/viewer/src/public/migration/types.ts
+++ b/viewer/src/public/migration/types.ts
@@ -58,11 +58,4 @@ export interface AddModelOptions {
   onComplete?: () => void;
 }
 
-export enum SupportedModelTypes {
-  PointCloud = 'pointcloud',
-  CAD = 'cad',
-  /**
-   * Not a model supported by Reveal.
-   */
-  NotSupported = ''
-}
+export type SupportedModelTypes = 'pointcloud' | 'cad';

--- a/viewer/src/public/types.ts
+++ b/viewer/src/public/types.ts
@@ -7,6 +7,12 @@ import { SectorGeometry } from '@/datamodels/cad/sector/types';
 import { SectorQuads } from '@/datamodels/cad/rendering/types';
 import { SectorCuller } from '@/internal';
 
+// we use these types in public API so they should be reexported here
+// to appear in the api reference docs
+export { CadRenderHints } from '../datamodels/cad/rendering/CadRenderHints';
+export { CadLoadingHints } from '../datamodels/cad/CadLoadingHints';
+export * from '../datamodels/base/SupportedModelTypes';
+
 /**
  * @property logMetrics might be used to disable usage statistics
  * @property nodeAppearanceProvider style node by tree-index


### PR DESCRIPTION
Replaced `SupportedModelTypes` enum with type union to avoid strings that mimic enum values in revealManager.addModel. Also removed NotSupported `''` from that type because it doesn't really make sense to have it in type that declares supported stuff. 