### PR TITLE
[REV-40] fix: remove ts type aliases

### DIFF
--- a/examples/src/pages/SectorWithPointcloud.tsx
+++ b/examples/src/pages/SectorWithPointcloud.tsx
@@ -164,10 +164,7 @@ export function SectorWithPointcloud() {
       }
       scene.add(model);
 
-      let pointCloud: [
-        reveal.internal.PotreeGroupWrapper,
-        reveal.internal.PotreeNodeWrapper
-      ];
+      let pointCloud
       if (pointCloudModelRevision) {
         pointCloud = await revealManager.addModel(
           'pointcloud',
@@ -181,7 +178,13 @@ export function SectorWithPointcloud() {
         );
       }
 
-      const [pointCloudGroup, pointCloudNode] = pointCloud;
+      // fixme: something wrong with the types here.
+      //    Why THREE.Group can be destructured like that?
+      //    example is broken here. It fails at runtime.
+      const [pointCloudGroup, pointCloudNode] = pointCloud as unknown as [
+        reveal.internal.PotreeGroupWrapper,
+        reveal.internal.PotreeNodeWrapper
+      ];
       scene.add(pointCloudGroup);
 
       const cadModelOffsetRoot = new THREE.Group();

--- a/viewer/jest.config.js
+++ b/viewer/jest.config.js
@@ -15,8 +15,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   moduleNameMapper: {
     '\\.(frag|vert)$': '<rootDir>/src/__mocks__/glslMocks.js',
-    '\\.css$': '<rootDir>/src/__mocks__/cssMock.js',
-    '^@/(.*)': '<rootDir>/src/$1'
+    '\\.css$': '<rootDir>/src/__mocks__/cssMock.js'
   },
   globals: {
     __webpack_public_path__: '',

--- a/viewer/src/__tests__/cache/MemoryCache.test.ts
+++ b/viewer/src/__tests__/cache/MemoryCache.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { MemoryRequestCache } from '@/utilities/cache/MemoryRequestCache';
+import { MemoryRequestCache } from '../../utilities/cache/MemoryRequestCache';
 
 describe('MemoryCache', () => {
   beforeEach(() => {

--- a/viewer/src/__tests__/culling/ByVisibilityGpuSectorCuller.test.ts
+++ b/viewer/src/__tests__/culling/ByVisibilityGpuSectorCuller.test.ts
@@ -3,15 +3,15 @@
  */
 import * as THREE from 'three';
 
-import { DetermineSectorsInput, SectorCost } from '@/datamodels/cad/sector/culling/types';
-import { MaterialManager } from '@/datamodels/cad/MaterialManager';
-import { OrderSectorsByVisibilityCoverage } from '@/datamodels/cad/sector/culling/OrderSectorsByVisibilityCoverage';
-import { ByVisibilityGpuSectorCuller, LevelOfDetail } from '@/internal';
-import { SectorMetadata, CadNode, CadModelMetadata } from '@/experimental';
+import { DetermineSectorsInput, SectorCost } from '../../datamodels/cad/sector/culling/types';
+import { MaterialManager } from '../../datamodels/cad/MaterialManager';
+import { OrderSectorsByVisibilityCoverage } from '../../datamodels/cad/sector/culling/OrderSectorsByVisibilityCoverage';
+import { ByVisibilityGpuSectorCuller, LevelOfDetail } from '../../internal';
+import { SectorMetadata, CadNode, CadModelMetadata } from '../../experimental';
 
 import { generateSectorTree } from '../testutils/createSectorMetadata';
 import { createCadModelMetadata } from '../testutils/createCadModelMetadata';
-import { CadModelSectorBudget } from '@/datamodels/cad/CadModelBudget';
+import { CadModelSectorBudget } from '../../datamodels/cad/CadModelBudget';
 
 type PropType<TObj, TProp extends keyof TObj> = TObj[TProp];
 
@@ -124,7 +124,7 @@ describe('ByVisibilityGpuSectorCuller', () => {
 
   test('determineSectors limits sectors by draw calls', () => {
     // Arrange
-    const determineSectorCost = (sector: SectorMetadata, lod: LevelOfDetail): SectorCost => {
+    const determineSectorCost = (_sector: SectorMetadata, lod: LevelOfDetail): SectorCost => {
       switch (lod) {
         case LevelOfDetail.Detailed:
           return { downloadSize: 0, drawCalls: 5 };

--- a/viewer/src/__tests__/culling/TakenSectorTree.test.ts
+++ b/viewer/src/__tests__/culling/TakenSectorTree.test.ts
@@ -4,10 +4,10 @@
 
 import { expectContainsSectorsWithLevelOfDetail } from '../expects';
 import { generateSectorTree } from '../testutils/createSectorMetadata';
-import { DetermineSectorCostDelegate, PrioritizedWantedSector } from '@/datamodels/cad/sector/culling/types';
-import { TakenSectorTree } from '@/datamodels/cad/sector/culling/TakenSectorTree';
-import { LevelOfDetail, traverseDepthFirst } from '@/internal';
-import { SectorMetadata, CadModelMetadata } from '@/experimental';
+import { DetermineSectorCostDelegate, PrioritizedWantedSector } from '../../datamodels/cad/sector/culling/types';
+import { TakenSectorTree } from '../../datamodels/cad/sector/culling/TakenSectorTree';
+import { LevelOfDetail, traverseDepthFirst } from '../../internal';
+import { SectorMetadata, CadModelMetadata } from '../../experimental';
 
 type PropType<TObj, TProp extends keyof TObj> = TObj[TProp];
 type Mutable<T> = { -readonly [P in keyof T]: T[P] };

--- a/viewer/src/__tests__/data/parser/CadSectorParser.test.ts
+++ b/viewer/src/__tests__/data/parser/CadSectorParser.test.ts
@@ -5,11 +5,11 @@
 import { of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
-import { CadSectorParser } from '@/datamodels/cad/sector/CadSectorParser';
-import { WorkerPool } from '@/utilities/workers/WorkerPool';
-import { SectorQuads } from '@/datamodels/cad/rendering/types';
+import { CadSectorParser } from '../../../datamodels/cad/sector/CadSectorParser';
+import { WorkerPool } from '../../../utilities/workers/WorkerPool';
+import { SectorQuads } from '../../../datamodels/cad/rendering/types';
 
-jest.mock('@/utilities/workers/WorkerPool');
+jest.mock('../../../utilities/workers/WorkerPool');
 
 describe('CadSectorParser', () => {
   const workerPool: WorkerPool = new WorkerPool();

--- a/viewer/src/__tests__/dataModels/cad/TransformOverrideBuffer.test.ts
+++ b/viewer/src/__tests__/dataModels/cad/TransformOverrideBuffer.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 import * as THREE from 'three';
-import { TransformOverrideBuffer } from '@/datamodels/cad/rendering/TransformOverrideBuffer';
+import { TransformOverrideBuffer } from '../../../datamodels/cad/rendering/TransformOverrideBuffer';
 
 describe('TransformOverrideBuffer', () => {
   const onGenerateNewTextureCb: (texture: THREE.DataTexture) => void = jest.fn();

--- a/viewer/src/__tests__/dataModels/cad/internal/CadModelUpdateHandler.test.ts
+++ b/viewer/src/__tests__/dataModels/cad/internal/CadModelUpdateHandler.test.ts
@@ -4,17 +4,17 @@
 
 import * as THREE from 'three';
 
-import { CadNode } from '@/datamodels/cad';
-import { MaterialManager } from '@/datamodels/cad/MaterialManager';
-import { CadSectorParser } from '@/datamodels/cad/sector/CadSectorParser';
-import { SimpleAndDetailedToSector3D } from '@/datamodels/cad/sector/SimpleAndDetailedToSector3D';
-import { CachedRepository } from '@/datamodels/cad/sector/CachedRepository';
-import { SectorCuller } from '@/datamodels/cad/sector/culling/SectorCuller';
+import { CadNode } from '../../../../datamodels/cad';
+import { MaterialManager } from '../../../../datamodels/cad/MaterialManager';
+import { CadSectorParser } from '../../../../datamodels/cad/sector/CadSectorParser';
+import { SimpleAndDetailedToSector3D } from '../../../../datamodels/cad/sector/SimpleAndDetailedToSector3D';
+import { CachedRepository } from '../../../../datamodels/cad/sector/CachedRepository';
+import { SectorCuller } from '../../../../datamodels/cad/sector/culling/SectorCuller';
 
 import { createCadModelMetadata } from '../../../testutils/createCadModelMetadata';
 import { generateSectorTree } from '../../../testutils/createSectorMetadata';
-import { CadModelUpdateHandler } from '@/datamodels/cad/CadModelUpdateHandler';
-import { BinaryFileProvider } from '@/utilities/networking/types';
+import { CadModelUpdateHandler } from '../../../../datamodels/cad/CadModelUpdateHandler';
+import { BinaryFileProvider } from '../../../../utilities/networking/types';
 
 describe('CadModelUpdateHandler', () => {
   const modelSectorProvider: BinaryFileProvider = {

--- a/viewer/src/__tests__/dataModels/cad/rendering/EffectRenderManager.test.ts
+++ b/viewer/src/__tests__/dataModels/cad/rendering/EffectRenderManager.test.ts
@@ -4,9 +4,9 @@
 
 import * as THREE from 'three';
 
-import { MaterialManager } from '@/datamodels/cad/MaterialManager';
-import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderManager';
-import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
+import { MaterialManager } from '../../../../datamodels/cad/MaterialManager';
+import { EffectRenderManager } from '../../../../datamodels/cad/rendering/EffectRenderManager';
+import { RenderMode } from '../../../../datamodels/cad/rendering/RenderMode';
 
 describe('EffectRenderManager', () => {
   const materialManager = new MaterialManager();

--- a/viewer/src/__tests__/expects.ts
+++ b/viewer/src/__tests__/expects.ts
@@ -3,8 +3,8 @@
  */
 
 import 'jest-extended';
-import { LevelOfDetail } from '@/datamodels/cad/sector/LevelOfDetail';
-import { WantedSector } from '@/datamodels/cad/sector/types';
+import { LevelOfDetail } from '../datamodels/cad/sector/LevelOfDetail';
+import { WantedSector } from '../datamodels/cad/sector/types';
 
 interface Matrix4 {
   elements: Float32Array;

--- a/viewer/src/__tests__/migration/Cognite3DViewer.test.ts
+++ b/viewer/src/__tests__/migration/Cognite3DViewer.test.ts
@@ -6,10 +6,10 @@ import * as THREE from 'three';
 import TWEEN from '@tweenjs/tween.js';
 import { CogniteClient } from '@cognite/sdk';
 
-import { Cognite3DViewer } from '@/public/migration/Cognite3DViewer';
+import { Cognite3DViewer } from '../../public/migration/Cognite3DViewer';
 
 import nock from 'nock';
-import { SectorCuller } from '@/datamodels/cad/sector/culling/SectorCuller';
+import { SectorCuller } from '../../datamodels/cad/sector/culling/SectorCuller';
 
 const sceneJson = require('./scene.json');
 
@@ -25,6 +25,12 @@ describe('Cognite3DViewer', () => {
   beforeAll(() => {
     jest.useFakeTimers();
     nock.disableNetConnect();
+
+    nock('https://api-js.mixpanel.com')
+      .persist(true)
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*', 'access-control-allow-credentials': 'true' })
+      .get(/.*/)
+      .reply(200);
 
     nock('https://api-js.mixpanel.com')
       .persist(true)

--- a/viewer/src/__tests__/migration/NodeIdAndTreeIndexMaps.test.ts
+++ b/viewer/src/__tests__/migration/NodeIdAndTreeIndexMaps.test.ts
@@ -3,12 +3,12 @@
  */
 
 import { CogniteClient, CogniteInternalId } from '@cognite/sdk';
-import { NodeIdAndTreeIndexMaps } from '@/public/migration/NodeIdAndTreeIndexMaps';
+import { NodeIdAndTreeIndexMaps } from '../../public/migration/NodeIdAndTreeIndexMaps';
 
 import { sleep } from '../wait';
-import { CogniteClientNodeIdAndTreeIndexMapper } from '@/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
+import { CogniteClientNodeIdAndTreeIndexMapper } from '../../utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
 
-jest.mock('@/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper');
+jest.mock('../../utilities/networking/CogniteClientNodeIdAndTreeIndexMapper');
 
 function stubTreeIndexToNodeId(treeIndex: number): CogniteInternalId {
   return treeIndex + 1337;

--- a/viewer/src/__tests__/migration/NodeStyleUpdater.test.ts
+++ b/viewer/src/__tests__/migration/NodeStyleUpdater.test.ts
@@ -2,8 +2,8 @@
  * Copyright 2020 Cognite AS
  */
 
-import { NodeStyleUpdater } from '@/public/migration/NodeStyleUpdater';
-import { NumericRange } from '@/utilities';
+import { NodeStyleUpdater } from '../../public/migration/NodeStyleUpdater';
+import { NumericRange } from '../../utilities';
 
 describe('NodeStyleUpdater', () => {
   const updateCallback: (treeIndices: number[]) => void = jest.fn();

--- a/viewer/src/__tests__/models/cad/CadMetadataParser.test.ts
+++ b/viewer/src/__tests__/models/cad/CadMetadataParser.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { CadMetadataParser } from '@/datamodels/cad/parsers/CadMetadataParser';
+import { CadMetadataParser } from '../../../datamodels/cad/parsers/CadMetadataParser';
 
 describe('CadMetadataParser', () => {
   const parser = new CadMetadataParser();

--- a/viewer/src/__tests__/models/cad/CadMetadataParserV8.test.ts
+++ b/viewer/src/__tests__/models/cad/CadMetadataParserV8.test.ts
@@ -2,10 +2,14 @@
  * Copyright 2020 Cognite AS
  */
 
-import { CadMetadataV8, parseCadMetadataV8, CadSectorMetadataV8 } from '@/datamodels/cad/parsers/CadMetadataParserV8';
-import { SectorMetadata } from '@/datamodels/cad/sector/types';
-import { Box3 } from '@/utilities/Box3';
-import { traverseDepthFirst } from '@/utilities/objectTraversal';
+import {
+  CadMetadataV8,
+  parseCadMetadataV8,
+  CadSectorMetadataV8
+} from '../../../datamodels/cad/parsers/CadMetadataParserV8';
+import { SectorMetadata } from '../../../datamodels/cad';
+import { Box3 } from '../../../utilities';
+import { traverseDepthFirst } from '../../../utilities/objectTraversal';
 
 import { vec3 } from 'gl-matrix';
 

--- a/viewer/src/__tests__/models/cad/SectorScene.test.ts
+++ b/viewer/src/__tests__/models/cad/SectorScene.test.ts
@@ -5,10 +5,10 @@
 import * as THREE from 'three';
 import { vec3 } from 'gl-matrix';
 
-import { SectorMetadata } from '@/datamodels/cad';
-import { SectorSceneImpl } from '@/datamodels/cad/sector/SectorScene';
-import { traverseDepthFirst } from '@/utilities/objectTraversal';
-import { Box3 } from '@/utilities';
+import { SectorMetadata } from '../../../datamodels/cad';
+import { SectorSceneImpl } from '../../../datamodels/cad/sector/SectorScene';
+import { traverseDepthFirst } from '../../../utilities/objectTraversal';
+import { Box3 } from '../../../utilities';
 
 import { createSectorMetadata } from '../../testutils/createSectorMetadata';
 

--- a/viewer/src/__tests__/models/cad/emptySector.ts
+++ b/viewer/src/__tests__/models/cad/emptySector.ts
@@ -3,7 +3,7 @@
  */
 
 import { ParsedPrimitives } from '@cognite/reveal-parser-worker';
-import { SectorGeometry } from '@/datamodels/cad/sector/types';
+import { SectorGeometry } from '../../../datamodels/cad/sector/types';
 
 export function createEmptyPrimitive(): ParsedPrimitives {
   return {

--- a/viewer/src/__tests__/models/cad/utilities.test.ts
+++ b/viewer/src/__tests__/models/cad/utilities.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { getNewestVersionedFile } from '@/utilities/networking/utilities';
+import { getNewestVersionedFile } from '../../../utilities/networking/utilities';
 import { Versioned3DFile } from '@cognite/sdk';
 
 describe('getNewestVersionedFile', () => {

--- a/viewer/src/__tests__/testutils/createCadModelMetadata.ts
+++ b/viewer/src/__tests__/testutils/createCadModelMetadata.ts
@@ -4,8 +4,8 @@
 
 import * as THREE from 'three';
 
-import { SectorMetadata, CadModelMetadata } from '@/datamodels/cad';
-import { SectorSceneImpl } from '@/datamodels/cad/sector/SectorScene';
+import { SectorMetadata, CadModelMetadata } from '../../datamodels/cad';
+import { SectorSceneImpl } from '../../datamodels/cad/sector/SectorScene';
 
 let modelIdRunningNumber = 0;
 

--- a/viewer/src/__tests__/testutils/createSectorMetadata.ts
+++ b/viewer/src/__tests__/testutils/createSectorMetadata.ts
@@ -2,8 +2,8 @@
  * Copyright 2020 Cognite AS
  */
 
-import { SectorMetadata } from '@/datamodels/cad';
-import { Box3 } from '@/utilities';
+import { SectorMetadata } from '../../datamodels/cad';
+import { Box3 } from '../../utilities';
 import { vec3 } from 'gl-matrix';
 
 export type SectorTree = [number, SectorTree[], Box3?];

--- a/viewer/src/__tests__/utilities/Box3.test.ts
+++ b/viewer/src/__tests__/utilities/Box3.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { vec3 } from 'gl-matrix';
-import { Box3 } from '@/utilities/Box3';
+import { Box3 } from '../../utilities/Box3';
 
 describe('Box3', () => {
   test('containsPoint, unit box', () => {

--- a/viewer/src/__tests__/utilities/NumericRange.test.ts
+++ b/viewer/src/__tests__/utilities/NumericRange.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { NumericRange } from '@/utilities';
+import { NumericRange } from '../../utilities';
 
 describe('NumericRange', () => {
   test('constructor does not accept negative count', () => {

--- a/viewer/src/__tests__/utilities/arrays.test.ts
+++ b/viewer/src/__tests__/utilities/arrays.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { createOffsets } from '@/utilities/arrays';
+import { createOffsets } from '../../utilities/arrays';
 import 'jest-extended';
 
 describe('createOffsets', () => {

--- a/viewer/src/__tests__/utilities/callActionWithIndicesAsync.test.ts
+++ b/viewer/src/__tests__/utilities/callActionWithIndicesAsync.test.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2020 Cognite AS
  */
-import { callActionWithIndicesAsync } from '@/utilities/callActionWithIndicesAsync';
+import { callActionWithIndicesAsync } from '../../utilities/callActionWithIndicesAsync';
 
 describe('test callActionWithIndicesAsync', () => {
   it('calls an action with specified indices range', async () => {

--- a/viewer/src/__tests__/utilities/determinePowerOfTwoDimensions.test.ts
+++ b/viewer/src/__tests__/utilities/determinePowerOfTwoDimensions.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { determinePowerOfTwoDimensions } from '@/utilities/determinePowerOfTwoDimensions';
+import { determinePowerOfTwoDimensions } from '../../utilities/determinePowerOfTwoDimensions';
 
 test('determinePowerOfTwoDimensions', () => {
   expect(determinePowerOfTwoDimensions(0)).toEqual({ width: 1, height: 1 });

--- a/viewer/src/__tests__/utilities/networking/CdfModelDataClient.test.ts
+++ b/viewer/src/__tests__/utilities/networking/CdfModelDataClient.test.ts
@@ -3,10 +3,10 @@
  */
 
 import nock from 'nock';
-import { CdfModelDataClient } from '@/utilities/networking/CdfModelDataClient';
+import { CdfModelDataClient } from '../../../utilities/networking/CdfModelDataClient';
 import { CogniteClient } from '@cognite/sdk';
-import { Model3DOutputList } from '@/utilities/networking/Model3DOutputList';
-import { File3dFormat } from '@/utilities';
+import { Model3DOutputList } from '../../../utilities/networking/Model3DOutputList';
+import { File3dFormat } from '../../../utilities';
 
 describe('CdfModelDataClient', () => {
   const appId = 'reveal-CdfModelDataClient-test';

--- a/viewer/src/__tests__/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper.test.ts
+++ b/viewer/src/__tests__/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper.test.ts
@@ -4,7 +4,7 @@
 
 import nock from 'nock';
 import { CogniteInternalId, CogniteClient } from '@cognite/sdk';
-import { CogniteClientNodeIdAndTreeIndexMapper } from '@/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
+import { CogniteClientNodeIdAndTreeIndexMapper } from '../../../utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
 
 function stubTreeIndexToNodeId(treeIndex: number): CogniteInternalId {
   return treeIndex + 1337;

--- a/viewer/src/__tests__/utilities/networking/isTheSameDomain.test.ts
+++ b/viewer/src/__tests__/utilities/networking/isTheSameDomain.test.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2020 Cognite AS
  */
-import { isTheSameDomain } from '@/utilities/networking/isTheSameDomain';
+import { isTheSameDomain } from '../../../utilities/networking/isTheSameDomain';
 
 describe('isTheSameDomain fn tests', () => {
   const baseOrigin = 'https://foo.bar';

--- a/viewer/src/__tests__/utilities/packFloat.test.ts
+++ b/viewer/src/__tests__/utilities/packFloat.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { packFloat, unpackFloat4 } from '@/utilities/packFloatToVec4';
+import { packFloat, unpackFloat4 } from '../../utilities/packFloatToVec4';
 import * as THREE from 'three';
 
 describe('Pack & unpack floats to 4 byte channels', () => {

--- a/viewer/src/__tests__/utilities/traversal.test.ts
+++ b/viewer/src/__tests__/utilities/traversal.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { traverseDepthFirst, traverseUpwards } from '@/utilities/objectTraversal';
+import { traverseDepthFirst, traverseUpwards } from '../../utilities/objectTraversal';
 
 describe('traversal', () => {
   type Element = {

--- a/viewer/src/__tests__/viewer/public/RevealManager.test.ts
+++ b/viewer/src/__tests__/viewer/public/RevealManager.test.ts
@@ -4,10 +4,10 @@
 
 import * as THREE from 'three';
 
-import { ModelDataClient } from '@/utilities/networking/types';
-import { SectorCuller } from '@/internal';
-import { createRevealManager } from '@/public/createRevealManager';
-import { RevealManager } from '@/public/RevealManager';
+import { ModelDataClient } from '../../../utilities/networking/types';
+import { SectorCuller } from '../../../internal';
+import { createRevealManager } from '../../../public/createRevealManager';
+import { RevealManager } from '../../../public/RevealManager';
 
 describe('RevealManager', () => {
   const mockClient: ModelDataClient<{ id: number }> = {

--- a/viewer/src/__tests__/views/threejs/BoundingBoxClipper.test.ts
+++ b/viewer/src/__tests__/views/threejs/BoundingBoxClipper.test.ts
@@ -3,7 +3,7 @@
  */
 
 import * as THREE from 'three';
-import { BoundingBoxClipper } from '@/utilities/BoundingBoxClipper';
+import { BoundingBoxClipper } from '../../../utilities/BoundingBoxClipper';
 
 describe('BoundingBoxClipper', () => {
   test('Clip planes placed correctly', () => {

--- a/viewer/src/__tests__/views/threejs/HtmlOverlayHelper.test.ts
+++ b/viewer/src/__tests__/views/threejs/HtmlOverlayHelper.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { HtmlOverlayHelper } from '@/utilities/HtmlOverlayHelper';
+import { HtmlOverlayHelper } from '../../../utilities/HtmlOverlayHelper';
 import * as THREE from 'three';
 
 describe('HtmlOverlayHelper', () => {

--- a/viewer/src/__tests__/views/threejs/OrderSectorsByVisibilityCoverage.test.ts
+++ b/viewer/src/__tests__/views/threejs/OrderSectorsByVisibilityCoverage.test.ts
@@ -5,11 +5,11 @@
 import * as THREE from 'three';
 
 import { createSectorMetadata, SectorTree } from '../../testutils/createSectorMetadata';
-import { Box3 } from '@/utilities/Box3';
-import { GpuOrderSectorsByVisibilityCoverage, traverseDepthFirst } from '@/internal';
-import { SectorSceneImpl } from '@/datamodels/cad/sector/SectorScene';
-import { CadModelMetadata } from '@/datamodels/cad/';
-import { SectorScene, SectorMetadata } from '@/datamodels/cad/sector/types';
+import { Box3 } from '../../../utilities/Box3';
+import { GpuOrderSectorsByVisibilityCoverage, traverseDepthFirst } from '../../../internal';
+import { SectorSceneImpl } from '../../../datamodels/cad/sector/SectorScene';
+import { CadModelMetadata } from '../../../datamodels/cad/';
+import { SectorScene, SectorMetadata } from '../../../datamodels/cad/sector/types';
 
 describe('OrderSectorsByVisibilityCoverage', () => {
   const glContext: WebGLRenderingContext = require('gl')(64, 64);

--- a/viewer/src/__tests__/views/threejs/cad/consumeSectorDetailed.test.ts
+++ b/viewer/src/__tests__/views/threejs/cad/consumeSectorDetailed.test.ts
@@ -2,15 +2,15 @@
  * Copyright 2020 Cognite AS
  */
 
-import { SectorMetadata, SectorGeometry } from '@/datamodels/cad/sector/types';
-import { Box3 } from '@/utilities/Box3';
+import { SectorMetadata, SectorGeometry } from '../../../../datamodels/cad/sector/types';
+import { Box3 } from '../../../../utilities/Box3';
 import { vec3 } from 'gl-matrix';
 import { createEmptySector } from '../../../models/cad/emptySector';
-import { createMaterials } from '@/datamodels/cad/rendering/materials';
+import { createMaterials } from '../../../../datamodels/cad/rendering/materials';
 import 'jest-extended';
-import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
-import { consumeSectorDetailed } from '@/datamodels/cad/sector/sectorUtilities';
-import { TriangleMesh, InstancedMeshFile, InstancedMesh } from '@/datamodels/cad/rendering/types';
+import { RenderMode } from '../../../../datamodels/cad/rendering/RenderMode';
+import { consumeSectorDetailed } from '../../../../datamodels/cad/sector/sectorUtilities';
+import { TriangleMesh, InstancedMeshFile, InstancedMesh } from '../../../../datamodels/cad/rendering/types';
 
 const materials = createMaterials(10, RenderMode.Color, []);
 

--- a/viewer/src/__tests__/views/threejs/cad/consumeSectorSimple.test.ts
+++ b/viewer/src/__tests__/views/threejs/cad/consumeSectorSimple.test.ts
@@ -2,11 +2,11 @@
  * Copyright 2020 Cognite AS
  */
 
-import { createMaterials } from '@/datamodels/cad/rendering/materials';
+import { createMaterials } from '../../../../datamodels/cad/rendering/materials';
 import 'jest-extended';
-import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
-import { SectorQuads } from '@/datamodels/cad/rendering/types';
-import { consumeSectorSimple } from '@/datamodels/cad/sector/sectorUtilities';
+import { RenderMode } from '../../../../datamodels/cad/rendering/RenderMode';
+import { SectorQuads } from '../../../../datamodels/cad/rendering/types';
+import { consumeSectorSimple } from '../../../../datamodels/cad/sector/sectorUtilities';
 
 const materials = createMaterials(64, RenderMode.Color, []);
 

--- a/viewer/src/__tests__/views/threejs/cad/discardSector.test.ts
+++ b/viewer/src/__tests__/views/threejs/cad/discardSector.test.ts
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import 'jest-extended';
-import { discardSector } from '@/datamodels/cad/sector/sectorUtilities';
+import { discardSector } from '../../../../datamodels/cad/sector/sectorUtilities';
 
 describe('discardSector', () => {
   let node: THREE.Group;

--- a/viewer/src/__tests__/views/threejs/cad/materials.test.ts
+++ b/viewer/src/__tests__/views/threejs/cad/materials.test.ts
@@ -2,8 +2,8 @@
  * Copyright 2020 Cognite AS
  */
 
-import { createMaterials } from '@/datamodels/cad/rendering/materials';
-import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
+import { createMaterials } from '../../../../datamodels/cad/rendering/materials';
+import { RenderMode } from '../../../../datamodels/cad/rendering/RenderMode';
 
 describe('createMaterials', () => {
   test('Positive treeIndexCount, creates materials', () => {

--- a/viewer/src/__tests__/views/threejs/cad/picking.test.ts
+++ b/viewer/src/__tests__/views/threejs/cad/picking.test.ts
@@ -4,8 +4,8 @@
 
 import * as THREE from 'three';
 
-import { intersectCadNodes } from '@/datamodels/cad/picking';
-import { CadNode } from '@/datamodels/cad/CadNode';
+import { intersectCadNodes } from '../../../../datamodels/cad/picking';
+import { CadNode } from '../../../../datamodels/cad/CadNode';
 
 describe('intersectCadNodes', () => {
   const camera = new THREE.PerspectiveCamera();

--- a/viewer/src/__tests__/views/threejs/cad/primitives.test.ts
+++ b/viewer/src/__tests__/views/threejs/cad/primitives.test.ts
@@ -2,13 +2,13 @@
  * Copyright 2020 Cognite AS
  */
 
-import { SectorGeometry } from '@/datamodels/cad/sector/types';
-import { createPrimitives } from '@/datamodels/cad/rendering/primitives';
+import { SectorGeometry } from '../../../../datamodels/cad/sector/types';
+import { createPrimitives } from '../../../../datamodels/cad/rendering/primitives';
 import { createEmptySector } from '../../../models/cad/emptySector';
-import { createMaterials, Materials } from '@/datamodels/cad/rendering/materials';
+import { createMaterials, Materials } from '../../../../datamodels/cad/rendering/materials';
 import { ParsePrimitiveAttribute } from '@cognite/reveal-parser-worker';
 import { InstancedBufferGeometry, LOD, Mesh } from 'three';
-import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
+import { RenderMode } from '../../../../datamodels/cad/rendering/RenderMode';
 
 function createMockAttributes(): Map<string, ParsePrimitiveAttribute> {
   const map = new Map<string, ParsePrimitiveAttribute>();

--- a/viewer/src/__tests__/views/threejs/utilities.test.ts
+++ b/viewer/src/__tests__/views/threejs/utilities.test.ts
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import { vec3 } from 'gl-matrix';
-import { toThreeJsBox3, toThreeVector3, Box3 } from '@/utilities';
+import { toThreeJsBox3, toThreeVector3, Box3 } from '../../../utilities';
 
 describe('toThreeVector3', () => {
   test('modifies provided out parameter', () => {

--- a/viewer/src/datamodels/cad/CadManager.ts
+++ b/viewer/src/datamodels/cad/CadManager.ts
@@ -10,12 +10,12 @@ import { CadModelUpdateHandler } from './CadModelUpdateHandler';
 import { discardSector } from './sector/sectorUtilities';
 import { Subscription, Observable } from 'rxjs';
 import { NodeAppearanceProvider } from './NodeAppearance';
-import { trackError } from '@/utilities/metrics';
+import { trackError } from '../../utilities/metrics';
 import { SectorGeometry } from './sector/types';
 import { SectorQuads } from './rendering/types';
 import { MaterialManager } from './MaterialManager';
 import { RenderMode } from './rendering/RenderMode';
-import { LoadingState } from '@/utilities';
+import { LoadingState } from '../../utilities';
 
 export class CadManager<TModelIdentifier> {
   private readonly _materialManager: MaterialManager;

--- a/viewer/src/datamodels/cad/CadModelMetadata.ts
+++ b/viewer/src/datamodels/cad/CadModelMetadata.ts
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import { SectorScene } from './sector/types';
-import { CameraConfiguration } from '@/utilities';
+import { CameraConfiguration } from '../../utilities';
 
 export interface CadModelMetadata {
   blobUrl: string;

--- a/viewer/src/datamodels/cad/CadModelMetadataRepository.ts
+++ b/viewer/src/datamodels/cad/CadModelMetadataRepository.ts
@@ -6,11 +6,11 @@ import * as THREE from 'three';
 
 import { CadMetadataParser } from './parsers/CadMetadataParser';
 import { SectorScene, WellKnownDistanceToMeterConversionFactors } from './sector/types';
-import { File3dFormat } from '@/utilities';
-import { CadModelMetadata } from '@/datamodels/cad/CadModelMetadata';
+import { File3dFormat } from '../../utilities';
+import { CadModelMetadata } from './CadModelMetadata';
 import { MetadataRepository } from '../base';
-import { transformCameraConfiguration } from '@/utilities/transformCameraConfiguration';
-import { ModelDataClient } from '@/utilities/networking/types';
+import { transformCameraConfiguration } from '../../utilities/transformCameraConfiguration';
+import { ModelDataClient } from '../../utilities/networking/types';
 
 type ModelIdentifierWithFormat<T> = T & { format: File3dFormat };
 

--- a/viewer/src/datamodels/cad/CadModelUpdateHandler.ts
+++ b/viewer/src/datamodels/cad/CadModelUpdateHandler.ts
@@ -29,7 +29,7 @@ import { CadLoadingHints } from './CadLoadingHints';
 import { ConsumedSector, SectorGeometry } from './sector/types';
 import { Repository } from './sector/Repository';
 import { SectorQuads } from './rendering/types';
-import { emissionLastMillis, LoadingState } from '@/utilities';
+import { emissionLastMillis, LoadingState } from '../../utilities';
 import { CadModelMetadata } from '.';
 import { loadingEnabled, handleDetermineSectorsInput } from './sector/rxSectorUtilities';
 import { CadModelSectorBudget, defaultCadModelSectorBudget } from './CadModelBudget';

--- a/viewer/src/datamodels/cad/CadNode.ts
+++ b/viewer/src/datamodels/cad/CadNode.ts
@@ -16,7 +16,7 @@ import { CadLoadingHints } from './CadLoadingHints';
 import { MaterialManager } from './MaterialManager';
 import { CadModelMetadata } from './CadModelMetadata';
 import { suggestCameraConfig } from './cameraconfig';
-import { toThreeVector3, toThreeJsBox3, NumericRange } from '@/utilities';
+import { toThreeVector3, toThreeJsBox3, NumericRange } from '../../utilities';
 
 export type ParseCallbackDelegate = (parsed: { lod: string; data: SectorGeometry | SectorQuads }) => void;
 

--- a/viewer/src/datamodels/cad/cameraconfig.ts
+++ b/viewer/src/datamodels/cad/cameraconfig.ts
@@ -4,8 +4,8 @@
 
 import { vec3 } from 'gl-matrix';
 import { SectorMetadata } from './sector/types';
-import { Box3 } from '@/utilities';
-import { traverseDepthFirst } from '@/utilities/objectTraversal';
+import { Box3 } from '../../utilities';
+import { traverseDepthFirst } from '../../utilities/objectTraversal';
 
 export interface SuggestedCameraConfig {
   position: vec3;

--- a/viewer/src/datamodels/cad/createCadManager.ts
+++ b/viewer/src/datamodels/cad/createCadManager.ts
@@ -12,10 +12,10 @@ import { CadSectorParser } from './sector/CadSectorParser';
 import { CachedRepository } from './sector/CachedRepository';
 import { SimpleAndDetailedToSector3D } from './sector/SimpleAndDetailedToSector3D';
 import { ByVisibilityGpuSectorCuller } from './sector/culling/ByVisibilityGpuSectorCuller';
-import { LocalModelDataClient } from '@/utilities/networking/LocalModelDataClient';
-import { CdfModelDataClient } from '@/utilities/networking/CdfModelDataClient';
-import { LocalModelIdentifier, CdfModelIdentifier, ModelDataClient } from '@/utilities/networking/types';
-import { RevealOptions } from '@/public/types';
+import { LocalModelDataClient } from '../../utilities/networking/LocalModelDataClient';
+import { CdfModelDataClient } from '../../utilities/networking/CdfModelDataClient';
+import { LocalModelIdentifier, CdfModelIdentifier, ModelDataClient } from '../../utilities/networking/types';
+import { RevealOptions } from '../../public/types';
 
 export function createLocalCadManager(
   client: LocalModelDataClient,

--- a/viewer/src/datamodels/cad/parsers/CadMetadataParserV8.ts
+++ b/viewer/src/datamodels/cad/parsers/CadMetadataParserV8.ts
@@ -6,8 +6,8 @@ import { vec3 } from 'gl-matrix';
 
 import { SectorMetadata, SectorMetadataFacesFileSection, SectorScene } from '../sector/types';
 import { SectorSceneImpl } from '../sector/SectorScene';
-import { Box3 } from '@/utilities';
-import { traverseUpwards } from '@/utilities/objectTraversal';
+import { Box3 } from '../../../utilities';
+import { traverseUpwards } from '../../../utilities/objectTraversal';
 
 export interface CadSectorMetadataV8 {
   readonly id: number;

--- a/viewer/src/datamodels/cad/picking.ts
+++ b/viewer/src/datamodels/cad/picking.ts
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 
 import { CadNode } from './CadNode';
-import { pickPixelColor, PickingInput } from '@/utilities/pickPixelColor';
+import { pickPixelColor, PickingInput } from '../../utilities/pickPixelColor';
 import { RenderMode } from './rendering/RenderMode';
 
 export interface TreeIndexPickingInput extends PickingInput {

--- a/viewer/src/datamodels/cad/rendering/EffectRenderManager.ts
+++ b/viewer/src/datamodels/cad/rendering/EffectRenderManager.ts
@@ -6,9 +6,9 @@ import { MaterialManager } from '../MaterialManager';
 import { RenderMode } from './RenderMode';
 import * as THREE from 'three';
 import { edgeDetectionShaders, fxaaShaders } from './shaders';
-import { CogniteColors } from '@/utilities';
+import { CogniteColors } from '../../../utilities';
 import { CadNode } from '..';
-import { Cognite3DModel } from '@/migration';
+import { Cognite3DModel } from '../../../migration';
 import { RootSectorNode } from '../sector/RootSectorNode';
 
 export class EffectRenderManager {

--- a/viewer/src/datamodels/cad/rendering/TransformOverrideBuffer.ts
+++ b/viewer/src/datamodels/cad/rendering/TransformOverrideBuffer.ts
@@ -3,8 +3,8 @@
  */
 
 import * as THREE from 'three';
-import { packFloatInto } from '@/utilities/packFloatToVec4';
-import { determinePowerOfTwoDimensions } from '@/utilities/determinePowerOfTwoDimensions';
+import { packFloatInto } from '../../../utilities/packFloatToVec4';
+import { determinePowerOfTwoDimensions } from '../../../utilities/determinePowerOfTwoDimensions';
 
 export class TransformOverrideBuffer {
   private static readonly MIN_NUMBER_OF_TREE_INDICES = 16;

--- a/viewer/src/datamodels/cad/rendering/instancedMeshes.ts
+++ b/viewer/src/datamodels/cad/rendering/instancedMeshes.ts
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import { InstancedMeshFile } from './types';
-import { disposeAttributeArrayOnUpload } from '@/utilities/disposeAttributeArrayOnUpload';
+import { disposeAttributeArrayOnUpload } from '../../../utilities/disposeAttributeArrayOnUpload';
 
 export function createInstancedMeshes(
   meshes: InstancedMeshFile[],

--- a/viewer/src/datamodels/cad/rendering/materials.ts
+++ b/viewer/src/datamodels/cad/rendering/materials.ts
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import { sectorShaders, shaderDefines } from './shaders';
 import { RenderMode } from './RenderMode';
-import { determinePowerOfTwoDimensions } from '@/utilities/determinePowerOfTwoDimensions';
+import { determinePowerOfTwoDimensions } from '../../../utilities/determinePowerOfTwoDimensions';
 import matCapTextureImage from './matCapTextureData';
 import { TransformOverrideBuffer } from './TransformOverrideBuffer';
 

--- a/viewer/src/datamodels/cad/rendering/post-processing/ssao.ts
+++ b/viewer/src/datamodels/cad/rendering/post-processing/ssao.ts
@@ -8,11 +8,11 @@ import * as THREE from 'three';
 import { RenderMode } from '../RenderMode';
 import { CadNode } from '../../CadNode';
 
-const vertexShaderAntialias = glsl(require('@/glsl/post-processing/fxaa.vert').default);
-const fragmentShaderAntialias = glsl(require('@/glsl/post-processing/fxaa.frag').default);
-const passThroughVertexShader = glsl(require('@/glsl/post-processing/passthrough.vert').default);
-const ssaoShader = glsl(require('@/glsl/post-processing/ssao.frag').default);
-const ssaoFinalShader = glsl(require('@/glsl/post-processing/ssao-final.frag').default);
+const vertexShaderAntialias = glsl(require('../../../../glsl/post-processing/fxaa.vert').default);
+const fragmentShaderAntialias = glsl(require('../../../../glsl/post-processing/fxaa.frag').default);
+const passThroughVertexShader = glsl(require('../../../../glsl/post-processing/passthrough.vert').default);
+const ssaoShader = glsl(require('../../../../glsl/post-processing/ssao.frag').default);
+const ssaoFinalShader = glsl(require('../../../../glsl/post-processing/ssao-final.frag').default);
 
 interface Uniforms {
   [uniform: string]: THREE.IUniform;

--- a/viewer/src/datamodels/cad/rendering/postRenderEffects.ts
+++ b/viewer/src/datamodels/cad/rendering/postRenderEffects.ts
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import { RenderMode } from './RenderMode';
-import { RevealManager } from '@/public/RevealManager';
+import { RevealManager } from '../../../public/RevealManager';
 
 export function addPostRenderEffects(
   renderManager: RevealManager<unknown>,

--- a/viewer/src/datamodels/cad/rendering/primitives.ts
+++ b/viewer/src/datamodels/cad/rendering/primitives.ts
@@ -14,12 +14,10 @@ import {
 } from './primitiveGeometries';
 import { Materials } from './materials';
 import { ParsePrimitiveAttribute } from '@cognite/reveal-parser-worker';
-import { disposeAttributeArrayOnUpload } from '@/utilities/disposeAttributeArrayOnUpload';
+import { disposeAttributeArrayOnUpload } from '../../../utilities/disposeAttributeArrayOnUpload';
 
 export function* createPrimitives(sector: SectorGeometry, materials: Materials) {
   const primitives = sector.primitives;
-
- 
 
   if (hasAny(primitives.boxCollection)) {
     yield createBoxes(primitives.boxCollection, primitives.boxAttributes, materials.box);

--- a/viewer/src/datamodels/cad/rendering/shaders.ts
+++ b/viewer/src/datamodels/cad/rendering/shaders.ts
@@ -19,84 +19,84 @@ export const sectorShaders = {
   // "Regular" meshes
   // ----------------
   simpleMesh: {
-    fragment: glsl(require('@/glsl/sector/simple.frag').default),
-    vertex: glsl(require('@/glsl/sector/simple.vert').default)
+    fragment: glsl(require('../../../glsl/sector/simple.frag').default),
+    vertex: glsl(require('../../../glsl/sector/simple.vert').default)
   },
   detailedMesh: {
-    fragment: glsl(require('@/glsl/sector/mesh.frag').default),
-    vertex: glsl(require('@/glsl/sector/mesh.vert').default)
+    fragment: glsl(require('../../../glsl/sector/mesh.frag').default),
+    vertex: glsl(require('../../../glsl/sector/mesh.vert').default)
   },
   instancedMesh: {
-    fragment: glsl(require('@/glsl/sector/instancedMesh.frag').default),
-    vertex: glsl(require('@/glsl/sector/instancedMesh.vert').default)
+    fragment: glsl(require('../../../glsl/sector/instancedMesh.frag').default),
+    vertex: glsl(require('../../../glsl/sector/instancedMesh.vert').default)
   },
 
   // ----------------
   // Primitives
   // ----------------
   boxPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/instanced.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/instanced.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/instanced.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/instanced.vert').default)
   },
   circlePrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/circle.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/circle.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/circle.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/circle.vert').default)
   },
   conePrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/cone.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/cone.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/cone.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/cone.vert').default)
   },
   eccentricConePrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/eccentricCone.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/eccentricCone.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/eccentricCone.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/eccentricCone.vert').default)
   },
   ellipsoidSegmentPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/ellipsoidSegment.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/ellipsoidSegment.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/ellipsoidSegment.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/ellipsoidSegment.vert').default)
   },
   generalCylinderPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/generalCylinder.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/generalCylinder.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/generalCylinder.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/generalCylinder.vert').default)
   },
   generalRingPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/generalring.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/generalring.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/generalring.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/generalring.vert').default)
   },
   nutPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/instanced.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/instanced.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/instanced.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/instanced.vert').default)
   },
   quadPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/instanced.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/instanced.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/instanced.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/instanced.vert').default)
   },
   torusSegmentPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/torusSegment.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/torusSegment.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/torusSegment.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/torusSegment.vert').default)
   },
   trapeziumPrimitive: {
-    fragment: glsl(require('@/glsl/sector/primitives/trapezium.frag').default),
-    vertex: glsl(require('@/glsl/sector/primitives/trapezium.vert').default)
+    fragment: glsl(require('../../../glsl/sector/primitives/trapezium.frag').default),
+    vertex: glsl(require('../../../glsl/sector/primitives/trapezium.vert').default)
   }
 };
 
 export const edgeDetectionShaders = {
-  fragment: glsl(require('@/glsl/post-processing/edge-detect-combine.frag').default),
-  vertex: glsl(require('@/glsl/post-processing/edge-detection.vert').default)
+  fragment: glsl(require('../../../glsl/post-processing/edge-detect-combine.frag').default),
+  vertex: glsl(require('../../../glsl/post-processing/edge-detection.vert').default)
 };
 
 /**
  * FXAA anti-aliasing shader
  */
 export const fxaaShaders = {
-  fragment: glsl(require('@/glsl/post-processing/fxaa.frag').default),
-  vertex: glsl(require('@/glsl/post-processing/fxaa.vert').default)
+  fragment: glsl(require('../../../glsl/post-processing/fxaa.frag').default),
+  vertex: glsl(require('../../../glsl/post-processing/fxaa.vert').default)
 };
 
 /**
  * Shaders use to estimate how many pixels a sector covers on screen.
  */
 export const coverageShaders = {
-  fragment: glsl(require('@/glsl/sector/sectorCoverage.frag').default),
-  vertex: glsl(require('@/glsl/sector/sectorCoverage.vert').default)
+  fragment: glsl(require('../../../glsl/sector/sectorCoverage.frag').default),
+  vertex: glsl(require('../../../glsl/sector/sectorCoverage.vert').default)
 };

--- a/viewer/src/datamodels/cad/rendering/triangleMeshes.ts
+++ b/viewer/src/datamodels/cad/rendering/triangleMeshes.ts
@@ -3,7 +3,7 @@
  */
 
 import * as THREE from 'three';
-import { disposeAttributeArrayOnUpload } from '@/utilities/disposeAttributeArrayOnUpload';
+import { disposeAttributeArrayOnUpload } from '../../../utilities/disposeAttributeArrayOnUpload';
 import { TriangleMesh } from './types';
 
 export function createTriangleMeshes(

--- a/viewer/src/datamodels/cad/sector/CachedRepository.ts
+++ b/viewer/src/datamodels/cad/sector/CachedRepository.ts
@@ -37,14 +37,14 @@ import {
 } from 'rxjs/operators';
 import { CadSectorParser } from './CadSectorParser';
 import { SimpleAndDetailedToSector3D } from './SimpleAndDetailedToSector3D';
-import { MemoryRequestCache } from '@/utilities/cache/MemoryRequestCache';
+import { MemoryRequestCache } from '../../../utilities/cache/MemoryRequestCache';
 import { ParseCtmResult, ParseSectorResult } from '@cognite/reveal-parser-worker';
 import { TriangleMesh, InstancedMeshFile, InstancedMesh, SectorQuads } from '../rendering/types';
-import { createOffsetsArray, LoadingState } from '@/utilities';
-import { trackError } from '@/utilities/metrics';
-import { BinaryFileProvider } from '@/utilities/networking/types';
+import { createOffsetsArray, LoadingState } from '../../../utilities';
+import { trackError } from '../../../utilities/metrics';
+import { BinaryFileProvider } from '../../../utilities/networking/types';
 import { Group } from 'three';
-import { RxTaskTracker } from '@/utilities/RxTaskTracker';
+import { RxTaskTracker } from '../../../utilities/RxTaskTracker';
 
 type KeyedWantedSector = { key: string; wantedSector: WantedSector };
 type WantedSecorWithRequestObservable = {

--- a/viewer/src/datamodels/cad/sector/CadSectorParser.ts
+++ b/viewer/src/datamodels/cad/sector/CadSectorParser.ts
@@ -2,7 +2,7 @@
  * Copyright 2020 Cognite AS
  */
 
-import { WorkerPool } from '@/utilities/workers/WorkerPool';
+import { WorkerPool } from '../../../utilities/workers/WorkerPool';
 import { ParseSectorResult, ParseCtmResult, RevealParserWorker } from '@cognite/reveal-parser-worker';
 import { SectorQuads } from '../rendering/types';
 

--- a/viewer/src/datamodels/cad/sector/ModelStateHandler.test.ts
+++ b/viewer/src/datamodels/cad/sector/ModelStateHandler.test.ts
@@ -5,7 +5,7 @@
 import { ModelStateHandler } from './ModelStateHandler';
 import { WantedSector, ConsumedSector } from './types';
 import { LevelOfDetail } from './LevelOfDetail';
-import { Box3 } from '@/utilities';
+import { Box3 } from '../../../utilities';
 
 describe('ModelStateHandler', () => {
   // TODO: 10-08-2020 j-bjorne: Consider changing WantedSector and ConsumedSector metadata field. Annoying to mock.

--- a/viewer/src/datamodels/cad/sector/Repository.ts
+++ b/viewer/src/datamodels/cad/sector/Repository.ts
@@ -5,7 +5,7 @@
 import { OperatorFunction, Observable } from 'rxjs';
 import { ConsumedSector, WantedSector, SectorGeometry } from './types';
 import { SectorQuads } from '../rendering/types';
-import { LoadingState } from '@/utilities';
+import { LoadingState } from '../../../utilities';
 
 // TODO move
 export type SectorId = number;

--- a/viewer/src/datamodels/cad/sector/SectorScene.ts
+++ b/viewer/src/datamodels/cad/sector/SectorScene.ts
@@ -4,9 +4,9 @@
 
 import * as THREE from 'three';
 import { vec3 } from 'gl-matrix';
-import { Box3 } from '@/utilities/Box3';
-import { traverseDepthFirst } from '@/utilities/objectTraversal';
-import { toThreeJsBox3 } from '@/utilities/threeConverters';
+import { Box3 } from '../../../utilities/Box3';
+import { traverseDepthFirst } from '../../../utilities/objectTraversal';
+import { toThreeJsBox3 } from '../../../utilities/threeConverters';
 import { SectorMetadata, SectorScene } from './types';
 
 export class SectorSceneImpl implements SectorScene {

--- a/viewer/src/datamodels/cad/sector/culling/ByVisibilityGpuSectorCuller.ts
+++ b/viewer/src/datamodels/cad/sector/culling/ByVisibilityGpuSectorCuller.ts
@@ -23,7 +23,7 @@ import {
 import { LevelOfDetail } from '../LevelOfDetail';
 import { CadModelMetadata } from '../../CadModelMetadata';
 import { SectorMetadata, WantedSector } from '../types';
-import { toThreeVector3 } from '@/utilities';
+import { toThreeVector3 } from '../../../../utilities';
 import { CadModelSectorBudget } from '../../CadModelBudget';
 
 /**

--- a/viewer/src/datamodels/cad/sector/culling/OrderSectorsByVisibilityCoverage.ts
+++ b/viewer/src/datamodels/cad/sector/culling/OrderSectorsByVisibilityCoverage.ts
@@ -7,7 +7,7 @@ import * as THREE from 'three';
 import { SectorMetadata } from '../types';
 import { coverageShaders } from '../../rendering/shaders';
 import { CadModelMetadata } from '../../CadModelMetadata';
-import { toThreeJsBox3, Box3 } from '@/utilities';
+import { toThreeJsBox3, Box3 } from '../../../../utilities';
 
 type SectorContainer = {
   model: CadModelMetadata;

--- a/viewer/src/datamodels/cad/sector/culling/TakenSectorTree.ts
+++ b/viewer/src/datamodels/cad/sector/culling/TakenSectorTree.ts
@@ -12,7 +12,7 @@ import {
   addSectorCost
 } from './types';
 import { CadModelMetadata } from '../../CadModelMetadata';
-import { traverseUpwards, traverseDepthFirst } from '@/utilities/objectTraversal';
+import { traverseUpwards, traverseDepthFirst } from '../../../../utilities/objectTraversal';
 
 export class TakenSectorTree {
   get totalCost(): SectorCost {

--- a/viewer/src/datamodels/cad/sector/sectorUtilities.ts
+++ b/viewer/src/datamodels/cad/sector/sectorUtilities.ts
@@ -12,9 +12,9 @@ import { createPrimitives } from '../rendering/primitives';
 import { createTriangleMeshes } from '../rendering/triangleMeshes';
 import { createInstancedMeshes } from '../rendering/instancedMeshes';
 import { SectorQuads } from '../rendering/types';
-import { disposeAttributeArrayOnUpload } from '@/utilities/disposeAttributeArrayOnUpload';
-import { toThreeJsBox3 } from '@/utilities';
-import { traverseDepthFirst } from '@/utilities/objectTraversal';
+import { disposeAttributeArrayOnUpload } from '../../../utilities/disposeAttributeArrayOnUpload';
+import { toThreeJsBox3 } from '../../../utilities';
+import { traverseDepthFirst } from '../../../utilities/objectTraversal';
 
 const emptyGeometry = new THREE.Geometry();
 

--- a/viewer/src/datamodels/cad/sector/types.ts
+++ b/viewer/src/datamodels/cad/sector/types.ts
@@ -6,7 +6,7 @@ import { vec3 } from 'gl-matrix';
 
 import { LevelOfDetail } from './LevelOfDetail';
 import { InstancedMeshFile, TriangleMesh, SectorQuads } from '../rendering/types';
-import { Box3 } from '@/utilities';
+import { Box3 } from '../../../utilities';
 import { ParsedPrimitives, ParseSectorResult, ParseCtmResult } from '@cognite/reveal-parser-worker';
 
 /**

--- a/viewer/src/datamodels/pointcloud/PointCloudFactory.ts
+++ b/viewer/src/datamodels/pointcloud/PointCloudFactory.ts
@@ -5,8 +5,8 @@ import * as Potree from '@cognite/potree-core';
 
 import { PotreeNodeWrapper } from './PotreeNodeWrapper';
 
-import { PointCloudMetadata } from '@/datamodels/pointcloud/PointCloudMetadata';
-import { HttpHeadersProvider } from '@/utilities/networking/HttpHeadersProvider';
+import { PointCloudMetadata } from './PointCloudMetadata';
+import { HttpHeadersProvider } from '../../utilities/networking/HttpHeadersProvider';
 
 export class PointCloudFactory {
   private readonly _httpHeadersProvider: HttpHeadersProvider;

--- a/viewer/src/datamodels/pointcloud/PointCloudManager.ts
+++ b/viewer/src/datamodels/pointcloud/PointCloudManager.ts
@@ -8,7 +8,7 @@ import { PointCloudMetadataRepository } from './PointCloudMetadataRepository';
 import { PotreeGroupWrapper } from './PotreeGroupWrapper';
 import { PotreeLoadHandler } from './PotreeLoadHandler';
 import { Observable } from 'rxjs';
-import { LoadingState } from '@/utilities';
+import { LoadingState } from '../../utilities';
 import { PointCloudNode } from './PointCloudNode';
 
 export class PointCloudManager<TModelIdentifier> {

--- a/viewer/src/datamodels/pointcloud/PointCloudMetadata.ts
+++ b/viewer/src/datamodels/pointcloud/PointCloudMetadata.ts
@@ -3,7 +3,7 @@
  */
 
 import * as THREE from 'three';
-import { CameraConfiguration } from '@/utilities';
+import { CameraConfiguration } from '../../utilities';
 
 export interface PointCloudMetadata {
   blobUrl: string;

--- a/viewer/src/datamodels/pointcloud/PointCloudMetadataRepository.ts
+++ b/viewer/src/datamodels/pointcloud/PointCloudMetadataRepository.ts
@@ -4,11 +4,11 @@
 
 import * as THREE from 'three';
 
-import { PointCloudMetadata } from '@/datamodels/pointcloud/PointCloudMetadata';
+import { PointCloudMetadata } from './PointCloudMetadata';
 import { MetadataRepository } from '../base';
-import { File3dFormat } from '@/utilities/types';
-import { transformCameraConfiguration } from '@/utilities/transformCameraConfiguration';
-import { ModelDataClient } from '@/utilities/networking/types';
+import { File3dFormat } from '../../utilities/types';
+import { transformCameraConfiguration } from '../../utilities/transformCameraConfiguration';
+import { ModelDataClient } from '../../utilities/networking/types';
 
 type ModelIdentifierWithFormat<T> = T & { format: File3dFormat };
 

--- a/viewer/src/datamodels/pointcloud/PointCloudNode.ts
+++ b/viewer/src/datamodels/pointcloud/PointCloudNode.ts
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import { PotreeGroupWrapper } from './PotreeGroupWrapper';
 import { PotreeNodeWrapper } from './PotreeNodeWrapper';
-import { CameraConfiguration, toThreeJsBox3 } from '@/utilities';
+import { CameraConfiguration, toThreeJsBox3 } from '../../utilities';
 import { PotreePointSizeType, PotreePointColorType, PotreePointShape, WellKnownAsprsPointClassCodes } from './types';
 
 const PotreeDefaultPointClass = 'DEFAULT';

--- a/viewer/src/datamodels/pointcloud/PotreeLoadHandler.ts
+++ b/viewer/src/datamodels/pointcloud/PotreeLoadHandler.ts
@@ -4,7 +4,7 @@
 import * as Potree from '@cognite/potree-core';
 import { Observable, interval } from 'rxjs';
 import { map, share, distinctUntilChanged, startWith } from 'rxjs/operators';
-import { LoadingState } from '@/utilities';
+import { LoadingState } from '../../utilities';
 
 export class PotreeLoadHandler {
   private static getLoadingState(): LoadingState {

--- a/viewer/src/datamodels/pointcloud/PotreeNodeWrapper.ts
+++ b/viewer/src/datamodels/pointcloud/PotreeNodeWrapper.ts
@@ -6,8 +6,8 @@ import * as Potree from '@cognite/potree-core';
 import * as THREE from 'three';
 
 import { PotreePointSizeType, PotreePointColorType, PotreePointShape } from './types';
-import { fromThreeJsBox3 } from '@/utilities';
-import { Box3 } from '@/utilities/Box3';
+import { fromThreeJsBox3 } from '../../utilities';
+import { Box3 } from '../../utilities/Box3';
 import { vec3 } from 'gl-matrix';
 
 export type PotreeClassification = { [pointClass: number]: { x: number; y: number; z: number; w: number } };

--- a/viewer/src/datamodels/pointcloud/createPointCloudManager.ts
+++ b/viewer/src/datamodels/pointcloud/createPointCloudManager.ts
@@ -4,10 +4,10 @@
 
 import { PointCloudManager } from './PointCloudManager';
 import { PointCloudMetadataRepository } from './PointCloudMetadataRepository';
-import { CdfModelDataClient } from '@/utilities/networking/CdfModelDataClient';
-import { LocalModelDataClient } from '@/utilities/networking/LocalModelDataClient';
+import { CdfModelDataClient } from '../../utilities/networking/CdfModelDataClient';
+import { LocalModelDataClient } from '../../utilities/networking/LocalModelDataClient';
 import { PointCloudFactory } from './PointCloudFactory';
-import { CdfModelIdentifier, LocalModelIdentifier, ModelDataClient } from '@/utilities/networking/types';
+import { CdfModelIdentifier, LocalModelIdentifier, ModelDataClient } from '../../utilities/networking/types';
 
 export function createLocalPointCloudManager(client: LocalModelDataClient): PointCloudManager<LocalModelIdentifier> {
   return createPointCloudManager(client);

--- a/viewer/src/index.ts
+++ b/viewer/src/index.ts
@@ -9,7 +9,7 @@ export { Cognite3DViewer } from './public/migration/Cognite3DViewer';
 export { Intersection } from './public/migration/types';
 export * from './public/migration/Cognite3DViewer';
 export * from './public/migration/types';
-export { SupportedModelTypes } from '@/datamodels/base/SupportedModelTypes';
+export { SupportedModelTypes } from './datamodels/base/SupportedModelTypes';
 export { CadLoadingHints } from './datamodels/cad/CadLoadingHints';
 export { BoundingBoxClipper } from './utilities';
 export * from './revealEnv';

--- a/viewer/src/migration.ts
+++ b/viewer/src/migration.ts
@@ -13,4 +13,4 @@ export {
   Intersection,
   CameraConfiguration
 } from './public/migration/types';
-export { SupportedModelTypes } from '@/datamodels/base/SupportedModelTypes';
+export { SupportedModelTypes } from './datamodels/base/SupportedModelTypes';

--- a/viewer/src/public/RevealManager.ts
+++ b/viewer/src/public/RevealManager.ts
@@ -4,8 +4,8 @@
 
 import * as THREE from 'three';
 
-import { CadManager } from '@/datamodels/cad/CadManager';
-import { PointCloudManager } from '@/datamodels/pointcloud/PointCloudManager';
+import { CadManager } from '../datamodels/cad/CadManager';
+import { PointCloudManager } from '../datamodels/pointcloud/PointCloudManager';
 import {
   SectorNodeIdToTreeIndexMapLoadedListener,
   SectorNodeIdToTreeIndexMapLoadedEvent,
@@ -13,13 +13,13 @@ import {
 } from './types';
 import { Subscription, combineLatest, asyncScheduler, Subject } from 'rxjs';
 import { map, share, filter, observeOn, subscribeOn, tap, auditTime } from 'rxjs/operators';
-import { trackError, trackLoadModel, trackCameraNavigation } from '@/utilities/metrics';
-import { NodeAppearanceProvider, CadNode } from '@/datamodels/cad';
-import { RenderMode } from '@/datamodels/cad/rendering/RenderMode';
-import { EffectRenderManager } from '@/datamodels/cad/rendering/EffectRenderManager';
-import { SupportedModelTypes } from '@/datamodels/base';
-import { LoadingState } from '@/utilities';
-import { PointCloudNode } from '@/datamodels/pointcloud/PointCloudNode';
+import { trackError, trackLoadModel, trackCameraNavigation } from '../utilities/metrics';
+import { NodeAppearanceProvider, CadNode } from '../datamodels/cad';
+import { RenderMode } from '../datamodels/cad/rendering/RenderMode';
+import { EffectRenderManager } from '../datamodels/cad/rendering/EffectRenderManager';
+import { SupportedModelTypes } from '../datamodels/base';
+import { LoadingState } from '../utilities';
+import { PointCloudNode } from '../datamodels/pointcloud/PointCloudNode';
 
 /* eslint-disable jsdoc/require-jsdoc */
 

--- a/viewer/src/public/createRevealManager.ts
+++ b/viewer/src/public/createRevealManager.ts
@@ -2,15 +2,15 @@
  * Copyright 2020 Cognite AS
  */
 
-import { LocalModelIdentifier, CdfModelIdentifier, ModelDataClient } from '@/utilities/networking/types';
-import { CdfModelDataClient } from '@/utilities/networking/CdfModelDataClient';
+import { LocalModelIdentifier, CdfModelIdentifier, ModelDataClient } from '../utilities/networking/types';
+import { CdfModelDataClient } from '../utilities/networking/CdfModelDataClient';
 import { CogniteClient } from '@cognite/sdk';
-import { createCadManager } from '@/datamodels/cad/createCadManager';
-import { createPointCloudManager } from '@/datamodels/pointcloud/createPointCloudManager';
+import { createCadManager } from '../datamodels/cad/createCadManager';
+import { createPointCloudManager } from '../datamodels/pointcloud/createPointCloudManager';
 import { RevealManager } from './RevealManager';
-import { LocalModelDataClient } from '@/utilities/networking/LocalModelDataClient';
+import { LocalModelDataClient } from '../utilities/networking/LocalModelDataClient';
 import { RevealOptions } from './types';
-import { initMetrics } from '@/utilities/metrics';
+import { initMetrics } from '../utilities/metrics';
 
 /**
  * Used to create an instance of reveal manager that works with localhost.

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -8,15 +8,15 @@ import { NodeIdAndTreeIndexMaps } from './NodeIdAndTreeIndexMaps';
 import { Color, CameraConfiguration } from './types';
 import { CogniteModelBase } from './CogniteModelBase';
 import { NotSupportedInMigrationWrapperError } from './NotSupportedInMigrationWrapperError';
-import { toThreeJsBox3, NumericRange } from '@/utilities';
-import { CadRenderHints, CadNode } from '@/experimental';
-import { CadLoadingHints } from '@/datamodels/cad/CadLoadingHints';
-import { CadModelMetadata } from '@/datamodels/cad/CadModelMetadata';
-import { NodeAppearanceProvider, DefaultNodeAppearance } from '@/datamodels/cad/NodeAppearance';
-import { trackError } from '@/utilities/metrics';
+import { toThreeJsBox3, NumericRange } from '../../utilities';
+import { CadRenderHints, CadNode } from '../../experimental';
+import { CadLoadingHints } from '../../datamodels/cad/CadLoadingHints';
+import { CadModelMetadata } from '../../datamodels/cad/CadModelMetadata';
+import { NodeAppearanceProvider, DefaultNodeAppearance } from '../../datamodels/cad/NodeAppearance';
+import { trackError } from '../../utilities/metrics';
 import { SupportedModelTypes } from '../types';
-import { callActionWithIndicesAsync } from '@/utilities/callActionWithIndicesAsync';
-import { CogniteClientNodeIdAndTreeIndexMapper } from '@/utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
+import { callActionWithIndicesAsync } from '../../utilities/callActionWithIndicesAsync';
+import { CogniteClientNodeIdAndTreeIndexMapper } from '../../utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
 import { NodeStyleUpdater } from './NodeStyleUpdater';
 
 const mapCoordinatesBuffers = {

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -12,8 +12,8 @@ import { CogniteClient } from '@cognite/sdk';
 import { debounceTime, filter, map } from 'rxjs/operators';
 import { merge, Subject, Subscription, fromEventPattern, Observable } from 'rxjs';
 
-import { from3DPositionToRelativeViewportCoordinates } from '@/utilities/worldToViewport';
-import { intersectCadNodes } from '@/datamodels/cad/picking';
+import { from3DPositionToRelativeViewportCoordinates } from '../../utilities/worldToViewport';
+import { intersectCadNodes } from '../../datamodels/cad/picking';
 
 import {
   AddModelOptions,
@@ -27,17 +27,17 @@ import { NotSupportedInMigrationWrapperError } from './NotSupportedInMigrationWr
 import RenderController from './RenderController';
 import { CogniteModelBase } from './CogniteModelBase';
 
-import { CdfModelDataClient } from '@/utilities/networking/CdfModelDataClient';
+import { CdfModelDataClient } from '../../utilities/networking/CdfModelDataClient';
 import { Cognite3DModel } from './Cognite3DModel';
 import { CognitePointCloudModel } from './CognitePointCloudModel';
-import { BoundingBoxClipper, File3dFormat, LoadingState } from '@/utilities';
-import { Spinner } from '@/utilities/Spinner';
-import { trackError, trackEvent } from '@/utilities/metrics';
+import { BoundingBoxClipper, File3dFormat, LoadingState } from '../../utilities';
+import { Spinner } from '../../utilities/Spinner';
+import { trackError, trackEvent } from '../../utilities/metrics';
 import { RevealManager } from '../RevealManager';
 import { createCdfRevealManager } from '../createRevealManager';
-import { CdfModelIdentifier } from '@/utilities/networking/types';
+import { CdfModelIdentifier } from '../../utilities/networking/types';
 import { RevealOptions, SectorNodeIdToTreeIndexMapLoadedEvent } from '../types';
-import { SupportedModelTypes } from '@/datamodels/base';
+import { SupportedModelTypes } from '../../datamodels/base';
 
 /**
  * @example

--- a/viewer/src/public/migration/CognitePointCloudModel.ts
+++ b/viewer/src/public/migration/CognitePointCloudModel.ts
@@ -7,7 +7,7 @@ import { CogniteModelBase } from './CogniteModelBase';
 import { SupportedModelTypes } from '../types';
 import { CameraConfiguration } from './types';
 import { PotreePointColorType, PotreePointShape, WellKnownAsprsPointClassCodes } from '../..';
-import { PointCloudNode } from '@/datamodels/pointcloud/PointCloudNode';
+import { PointCloudNode } from '../../datamodels/pointcloud/PointCloudNode';
 
 /**
  * Represents a point clouds model loaded from CDF.

--- a/viewer/src/public/migration/NodeStyleUpdater.ts
+++ b/viewer/src/public/migration/NodeStyleUpdater.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2020 Cognite AS
  */
-import { NumericRange } from '@/utilities';
+import { NumericRange } from '../../utilities';
 
 /**
  * Helper class that schedules node apperance update to avoid

--- a/viewer/src/public/migration/types.ts
+++ b/viewer/src/public/migration/types.ts
@@ -4,7 +4,7 @@
 
 import { CogniteClient } from '@cognite/sdk';
 
-import { SectorCuller } from '@/datamodels/cad/sector/culling/SectorCuller';
+import { SectorCuller } from '../../datamodels/cad/sector/culling/SectorCuller';
 import { Cognite3DModel } from './Cognite3DModel';
 
 /**
@@ -94,7 +94,7 @@ export interface Intersection {
 /**
  * @module @cognite/reveal
  */
-export { CameraConfiguration } from '@/utilities';
+export { CameraConfiguration } from '../../utilities';
 
 /**
  * Delegate for pointer events.

--- a/viewer/src/public/types.ts
+++ b/viewer/src/public/types.ts
@@ -2,17 +2,17 @@
  * Copyright 2020 Cognite AS
  */
 
-import { NodeAppearanceProvider } from '@/datamodels/cad';
-import { SectorGeometry } from '@/datamodels/cad/sector/types';
-import { SectorQuads } from '@/datamodels/cad/rendering/types';
-import { SectorCuller } from '@/internal';
-import { LoadingState } from '@/utilities';
+import { NodeAppearanceProvider } from '../datamodels/cad';
+import { SectorGeometry } from '../datamodels/cad/sector/types';
+import { SectorQuads } from '../datamodels/cad/rendering/types';
+import { SectorCuller } from '../internal';
+import { LoadingState } from '../utilities';
 
 // we use these types in public API so they should be reexported here
 // to appear in the api reference docs
-export { CadRenderHints } from '@/datamodels/cad/rendering/CadRenderHints';
-export { CadLoadingHints } from '@/datamodels/cad/CadLoadingHints';
-export * from '@/datamodels/base/SupportedModelTypes';
+export { CadRenderHints } from '../datamodels/cad/rendering/CadRenderHints';
+export { CadLoadingHints } from '../datamodels/cad/CadLoadingHints';
+export * from '../datamodels/base/SupportedModelTypes';
 
 /**
  * @property logMetrics Might be used to disable usage statistics.

--- a/viewer/src/utilities/index.ts
+++ b/viewer/src/utilities/index.ts
@@ -4,10 +4,10 @@
 
 // TODO 02-06-2020 j-bjorne: Make index file the source of import for other packages? Adding all relative sub exports to index.ts
 // This would enable/enforce :
-// import { NetworkBlaBlaBla, CogniteClient } from '@/utilities';
+// import { NetworkBlaBlaBla, CogniteClient } from '../utilities';
 // rather than
-// import NetworkBlaBlaBla from '@/utilities/network/types';
-// import CogniteClient from '@/utilities/network/CogniteClient';
+// import NetworkBlaBlaBla from './network/types';
+// import CogniteClient from './network/CogniteClient';
 
 export { File3dFormat, CameraConfiguration, CogniteColors, LoadingState } from './types';
 export { LocalModelIdentifier, CdfModelIdentifier } from './networking/types';

--- a/viewer/src/utilities/workers/WorkerPool.ts
+++ b/viewer/src/utilities/workers/WorkerPool.ts
@@ -3,8 +3,8 @@
  */
 import * as Comlink from 'comlink';
 import type { RevealParserWorker } from '@cognite/reveal-parser-worker';
-import { revealEnv } from '@/revealEnv';
-import { isTheSameDomain } from '@/utilities/networking/isTheSameDomain';
+import { revealEnv } from '../../revealEnv';
+import { isTheSameDomain } from '../networking/isTheSameDomain';
 
 type WorkDelegate<T> = (worker: RevealParserWorker) => Promise<T>;
 

--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -22,12 +22,8 @@
     "lib": [
         "dom",
         "esnext"
-    ],
-
-    "baseUrl": "./src/",
-    "paths": {
-      "@/*": ["*"]
-    }
+    ]
+    // do not add path aliases. They'll end up in generated declaration files.
   },
   // include is also used for eslint to understand which files should be linted
   "include": ["*.js", "*.ts", "src/**/*", ".eslintrc.js", "script", "src/@types", "src/utilities/disposeAttributeArrayOnUpload.ts"],

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -31,10 +31,7 @@ module.exports = env => {
     target: 'web',
     resolve: {
       extensions: ['.tsx', '.ts', '.js'],
-      symlinks: false,
-      alias: {
-        '@': resolve('src')
-      }
+      symlinks: false
     },
     module: {
       rules: [


### PR DESCRIPTION
That's done to avoid having aliases in the production build.

See
* https://stackoverflow.com/a/57290924/2670121
* https://github.com/microsoft/TypeScript/issues/10866
* https://github.com/microsoft/TypeScript/issues/5039#issuecomment-232470330

Please don't hate me for that 😅 

put it on hold for 1.2.1

---


Just to summarise, currently, we use `@` alias in imports. And they are left unchanged in resulting type declarations. And that is not good because some types are just replaced with `any` and it doesn’t work at all in angular-cli based setups (failed with compile-time errors that fairly blame aliases). 

There are 3 solutions for that

1. Just use relative paths (PR :point_up: ) - no cons for the resulting package, only some headache for you as developers because you will see `../../../../../` a lot
2. Instead of using `@` alias we can use `@cognite/reveal` alias. It works fine, but it breaks the perfectly valid (though more rare) case when the package is installed under a different name, e.g. package.json has this `"my-reveal-v1.2": "npm:@cognite/reveal@1.2.0"`  I personally use such things from time to time :man_shrugging: so for this case the problem remains unfixed. 
3. Use some transformation plugin for typescript in pair with an alternative compiler (e.g. **tt**ypescript). It requires replacement of the compiler and probably locking of typescript version on 3.5. I didn’t make it work when tried, because I used it with our current version (4.0.5) and that didn’t work. It should work fine, but IMO that option is bad because of ts version locking and it just feels unreliable when some third-party package uses something from TSC that not really supposed to be used.