### PR TITLE
chore(viewer): move three.js under dependencies instead of peer

### DIFF
--- a/documentation/docs/migration-guide.md
+++ b/documentation/docs/migration-guide.md
@@ -144,15 +144,3 @@ where `PROJECT`, `MODELID`, `REVISIONID` and `APIKEY` must be set in the environ
 If the model isn't compatible with `@cognite/reveal`, it must be reprocessed. This can be done by [uploading a new revision in Cognite Data Fusion](https://docs.cognite.com/cdf/3d/guides/3dmodels_upload.html). When uploading a new revision, asset mappings must be recreated. If the node hierarchy in the new revision is identical to the previous model node IDs should be identical and the asset mappings can be copied from one revision to the other by using the [get3DMappings](https://docs.cognite.com/api/v1/#operation/get3DMappings) and [create3DMappings](https://docs.cognite.com/api/v1/#operation/create3DMappings) API endpoints.
 
 Another alternative is to use the experimental 'reprocess' endpoint which generates new model outputs for a 3D model and is less intrusive than uploading a new revision. Since this endpoint is experimental it's not publicly exposed in the API yet. Please contact [lars.moastuen@cognite.com](mailto:lars.moastuen@cognite.com) if you want to explore this option.
-
-## Common issues
-
-**`TypeError: e.applyMatrix4 is not a function`**
-
-If you experience  `TypeError: e.applyMatrix4 is not a function` after migrating from 
-`@cognite/3d-viewer` to `@cognite/reveal`, the problem is usually caused by missing or 
-outdated ThreeJS.
-
-To fix this issue, install or update ThreeJS using the 
-[`three`-package](https://www.npmjs.com/package/three). This should match the version 
-used by `@cognite/reveal`.

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -32,7 +32,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "styled-components": "^5.1.1",
-    "three": "^0.115.0"
+    "three": "link:../viewer/node_modules/three"
   },
   "devDependencies": {
     "@types/react": "^16.9.41",

--- a/documentation/versioned_docs/version-1.x/migration-guide.md
+++ b/documentation/versioned_docs/version-1.x/migration-guide.md
@@ -143,3 +143,15 @@ where `PROJECT`, `MODELID`, `REVISIONID` and `APIKEY` must be set in the environ
 If the model isn't compatible with `@cognite/reveal`, it must be reprocessed. This can be done by [uploading a new revision in Cognite Data Fusion](https://docs.cognite.com/cdf/3d/guides/3dmodels_upload.html). When uploading a new revision, asset mappings must be recreated. If the node hierarchy in the new revision is identical to the previous model node IDs should be identical and the asset mappings can be copied from one revision to the other by using the [get3DMappings](https://docs.cognite.com/api/v1/#operation/get3DMappings) and [create3DMappings](https://docs.cognite.com/api/v1/#operation/create3DMappings) API endpoints.
 
 Another alternative is to use the experimental 'reprocess' endpoint which generates new model outputs for a 3D model and is less intrusive than uploading a new revision. Since this endpoint is experimental it's not publicly exposed in the API yet. Please contact [lars.moastuen@cognite.com](mailto:lars.moastuen@cognite.com) if you want to explore this option.
+
+## Common issues
+
+**`TypeError: e.applyMatrix4 is not a function`**
+
+If you experience  `TypeError: e.applyMatrix4 is not a function` after migrating from 
+`@cognite/3d-viewer` to `@cognite/reveal`, the problem is usually caused by missing or 
+outdated ThreeJS.
+
+To fix this issue, install or update ThreeJS using the 
+[`three`-package](https://www.npmjs.com/package/three). This should match the version 
+used by `@cognite/reveal`.

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -12694,10 +12694,9 @@ text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.115.0:
-  version "0.115.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.115.0.tgz#540d800c381b9da2334c024f0fbe4d23f84eb05e"
-  integrity sha512-mAV2Ky3RdcbdSbR9capI+tKLvRldWYxd4151PZTT/o7+U2jh9Is3a4KmnYwzyUAhB2ZA3pXSgCd2DOY4Tj5kow==
+"three@link:../viewer/node_modules/three":
+  version "0.0.0"
+  uid ""
 
 through2@^0.6.3:
   version "0.6.5"

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -76,7 +76,6 @@
     "raw-loader": "^4.0.1",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.1",
-    "three": "0.117.1",
     "ts-jest": "^26.2.0",
     "ts-loader": "8.0.2",
     "typescript": "3.9.7",
@@ -100,11 +99,11 @@
     "glslify-import": "^3.1.0",
     "lodash": "^4.17.15",
     "mixpanel-browser": "^2.38.0",
-    "rxjs": "^6.5.5"
+    "rxjs": "^6.5.5",
+    "three": "0.117.1"
   },
   "peerDependencies": {
-    "@cognite/sdk": "^3.0.0",
-    "three": "0.117.x"
+    "@cognite/sdk": "^3.0.0"
   },
   "husky": {
     "hooks": {

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -8466,7 +8466,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.117.1:
+three@0.117.1:
   version "0.117.1"
   resolved "https://registry.yarnpkg.com/three/-/three-0.117.1.tgz#a49bcb1a6ddea2f250003e42585dc3e78e92b9d3"
   integrity sha512-t4zeJhlNzUIj9+ub0l6nICVimSuRTZJOqvk3Rmlu+YGdTOJ49Wna8p7aumpkXJakJfITiybfpYE1XN1o1Z34UQ==


### PR DESCRIPTION
Tried to test it in console with installed old viewer and old three version. Looks ok, but there are some issues with old three + old 3d-viewer version. Since the old three version doesn't have types ts complains on the code where types for the old three are needed, for example on that code:

```
model.matrix
````

since matrix is inherited from THREE.Object3D ts complains that there is no such property (because it doesn't know where to find it). I think the right thing to do here is to update 3d-viewer with dependency on types for the old threejs (will submit PR).