### PR TITLE
improvement: avoid calling updateMatrixWorld for entire scene graph each frame [REV-129]

### DIFF
--- a/viewer/src/datamodels/cad/rendering/EffectRenderManager.ts
+++ b/viewer/src/datamodels/cad/rendering/EffectRenderManager.ts
@@ -115,13 +115,21 @@ export class EffectRenderManager {
     this.renderTarget = null;
 
     this._cadScene = new THREE.Scene();
+    this._cadScene.autoUpdate = false;
     this._normalScene = new THREE.Scene();
+    this._normalScene.autoUpdate = false;
     this._inFrontScene = new THREE.Scene();
+    this._inFrontScene.autoUpdate = false;
     this._compositionScene = new THREE.Scene();
+    this._compositionScene.autoUpdate = false;
     this._fxaaScene = new THREE.Scene();
+    this._fxaaScene.autoUpdate = false;
     this._ssaoScene = new THREE.Scene();
+    this._ssaoScene.autoUpdate = false;
     this._ssaoBlurScene = new THREE.Scene();
+    this._ssaoBlurScene.autoUpdate = false;
     this._emptyScene = new THREE.Scene();
+    this._emptyScene.autoUpdate = false;
     this._normalSceneBuilder = new TemporarySceneBuilder(this._normalScene);
     this._inFrontSceneBuilder = new TemporarySceneBuilder(this._inFrontScene);
 

--- a/viewer/src/datamodels/cad/sector/SectorNode.ts
+++ b/viewer/src/datamodels/cad/sector/SectorNode.ts
@@ -35,6 +35,8 @@ export class SectorNode extends THREE.Group {
     this.resetGeometry();
     this._group = geomtryGroup;
     this._lod = levelOfDetail;
+
+    this.updateMatrixWorld(true);
   }
 
   resetGeometry() {

--- a/viewer/src/datamodels/cad/sector/sectorUtilities.ts
+++ b/viewer/src/datamodels/cad/sector/sectorUtilities.ts
@@ -8,13 +8,14 @@ import { groupBy, distinctUntilKeyChanged, withLatestFrom, mergeMap, filter, map
 
 import { SectorGeometry, SectorMetadata, WantedSector, ConsumedSector } from './types';
 import { Materials } from '../rendering/materials';
-import { createPrimitives } from '../rendering/primitives';
-import { createTriangleMeshes } from '../rendering/triangleMeshes';
+
 import { createInstancedMeshes } from '../rendering/instancedMeshes';
 import { SectorQuads } from '../rendering/types';
 import { disposeAttributeArrayOnUpload } from '../../../utilities/disposeAttributeArrayOnUpload';
 import { toThreeJsBox3 } from '../../../utilities';
 import { traverseDepthFirst } from '../../../utilities/objectTraversal';
+import { createTriangleMeshes } from '../rendering/triangleMeshes';
+import { createPrimitives } from '../rendering/primitives';
 
 const quadVertexData = new Float32Array([
   /* eslint-disable prettier/prettier */

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -210,6 +210,7 @@ export class Cognite3DViewer {
     this.camera.lookAt(new THREE.Vector3());
 
     this.scene = new THREE.Scene();
+    this.scene.autoUpdate = false;
     this.controls = new ComboControls(this.camera, this.canvas);
     this.controls.dollyFactor = 0.992;
     this.controls.minDistance = 1.0;
@@ -620,6 +621,7 @@ export class Cognite3DViewer {
       return;
     }
     this.scene.add(object);
+    object.updateMatrixWorld(true);
     this.extraObjects.push(object);
     this.renderController.redraw();
     this.triggerUpdateCameraNearAndFar(true);


### PR DESCRIPTION
For a complex model with a lot of individual objects in the scene, this reduces rendering time from ~35ms to ~31 ms:

**Before:**
![image](https://user-images.githubusercontent.com/6741854/111772900-b9089800-88ad-11eb-819a-8eba3a13e840.png)

**After:**
![image](https://user-images.githubusercontent.com/6741854/111772339-06d0d080-88ad-11eb-96af-f3fb8e35265d.png)
