### PR TITLE
chore: update three.js version in peer dependencies

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -107,7 +107,7 @@
   },
   "peerDependencies": {
     "@cognite/sdk": "^3.0.0",
-    "three": "0.117.x"
+    "three": "^0.122.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
we updated it in dev dependencies but it remains fixed to 0.117.x in peers. It causes an unmet peer dependency warning if newer of three.js is installed. 