### PR TITLE
fix: issue causing worldToScreen() returning wrong values when camera is being moved

### DIFF
--- a/documentation/docs/examples/cad-colors.mdx
+++ b/documentation/docs/examples/cad-colors.mdx
@@ -51,6 +51,6 @@ subtree. Reveal supports this through the use of `Cognite3DModel.setNodesColorsB
 set to `true`:
 <LiveCodeSnippet>
 {`
-model.setNodeColorByTreeIndex(122, 240, 100, 60, true /* apply to children */);
+model.setNodeColorByTreeIndex(122, 240, 100, 60, applyToChildren=true);
 `}
 </LiveCodeSnippet>

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -766,6 +766,7 @@ export class Cognite3DViewer {
    * ```
    */
   worldToScreen(point: THREE.Vector3, normalize?: boolean): THREE.Vector2 | null {
+    this.camera.updateMatrixWorld();
     const p = from3DPositionToRelativeViewportCoordinates(this.camera, point);
     if (p.x < 0 || p.x > 1 || p.y < 0 || p.y > 1 || p.z < 0 || p.z > 1) {
       // Return null if point is outside camera frustum.


### PR DESCRIPTION
This fixes an issue causing 2D HTML overlays to be appearing to "lag behind" when they their position was updated when Cognite3DViewer triggered 'cameraChanged'.