### PR TITLE
Revert "chore: report NPM package size in CI builds (#1326)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,9 @@ jobs:
       run: |
         xvfb-run yarn run coverage
 
-    - name: Build
-      # Note! We use this target to also determine the NPM size during build
-      uses: Arhia/action-check-compressed-size@v0.7
-      with:
-        directory: viewer
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        build-script: "build:prod"
-        pattern: "./dist/**/*"
-        minimum-change-threshold: 100
+    - name: Build prod version
+      working-directory: viewer
+      run: yarn run build:prod
 
     - name: Publish to codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
This reverts commit 1fc957e48ab1e5d8c2a87a9b651bca3922d5eca0.

The plugin is too chatty and ends up being spam.