### PR TITLE
improvement: don't update treeIndex<>nodeId maps every time a sector is loaded to avoid allocation hot path

### DIFF
--- a/viewer/src/datamodels/cad/CadManager.ts
+++ b/viewer/src/datamodels/cad/CadManager.ts
@@ -10,8 +10,7 @@ import { CadModelUpdateHandler } from './CadModelUpdateHandler';
 import { Subscription, Observable } from 'rxjs';
 import { NodeAppearanceProvider } from './NodeAppearance';
 import { trackError } from '../../utilities/metrics';
-import { SectorGeometry } from './sector/types';
-import { SectorQuads } from './rendering/types';
+
 import { MaterialManager } from './MaterialManager';
 import { RenderMode } from './rendering/RenderMode';
 import { LoadingState } from '../../utilities';
@@ -169,10 +168,6 @@ export class CadManager<TModelIdentifier> {
 
   getLoadingStateObserver(): Observable<LoadingState> {
     return this._cadModelUpdateHandler.getLoadingStateObserver();
-  }
-
-  getParsedData(): Observable<{ blobUrl: string; lod: string; data: SectorGeometry | SectorQuads }> {
-    return this._cadModelUpdateHandler.getParsedData();
   }
 
   private markNeedsRedraw(): void {

--- a/viewer/src/datamodels/cad/CadModelUpdateHandler.ts
+++ b/viewer/src/datamodels/cad/CadModelUpdateHandler.ts
@@ -15,9 +15,9 @@ import { CadNode } from './CadNode';
 import { scan, share, startWith, auditTime, filter, map, finalize, observeOn } from 'rxjs/operators';
 import { SectorCuller } from './sector/culling/SectorCuller';
 import { CadLoadingHints } from './CadLoadingHints';
-import { ConsumedSector, SectorGeometry } from './sector/types';
+import { ConsumedSector } from './sector/types';
 import { Repository } from './sector/Repository';
-import { SectorQuads } from './rendering/types';
+
 import { assertNever, emissionLastMillis, LoadingState } from '../../utilities';
 import { CadModelMetadata } from '.';
 import { loadingEnabled, handleDetermineSectorsInput } from './sector/rxSectorUtilities';
@@ -145,10 +145,6 @@ export class CadModelUpdateHandler {
 
   getLoadingStateObserver(): Observable<LoadingState> {
     return this._sectorRepository.getLoadingStateObserver();
-  }
-
-  getParsedData(): Observable<{ blobUrl: string; lod: string; data: SectorGeometry | SectorQuads }> {
-    return this._sectorRepository.getParsedData();
   }
 
   /* When loading hints of a cadmodel changes, propagate the event down to the stream and either add or remove

--- a/viewer/src/datamodels/cad/sector/CachedRepository.ts
+++ b/viewer/src/datamodels/cad/sector/CachedRepository.ts
@@ -36,7 +36,7 @@ import { CadSectorParser } from './CadSectorParser';
 import { SimpleAndDetailedToSector3D } from './SimpleAndDetailedToSector3D';
 import { MemoryRequestCache } from '../../../utilities/cache/MemoryRequestCache';
 import { ParseCtmResult, ParseSectorResult } from '@cognite/reveal-parser-worker';
-import { TriangleMesh, InstancedMeshFile, InstancedMesh, SectorQuads } from '../rendering/types';
+import { TriangleMesh, InstancedMeshFile, InstancedMesh } from '../rendering/types';
 import { createOffsetsArray, LoadingState } from '../../../utilities';
 import { trackError } from '../../../utilities/metrics';
 import { BinaryFileProvider } from '../../../utilities/networking/types';
@@ -52,7 +52,6 @@ type WantedSecorWithRequestObservable = {
 };
 type CtmFileRequest = { blobUrl: string; fileName: string };
 type CtmFileResult = { fileName: string; data: ParseCtmResult };
-type ParsedData = { blobUrl: string; lod: string; data: SectorGeometry | SectorQuads };
 
 // TODO: j-bjorne 16-04-2020: REFACTOR FINALIZE INTO SOME OTHER FILE PLEZ!
 export class CachedRepository implements Repository {

--- a/viewer/src/datamodels/cad/sector/Repository.ts
+++ b/viewer/src/datamodels/cad/sector/Repository.ts
@@ -3,8 +3,7 @@
  */
 
 import { OperatorFunction, Observable } from 'rxjs';
-import { ConsumedSector, WantedSector, SectorGeometry } from './types';
-import { SectorQuads } from '../rendering/types';
+import { ConsumedSector, WantedSector } from './types';
 import { LoadingState } from '../../../utilities';
 
 // TODO move
@@ -12,8 +11,6 @@ export type SectorId = number;
 
 export interface Repository {
   loadSector(): OperatorFunction<WantedSector, ConsumedSector>;
-
   getLoadingStateObserver(): Observable<LoadingState>;
-  getParsedData(): Observable<{ blobUrl: string; lod: string; data: SectorGeometry | SectorQuads }>;
   clear(): void;
 }

--- a/viewer/src/public/migration/Cognite3DModel.ts
+++ b/viewer/src/public/migration/Cognite3DModel.ts
@@ -245,14 +245,6 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
   }
 
   /**
-   * @param sector
-   * @internal
-   */
-  updateNodeIdMaps(sector: Map<number, number>) {
-    this.nodeIdAndTreeIndexMaps.updateMaps(sector);
-  }
-
-  /**
    * Fetches a bounding box from the CDF by the nodeId.
    * @param nodeId
    * @param box Optional. Used to write result to.

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -34,7 +34,6 @@ import {
   defaultRenderOptions,
   DisposedDelegate,
   SceneRenderedDelegate,
-  SectorNodeIdToTreeIndexMapLoadedEvent,
   SsaoParameters,
   SsaoSampleQuality
 } from '../types';
@@ -483,17 +482,6 @@ export class Cognite3DViewer {
     const model3d = new Cognite3DModel(modelId, revisionId, cadNode, this.sdkClient);
     this.models.push(model3d);
     this.scene.add(model3d);
-    this._subscription.add(
-      fromEventPattern<SectorNodeIdToTreeIndexMapLoadedEvent>(
-        h => this._revealManager.on('nodeIdToTreeIndexMapLoaded', h),
-        h => this._revealManager.off('nodeIdToTreeIndexMapLoaded', h)
-      ).subscribe(event => {
-        // TODO 2020-07-05 larsmoa: Fix a better way of identifying a model than blobUrl
-        if (event.blobUrl === cadNode.cadModelMetadata.blobUrl) {
-          model3d.updateNodeIdMaps(event.nodeIdToTreeIndexMap);
-        }
-      })
-    );
 
     if (options.geometryFilter) {
       const geometryFilter = transformGeometryFilterToModelSpace(options.geometryFilter, model3d);

--- a/viewer/src/public/migration/NodeIdAndTreeIndexMaps.ts
+++ b/viewer/src/public/migration/NodeIdAndTreeIndexMaps.ts
@@ -213,12 +213,6 @@ export class NodeIdAndTreeIndexMaps {
     return mapped;
   }
 
-  updateMaps(nodeIdToTreeIndexMap: Map<number, number>) {
-    for (const [nodeId, treeIndex] of nodeIdToTreeIndexMap) {
-      this.add(nodeId, treeIndex);
-    }
-  }
-
   add(nodeId: number, treeIndex: number) {
     this.nodeIdToTreeIndexMap.set(nodeId, treeIndex);
     this.treeIndexToNodeIdMap.set(treeIndex, nodeId);

--- a/viewer/src/public/types.ts
+++ b/viewer/src/public/types.ts
@@ -107,22 +107,6 @@ export type RevealOptions = {
 };
 
 /**
- * Event notifying about a nodeId -> treeIndex map being loaded
- * as a result of parsing a sector.
- * @property blobUrl Identifies the model the nodeID map was loaded for.
- * @property nodeIdToTreeIndexMap Map defining a mapping from nodeId to treeIndex.
- */
-export type SectorNodeIdToTreeIndexMapLoadedEvent = {
-  blobUrl: string;
-  nodeIdToTreeIndexMap: Map<number, number>;
-};
-
-/**
- * Handler for SectorNodeIdToTreeIndexMapLoadedEvent.
- */
-export type SectorNodeIdToTreeIndexMapLoadedListener = (event: SectorNodeIdToTreeIndexMapLoadedEvent) => void;
-
-/**
  * Handler for events about data being loaded.
  */
 export type LoadingStateChangeListener = (loadingState: LoadingState) => any;


### PR DESCRIPTION
Updating these maps accounted for 30% of the allocations we do during sector loaded, so we deemed this not worth it.

Note that this can cause us to need more lookups to map between nodeId and treeIndex, but I believe that this isn't a problem in practice, especially since most users are using *ByTreeIndex() functions which doesn't require mapping (expect for fetching bounding boxes and a few exceptions which are rather rare).