### PR TITLE
chore: make jest config more forgiving to avoid lint errors during development

### DIFF
--- a/viewer/jest.config.js
+++ b/viewer/jest.config.js
@@ -19,7 +19,10 @@ module.exports = {
     '^@/(.*)': '<rootDir>/src/$1'
   },
   globals: {
-    __webpack_public_path__: ''
+    __webpack_public_path__: '',
+    'ts-jest': {
+      tsConfig: 'tsconfig.test.json'
+    }
   },
   coverageDirectory: '../coverage',
   collectCoverageFrom: ['!src/__tests__/**/*.ts', '!**/*.d.ts', '!**/*.json'],

--- a/viewer/tsconfig.test.json
+++ b/viewer/tsconfig.test.json
@@ -1,35 +1,7 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "incremental": true,
-    "target": "ES2019",
-    "module": "esnext",
-    "declaration": true,
-    "declarationDir": "dist",
-    "outDir": "dist-ts",
-    "rootDir": "src",
-    "esModuleInterop": true,
-    "downlevelIteration": true,
-    "sourceMap": true,
-    "moduleResolution": "node",
-    "strict": true,
-    "stripInternal": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "typeRoots": [
-        "node_modules/@types",
-        "src/@types"
-    ],
-    "lib": [
-        "dom",
-        "esnext"
-    ],
-
-    "baseUrl": "./src/",
-    "paths": {
-      "@/*": ["*"]
-    }
-  },
-  // include is also used for eslint to understand which files should be linted
-  "include": ["*.js", "*.ts", "src/**/*", ".eslintrc.js", "script", "src/@types"],
-  "exclude": ["node_modules/**/*", "dist/**/*"]
+    "noUnusedParameters": false
+  }
 }

--- a/viewer/tsconfig.test.json
+++ b/viewer/tsconfig.test.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "target": "ES2019",
+    "module": "esnext",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist-ts",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "strict": true,
+    "stripInternal": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "typeRoots": [
+        "node_modules/@types",
+        "src/@types"
+    ],
+    "lib": [
+        "dom",
+        "esnext"
+    ],
+
+    "baseUrl": "./src/",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  // include is also used for eslint to understand which files should be linted
+  "include": ["*.js", "*.ts", "src/**/*", ".eslintrc.js", "script", "src/@types"],
+  "exclude": ["node_modules/**/*", "dist/**/*"]
+}


### PR DESCRIPTION
- errors will still be catched by lint step