### PR TITLE
fix(viewer): avoid direct dependency on sdk; loose three.js peer dependency version

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -88,6 +88,7 @@
     "whatwg-fetch": "^3.4.0"
   },
   "dependencies": {
+    "@cognite/sdk-core": "^1.0.0",
     "@cognite/potree-core": "^1.1.3",
     "@cognite/reveal-parser-worker": "1.0.0-beta-1",
     "@cognite/three-combo-controls": "^1.4.2",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -76,7 +76,7 @@
     "raw-loader": "^4.0.1",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.1",
-    "three": "^0.117.1",
+    "three": "0.117.1",
     "ts-jest": "^26.2.0",
     "ts-loader": "8.0.2",
     "typescript": "3.9.7",
@@ -104,7 +104,7 @@
   },
   "peerDependencies": {
     "@cognite/sdk": "^3.0.0",
-    "three": "^0.117.1"
+    "three": "0.117.x"
   },
   "husky": {
     "hooks": {

--- a/viewer/src/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper.ts
+++ b/viewer/src/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper.ts
@@ -1,7 +1,11 @@
 /*!
  * Copyright 2020 Cognite AS
  */
-import { CogniteClient, CogniteInternalId, HttpError } from '@cognite/sdk';
+import { CogniteClient, CogniteInternalId } from '@cognite/sdk';
+
+// To avoid direct dependency on @cognite/sdk we use sdk-core here for HttpError.
+// that's why it's avoided https://github.com/cognitedata/cdf-hub/pull/687/files#r489204315
+import { HttpError } from '@cognite/sdk-core';
 
 type ByTreeIndicesResponse = {
   items: CogniteInternalId[];

--- a/viewer/src/utilities/networking/utilities.ts
+++ b/viewer/src/utilities/networking/utilities.ts
@@ -2,7 +2,11 @@
  * Copyright 2020 Cognite AS
  */
 
-import { Versioned3DFile, HttpError } from '@cognite/sdk';
+import { Versioned3DFile } from '@cognite/sdk';
+
+// To avoid direct dependency on @cognite/sdk we use sdk-core here for HttpError.
+// that's why it's avoided https://github.com/cognitedata/cdf-hub/pull/687/files#r489204315
+import { HttpError } from '@cognite/sdk-core';
 
 export const supportedVersions = [8];
 


### PR DESCRIPTION
1) dependency on cognite/sdk - we shouldn't use HttpError to avoid having @cognite/sdk module as a direct dependency for the reveal. Well, it's arguable, but it's a quick fix for this problem https://github.com/cognitedata/cdf-hub/pull/687/files#r489204315. 

And, by the way, the guys from cognite-sdk-js mark [HttpError with `@hidden` annotation](https://github.com/cognitedata/cognite-sdk-js/blob/master/packages/core/src/httpClient/httpError.ts#L5), perhaps it shouldn't be used outside (but it is used outside of sdk, not only in reveal). 

2) I set 0.117.x as the version range for the three.js to avoid warning when 117.1 is installed instead of 117.0 in projects that use reveal.

But should we move three.js under common dependencies? It’s a dependency. We use it directly and even re-export it. So… I don’t really understand why we should mark it as a peer dependency (except that it was peer dependency in the old 3d viewer). 
