### PR TITLE
chore(viewer): set target es2019 to get rid of jest warn

### DIFF
--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "incremental": true,
-    "target": "esnext",
+    "target": "ES2019",
     "module": "esnext",
     "declaration": true,
     "declarationDir": "dist",


### PR DESCRIPTION
Shuts up this message from jest. We don't really need to stick with esnext, es2019 should be quite enough. 

> ts-jest[config] (WARN) There is a mismatch between your NodeJs version v12.18.3 and your TypeScript target esnext. This might lead to some unexpected errors when running tests with `ts-jest`. To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
