### PR TITLE
 docs: cdf-hub-bundles as an easy option for cognite developers to get parser-worker + remove unused vars in test

### DIFF
--- a/documentation/docs/installation.mdx
+++ b/documentation/docs/installation.mdx
@@ -60,12 +60,31 @@ revealEnv.publicPath = `/worker-custom-folder/`;
 const viewer = new Cognite3DViewer(/*...*/)
 ```
 
-### Option 2: host Web Worker and WebAssmbly files externally
+### Option 2: host Web Worker and WebAssembly files externally
 
 In case if there is no such `/public` or similar folder in your project, you're likely using a different service
 to host static assets. The domain of that service is probably whitelisted in Content Security Policy and can be used to host the necessary files.
 
 In that case, the only thing you can do is build the reveal-parser-worker from sources with correct `publicPath`.
+
+:::note
+
+**If you're developing a Cognite application,
+you likely can use our own whitelisted CDN where we already have
+[parser-worker](https://cdf-hub-bundles.cogniteapp.com/dependencies/@cognite/reveal-parser-worker/1.1.0/reveal.parser.worker.js)
+uploaded.**
+
+In that case, skip to the [latest step](#lastCDNstep) for this option and use
+
+```js
+import { revealEnv } from '@cognite/reveal'
+revealEnv.publicPath =
+    `https://cdf-hub-bundles.cogniteapp.com/dependencies/@cognite/reveal-parser-worker/1.1.0/`
+```
+
+Parser-worker version can be different,
+see the latest versions on [npm page](https://www.npmjs.com/package/@cognite/reveal-parser-worker).
+:::
 
 Let's say your static server has that URL `https://static.server/`. And you can upload the files
 at some folder, so files should be available at `https://static.server/parser-worker/`
@@ -108,6 +127,9 @@ If you set the environment variable correctly, you should see it be printed to c
 ```
 
 5. Take the files from `./parser-worker/dist/local` and host them at the path you specified.
+
+<a aria-hidden="true" tabIndex="-1" className="anchor enhancedAnchor_node_modules-@docusaurus-theme-classic-lib-theme-Heading-" id="lastCDNstep"></a>
+
 6. In your project, specify `revealEnv.publicPath`
 
 ```js

--- a/documentation/docs/installation.mdx
+++ b/documentation/docs/installation.mdx
@@ -74,7 +74,7 @@ you likely can use our own whitelisted CDN where we already have
 [parser-worker](https://cdf-hub-bundles.cogniteapp.com/dependencies/@cognite/reveal-parser-worker/1.1.0/reveal.parser.worker.js)
 uploaded.**
 
-In that case, skip to the [latest step](#lastCDNstep) for this option and use
+In that case, skip to the [last step](#lastCDNstep) for this option and use
 
 ```js
 import { revealEnv } from '@cognite/reveal'

--- a/documentation/versioned_docs/version-1.x/installation.mdx
+++ b/documentation/versioned_docs/version-1.x/installation.mdx
@@ -60,12 +60,31 @@ revealEnv.publicPath = `/worker-custom-folder/`;
 const viewer = new Cognite3DViewer(/*...*/)
 ```
 
-### Option 2: host Web Worker and WebAssmbly files externally
+### Option 2: host Web Worker and WebAssembly files externally
 
 In case if there is no such `/public` or similar folder in your project, you're likely using a different service
 to host static assets. The domain of that service is probably whitelisted in Content Security Policy and can be used to host the necessary files.
 
 In that case, the only thing you can do is build the reveal-parser-worker from sources with correct `publicPath`.
+
+:::note
+
+**If you're developing a Cognite application,
+you likely can use our own whitelisted CDN where we already have
+[parser-worker](https://cdf-hub-bundles.cogniteapp.com/dependencies/@cognite/reveal-parser-worker/1.1.0/reveal.parser.worker.js)
+uploaded.**
+
+In that case, skip to the [latest step](#lastCDNstep) for this option and use
+
+```js
+import { revealEnv } from '@cognite/reveal'
+revealEnv.publicPath =
+    `https://cdf-hub-bundles.cogniteapp.com/dependencies/@cognite/reveal-parser-worker/1.1.0/`
+```
+
+Parser-worker version can be different,
+see the latest versions on [npm page](https://www.npmjs.com/package/@cognite/reveal-parser-worker).
+:::
 
 Let's say your static server has that URL `https://static.server/`. And you can upload the files
 at some folder, so files should be available at `https://static.server/parser-worker/`
@@ -108,6 +127,9 @@ If you set the environment variable correctly, you should see it be printed to c
 ```
 
 5. Take the files from `./parser-worker/dist/local` and host them at the path you specified.
+
+<a aria-hidden="true" tabIndex="-1" className="anchor enhancedAnchor_node_modules-@docusaurus-theme-classic-lib-theme-Heading-" id="lastCDNstep"></a>
+
 6. In your project, specify `revealEnv.publicPath`
 
 ```js

--- a/viewer/src/__tests__/dataModels/cad/internal/CadModelUpdateHandler.test.ts
+++ b/viewer/src/__tests__/dataModels/cad/internal/CadModelUpdateHandler.test.ts
@@ -2,23 +2,18 @@
  * Copyright 2021 Cognite AS
  */
 
-import { CadModelMetadata, CadNode } from '../../../../datamodels/cad';
 import { MaterialManager } from '../../../../datamodels/cad/MaterialManager';
 import { CadSectorParser } from '../../../../datamodels/cad/sector/CadSectorParser';
 import { SimpleAndDetailedToSector3D } from '../../../../datamodels/cad/sector/SimpleAndDetailedToSector3D';
 import { CachedRepository } from '../../../../datamodels/cad/sector/CachedRepository';
 import { SectorCuller } from '../../../../datamodels/cad/sector/culling/SectorCuller';
 
-import { createCadModelMetadata } from '../../../testutils/createCadModelMetadata';
-import { generateSectorTree } from '../../../testutils/createSectorMetadata';
 import { CadModelUpdateHandler } from '../../../../datamodels/cad/CadModelUpdateHandler';
 import { BinaryFileProvider } from '../../../../utilities/networking/types';
 
 describe('CadModelUpdateHandler', () => {
   let repository: CachedRepository;
   let mockCuller: SectorCuller;
-  let cadModelMetadata: CadModelMetadata;
-  let cadModel: CadNode;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -35,8 +30,6 @@ describe('CadModelUpdateHandler', () => {
       determineSectors: jest.fn(),
       dispose: jest.fn()
     };
-    cadModelMetadata = createCadModelMetadata(generateSectorTree(5));
-    cadModel = new CadNode(cadModelMetadata, materialManager);
   });
 
   afterAll(() => {


### PR DESCRIPTION
Mentioning cdf-hub-bundles as @sindresh suggested. 