### PR TITLE
improvement: replace huge CTM LRU cache with slim most frequently used cache to save memory

### DIFF
--- a/viewer/src/datamodels/cad/sector/CachedRepository.ts
+++ b/viewer/src/datamodels/cad/sector/CachedRepository.ts
@@ -46,6 +46,7 @@ import { BinaryFileProvider } from '../../../utilities/networking/types';
 import { Group } from 'three';
 import { RxTaskTracker } from '../../../utilities/RxTaskTracker';
 import { groupMeshesByNumber } from './groupMeshesByNumber';
+import { MostFrequentlyUsedCache } from '../../../utilities/MostFrequentlyUsedCache';
 
 type KeyedWantedSector = { key: string; wantedSector: WantedSector };
 type WantedSecorWithRequestObservable = {
@@ -65,9 +66,10 @@ export class CachedRepository implements Repository {
   > = new MemoryRequestCache({
     maxElementsInCache: 50
   });
-  private readonly _ctmFileCache: MemoryRequestCache<string, Observable<CtmFileResult>> = new MemoryRequestCache({
-    maxElementsInCache: 300
-  });
+  private readonly _ctmFileCache: MostFrequentlyUsedCache<
+    string,
+    Observable<CtmFileResult>
+  > = new MostFrequentlyUsedCache(10);
   private readonly _modelSectorProvider: BinaryFileProvider;
   private readonly _modelDataParser: CadSectorParser;
   private readonly _modelDataTransformer: SimpleAndDetailedToSector3D;
@@ -148,7 +150,9 @@ export class CachedRepository implements Repository {
        * \---------- cached wantedSectors ----------------
        *  \--------- uncached wantedSectors --------------
        */
-      const existsInCache = ({ key }: KeyedWantedSector) => this._consumedSectorCache.has(key);
+      const existsInCache = ({ key }: KeyedWantedSector) => {
+        return this._consumedSectorCache.has(key);
+      };
       const cached$ = simpleAndDetailed$.pipe(filter(existsInCache));
       const uncached$ = simpleAndDetailed$.pipe(
         filter((keyedWantedSector: KeyedWantedSector) => !existsInCache(keyedWantedSector))
@@ -315,8 +319,9 @@ export class CachedRepository implements Repository {
   private loadCtmFile(): OperatorFunction<CtmFileRequest, CtmFileResult> {
     return mergeMap(ctmRequest => {
       const key = this.ctmFileCacheKey(ctmRequest);
-      if (this._ctmFileCache.has(key)) {
-        return this._ctmFileCache.get(key);
+      const ctmFile = this._ctmFileCache.get(key);
+      if (ctmFile !== undefined) {
+        return ctmFile;
       } else {
         return this.loadCtmFileFromNetwork(ctmRequest);
       }
@@ -334,7 +339,7 @@ export class CachedRepository implements Repository {
         take(1)
       )
     );
-    this._ctmFileCache.forceInsert(this.ctmFileCacheKey(ctmRequest), networkObservable);
+    this._ctmFileCache.set(this.ctmFileCacheKey(ctmRequest), networkObservable);
     return networkObservable;
   }
 

--- a/viewer/src/utilities/MostFrequentlyUsedCache.test.ts
+++ b/viewer/src/utilities/MostFrequentlyUsedCache.test.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2021 Cognite AS
+ */
+
+import { MostFrequentlyUsedCache } from './MostFrequentlyUsedCache';
+
+describe('MostFrequentlyUsedCache', () => {
+  test('set within capacity, returns true', () => {
+    const cache = new MostFrequentlyUsedCache<string, number>(1);
+    cache.set('key', 1);
+  });
+
+  test('set overfilling capacity, returns true for kept item, false for rejected', () => {
+    const cache = new MostFrequentlyUsedCache<string, number>(1);
+    cache.get('key2'); // Ask for key1 to give it priority
+    expect(cache.set('key1', 1)).toBeTrue();
+    expect(cache.set('key2', 2)).toBeTrue();
+    expect(cache.set('key3', 1)).toBeFalse(); // Not added
+  });
+
+  test('get return undefined for non-existant key', () => {
+    const cache = new MostFrequentlyUsedCache<string, number>(1);
+    expect(cache.get('key')).toBeUndefined();
+  });
+
+  test('get return value of existing key', () => {
+    const cache = new MostFrequentlyUsedCache<string, number>(1);
+    cache.set('key', 1);
+    expect(cache.get('key')).toBe(1);
+    // Make 'newKey' have higher priorty then add it
+    cache.get('newKey');
+    cache.get('newKey');
+    cache.set('newKey', 2);
+    expect(cache.get('newKey')).toBe(2);
+    expect(cache.get('key')).toBeUndefined();
+  });
+});

--- a/viewer/src/utilities/MostFrequentlyUsedCache.test.ts
+++ b/viewer/src/utilities/MostFrequentlyUsedCache.test.ts
@@ -34,4 +34,32 @@ describe('MostFrequentlyUsedCache', () => {
     expect(cache.get('newKey')).toBe(2);
     expect(cache.get('key')).toBeUndefined();
   });
+
+  test('remove returns true if element is added and removes element', () => {
+    const cache = new MostFrequentlyUsedCache<string, number>(1);
+    cache.set('key', 1);
+    expect(cache.get('key')).toBe(1);
+
+    const wasRemoved = cache.remove('key');
+
+    expect(wasRemoved).toBeTrue();
+    expect(cache.get('key')).toBeUndefined();
+  });
+
+  test('remove returns false if element is not added', () => {
+    const cache = new MostFrequentlyUsedCache<string, number>(1);
+    const wasRemoved = cache.remove('key');
+    expect(wasRemoved).toBeFalse();
+  });
+
+  test('clear() removes all elements', () => {
+    const cache = new MostFrequentlyUsedCache<string, number>(10);
+    for (let i = 0; i < 10; i++) {
+      cache.set(`${i}`, i);
+    }
+    cache.clear();
+    for (let i = 0; i < 10; i++) {
+      expect(cache.get(`${i}`)).toBeUndefined();
+    }
+  });
 });

--- a/viewer/src/utilities/MostFrequentlyUsedCache.ts
+++ b/viewer/src/utilities/MostFrequentlyUsedCache.ts
@@ -21,11 +21,7 @@ export class MostFrequentlyUsedCache<TKey, TValue> {
   }
 
   set(key: TKey, value: TValue): boolean {
-    if (this._cache.has(key)) {
-      this._cache.set(key, value);
-      return true;
-    } else if (this._capacity < this._cache.size) {
-      // Still room
+    if (this._cache.has(key) || this._capacity < this._cache.size) {
       this._cache.set(key, value);
       return true;
     } else {

--- a/viewer/src/utilities/MostFrequentlyUsedCache.ts
+++ b/viewer/src/utilities/MostFrequentlyUsedCache.ts
@@ -38,6 +38,20 @@ export class MostFrequentlyUsedCache<TKey, TValue> {
     }
   }
 
+  remove(key: TKey): boolean {
+    this._retrieves.delete(key);
+    if (this._cache.has(key)) {
+      this._cache.delete(key);
+      return true;
+    }
+    return false;
+  }
+
+  clear() {
+    this._retrieves.clear();
+    this._cache.clear();
+  }
+
   private ensureWithinCapacity(): void {
     if (this._capacity < this._cache.size) {
       const keys = Array.from(this._cache.keys());

--- a/viewer/src/utilities/MostFrequentlyUsedCache.ts
+++ b/viewer/src/utilities/MostFrequentlyUsedCache.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright 2021 Cognite AS
+ */
+/**
+ * A cache that keeps values that is most frequently used (MFU) rather than a more common
+ * least recently used (LRU) approach.
+ */
+export class MostFrequentlyUsedCache<TKey, TValue> {
+  private readonly _capacity: number;
+  private readonly _cache = new Map<TKey, TValue>();
+  private readonly _retrieves = new Map<TKey, number>();
+
+  constructor(capacity: number) {
+    this._capacity = capacity;
+  }
+
+  get(key: TKey): TValue | undefined {
+    const retrieveCount = this._retrieves.get(key) || 0;
+    this._retrieves.set(key, retrieveCount + 1);
+    return this._cache.get(key);
+  }
+
+  set(key: TKey, value: TValue): boolean {
+    if (this._cache.has(key)) {
+      this._cache.set(key, value);
+      return true;
+    } else if (this._capacity < this._cache.size) {
+      // Still room
+      this._cache.set(key, value);
+      return true;
+    } else {
+      // TODO 2020-12-05 larsmoa: Very inefficient way to set value.
+      // We often set a value and discard it a moment later because its not
+      // imporant. Fix this.
+      this._cache.set(key, value);
+      this.ensureWithinCapacity();
+      return this._cache.has(key);
+    }
+  }
+
+  private ensureWithinCapacity(): void {
+    if (this._capacity < this._cache.size) {
+      const keys = Array.from(this._cache.keys());
+      // Figure out what to remove
+      const keysForRemoval = keys
+        .map(x => ({ key: x, retrivalCount: this._retrieves.get(x) || 0 }))
+        .sort((a, b) => a.retrivalCount - b.retrivalCount)
+        .slice(0, this._cache.size - this._capacity)
+        .map(x => x.key);
+      for (const key of keysForRemoval) {
+        this._cache.delete(key);
+      }
+    }
+  }
+}

--- a/viewer/src/utilities/MostFrequentlyUsedCache.ts
+++ b/viewer/src/utilities/MostFrequentlyUsedCache.ts
@@ -53,17 +53,16 @@ export class MostFrequentlyUsedCache<TKey, TValue> {
   }
 
   private ensureWithinCapacity(): void {
-    if (this._capacity < this._cache.size) {
-      const keys = Array.from(this._cache.keys());
-      // Figure out what to remove
-      const keysForRemoval = keys
-        .map(x => ({ key: x, retrivalCount: this._retrieves.get(x) || 0 }))
-        .sort((a, b) => a.retrivalCount - b.retrivalCount)
-        .slice(0, this._cache.size - this._capacity)
-        .map(x => x.key);
-      for (const key of keysForRemoval) {
-        this._cache.delete(key);
-      }
+    if (this._capacity >= this._cache.size) return;
+    const keys = Array.from(this._cache.keys());
+    // Figure out what to remove
+    const keysForRemoval = keys
+      .map(x => ({ key: x, retrivalCount: this._retrieves.get(x) || 0 }))
+      .sort((a, b) => a.retrivalCount - b.retrivalCount)
+      .slice(0, this._cache.size - this._capacity)
+      .map(x => x.key);
+    for (const key of keysForRemoval) {
+      this._cache.delete(key);
     }
   }
 }


### PR DESCRIPTION
Before:
`{consumedSectorHit: 516, consumedSectorMiss: 3423, ctmHit: 797, ctmMiss: 176}`
Cache size: 123.435 Kb

After:
`{consumedSectorHit: 516, consumedSectorMiss: 3423, ctmHit: 708, ctmMiss: 265}`
Cache size: 10.791 Kb