### PR TITLE
fix(Cognite3DModel): async iteration over nodes

### DIFF
--- a/viewer/src/__tests__/utilities/NumericRange.test.ts
+++ b/viewer/src/__tests__/utilities/NumericRange.test.ts
@@ -39,10 +39,10 @@ describe('NumericRange', () => {
     expect(range.contains(10)).toBeFalse();
   });
 
-  test('forEach applies callback to each value', () => {
+  test('forEach applies callback to each value', async () => {
     const applied: number[] = [];
     const range = new NumericRange(1, 4);
-    range.forEach(v => {
+    await range.forEach(v => {
       applied.push(v);
     });
     expect(applied).toEqual([1, 2, 3, 4]);

--- a/viewer/src/__tests__/utilities/callActionWithIndicesAsync.test.ts
+++ b/viewer/src/__tests__/utilities/callActionWithIndicesAsync.test.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2020 Cognite AS
+ */
+import { callActionWithIndicesAsync } from '@/utilities/callActionWithIndicesAsync';
+
+describe('test callActionWithIndicesAsync', () => {
+  it('calls an action with specified indices range', async () => {
+    const start = 10;
+    const end = 100000;
+    const timesToCall = end - start + 1;
+    const action = jest.fn();
+    await callActionWithIndicesAsync(start, end, action);
+    expect(action).toBeCalledTimes(timesToCall);
+    expect(action).toHaveBeenNthCalledWith(1, start);
+    expect(action).toHaveBeenNthCalledWith(1 + 1234, start + 1234);
+    expect(action).toHaveBeenNthCalledWith(timesToCall, end);
+  });
+});

--- a/viewer/src/utilities/NumericRange.ts
+++ b/viewer/src/utilities/NumericRange.ts
@@ -1,6 +1,9 @@
 /*!
  * Copyright 2020 Cognite AS
  */
+
+import { callActionWithIndicesAsync } from '@/utilities/callActionWithIndicesAsync';
+
 export class NumericRange {
   readonly from: number;
   readonly count: number;
@@ -30,9 +33,7 @@ export class NumericRange {
     return value >= this.from && value <= this.toInclusive;
   }
 
-  forEach(action: (value: number) => void) {
-    for (let i = this.from; i <= this.toInclusive; ++i) {
-      action(i);
-    }
+  async forEach(action: (value: number) => any): Promise<void> {
+    return callActionWithIndicesAsync(this.from, this.toInclusive, action);
   }
 }

--- a/viewer/src/utilities/callActionWithIndicesAsync.ts
+++ b/viewer/src/utilities/callActionWithIndicesAsync.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2020 Cognite AS
+ */
+export async function callActionWithIndicesAsync(
+  startIndex: number,
+  lastIndexInclusive: number,
+  action: (index: number) => any,
+  timesPerChunk = 15000
+): Promise<void> {
+  let index = startIndex;
+  return new Promise(resolve => {
+    function doChunk() {
+      for (let count = 0; count < timesPerChunk && index <= lastIndexInclusive; count++) {
+        action(index++);
+      }
+      if (index <= lastIndexInclusive) {
+        setTimeout(doChunk);
+      } else {
+        resolve();
+      }
+    }
+    doChunk();
+  });
+}


### PR DESCRIPTION
Motivation for that was [that example](https://cognitedata.github.io/reveal/docs/examples/cad-colors) which currently just freezes my browser if I click "run" in the first example.

Would it be better to do that iteration without freezing a browser? We can make it to be async and it will call an action ~10k times per event loop cycle. It still will decrease FPS but won’t completely freeze a browser.