### PR TITLE
fix: improve performance of all node styling functions in Cognite3DModel

### DIFF
--- a/viewer/src/__tests__/migration/NodeStyleUpdater.test.ts
+++ b/viewer/src/__tests__/migration/NodeStyleUpdater.test.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright 2020 Cognite AS
+ */
+
+import { NodeStyleUpdater } from '@/public/migration/NodeStyleUpdater';
+import { NumericRange } from '@/utilities';
+
+describe('NodeStyleUpdater', () => {
+  const updateCallback: (treeIndices: number[]) => void = jest.fn();
+  const updater = new NodeStyleUpdater(updateCallback);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.useFakeTimers();
+  });
+
+  test('triggerUpdateRange, schedules update', () => {
+    updater.triggerUpdateRange(new NumericRange(0, 100));
+    jest.runAllTimers();
+    expect(updateCallback).toBeCalledTimes(1);
+  });
+
+  test('triggerUpdateArray, schedules update', () => {
+    updater.triggerUpdateArray([1, 2, 3]);
+    jest.runAllTimers();
+    expect(updateCallback).toBeCalledTimes(1);
+  });
+
+  test('triggerUpdateSingle, schedules update', () => {
+    updater.triggerUpdateSingle(1);
+    jest.runAllTimers();
+    expect(updateCallback).toBeCalledTimes(1);
+  });
+
+  test('many triggers in one batch, triggers update once', () => {
+    updater.triggerUpdateRange(new NumericRange(0, 100));
+    updater.triggerUpdateArray([1000, 1002, 1003]);
+    updater.triggerUpdateSingle(2000);
+    jest.runAllTimers();
+    expect(updateCallback).toBeCalledTimes(1);
+  });
+});

--- a/viewer/src/__tests__/utilities/NumericRange.test.ts
+++ b/viewer/src/__tests__/utilities/NumericRange.test.ts
@@ -39,10 +39,10 @@ describe('NumericRange', () => {
     expect(range.contains(10)).toBeFalse();
   });
 
-  test('forEach applies callback to each value', async () => {
+  test('forEach applies callback to each value', () => {
     const applied: number[] = [];
     const range = new NumericRange(1, 4);
-    await range.forEach(v => {
+    range.forEach(v => {
       applied.push(v);
     });
     expect(applied).toEqual([1, 2, 3, 4]);

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -427,7 +427,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     applyToChildren = false
   ): Promise<number> {
     const color: [number, number, number] = [r, g, b];
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeColors.set(idx, color));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, true);
+      treeIndices.forEach(idx => this.nodeColors.set(idx, color));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeColors.set(treeIndex, color);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -447,7 +456,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async resetNodeColorByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeColors.delete(idx));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.nodeColors.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeColors.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -492,7 +510,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise with a number of selected tree indices.
    */
   async selectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.selectedNodes.add(idx));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.selectedNodes.add(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.selectedNodes.add(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -510,7 +537,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async deselectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.selectedNodes.delete(idx));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.selectedNodes.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.selectedNodes.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -534,7 +570,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     transform: THREE.Matrix4,
     applyToChildren = true
   ): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeTransforms.set(idx, transform));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.nodeTransforms.set(idx, transform));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeTransforms.set(treeIndex, transform);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -544,7 +589,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async resetNodeTransformByTreeIndex(treeIndex: number, applyToChildren = true): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeTransforms.delete(idx));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.nodeTransforms.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeTransforms.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -556,7 +610,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async ghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.ghostedNodes.add(idx));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.ghostedNodes.add(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.ghostedNodes.add(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -567,7 +630,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async unghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.ghostedNodes.delete(idx));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.ghostedNodes.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.ghostedNodes.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -617,7 +689,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Number of nodes affected.
    */
   async showNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.hiddenNodes.delete(idx));
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.hiddenNodes.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.hiddenNodes.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -668,7 +749,10 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     if (makeGray) {
       throw new NotSupportedInMigrationWrapperError('makeGray is not supported');
     }
-    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.hiddenNodes.add(idx));
+    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+    treeIndices.forEach(idx => this.hiddenNodes.add(idx));
+    this.updateNodeStyle(treeIndices);
+    return treeIndices.count;
   }
 
   /**
@@ -742,30 +826,6 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
       this.nodeStyleUpdater.triggerUpdateArray(treeIndices);
     } else {
       this.nodeStyleUpdater.triggerUpdateSingle(treeIndices);
-    }
-  }
-
-  /**
-   * Apply node styling to the tree index given and it's descendants, if applyToChildren
-   * is true.
-   * @param treeIndex
-   * @param applyToChildren
-   * @param applyChangeToTreeIndexCb Callback to apply a given change.
-   */
-  private async applyNodeStyling(
-    treeIndex: number,
-    applyToChildren: boolean,
-    applyChangeToTreeIndexCb: (treeIndex: number) => void
-  ): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(applyChangeToTreeIndexCb);
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      applyChangeToTreeIndexCb(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
     }
   }
 }

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -426,10 +426,15 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     b: number,
     applyToChildren = false
   ): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     const color: [number, number, number] = [r, g, b];
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, true);
-      treeIndices.forEach(idx => this.nodeColors.set(idx, color));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.nodeColors.set(idx, color);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -456,9 +461,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async resetNodeColorByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.nodeColors.delete(idx));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.nodeColors.delete(idx);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -510,9 +520,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise with a number of selected tree indices.
    */
   async selectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.selectedNodes.add(idx));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.selectedNodes.add(idx);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -537,9 +552,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async deselectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.selectedNodes.delete(idx));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.selectedNodes.delete(idx);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -570,9 +590,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     transform: THREE.Matrix4,
     applyToChildren = true
   ): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.nodeTransforms.set(idx, transform));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.nodeTransforms.set(idx, transform);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -589,9 +614,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async resetNodeTransformByTreeIndex(treeIndex: number, applyToChildren = true): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.nodeTransforms.delete(idx));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.nodeTransforms.delete(idx);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -610,9 +640,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async ghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.ghostedNodes.add(idx));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.ghostedNodes.add(idx);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -630,9 +665,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async unghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.ghostedNodes.delete(idx));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.ghostedNodes.delete(idx);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {
@@ -689,9 +729,14 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Number of nodes affected.
    */
   async showNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
+    // Note! There's a lot of code duplication in this function. This is done because
+    // all our efforts into trying to share code here has reduced it's performance.
+    // Since performance is key for this function we've decided to duplicate code.
     if (applyToChildren) {
       const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.hiddenNodes.delete(idx));
+      for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; ++idx) {
+        this.hiddenNodes.delete(idx);
+      }
       this.updateNodeStyle(treeIndices);
       return treeIndices.count;
     } else {

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -17,6 +17,7 @@ import { trackError } from '@/utilities/metrics';
 import { SupportedModelTypes } from '../types';
 import { callActionWithIndicesAsync } from '@/utilities/callActionWithIndicesAsync';
 import { CogniteClientNodeIdAndTreeIndexMapper } from '@/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
+import { NodeStyleUpdater } from './NodeStyleUpdater';
 
 const mapCoordinatesBuffers = {
   inverseModelMatrix: new THREE.Matrix4()
@@ -78,6 +79,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
   private readonly ghostedNodes: Set<number>;
   private readonly client: CogniteClient;
   private readonly nodeIdAndTreeIndexMaps: NodeIdAndTreeIndexMaps;
+  private readonly nodeStyleUpdater: NodeStyleUpdater;
 
   /**
    * @param modelId
@@ -99,6 +101,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     this.ghostedNodes = new Set();
     const indexMapper = new CogniteClientNodeIdAndTreeIndexMapper(client);
     this.nodeIdAndTreeIndexMaps = new NodeIdAndTreeIndexMaps(modelId, revisionId, client, indexMapper);
+    this.nodeStyleUpdater = new NodeStyleUpdater(cadNode.requestNodeUpdate.bind(cadNode));
 
     const nodeAppearanceProvider: NodeAppearanceProvider = {
       styleNode: (treeIndex: number) => {
@@ -340,7 +343,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * ```
    */
   iterateNodesByTreeIndex(action: (treeIndex: number) => void): Promise<void> {
-    return callActionWithIndicesAsync(0, this.cadModel.scene.maxTreeIndex - 1, action);
+    return callActionWithIndicesAsync(0, this.cadModel.scene.maxTreeIndex, action);
   }
 
   /**
@@ -423,11 +426,17 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     b: number,
     applyToChildren = false
   ): Promise<number> {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
     const color: [number, number, number] = [r, g, b];
-    await treeIndices.forEach(idx => this.nodeColors.set(idx, color));
-    this.cadNode.requestNodeUpdate(treeIndices);
-    return treeIndices.count;
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, true);
+      treeIndices.forEach(idx => this.nodeColors.set(idx, color));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeColors.set(treeIndex, color);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -447,10 +456,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async resetNodeColorByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    await treeIndices.forEach(idx => this.nodeColors.delete(idx));
-    this.cadNode.requestNodeUpdate(treeIndices);
-    return treeIndices.count;
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.nodeColors.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeColors.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -465,7 +480,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     for (let i = 0; i <= this.cadModel.scene.maxTreeIndex; i++) {
       this.nodeColors.set(i, color);
     }
-    this.cadNode.requestNodeUpdate([...this.nodeColors.keys()]);
+    this.updateNodeStyle(new NumericRange(0, this.cadModel.scene.maxTreeIndex));
   }
 
   /**
@@ -474,7 +489,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
   resetAllNodeColors() {
     const treeIndices = [...this.nodeColors.keys()];
     this.nodeColors.clear();
-    this.cadNode.requestNodeUpdate(treeIndices);
+    this.updateNodeStyle(treeIndices);
   }
 
   /**
@@ -495,10 +510,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise with a number of selected tree indices.
    */
   async selectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    await treeIndices.forEach(idx => this.selectedNodes.add(idx));
-    this.cadNode.requestNodeUpdate(treeIndices);
-    return treeIndices.count;
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.selectedNodes.add(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.selectedNodes.add(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -516,10 +537,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async deselectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    await treeIndices.forEach(idx => this.selectedNodes.delete(idx));
-    this.cadNode.requestNodeUpdate(treeIndices);
-    return treeIndices.count;
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.selectedNodes.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.selectedNodes.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -528,7 +555,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
   deselectAllNodes(): void {
     const selectedNodes = Array.from(this.selectedNodes);
     this.selectedNodes.clear();
-    this.cadNode.requestNodeUpdate(selectedNodes);
+    this.updateNodeStyle(selectedNodes);
   }
 
   /**
@@ -538,10 +565,21 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param transform
    * @param applyToChildren
    */
-  async setNodeTransformByTreeIndex(treeIndex: number, transform: THREE.Matrix4, applyToChildren = true) {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    treeIndices.forEach(idx => this.nodeTransforms.set(idx, transform));
-    this.cadNode.requestNodeUpdate(treeIndices);
+  async setNodeTransformByTreeIndex(
+    treeIndex: number,
+    transform: THREE.Matrix4,
+    applyToChildren = true
+  ): Promise<number> {
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.nodeTransforms.set(idx, transform));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeTransforms.set(treeIndex, transform);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -550,10 +588,17 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param treeIndex
    * @param applyToChildren
    */
-  async resetNodeTransformByTreeIndex(treeIndex: number, applyToChildren = true) {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    treeIndices.forEach(idx => this.nodeTransforms.delete(idx));
-    this.cadNode.requestNodeUpdate(treeIndices);
+  async resetNodeTransformByTreeIndex(treeIndex: number, applyToChildren = true): Promise<number> {
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.nodeTransforms.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.nodeTransforms.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -565,10 +610,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async ghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    treeIndices.forEach(idx => this.ghostedNodes.add(idx));
-    this.cadNode.requestNodeUpdate(treeIndices.toArray());
-    return treeIndices.count;
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.ghostedNodes.add(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.ghostedNodes.add(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -579,11 +630,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async unghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    treeIndices.forEach(idx => this.ghostedNodes.delete(idx));
-    const allIndices = Array.from(new Array(this.cadModel.scene.maxTreeIndex + 1).keys());
-    this.cadNode.requestNodeUpdate(allIndices);
-    return treeIndices.count;
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.ghostedNodes.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.ghostedNodes.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -595,7 +651,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     for (let i = 0; i <= this.cadModel.scene.maxTreeIndex; i++) {
       this.ghostedNodes.add(i);
     }
-    this.cadNode.requestNodeUpdate(Array.from(this.ghostedNodes.values()));
+    this.updateNodeStyle(new NumericRange(0, this.cadModel.scene.maxTreeIndex));
   }
 
   /**
@@ -605,7 +661,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
   unghostAllNodes(): void {
     const ghostedNodes = Array.from(this.ghostedNodes);
     this.ghostedNodes.clear();
-    this.cadNode.requestNodeUpdate(ghostedNodes);
+    this.updateNodeStyle(ghostedNodes);
   }
 
   /**
@@ -633,10 +689,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Number of nodes affected.
    */
   async showNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    await treeIndices.forEach(idx => this.hiddenNodes.delete(idx));
-    this.cadNode.requestNodeUpdate(treeIndices.toArray());
-    return treeIndices.count;
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(idx => this.hiddenNodes.delete(idx));
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      this.hiddenNodes.delete(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
+    }
   }
 
   /**
@@ -646,7 +708,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
   showAllNodes(): void {
     const wasHidden = Array.from(this.hiddenNodes.values());
     this.hiddenNodes.clear();
-    this.cadNode.requestNodeUpdate(wasHidden);
+    this.updateNodeStyle(wasHidden);
   }
 
   /**
@@ -658,10 +720,9 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     if (makeGray) {
       throw new NotSupportedInMigrationWrapperError('makeGray is not supported');
     }
-    for (let i = 0; i <= this.cadModel.scene.maxTreeIndex; i++) {
-      this.hiddenNodes.add(i);
-    }
-    this.cadNode.requestNodeUpdate(Array.from(this.hiddenNodes.values()));
+    const treeIndices = new NumericRange(0, this.cadModel.scene.maxTreeIndex);
+    treeIndices.forEach(idx => this.hiddenNodes.add(idx));
+    this.updateNodeStyle(treeIndices);
   }
 
   /**
@@ -689,8 +750,8 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
       throw new NotSupportedInMigrationWrapperError('makeGray is not supported');
     }
     const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    await treeIndices.forEach(idx => this.hiddenNodes.add(idx));
-    this.cadNode.requestNodeUpdate(treeIndices);
+    treeIndices.forEach(idx => this.hiddenNodes.add(idx));
+    this.updateNodeStyle(treeIndices);
     return treeIndices.count;
   }
 
@@ -755,5 +816,16 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
       subtreeSize = subtreeSizePromise ? subtreeSizePromise : 1;
     }
     return new NumericRange(treeIndex, subtreeSize);
+  }
+
+  /** @private */
+  private updateNodeStyle(treeIndices: number[] | NumericRange | number) {
+    if (treeIndices instanceof NumericRange) {
+      this.nodeStyleUpdater.triggerUpdateRange(treeIndices);
+    } else if (treeIndices instanceof Array) {
+      this.nodeStyleUpdater.triggerUpdateArray(treeIndices);
+    } else {
+      this.nodeStyleUpdater.triggerUpdateSingle(treeIndices);
+    }
   }
 }

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -427,16 +427,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     applyToChildren = false
   ): Promise<number> {
     const color: [number, number, number] = [r, g, b];
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, true);
-      treeIndices.forEach(idx => this.nodeColors.set(idx, color));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.nodeColors.set(treeIndex, color);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeColors.set(idx, color));
   }
 
   /**
@@ -456,16 +447,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async resetNodeColorByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.nodeColors.delete(idx));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.nodeColors.delete(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeColors.delete(idx));
   }
 
   /**
@@ -510,16 +492,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise with a number of selected tree indices.
    */
   async selectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.selectedNodes.add(idx));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.selectedNodes.add(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.selectedNodes.add(idx));
   }
 
   /**
@@ -537,16 +510,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async deselectNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.selectedNodes.delete(idx));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.selectedNodes.delete(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.selectedNodes.delete(idx));
   }
 
   /**
@@ -570,16 +534,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     transform: THREE.Matrix4,
     applyToChildren = true
   ): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.nodeTransforms.set(idx, transform));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.nodeTransforms.set(treeIndex, transform);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeTransforms.set(idx, transform));
   }
 
   /**
@@ -589,16 +544,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @param applyToChildren
    */
   async resetNodeTransformByTreeIndex(treeIndex: number, applyToChildren = true): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.nodeTransforms.delete(idx));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.nodeTransforms.delete(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.nodeTransforms.delete(idx));
   }
 
   /**
@@ -610,16 +556,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async ghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.ghostedNodes.add(idx));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.ghostedNodes.add(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.ghostedNodes.add(idx));
   }
 
   /**
@@ -630,16 +567,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Promise that resolves to the number of affected nodes.
    */
   async unghostNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.ghostedNodes.delete(idx));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.ghostedNodes.delete(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.ghostedNodes.delete(idx));
   }
 
   /**
@@ -689,16 +617,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * @returns Number of nodes affected.
    */
   async showNodeByTreeIndex(treeIndex: number, applyToChildren = false): Promise<number> {
-    if (applyToChildren) {
-      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-      treeIndices.forEach(idx => this.hiddenNodes.delete(idx));
-      this.updateNodeStyle(treeIndices);
-      return treeIndices.count;
-    } else {
-      this.hiddenNodes.delete(treeIndex);
-      this.updateNodeStyle(treeIndex);
-      return 1;
-    }
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.hiddenNodes.delete(idx));
   }
 
   /**
@@ -749,10 +668,7 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     if (makeGray) {
       throw new NotSupportedInMigrationWrapperError('makeGray is not supported');
     }
-    const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
-    treeIndices.forEach(idx => this.hiddenNodes.add(idx));
-    this.updateNodeStyle(treeIndices);
-    return treeIndices.count;
+    return this.applyNodeStyling(treeIndex, applyToChildren, idx => this.hiddenNodes.add(idx));
   }
 
   /**
@@ -826,6 +742,30 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
       this.nodeStyleUpdater.triggerUpdateArray(treeIndices);
     } else {
       this.nodeStyleUpdater.triggerUpdateSingle(treeIndices);
+    }
+  }
+
+  /**
+   * Apply node styling to the tree index given and it's descendants, if applyToChildren
+   * is true.
+   * @param treeIndex
+   * @param applyToChildren
+   * @param applyChangeToTreeIndexCb Callback to apply a given change.
+   */
+  private async applyNodeStyling(
+    treeIndex: number,
+    applyToChildren: boolean,
+    applyChangeToTreeIndexCb: (treeIndex: number) => void
+  ): Promise<number> {
+    if (applyToChildren) {
+      const treeIndices = await this.determineTreeIndices(treeIndex, applyToChildren);
+      treeIndices.forEach(applyChangeToTreeIndexCb);
+      this.updateNodeStyle(treeIndices);
+      return treeIndices.count;
+    } else {
+      applyChangeToTreeIndexCb(treeIndex);
+      this.updateNodeStyle(treeIndex);
+      return 1;
     }
   }
 }

--- a/viewer/src/public/migration/NodeStyleUpdater.ts
+++ b/viewer/src/public/migration/NodeStyleUpdater.ts
@@ -8,12 +8,12 @@ import { NumericRange } from '@/utilities';
  * node apperance being updated unnecessary much.
  */
 export class NodeStyleUpdater {
-  private readonly updateNodesApperanceCb: (treeIndices: number[]) => void;
+  private readonly updateNodesApperanceCallback: (treeIndices: number[]) => void;
   private readonly toBeUpdatedTreeIndices: Set<number> = new Set();
   private updateHandle: ReturnType<typeof setTimeout> | undefined;
 
-  constructor(updateNodesApperanceCb: (treeIndices: number[]) => void) {
-    this.updateNodesApperanceCb = updateNodesApperanceCb;
+  constructor(updateNodesApperanceCallback: (treeIndices: number[]) => void) {
+    this.updateNodesApperanceCallback = updateNodesApperanceCallback;
   }
 
   /**
@@ -63,7 +63,7 @@ export class NodeStyleUpdater {
         const treeIndices = Array.from(this.toBeUpdatedTreeIndices);
         treeIndices.sort((a, b) => a - b);
         this.toBeUpdatedTreeIndices.clear();
-        this.updateNodesApperanceCb(treeIndices);
+        this.updateNodesApperanceCallback(treeIndices);
         this.updateHandle = undefined;
       }, 0);
     }

--- a/viewer/src/public/migration/NodeStyleUpdater.ts
+++ b/viewer/src/public/migration/NodeStyleUpdater.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2020 Cognite AS
+ */
+import { NumericRange } from '@/utilities';
+
+/**
+ * Helper class that schedules node apperance update to avoid
+ * node apperance being updated unnecessary much.
+ */
+export class NodeStyleUpdater {
+  private readonly updateNodesApperanceCb: (treeIndices: number[]) => void;
+  private readonly toBeUpdatedTreeIndices: Set<number> = new Set();
+  private updateHandle: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(updateNodesApperanceCb: (treeIndices: number[]) => void) {
+    this.updateNodesApperanceCb = updateNodesApperanceCb;
+  }
+
+  /**
+   * Notify the updater that the apperance for given tree index range needs to be updated.
+   * @param treeIndices
+   */
+  triggerUpdateRange(treeIndices: NumericRange): void {
+    const sizeBefore = this.toBeUpdatedTreeIndices.size;
+    for (let idx = treeIndices.from; idx <= treeIndices.toInclusive; idx++) {
+      this.toBeUpdatedTreeIndices.add(idx);
+    }
+    if (this.toBeUpdatedTreeIndices.size > sizeBefore) {
+      this.scheduleUpdate();
+    }
+  }
+
+  /**
+   * Notify the updater that the apperance for the given tree indices given needs to be updated.
+   * @param treeIndices
+   */
+  triggerUpdateArray(treeIndices: number[]): void {
+    const sizeBefore = this.toBeUpdatedTreeIndices.size;
+    for (let i = 0; i < treeIndices.length; i++) {
+      this.toBeUpdatedTreeIndices.add(treeIndices[i]);
+    }
+    if (this.toBeUpdatedTreeIndices.size > sizeBefore) {
+      this.scheduleUpdate();
+    }
+  }
+
+  /**
+   * Notify the updater that the apperance for the given tree index given needs to be updated.
+   * @param treeIndex
+   */
+  triggerUpdateSingle(treeIndex: number): void {
+    const sizeBefore = this.toBeUpdatedTreeIndices.size;
+    this.toBeUpdatedTreeIndices.add(treeIndex);
+    if (this.toBeUpdatedTreeIndices.size > sizeBefore) {
+      this.scheduleUpdate();
+    }
+  }
+
+  /** @private */
+  private scheduleUpdate() {
+    if (this.updateHandle === undefined) {
+      this.updateHandle = setTimeout(() => {
+        const treeIndices = Array.from(this.toBeUpdatedTreeIndices);
+        treeIndices.sort((a, b) => a - b);
+        this.toBeUpdatedTreeIndices.clear();
+        this.updateNodesApperanceCb(treeIndices);
+        this.updateHandle = undefined;
+      }, 0);
+    }
+  }
+}

--- a/viewer/src/utilities/NumericRange.ts
+++ b/viewer/src/utilities/NumericRange.ts
@@ -2,8 +2,6 @@
  * Copyright 2020 Cognite AS
  */
 
-import { callActionWithIndicesAsync } from '@/utilities/callActionWithIndicesAsync';
-
 export class NumericRange {
   readonly from: number;
   readonly count: number;

--- a/viewer/src/utilities/NumericRange.ts
+++ b/viewer/src/utilities/NumericRange.ts
@@ -33,7 +33,9 @@ export class NumericRange {
     return value >= this.from && value <= this.toInclusive;
   }
 
-  async forEach(action: (value: number) => any): Promise<void> {
-    return callActionWithIndicesAsync(this.from, this.toInclusive, action);
+  forEach(action: (value: number) => void): void {
+    for (let i = this.from; i <= this.toInclusive; ++i) {
+      action(i);
+    }
   }
 }


### PR DESCRIPTION
This improves performance when the user repeatedly calls `Cognite3dModel.setNodeColorByTreeIndex` and other node style modification functions by batching calls to `requestNodeUpdate`.

A good test case is the following (which can be used in the documentation):
```
const start = performance.now();
const promises = [];
for (let i = 0; i < 1000000; i++) {
  promises.push(model.setNodeColorByTreeIndex(i, 255, 255, 255));
}
Promise.all(promises).then(() => {
  window.alert('Took ' + (performance.now() - start) + ' ms');
});
```

In my test the time is reduced from 4.5 s to about 1 s.