### PR TITLE
doc: update tree index used in color example

### DIFF
--- a/documentation/docs/examples/cad-colors.mdx
+++ b/documentation/docs/examples/cad-colors.mdx
@@ -48,5 +48,5 @@ subtree. Reveal supports this through the use of `Cognite3DModel.setNodesColorsB
 set to `true`:
 
 ```jsx runnable
-model.setNodeColorByTreeIndex(917985, 240, 100, 60, applyToChildren=true);
+model.setNodeColorByTreeIndex(778306, 240, 100, 60, applyToChildren=true);
 ```


### PR DESCRIPTION
We've switched CAD model and the tree index has changed