### PR TITLE
Documentation: fix alias resolving, run build on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,6 @@ jobs:
     - name: Publish to codecov
       uses: codecov/codecov-action@v1
 
-
   ci-examples:
     name: Examples
     runs-on: ubuntu-latest
@@ -181,3 +180,18 @@ jobs:
       with:
         name: image-diffs-${{ github.sha }}
         path: examples/src/visual_tests/__image_snapshots__/__diff_output__/*
+
+  # used to validate there is no fails for generated docs
+  ci-documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install NPM dependencies
+        working-directory: documentation
+        run: yarn
+
+      - name: Build docs
+        working-directory: documentation
+        run: yarn run build

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -15,7 +15,7 @@
     "swizzle": "docusaurus swizzle",
     "reveal:copy": "cpy ./node_modules/@cognite/reveal/*.wasm ./node_modules/@cognite/reveal/*.worker.js ./static --dot",
     "apiref": "yarn run apiref:generate && yarn run apiref:concat",
-    "apiref:generate": "typedoc --inputFiles ../viewer/src/public --out ./generated --mode library --excludeExternals --externalPattern '../viewer/src/__tests__/**/*.ts' --entryPoint '\"index\"' --exclude \"**/*+(index|.spec|.test).ts\" --excludeNotExported --excludePrivate --excludeProtected --stripInternal --ignoreCompilerErrors --readme none --tsconfig ../viewer/tsconfig.json",
+    "apiref:generate": "typedoc --inputFiles ../viewer/src/public --out ./generated --mode library --excludeExternals --externalPattern '../viewer/src/__tests__/**/*.ts' --exclude \"**/*+(index|.spec|.test).ts\" --excludeNotExported --excludePrivate --excludeProtected --stripInternal --ignoreCompilerErrors --readme none --tsconfig ../viewer/tsconfig.json",
     "apiref:concat": "concat-md ./generated --startTitleLevelAt 1 --decrease-title-levels --dir-name-as-title > \"./docs/API Reference.md\""
   },
   "dependencies": {

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -15,7 +15,7 @@
     "swizzle": "docusaurus swizzle",
     "reveal:copy": "cpy ./node_modules/@cognite/reveal/*.wasm ./node_modules/@cognite/reveal/*.worker.js ./static --dot",
     "apiref": "yarn run apiref:generate && yarn run apiref:concat",
-    "apiref:generate": "typedoc --inputFiles ../viewer/src/public --out ./generated --mode library --excludeExternals --externalPattern '../viewer/src/__tests__/**/*.ts' --entryPoint '\"index\"' --exclude \"**/*+(index|.spec|.test).ts\" --excludeNotExported --excludePrivate --excludeProtected --stripInternal --ignoreCompilerErrors --readme none",
+    "apiref:generate": "typedoc --inputFiles ../viewer/src/public --out ./generated --mode library --excludeExternals --externalPattern '../viewer/src/__tests__/**/*.ts' --entryPoint '\"index\"' --exclude \"**/*+(index|.spec|.test).ts\" --excludeNotExported --excludePrivate --excludeProtected --stripInternal --ignoreCompilerErrors --readme none --tsconfig ../viewer/tsconfig.json",
     "apiref:concat": "concat-md ./generated --startTitleLevelAt 1 --decrease-title-levels --dir-name-as-title > \"./docs/API Reference.md\""
   },
   "dependencies": {

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -5912,9 +5912,9 @@ hex-color-regex@^1.1.0:
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
 highlight.js@^9.18.0:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+  version "9.18.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.3.tgz#a1a0a2028d5e3149e2380f8a865ee8516703d634"
+  integrity sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==
 
 history@^4.9.0:
   version "4.10.1"

--- a/viewer/src/public/types.ts
+++ b/viewer/src/public/types.ts
@@ -9,9 +9,9 @@ import { SectorCuller } from '@/internal';
 
 // we use these types in public API so they should be reexported here
 // to appear in the api reference docs
-export { CadRenderHints } from '../datamodels/cad/rendering/CadRenderHints';
-export { CadLoadingHints } from '../datamodels/cad/CadLoadingHints';
-export * from '../datamodels/base/SupportedModelTypes';
+export { CadRenderHints } from '@/datamodels/cad/rendering/CadRenderHints';
+export { CadLoadingHints } from '@/datamodels/cad/CadLoadingHints';
+export * from '@/datamodels/base/SupportedModelTypes';
 
 /**
  * @property logMetrics might be used to disable usage statistics


### PR DESCRIPTION
* Added a CI step to check docs build failures. 
* Added tsconfig from viewer to allow resolving of `@` aliases (no idea at all why it was working before). 