### PR TITLE
fix: bug causing custom 3d objects always to be rendered in front of ghosted objects

### DIFF
--- a/viewer/src/glsl/post-processing/edge-detect-combine.frag
+++ b/viewer/src/glsl/post-processing/edge-detect-combine.frag
@@ -74,36 +74,44 @@ void main() {
     return;
   }
 
-  if(customDepth < backDepth){
-    gl_FragColor = customAlbedo;
-    return;
-  }
+  // if(customDepth < backDepth){
+  //  gl_FragColor = customAlbedo;
+  //  return;
+  // }
 
-  float backOutlineIndex = floatBitsSubset(floor((backAlbedo.a * 255.0) + 0.5), 3, 6);
-  float backOutlineIndex0 = floatBitsSubset(floor((texture2D(tBack, vUv0).a * 255.0) + 0.5), 3, 6);
-  float backOutlineIndex1 = floatBitsSubset(floor((texture2D(tBack, vUv1).a * 255.0) + 0.5), 3, 6);
-  float backOutlineIndex2 = floatBitsSubset(floor((texture2D(tBack, vUv2).a * 255.0) + 0.5), 3, 6);
-  float backOutlineIndex3 = floatBitsSubset(floor((texture2D(tBack, vUv3).a * 255.0) + 0.5), 3, 6);
+  if (customDepth >= backDepth) {
+    float backOutlineIndex = floatBitsSubset(floor((backAlbedo.a * 255.0) + 0.5), 3, 6);
+    float backOutlineIndex0 = floatBitsSubset(floor((texture2D(tBack, vUv0).a * 255.0) + 0.5), 3, 6);
+    float backOutlineIndex1 = floatBitsSubset(floor((texture2D(tBack, vUv1).a * 255.0) + 0.5), 3, 6);
+    float backOutlineIndex2 = floatBitsSubset(floor((texture2D(tBack, vUv2).a * 255.0) + 0.5), 3, 6);
+    float backOutlineIndex3 = floatBitsSubset(floor((texture2D(tBack, vUv3).a * 255.0) + 0.5), 3, 6);
 
-  if( any(equal(vec4(backOutlineIndex0, backOutlineIndex1, backOutlineIndex2, backOutlineIndex3), vec4(0.0)))
-      && backOutlineIndex > 0.0) 
-   { 
-    
-    float d0 = readDepth(tBackDepth, vUv);
-    float d1 = readDepth(tBackDepth, vUv0);
-    float d2 = readDepth(tBackDepth, vUv1);
-    float d3 = readDepth(tBackDepth, vUv2);
-    float d4 = readDepth(tBackDepth, vUv3);
+    if( any(equal(vec4(backOutlineIndex0, backOutlineIndex1, backOutlineIndex2, backOutlineIndex3), vec4(0.0)))
+        && backOutlineIndex > 0.0) 
+     { 
 
-    float averageNeighbourFragmentDepth = (d1 + d2 + d3 + d4) / 4.0;
+      float d0 = readDepth(tBackDepth, vUv);
+      float d1 = readDepth(tBackDepth, vUv0);
+      float d2 = readDepth(tBackDepth, vUv1);
+      float d3 = readDepth(tBackDepth, vUv2);
+      float d4 = readDepth(tBackDepth, vUv3);
 
-    if(d0 < averageNeighbourFragmentDepth){
-      float borderColorIndex = max(max(backOutlineIndex0, backOutlineIndex1), max(backOutlineIndex2, backOutlineIndex3));
-      gl_FragColor = texture2D(tOutlineColors, vec2(0.125 * borderColorIndex + (0.125 / 2.0), 0.5));
-      return;
+      float averageNeighbourFragmentDepth = (d1 + d2 + d3 + d4) / 4.0;
+
+      if(d0 < averageNeighbourFragmentDepth){
+        float borderColorIndex = max(max(backOutlineIndex0, backOutlineIndex1), max(backOutlineIndex2, backOutlineIndex3));
+        gl_FragColor = texture2D(tOutlineColors, vec2(0.125 * borderColorIndex + (0.125 / 2.0), 0.5));
+        return;
+      }
     }
   }
+  
+  if(customDepth < backDepth){
+    backDepth = customDepth;
+    backAlbedo = customAlbedo;
+  }
 
+  backDepth = min(customDepth, backDepth);
   float ghostDepth = readDepth(tGhostDepth, vUv);
   ghostDepth = ghostDepth > 0.0 ? ghostDepth : infinity; 
 

--- a/viewer/src/glsl/post-processing/edge-detect-combine.frag
+++ b/viewer/src/glsl/post-processing/edge-detect-combine.frag
@@ -74,10 +74,6 @@ void main() {
     return;
   }
 
-  // if(customDepth < backDepth){
-  //  gl_FragColor = customAlbedo;
-  //  return;
-  // }
 
   if (customDepth >= backDepth) {
     float backOutlineIndex = floatBitsSubset(floor((backAlbedo.a * 255.0) + 0.5), 3, 6);


### PR DESCRIPTION
Can be tested with the following snippet in docs:
```
model.ghostAllNodes();
model.unghostNodeByTreeIndex(409228, applyToChildren=true);
const box = new THREE.BoxGeometry(10, 10, 10);
const material = new THREE.MeshBasicMaterial({color: 'white'});
const mesh = new THREE.Mesh(box, material);
mesh.position.set(121.84861758965458, 58.620189040381064, -89.28303211581611);
viewer.addObject3D(mesh);
```
Before this would render the custom object in front of ghosted objects:

![image](https://user-images.githubusercontent.com/6741854/94198124-0edc2480-feb7-11ea-9b46-ee37d68908c0.png)

Now its blended correctly:

![image](https://user-images.githubusercontent.com/6741854/94198234-434fe080-feb7-11ea-85ac-d4b324479f0b.png)
