### PR TITLE
fix: adjust spinner styles

### DIFF
--- a/viewer/src/utilities/spinnerStyles.css
+++ b/viewer/src/utilities/spinnerStyles.css
@@ -3,6 +3,7 @@
     border-radius: 50%;
     width: 32px;
     height: 32px;
+    box-sizing: border-box;
 }
 .reveal-viewer-spinner {
     margin: 10px;


### PR DESCRIPTION
`box-sizing: border-box` should be set. Usually, apps set it globally for everything, but not always though. It affects spinner size.