### PR TITLE
chore: ignore husky@5.x updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -21,6 +21,10 @@ update_configs:
     package_manager: "javascript"
     directory: "/viewer"
     update_schedule: live
+    ignored_updates:
+      - match:
+          dependency_name: 'husky'
+          version_requirement: '5.x' # messes with hooks
     automerged_updates:
       - match:
           dependency_name: "*"


### PR DESCRIPTION
From my experience migration from 4.x to 5.x isn't smooth at all, so I ended up doing a rollback of husky for another project.