### PR TITLE
chore: deploy preview documentation on PR build

### DIFF
--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -40,5 +40,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: documentation/docs-preview # The folder the action should deploy.
+          BRANCH: master # The branch the action should deploy to.
+          FOLDER: documentation/docs-preview/build # The folder the action should deploy.
+          REPOSITORY: cognitedata/reveal-docs-preview

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           mkdir -p "docs-preview/$PR_NUMBER"
-          mv "build/*" "docs-preview/$PR_NUMBER/"
+          ls "docs-preview/"
+          cp -R build/ "docs-preview/$PR_NUMBER/"
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -35,7 +35,7 @@ jobs:
           echo "::set-env name=PR_NUMBER::$PR_NUMBER"
           mkdir -p "docs-preview/$PR_NUMBER"
           ls "docs-preview/"
-          cp -R "build/*" "docs-preview/$PR_NUMBER/"
+          cp -R build/* "docs-preview/$PR_NUMBER/"
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -2,8 +2,8 @@ name: preview-documentation
 
 on:
   pull_request:
-    branches:
-      - '**'
+    branches-ignore:
+      - 'dependabot/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -44,7 +44,6 @@ jobs:
           BRANCH: master # The branch the action should deploy to.
           FOLDER: documentation/docs-preview # The folder the action should deploy.
           REPOSITORY_NAME: cognitedata/reveal-docs-preview
-
 
       - name: Add comment about preview URL
         uses: unsplash/comment-on-pr@master

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -45,10 +45,13 @@ jobs:
           FOLDER: documentation/docs-preview # The folder the action should deploy.
           REPOSITORY_NAME: cognitedata/reveal-docs-preview
 
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@v1
+
+      - name: comment PR
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          issue-number: ${{ env.PR_NUMBER }}
-          body: |
+          msg: |
             :orange_book: Documentation preview is available from
             https://cognitedata.github.io/reveal-docs-preview/${{ env.PR_NUMBER }}/docs.
+          check_for_duplicate_msg: true

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -1,0 +1,43 @@
+name: preview-documentation
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-and-deploy:
+    name: Publish documentation preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Build Reveal
+        working-directory: viewer
+        run: |
+          yarn
+          yarn build:prod
+
+      - name: Install and Build documentation 🔧
+        working-directory: documentation
+        run: |
+          yarn
+          yarn build
+
+      - name: Create preview folder structure
+        working-directory: documentation
+        run: |
+          export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          mkdir -p "docs-preview/$PR_NUMBER"
+          mv "build/*" "docs-preview/$PR_NUMBER/"
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: documentation/docs-preview # The folder the action should deploy.

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -48,5 +48,6 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1
         with:
+          issue-number: ${{ PR_NUMBER }}
           body: |
             Documentation preview is available form https://cognitedata.github.io/reveal-preview-docs/$PR_NUMBER

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -48,6 +48,6 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          issue-number: ${{ PR_NUMBER }}
+          issue-number: ${{ env.PR_NUMBER }}
           body: |
-            Documentation preview is available form https://cognitedata.github.io/reveal-preview-docs/$PR_NUMBER
+            Documentation preview is available form https://cognitedata.github.io/reveal-preview-docs/${{ env.PR_NUMBER }}/docs.

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -41,5 +41,5 @@ jobs:
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: master # The branch the action should deploy to.
-          FOLDER: documentation/docs-preview/build # The folder the action should deploy.
-          REPOSITORY: cognitedata/reveal-docs-preview
+          FOLDER: documentation/docs-preview # The folder the action should deploy.
+          REPOSITORY_NAME: cognitedata/reveal-docs-preview

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -46,7 +46,7 @@ jobs:
           REPOSITORY_NAME: cognitedata/reveal-docs-preview
 
 
-      - name: comment PR
+      - name: Add comment about preview URL
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -32,9 +32,10 @@ jobs:
         working-directory: documentation
         run: |
           export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          echo "::set-env name=PR_NUMBER::$PR_NUMBER"
           mkdir -p "docs-preview/$PR_NUMBER"
           ls "docs-preview/"
-          cp -R build/ "docs-preview/$PR_NUMBER/"
+          cp -R "build/*" "docs-preview/$PR_NUMBER/"
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
@@ -43,3 +44,9 @@ jobs:
           BRANCH: master # The branch the action should deploy to.
           FOLDER: documentation/docs-preview # The folder the action should deploy.
           REPOSITORY_NAME: cognitedata/reveal-docs-preview
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          body: |
+            Documentation preview is available form https://cognitedata.github.io/reveal-preview-docs/$PR_NUMBER

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -50,4 +50,5 @@ jobs:
         with:
           issue-number: ${{ env.PR_NUMBER }}
           body: |
-            Documentation preview is available form https://cognitedata.github.io/reveal-preview-docs/${{ env.PR_NUMBER }}/docs.
+            :orange_book: Documentation preview is available from
+            https://cognitedata.github.io/reveal-docs-preview/${{ env.PR_NUMBER }}/docs.


### PR DESCRIPTION
Deploy documentation to a Github pages site and post a comment about the URL. Uses repository https://github.com/cognitedata/reveal-docs-preview to store the preview docs.