### PR TITLE
doc: embed current Reveal in documentation, rather than a fixed version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install Reveal dependencies
+        working-directory: viewer
+        run: yarn
+
+      - name: Build Reveal
+        working-directory: viewer
+        run: yarn build:prod
+
       - name: Install NPM dependencies
         working-directory: documentation
         run: yarn

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -18,8 +18,8 @@
     "apiref:concat": "concat-md ./generated --startTitleLevelAt 1 --decrease-title-levels --dir-name-as-title > \"./docs/API Reference.md\""
   },
   "dependencies": {
-    "@cognite/reveal": "^1.0.0-beta-3",
-    "@cognite/sdk": "^3.0.0",
+    "@cognite/reveal": "link:../viewer/dist",
+    "@cognite/sdk": "link:../viewer/node_modules/@cognite/sdk",
     "@docusaurus/core": "2.0.0-alpha.62",
     "@docusaurus/module-type-aliases": "2.0.0-alpha.62",
     "@docusaurus/preset-classic": "2.0.0-alpha.62",


### PR DESCRIPTION
Rather than using a public NPM package, embed Reveal in the doc. I believe this is the right thing because:
- It allows us to publish nightly documentation
- It allows us to create a PR documentation server for viewing the doc for a feature being developed
- It avoids doc that is not in sync with our codebase