### PR TITLE
fix: avoid sending data to MixPanel that can be used to identify users

### DIFF
--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -54,6 +54,7 @@ export function initMetrics(logMetrics: boolean, project: string, applicationId:
   mixpanel.identify(randomIdentifier);
 
   mixpanel.init(MIXPANEL_TOKEN, { persistence: 'localStorage' });
+  mixpanel.identify(randomIdentifier);
   if (project) {
     globalProps.project = project;
   }

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -48,13 +48,13 @@ export function initMetrics(logMetrics: boolean, project: string, applicationId:
     return;
   }
 
+  mixpanel.init(MIXPANEL_TOKEN, { persistence: 'localStorage' });
+
   // Use a random identifier because we want to don't track users over multiple sessions to not
   // violate GDPR
   const randomIdentifier = generateUuidv4();
   mixpanel.identify(randomIdentifier);
 
-  mixpanel.init(MIXPANEL_TOKEN, { persistence: 'localStorage' });
-  mixpanel.identify(randomIdentifier);
   if (project) {
     globalProps.project = project;
   }

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -48,7 +48,25 @@ export function initMetrics(logMetrics: boolean, project: string, applicationId:
     return;
   }
 
-  mixpanel.init(MIXPANEL_TOKEN, { persistence: 'localStorage' });
+  mixpanel.init(MIXPANEL_TOKEN, {
+    persistence: 'localStorage',
+    disable_cookie: true,
+    disable_persistence: true,
+    ip: false
+  });
+
+  // https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel#profile-properties-javascript
+  mixpanel.people.set('$city', '<none>');
+  mixpanel.people.set('$region', '<none>');
+  mixpanel.people.set('mp_country_code', '<none>');
+  mixpanel.people.set('$geo_source', '<none>');
+  mixpanel.people.set('$timezone', '<none>');
+  mixpanel.people.set('mp_lib', '<none>');
+  mixpanel.people.set('$device_id', '<none>');
+  mixpanel.people.set('$user_id', '<none>');
+  mixpanel.people.set('$current_url', '<none>');
+  mixpanel.people.set('$screen_width', '<none>');
+  mixpanel.people.set('$screen_height', '<none>');
 
   // Use a random identifier because we want to don't track users over multiple sessions to not
   // violate GDPR

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -49,27 +49,36 @@ export function initMetrics(logMetrics: boolean, project: string, applicationId:
   }
 
   mixpanel.init(MIXPANEL_TOKEN, {
-    persistence: 'localStorage',
     disable_cookie: true,
     disable_persistence: true,
-    ip: false
+    // Don't send IP which disables geolocation
+    ip: false,
+    // Avoid sending a bunch of properties that might help identifying a user
+    property_blacklist: [
+      // https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel#profile-properties-javascript
+      '$city',
+      '$region',
+      'mp_country_code',
+      '$geo_source',
+      '$timezone',
+      'mp_lib',
+      '$lib_version',
+      '$device_id',
+      '$user_id',
+      '$current_url',
+      '$screen_width',
+      '$screen_height',
+      '$referrer',
+      '$referring_domain',
+      '$initial_referrer',
+      '$initial_referring_domain'
+    ]
   });
-
-  // https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel#profile-properties-javascript
-  mixpanel.people.set('$city', '<none>');
-  mixpanel.people.set('$region', '<none>');
-  mixpanel.people.set('mp_country_code', '<none>');
-  mixpanel.people.set('$geo_source', '<none>');
-  mixpanel.people.set('$timezone', '<none>');
-  mixpanel.people.set('mp_lib', '<none>');
-  mixpanel.people.set('$device_id', '<none>');
-  mixpanel.people.set('$user_id', '<none>');
-  mixpanel.people.set('$current_url', '<none>');
-  mixpanel.people.set('$screen_width', '<none>');
-  mixpanel.people.set('$screen_height', '<none>');
+  // Reset device ID (even if we don't send it)
+  mixpanel.reset();
 
   // Use a random identifier because we want to don't track users over multiple sessions to not
-  // violate GDPR
+  // violate GDPR. This overrides "distinct_id".
   const randomIdentifier = generateUuidv4();
   mixpanel.identify(randomIdentifier);
 

--- a/viewer/src/utilities/metrics.ts
+++ b/viewer/src/utilities/metrics.ts
@@ -29,6 +29,17 @@ const globalProps = {
   application: 'unknown'
 };
 
+/**
+ * Source: https://stackoverflow.com/a/2117523/167251
+ */
+function generateUuidv4(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 export function initMetrics(logMetrics: boolean, project: string, applicationId: string, eventProps: EventProps) {
   // Even though mixpanel has an opt out property, the mixpanel object
   // used by Metrics is not available here, so we have our own way of opting out.
@@ -36,6 +47,12 @@ export function initMetrics(logMetrics: boolean, project: string, applicationId:
   if (!globalLogMetrics) {
     return;
   }
+
+  // Use a random identifier because we want to don't track users over multiple sessions to not
+  // violate GDPR
+  const randomIdentifier = generateUuidv4();
+  mixpanel.identify(randomIdentifier);
+
   mixpanel.init(MIXPANEL_TOKEN, { persistence: 'localStorage' });
   if (project) {
     globalProps.project = project;


### PR DESCRIPTION
Avoid sending user identifiable information to MixPanel to comply with GDPR.