### PR TITLE
feat: report application ID to MixPanel and improve events

### DIFF
--- a/documentation/docs/migration-guide.md
+++ b/documentation/docs/migration-guide.md
@@ -85,9 +85,9 @@ The API for accessing node information has not changed `@cognite/3d-viewer`, but
 
 ## Ray picking and intersection for handling click events
 
-In `@cognite/3d-viewer` `Cognite3dViewer.getIntersectionFromPixel` optionally accepts a `model`-argument to restrict the result to a single model. Support for this has been removed
-in `@cognite/reveal`. Previously `getIntersectionFromPixel` would return a struct with both `nodeId` and `treeIndex`. Now this has been changed to only include `treeIndex` (to
-determine `nodeId` use `async Cognite3DModel.mapNodeId(nodeId)`).
+In `@cognite/3d-viewer` `Cognite3dViewer.getIntersectionFromPixel` optionally accepts a `model`-argument to restrict the result to a single model. Support for this has been removed 
+in `@cognite/reveal`. Previously `getIntersectionFromPixel` would return a struct with both `nodeId` and `treeIndex`. Now this has been changed to only include `treeIndex` (to 
+determine `nodeId` use `async Cognite3DModel.mapTreeIndexToNodeId(treeIndex)`).
 
 ## Other differences
 
@@ -96,7 +96,13 @@ There are a few other noticeable changes from `@cognite/3d-viewer` and `@cognite
 - `@cognite/3d-viewer` supports local caching to reduce the time to load previously opened 3D models. Currently, this is not supported by `@cognite/reveal`, but the need for such functionality is reduced by adding streaming capabilities.
 - In `@cognite/3d-viewer` `Cognite3DViewer.addModel(...)` will always return a `Cognite3DModel`. In `@cognite/reveal` this function might also return a `CognitePointCloudModel`. To explicitly add a CAD model or point cloud model use `Cognite3DViewer.addCadModel(...)` or `Cognite3DViewer.addPointCloudModel(...)`
 - `Cognite3DViewer.loadCameraFromModel(...)`] has been added for loading camera settings from CDF when available.
-- The `onComplete`-callback when loading models using `Cognite3DViewer.addModel`, `Cognite3DViewer.addCadModel` or `Cognite3DViewer.addPointCloudModel` is not supported since models are streamed on demand, and will never complete. To monitor loading activity, use the `onLoading`-callback provided as an option when constructing `Cognite3DViewer`.
+- Due to the way `@cognite/reveal` streams data, the `OnProgressData` is no longer exported, and the `addModel` function 
+  no longer accepts an `onProgress` parameter. Because of this the `onComplete` option in `Cognite3DViewer.addModel` has 
+  been deprecated. To monitor loading activity, use the `onLoading`-callback provided as an option when constructing `Cognite3DViewer`.
+- `Cognite3DViewer.getCamera()` can now be used to access the `THREE.Camera` of the viewer. Note that this camera shouldn't be
+  modified.
+- `Cognite3DViewer.addModel` no longer supports options `localPath`, `orthographicCamera` and `onComplete`. Point clouds currently
+  don't support `geometryFilter`.
 - Textures are not supported by `@cognite/reveal`. Models can be loaded, but textures are not applied to the geometry.
 
 ## Preparing models

--- a/examples/src/pages/DistanceMeasurement.tsx
+++ b/examples/src/pages/DistanceMeasurement.tsx
@@ -80,10 +80,10 @@ export function DistanceMeasurement() {
 
       let model: CadNode;
       if(modelRevision) {
-        revealManager = createCdfRevealManager(client);
+        revealManager = createCdfRevealManager(client, { logMetrics: false });
         model = await revealManager.addModel('cad', modelRevision);
       } else if (modelUrl) {
-        revealManager = createLocalRevealManager();
+        revealManager = createLocalRevealManager({ logMetrics: false });
         model = await revealManager.addModel('cad', modelUrl);
       } else {
         throw new Error(

--- a/examples/src/pages/Filtering.tsx
+++ b/examples/src/pages/Filtering.tsx
@@ -46,7 +46,8 @@ export function Filtering() {
         }
       };
       const revealOptions: RevealOptions = {
-        nodeAppearanceProvider
+        nodeAppearanceProvider,
+        logMetrics: false
       }
 
       let model: reveal.CadNode;

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -84,7 +84,8 @@ export function Migration() {
       viewer = new Cognite3DViewer({
         sdk: client,
         domElement: canvasWrapperRef.current!,
-        onLoading: progress
+        onLoading: progress,
+        logMetrics: false
       });
       (window as any).viewer = viewer;
 

--- a/examples/src/pages/Picking.tsx
+++ b/examples/src/pages/Picking.tsx
@@ -49,7 +49,7 @@ export function Picking() {
         }
       };
 
-      const revealOptions: RevealOptions = { nodeAppearanceProvider };
+      const revealOptions: RevealOptions = { nodeAppearanceProvider, logMetrics: false };
       let model: reveal.CadNode;
       if (modelRevision) {
         revealManager = reveal.createCdfRevealManager(client, revealOptions);

--- a/examples/src/pages/SSAO.tsx
+++ b/examples/src/pages/SSAO.tsx
@@ -33,10 +33,10 @@ export function SSAO() {
 
       let model: reveal.CadNode;
       if (modelRevision) {
-        revealManager = reveal.createCdfRevealManager(client);
+        revealManager = reveal.createCdfRevealManager(client, { logMetrics: false });
         model = await revealManager.addModel('cad', modelRevision);
       } else if (modelUrl) {
-        revealManager = reveal.createLocalRevealManager();
+        revealManager = reveal.createLocalRevealManager({ logMetrics: false });
         model = await revealManager.addModel('cad', modelUrl);
       } else {
         throw new Error(

--- a/examples/src/pages/SectorWithPointcloud.tsx
+++ b/examples/src/pages/SectorWithPointcloud.tsx
@@ -152,10 +152,10 @@ export function SectorWithPointcloud() {
 
       let model: reveal.CadNode;
       if (modelRevision) {
-        revealManager = reveal.createCdfRevealManager(client);
+        revealManager = reveal.createCdfRevealManager(client, { logMetrics: false });
         model = await revealManager.addModel('cad', modelRevision);
       } else if (modelUrl) {
-        revealManager = reveal.createLocalRevealManager();
+        revealManager = reveal.createLocalRevealManager({ logMetrics: false });
         model = await revealManager.addModel('cad', modelUrl);
       } else {
         throw new Error(

--- a/examples/src/pages/SideBySide.tsx
+++ b/examples/src/pages/SideBySide.tsx
@@ -81,7 +81,8 @@ export function SideBySide() {
 
       const sectorCuller1 = new OverrideSectorCuller();
       const revealOptions1: RevealOptions = {
-        internal: { sectorCuller: sectorCuller1 }
+        internal: { sectorCuller: sectorCuller1 },
+        logMetrics: false
       }
       let model1: CadNode;
       if(modelRevision) {
@@ -98,7 +99,8 @@ export function SideBySide() {
 
       const sectorCuller2 = new OverrideSectorCuller();
       const revealOptions2: RevealOptions = {
-        internal: { sectorCuller: sectorCuller2 }
+        internal: { sectorCuller: sectorCuller2 },
+        logMetrics: false
       };
       let model2: CadNode;
       if(modelRevision2) {

--- a/examples/src/pages/Simple.tsx
+++ b/examples/src/pages/Simple.tsx
@@ -35,10 +35,10 @@ export function Simple() {
       const scene = new THREE.Scene();
       let model: reveal.CadNode;
       if (modelRevision) {
-        revealManager = reveal.createCdfRevealManager(client);
+        revealManager = reveal.createCdfRevealManager(client, { logMetrics: false });
         model = await revealManager.addModel('cad', modelRevision);
       } else if (modelUrl) {
-        revealManager = reveal.createLocalRevealManager();
+        revealManager = reveal.createLocalRevealManager({ logMetrics: false });
         model = await revealManager.addModel('cad', modelUrl);
       } else {
         throw new Error(

--- a/examples/src/pages/SimplePointcloud.tsx
+++ b/examples/src/pages/SimplePointcloud.tsx
@@ -91,10 +91,10 @@ export function SimplePointcloud() {
       let pointCloudNode: reveal.internal.PointCloudNode;
       if(modelRevision) {
         await client.authenticate();
-        revealManager = reveal.createCdfRevealManager(client);
+        revealManager = reveal.createCdfRevealManager(client, { logMetrics: false });
         pointCloudNode = await revealManager.addModel('pointcloud', modelRevision);
       } else if(modelUrl) {
-        revealManager = reveal.createLocalRevealManager();
+        revealManager = reveal.createLocalRevealManager({ logMetrics: false });
         pointCloudNode = await revealManager.addModel('pointcloud', modelUrl);
       } else {
         throw new Error(

--- a/examples/src/pages/Testable.tsx
+++ b/examples/src/pages/Testable.tsx
@@ -59,10 +59,10 @@ export function Testable() {
 
       let model: reveal.CadNode;
       if (modelRevision) {
-        revealManager = reveal.createCdfRevealManager(client);
+        revealManager = reveal.createCdfRevealManager(client, { logMetrics: false });
         model = await revealManager.addModel('cad', modelRevision, nodeAppearanceProvider);
       } else if (modelUrl) {
-        revealManager = reveal.createLocalRevealManager();
+        revealManager = reveal.createLocalRevealManager({ logMetrics: false });
         model = await revealManager.addModel('cad', modelUrl, nodeAppearanceProvider);
       } else {
         throw new Error(

--- a/examples/src/pages/TwoModels.tsx
+++ b/examples/src/pages/TwoModels.tsx
@@ -49,10 +49,10 @@ export function TwoModels() {
 
       let model: reveal.CadNode;
       if(modelRevision) {
-        revealManager = reveal.createCdfRevealManager(client);
+        revealManager = reveal.createCdfRevealManager(client, { logMetrics: false });
         model = await revealManager.addModel('cad', modelRevision);
       } else if(modelUrl) {
-        revealManager = reveal.createLocalRevealManager();
+        revealManager = reveal.createLocalRevealManager({ logMetrics: false });
         model = await revealManager.addModel('cad', modelUrl);
       } else {
         throw new Error(

--- a/examples/src/pages/WalkablePath.tsx
+++ b/examples/src/pages/WalkablePath.tsx
@@ -80,10 +80,10 @@ export function WalkablePath() {
 
       let model: reveal.CadNode;
       if (modelRevision) {
-        revealManager = reveal.createCdfRevealManager(client);
+        revealManager = reveal.createCdfRevealManager(client, { logMetrics: false });
         model = await revealManager.addModel('cad', modelRevision);
       } else if (modelUrl) {
-        revealManager = reveal.createLocalRevealManager();
+        revealManager = reveal.createLocalRevealManager({ logMetrics: false });
         model = await revealManager.addModel('cad', modelUrl);
       } else {
         throw new Error(

--- a/viewer/src/__tests__/viewer/public/RevealManager.test.ts
+++ b/viewer/src/__tests__/viewer/public/RevealManager.test.ts
@@ -10,12 +10,16 @@ import { createRevealManager } from '@/public/createRevealManager';
 import { RevealManager } from '@/public/RevealManager';
 
 describe('RevealManager', () => {
-  const mockClient: ModelDataClient<{ id: number }> = jest.fn() as any;
+  const mockClient: ModelDataClient<{ id: number }> = {
+    getApplicationIdentifier: () => {
+      return 'dummy';
+    }
+  } as any;
   const sectorCuller: SectorCuller = {
     determineSectors: jest.fn(),
     dispose: jest.fn()
   };
-  let manager: RevealManager<{id: number}>;
+  let manager: RevealManager<{ id: number }>;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/viewer/src/index.ts
+++ b/viewer/src/index.ts
@@ -5,15 +5,16 @@
 export { CogniteModelBase } from './public/migration/CogniteModelBase';
 export { Cognite3DModel } from './public/migration/Cognite3DModel';
 export { CognitePointCloudModel } from './public/migration/CognitePointCloudModel';
+export { Cognite3DViewer } from './public/migration/Cognite3DViewer';
+export { Intersection } from './public/migration/types';
 export * from './public/migration/Cognite3DViewer';
 export * from './public/migration/types';
+export { SupportedModelTypes } from '@/datamodels/base/SupportedModelTypes';
 export { CadLoadingHints } from './datamodels/cad/CadLoadingHints';
 export { BoundingBoxClipper } from './utilities';
-
+export * from './revealEnv';
 export * from './datamodels/pointcloud/types';
 
 // Export ThreeJS to enable easy import for our users
 import * as THREE from 'three';
 export { THREE };
-export { SupportedModelTypes } from '@/datamodels/base/SupportedModelTypes';
-export * from './revealEnv';

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -173,6 +173,7 @@ export class RevealManager<TModelIdentifier> {
       {
         moduleName: 'RevealManager',
         methodName: 'addModel',
+        type,
         options: { nodeAppearanceProvider }
       },
       modelIdentifier

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -13,7 +13,7 @@ import {
 } from './types';
 import { Subscription, combineLatest, asyncScheduler } from 'rxjs';
 import { map, share, filter, observeOn, subscribeOn } from 'rxjs/operators';
-import { trackError, trackLoadModel } from '@/utilities/metrics';
+import { trackError, trackEvent, trackLoadModel, trackNavigation } from '@/utilities/metrics';
 import { NodeAppearanceProvider, CadNode } from '@/datamodels/cad';
 import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
 import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderManager';
@@ -87,6 +87,7 @@ export class RevealManager<TModelIdentifier> {
       this._lastCamera.zoom = camera.zoom;
 
       this._cadManager.updateCamera(camera);
+      trackNavigation({ moduleName: 'RevealManager', methodName: 'update' });
     }
   }
 

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -155,11 +155,13 @@ export class RevealManager<TModelIdentifier> {
   ): void {
     switch (event) {
       case 'loadingStateChanged':
-        this.eventListeners.loadingStateChanged.filter(x => x !== listener);
+        this.eventListeners.loadingStateChanged = this.eventListeners.loadingStateChanged.filter(x => x !== listener);
         break;
 
       case 'nodeIdToTreeIndexMapLoaded':
-        this.eventListeners.sectorNodeIdToTreeIndexMapLoaded.filter(x => x !== listener);
+        this.eventListeners.sectorNodeIdToTreeIndexMapLoaded = this.eventListeners.sectorNodeIdToTreeIndexMapLoaded.filter(
+          x => x !== listener
+        );
         break;
 
       default:

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -13,7 +13,7 @@ import {
 } from './types';
 import { Subscription, combineLatest, asyncScheduler, Subject } from 'rxjs';
 import { map, share, filter, observeOn, subscribeOn, tap, auditTime } from 'rxjs/operators';
-import { trackError, trackLoadModel, trackNavigation } from '@/utilities/metrics';
+import { trackError, trackLoadModel, trackCameraNavigation } from '@/utilities/metrics';
 import { NodeAppearanceProvider, CadNode } from '@/datamodels/cad';
 import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
 import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderManager';
@@ -58,7 +58,7 @@ export class RevealManager<TModelIdentifier> {
       .pipe(
         auditTime(5000),
         tap(() => {
-          trackNavigation({ moduleName: 'RevealManager', methodName: 'update' });
+          trackCameraNavigation({ moduleName: 'RevealManager', methodName: 'update' });
         })
       )
       .subscribe();

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -12,7 +12,7 @@ import {
   LoadingStateChangeListener
 } from './types';
 import { Subscription, combineLatest, asyncScheduler, Subject } from 'rxjs';
-import { map, share, filter, observeOn, subscribeOn, throttleTime, tap, auditTime } from 'rxjs/operators';
+import { map, share, filter, observeOn, subscribeOn, tap, auditTime } from 'rxjs/operators';
 import { trackError, trackLoadModel, trackNavigation } from '@/utilities/metrics';
 import { NodeAppearanceProvider, CadNode } from '@/datamodels/cad';
 import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
@@ -20,7 +20,6 @@ import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderMana
 import { SupportedModelTypes } from '@/datamodels/base';
 import { LoadingState } from '@/utilities';
 import { PointCloudNode } from '@/datamodels/pointcloud/PointCloudNode';
-import { throttle } from 'lodash';
 
 /* eslint-disable jsdoc/require-jsdoc */
 

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -13,7 +13,7 @@ import {
 } from './types';
 import { Subscription, combineLatest, asyncScheduler } from 'rxjs';
 import { map, share, filter, observeOn, subscribeOn } from 'rxjs/operators';
-import { trackError, trackEvent, trackLoadModel, trackNavigation } from '@/utilities/metrics';
+import { trackError, trackLoadModel, trackNavigation } from '@/utilities/metrics';
 import { NodeAppearanceProvider, CadNode } from '@/datamodels/cad';
 import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
 import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderManager';

--- a/viewer/src/public/createRevealManager.ts
+++ b/viewer/src/public/createRevealManager.ts
@@ -11,7 +11,6 @@ import { RevealManager } from './RevealManager';
 import { LocalModelDataClient } from '@/utilities/networking/LocalModelDataClient';
 import { RevealOptions } from './types';
 import { initMetrics } from '@/utilities/metrics';
-import { omit } from 'lodash';
 
 /**
  * Used to create an instance of reveal manager that works with localhost.
@@ -52,7 +51,7 @@ export function createRevealManager<T>(
   initMetrics(revealOptions.logMetrics !== false, project, applicationId, {
     moduleName: 'createRevealManager',
     methodName: 'createRevealManager',
-    constructorOptions: omit(revealOptions, ['internal'])
+    constructorOptions: revealOptions
   });
   const cadManager = createCadManager(client, revealOptions);
   const pointCloudManager = createPointCloudManager(client);

--- a/viewer/src/public/createRevealManager.ts
+++ b/viewer/src/public/createRevealManager.ts
@@ -48,7 +48,8 @@ export function createRevealManager<T>(
   client: ModelDataClient<T>,
   revealOptions: RevealOptions = {}
 ): RevealManager<T> {
-  initMetrics(revealOptions.logMetrics !== false, project, {
+  const applicationId = client.getApplicationIdentifier();
+  initMetrics(revealOptions.logMetrics !== false, project, applicationId, {
     moduleName: 'createRevealManager',
     methodName: 'createRevealManager',
     constructorOptions: omit(revealOptions, ['internal'])

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -38,6 +38,7 @@ import { createCdfRevealManager } from '../createRevealManager';
 import { CdfModelIdentifier } from '@/utilities/networking/types';
 import { RevealOptions, SectorNodeIdToTreeIndexMapLoadedEvent } from '../types';
 import { SupportedModelTypes } from '@/datamodels/base';
+import { getSdkApplicationId } from '@/utilities/networking/utilities';
 
 /**
  * @example
@@ -127,7 +128,8 @@ export class Cognite3DViewer {
       throw new NotSupportedInMigrationWrapperError('ViewCube is not supported');
     }
 
-    initMetrics(options.logMetrics !== false, options.sdk.project, {
+    const applicationId = getSdkApplicationId(options.sdk);
+    initMetrics(options.logMetrics !== false, options.sdk.project, applicationId, {
       moduleName: 'Cognite3DViewer',
       methodName: 'constructor',
       constructorOptions: omit(options, ['sdk', 'domElement', 'renderer', '_sectorCuller'])

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -15,7 +15,14 @@ import { merge, Subject, Subscription, fromEventPattern, Observable } from 'rxjs
 import { from3DPositionToRelativeViewportCoordinates } from '@/utilities/worldToViewport';
 import { intersectCadNodes } from '@/datamodels/cad/picking';
 
-import { AddModelOptions, Cognite3DViewerOptions, GeometryFilter, Intersection } from './types';
+import {
+  AddModelOptions,
+  Cognite3DViewerOptions,
+  GeometryFilter,
+  Intersection,
+  CameraChangeDelegate,
+  PointerEventDelegate
+} from './types';
 import { NotSupportedInMigrationWrapperError } from './NotSupportedInMigrationWrapperError';
 import RenderController from './RenderController';
 import { CogniteModelBase } from './CogniteModelBase';
@@ -31,9 +38,6 @@ import { createCdfRevealManager } from '../createRevealManager';
 import { CdfModelIdentifier } from '@/utilities/networking/types';
 import { RevealOptions, SectorNodeIdToTreeIndexMapLoadedEvent } from '../types';
 import { SupportedModelTypes } from '@/datamodels/base';
-
-export type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
-export type CameraChangeDelegate = (position: THREE.Vector3, target: THREE.Vector3) => void;
 
 /**
  * @example
@@ -367,10 +371,13 @@ export class Cognite3DViewer {
     );
 
     if (options.localPath) {
-      throw new NotSupportedInMigrationWrapperError();
+      throw new NotSupportedInMigrationWrapperError('localPath is not supported');
+    }
+    if (options.orthographicCamera) {
+      throw new NotSupportedInMigrationWrapperError('ortographicsCamera is not supported');
     }
     if (options.onComplete) {
-      throw new NotSupportedInMigrationWrapperError();
+      throw new NotSupportedInMigrationWrapperError('onComplete is not supported');
     }
     if (options.geometryFilter) {
       this._geometryFilters.push(options.geometryFilter);
@@ -429,16 +436,16 @@ export class Cognite3DViewer {
     );
 
     if (options.localPath) {
-      throw new NotSupportedInMigrationWrapperError();
+      throw new NotSupportedInMigrationWrapperError('localPath is not supported');
     }
     if (options.geometryFilter) {
-      throw new NotSupportedInMigrationWrapperError();
+      throw new NotSupportedInMigrationWrapperError('geometryFilter is not supported for point clouds');
     }
     if (options.orthographicCamera) {
-      throw new NotSupportedInMigrationWrapperError();
+      throw new NotSupportedInMigrationWrapperError('ortographicsCamera is not supported');
     }
     if (options.onComplete) {
-      throw new NotSupportedInMigrationWrapperError();
+      throw new NotSupportedInMigrationWrapperError('onComplete is not supported');
     }
 
     const { modelId, revisionId } = options;

--- a/viewer/src/public/migration/types.ts
+++ b/viewer/src/public/migration/types.ts
@@ -94,3 +94,17 @@ export interface Intersection {
  * @module @cognite/reveal
  */
 export { CameraConfiguration } from '@/utilities';
+
+/**
+ * Delegate for pointer events.
+ * @module @cognite/reveal
+ * @see {@link Cognite3DViewer.on}
+ */
+export type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
+
+/**
+ * Delegate for camera update events.
+ * @module @cognite/reveal
+ * @see {@link Cognite3DViewer.on}
+ */
+export type CameraChangeDelegate = (position: THREE.Vector3, target: THREE.Vector3) => void;

--- a/viewer/src/public/migration/types.ts
+++ b/viewer/src/public/migration/types.ts
@@ -26,6 +26,7 @@ export type OnLoadingCallback = (itemsDownloaded: number, itemsRequested: number
  * @module @cognite/reveal
  */
 export interface Cognite3DViewerOptions {
+  /** Initialized connection to CDF used to load data. */
   sdk: CogniteClient;
 
   /** An existing DOM element that we will render canvas into. */
@@ -98,13 +99,13 @@ export { CameraConfiguration } from '@/utilities';
 /**
  * Delegate for pointer events.
  * @module @cognite/reveal
- * @see {@link Cognite3DViewer.on}
+ * @see {@link Cognite3DViewer.on}.
  */
 export type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
 
 /**
  * Delegate for camera update events.
  * @module @cognite/reveal
- * @see {@link Cognite3DViewer.on}
+ * @see {@link Cognite3DViewer.on}.
  */
 export type CameraChangeDelegate = (position: THREE.Vector3, target: THREE.Vector3) => void;

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -4,7 +4,7 @@
 
 import mixpanel from 'mixpanel-browser';
 
-type TrackedEvents = 'init' | 'loadModel' | 'error';
+type TrackedEvents = 'init' | 'construct3dViewer' | 'loadModel' | 'error';
 type EventProps = {
   [key: string]: any;
   // names mentioned instead of just `string` type for typo protection,

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -4,7 +4,7 @@
 
 import mixpanel from 'mixpanel-browser';
 
-type TrackedEvents = 'init' | 'construct3dViewer' | 'loadModel' | 'error';
+type TrackedEvents = 'init' | 'construct3dViewer' | 'loadModel' | 'error' | 'navigated';
 type EventProps = {
   [key: string]: any;
   // names mentioned instead of just `string` type for typo protection,
@@ -67,4 +67,8 @@ export function trackError(error: Error, eventProps: EventProps) {
     stack: error.stack,
     ...eventProps
   });
+}
+
+export function trackNavigation(eventProps: EventProps) {
+  trackEvent('navigated', eventProps);
 }

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -4,7 +4,7 @@
 
 import mixpanel from 'mixpanel-browser';
 
-type TrackedEvents = 'init' | 'construct3dViewer' | 'loadModel' | 'error' | 'navigated';
+type TrackedEvents = 'init' | 'construct3dViewer' | 'loadModel' | 'error' | 'cameraNavigated';
 type EventProps = {
   [key: string]: any;
   // names mentioned instead of just `string` type for typo protection,
@@ -69,6 +69,6 @@ export function trackError(error: Error, eventProps: EventProps) {
   });
 }
 
-export function trackNavigation(eventProps: EventProps) {
-  trackEvent('navigated', eventProps);
+export function trackCameraNavigation(eventProps: EventProps) {
+  trackEvent('cameraNavigated', eventProps);
 }

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -25,10 +25,11 @@ const { VERSION, MIXPANEL_TOKEN } = process.env;
 let globalLogMetrics = true;
 const globalProps = {
   VERSION,
-  project: 'unknown'
+  project: 'unknown',
+  application: 'unknown'
 };
 
-export function initMetrics(logMetrics: boolean, project: string, eventProps: EventProps) {
+export function initMetrics(logMetrics: boolean, project: string, applicationId: string, eventProps: EventProps) {
   // Even though mixpanel has an opt out property, the mixpanel object
   // used by Metrics is not available here, so we have our own way of opting out.
   globalLogMetrics = logMetrics;
@@ -39,7 +40,9 @@ export function initMetrics(logMetrics: boolean, project: string, eventProps: Ev
   if (project) {
     globalProps.project = project;
   }
-
+  if (applicationId) {
+    globalProps.application = applicationId;
+  }
   trackEvent('init', eventProps);
 }
 

--- a/viewer/src/utilities/networking/CdfModelDataClient.ts
+++ b/viewer/src/utilities/networking/CdfModelDataClient.ts
@@ -8,6 +8,7 @@ import { BlobOutputMetadata, ModelDataClient } from './types';
 import { Model3DOutputList } from './Model3DOutputList';
 import { File3dFormat, CameraConfiguration } from '../types';
 import { applyDefaultModelTransformation } from './applyDefaultModelTransformation';
+import { getSdkApplicationId } from './utilities';
 
 // TODO 2020-06-25 larsmoa: Extend CogniteClient.files3d.retrieve() to support subpath instead of
 // using URLs directly. Also add support for listing outputs in the SDK.
@@ -18,6 +19,7 @@ import { applyDefaultModelTransformation } from './applyDefaultModelTransformati
 export class CdfModelDataClient
   implements ModelDataClient<{ modelId: number; revisionId: number; format: File3dFormat }> {
   private readonly client: CogniteClient;
+  private appId: string | undefined;
 
   constructor(client: CogniteClient) {
     this.client = client;
@@ -105,6 +107,13 @@ export class CdfModelDataClient
       };
     }
     return undefined;
+  }
+
+  public getApplicationIdentifier(): string {
+    if (this.appId === undefined) {
+      this.appId = getSdkApplicationId(this.client);
+    }
+    return this.appId;
   }
 
   private buildBlobRequestPath(blobId: number): string {

--- a/viewer/src/utilities/networking/LocalModelDataClient.ts
+++ b/viewer/src/utilities/networking/LocalModelDataClient.ts
@@ -36,4 +36,8 @@ export class LocalModelDataClient implements ModelDataClient<{ fileName: string 
   getModelCamera(_identifier: { fileName: string }): Promise<CameraConfiguration | undefined> {
     return Promise.resolve(undefined);
   }
+
+  getApplicationIdentifier(): string {
+    return 'LocalClient';
+  }
 }

--- a/viewer/src/utilities/networking/types.ts
+++ b/viewer/src/utilities/networking/types.ts
@@ -47,4 +47,9 @@ export interface ModelDataClient<TModelIdentifier>
     ModelCameraConfigurationProvider<TModelIdentifier>,
     JsonFileProvider,
     BinaryFileProvider,
-    HttpHeadersProvider {}
+    HttpHeadersProvider {
+  /**
+   * Returns an identifier that can be used to identify the application Reveal is used in.
+   */
+  getApplicationIdentifier(): string;
+}

--- a/viewer/src/utilities/networking/utilities.ts
+++ b/viewer/src/utilities/networking/utilities.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { Versioned3DFile } from '@cognite/sdk';
+import { CogniteClient, Versioned3DFile } from '@cognite/sdk';
 
 // To avoid direct dependency on @cognite/sdk we use sdk-core here for HttpError.
 // that's why it's avoided https://github.com/cognitedata/cdf-hub/pull/687/files#r489204315
@@ -29,4 +29,14 @@ export async function fetchWithStatusCheck(url: string): Promise<Response> {
     throw new HttpError(response.status, response.body, headers);
   }
   return response;
+}
+
+/**
+ * Determines the `appId` of the `CogniteClient` provided.
+ * @param sdk Instance of `CogniteClient`.
+ * @returns Application ID or 'unknown' if not found.
+ */
+export function getSdkApplicationId(sdk: CogniteClient): string {
+  const headers = sdk.getDefaultRequestHeaders();
+  return headers['x-cdp-app'] || 'unknown';
 }


### PR DESCRIPTION
Send application ID to MixPanel to be able to see what apps use Reveal. Also, clean up events to avoid duplicates and track when user has navigated to keep a track of the activity per session.