### PR TITLE
fix: don't call decrecated function THREE.Scene.dispose

### DIFF
--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -227,7 +227,6 @@ export class Cognite3DViewer {
     this._revealManager.dispose();
     this.domElement.removeChild(this.canvas);
     this.renderer.dispose();
-    this.scene.dispose();
     for (const model of this.models.values()) {
       model.dispose();
     }


### PR DESCRIPTION
THREE.Scene.dispose() now only outputs an error to console (not fatal).