### PR TITLE
feat: fitCameraToModel now uses K-means clustering for determining bounds of CAD models

### DIFF
--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -122,7 +122,11 @@ export function Migration() {
           addModel({
             modelId: guiState.modelId,
             revisionId: guiState.revisionId,
-          })
+          }),
+        fitToModel: () => {
+          const model = cadModels[0] || pointCloudModels[0];
+          viewer.fitCameraToModel(model);
+        }
       };
 
       const settingsGui = gui.addFolder('settings');
@@ -133,6 +137,7 @@ export function Migration() {
       gui.add(guiState, 'modelId').name('Model ID');
       gui.add(guiState, 'revisionId').name('Revision ID');
       gui.add(guiActions, 'addModel').name('Load model');
+      gui.add(guiActions, 'fitToModel').name('Fit camera');
       gui.add(guiState, 'antiAliasing', 
         [
           'disabled','fxaa','msaa4','msaa8','msaa16',

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -97,13 +97,15 @@
     "@cognite/three-combo-controls": "^1.4.3",
     "@tweenjs/tween.js": "^18.6.4",
     "@types/lodash": "^4.14.162",
+    "@types/skmeans": "^0.11.0",
     "comlink": "^4.3.0",
     "gl-matrix": "^3.3.0",
     "glslify": "^7.1.1",
     "glslify-import": "^3.1.0",
     "lodash": "^4.17.20",
     "mixpanel-browser": "^2.39.0",
-    "rxjs": "^6.6.3"
+    "rxjs": "^6.6.3",
+    "skmeans": "^0.11.3"
   },
   "peerDependencies": {
     "@cognite/sdk": "^3.0.0",

--- a/viewer/src/datamodels/cad/sector/types.ts
+++ b/viewer/src/datamodels/cad/sector/types.ts
@@ -58,6 +58,13 @@ export interface SectorScene {
   getSectorsIntersectingBox(b: Box3): SectorMetadata[];
 
   /**
+   * Returns bounds that contains "most geometry". This bounds is an
+   * attempt to remove junk geometry from the bounds to allow e.g. setting
+   * a good camera position.
+   */
+  getBoundsOfMostGeometry(): Box3;
+
+  /**
    * Gets the sectors intersecting the frustum provided from the projection and inverse
    * camera matrix. Note that this function expects matrices in the the coordinate system
    * of the metadata. See below how to convert ThreeJS camera matrices to the correct format.

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -737,7 +737,7 @@ export class Cognite3DViewer {
    * ```
    */
   fitCameraToModel(model: CogniteModelBase, duration?: number): void {
-    const bounds = model.getModelBoundingBox();
+    const bounds = model.getModelBoundingBox(new THREE.Box3(), true);
     this.fitCameraToBoundingBox(bounds, duration);
   }
 

--- a/viewer/src/public/migration/CogniteModelBase.ts
+++ b/viewer/src/public/migration/CogniteModelBase.ts
@@ -12,7 +12,7 @@ import { SupportedModelTypes } from '../../datamodels/base';
 export interface CogniteModelBase {
   readonly type: SupportedModelTypes;
   dispose(): void;
-  getModelBoundingBox(outBbox?: THREE.Box3): THREE.Box3;
+  getModelBoundingBox(outBbox?: THREE.Box3, restrictToMostGeometry?: boolean): THREE.Box3;
   getCameraConfiguration(): CameraConfiguration | undefined;
   setModelTransformation(matrix: THREE.Matrix4): void;
   getModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;

--- a/viewer/src/utilities/Box3.ts
+++ b/viewer/src/utilities/Box3.ts
@@ -15,6 +15,11 @@ export class Box3 {
     return vec3.subtract(vec3.create(), this.max, this.min);
   }
 
+  get diagonalLength(): number {
+    const size = this.size;
+    return Math.sqrt(size[0] * size[0] + size[1] * size[1] + size[2] * size[2]);
+  }
+
   static fromBounds(xMin: number, yMin: number, zMin: number, xMax: number, yMax: number, zMax: number): Box3 {
     return new Box3([vec3.fromValues(xMin, yMin, zMin), vec3.fromValues(xMax, yMax, zMax)]);
   }
@@ -25,6 +30,10 @@ export class Box3 {
     return new Box3([min, max]);
   }
 
+  static mergeBoxes(boxes: Box3[]) {
+    return new Box3(boxes.flatMap(x => [x.min, x.max]));
+  }
+
   public readonly min: vec3;
   public readonly max: vec3;
 
@@ -32,13 +41,22 @@ export class Box3 {
     this.min = vec3.fromValues(Infinity, Infinity, Infinity);
     this.max = vec3.fromValues(-Infinity, -Infinity, -Infinity);
     for (const p of points) {
-      this.min[0] = Math.min(p[0], this.min[0]);
-      this.min[1] = Math.min(p[1], this.min[1]);
-      this.min[2] = Math.min(p[2], this.min[2]);
-      this.max[0] = Math.max(p[0], this.max[0]);
-      this.max[1] = Math.max(p[1], this.max[1]);
-      this.max[2] = Math.max(p[2], this.max[2]);
+      this.extendByPoint(p);
     }
+  }
+
+  extendByPoint(p: vec3): void {
+    this.min[0] = Math.min(p[0], this.min[0]);
+    this.min[1] = Math.min(p[1], this.min[1]);
+    this.min[2] = Math.min(p[2], this.min[2]);
+    this.max[0] = Math.max(p[0], this.max[0]);
+    this.max[1] = Math.max(p[1], this.max[1]);
+    this.max[2] = Math.max(p[2], this.max[2]);
+  }
+
+  extendByBox(b: Box3): void {
+    this.extendByPoint(b.min);
+    this.extendByPoint(b.max);
   }
 
   createTransformed(matrix: mat4): Box3 {

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -792,6 +792,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.2.tgz#5bb52ee68d0f8efa9cc0099920e56be6cc4e37f3"
   integrity sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
 
+"@types/skmeans@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@types/skmeans/-/skmeans-0.11.0.tgz#3beaf8786dc7fc84921abebe79a1bfb8b6a59115"
+  integrity sha512-600D56sPgbKHfNKsBl/umleMDihVKLEzCocfC4N7AHOgDoGIOX6Mef/ZZpPg6Yj+nhPLpeJfw/rriE3sAw+sew==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
@@ -8306,6 +8311,11 @@ sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+skmeans@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/skmeans/-/skmeans-0.11.3.tgz#6d4dafb8058520a792c10bae9d9b953a6b6379f4"
+  integrity sha512-nccEnlSeOMNAYM9ETMSq+m15u8g0KRCIvH2an/ROTx4Igmci/j3oYHBPGdAeGjhR7knAVoIIQwr/wy2dN/eKQA==
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This avoids many cases where fitToModel() zooms out to an "empty view" because there are junk geometry far away from the main model.

Examples (left is before, right after):

![image](https://user-images.githubusercontent.com/6741854/102282435-e8b3a700-3f30-11eb-85b0-f344f97935e5.png)