### PR TITLE
improvement: add ability to color sector bounding boxes by loaded timestamp for debugging

### DIFF
--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -228,7 +228,7 @@ export function Migration() {
       
       const debugSectorsGui = debugGui.addFolder('Loaded sectors');
 
-      debugSectorsGui.add(guiState.debug.loadedSectors.options, 'colorBy', ['lod', 'depth']).name('Color by');
+      debugSectorsGui.add(guiState.debug.loadedSectors.options, 'colorBy', ['lod', 'depth', 'loadedTimestamp']).name('Color by');
       debugSectorsGui.add(guiState.debug.loadedSectors.options, 'leafsOnly').name('Leaf nodes only');
       debugSectorsGui.add(guiState.debug.loadedSectors.options, 'showSimpleSectors').name('Show simple sectors');
       debugSectorsGui.add(guiState.debug.loadedSectors.options, 'showDetailedSectors').name('Show detailed sectors');
@@ -271,7 +271,7 @@ export function Migration() {
         debugSectorsGui.updateDisplay();
       }, 500);
 
-      debugSectorsGui.add(guiActions, 'showSectorBoundingBoxes').name('Show loaded sectors');
+      debugSectorsGui.add(guiActions, 'showSectorBoundingBoxes').name('Show sectors');
       debugGui.add(guiActions, 'showCameraHelper').name('Show camera');
       debugGui.add(guiActions, 'showBoundsForAllGeometries').name('Show geometry bounds');
       debugGui.add(guiState.debug, 'suspendLoading').name('Suspend loading').onFinishChange(suspend => {

--- a/viewer/src/datamodels/cad/sector/SectorNode.ts
+++ b/viewer/src/datamodels/cad/sector/SectorNode.ts
@@ -14,6 +14,7 @@ export class SectorNode extends THREE.Group {
 
   private _group?: THREE.Group;
   private _lod = LevelOfDetail.Discarded;
+  private _updatedTimestamp: number = Date.now();
 
   constructor(sectorId: number, sectorPath: string, bounds: THREE.Box3) {
     super();
@@ -31,10 +32,15 @@ export class SectorNode extends THREE.Group {
     return this._group;
   }
 
+  get updatedTimestamp(): number {
+    return this._updatedTimestamp;
+  }
+
   updateGeometry(geomtryGroup: THREE.Group | undefined, levelOfDetail: LevelOfDetail) {
     this.resetGeometry();
     this._group = geomtryGroup;
     this._lod = levelOfDetail;
+    this._updatedTimestamp = Date.now();
     this.visible = this._lod !== LevelOfDetail.Discarded;
     this.updateMatrixWorld(true);
   }
@@ -54,6 +60,7 @@ export class SectorNode extends THREE.Group {
 
     this._group = undefined;
     this._lod = LevelOfDetail.Discarded;
+    this._updatedTimestamp = Date.now();
   }
 }
 

--- a/viewer/src/tools/DebugLoadedSectorsTool.ts
+++ b/viewer/src/tools/DebugLoadedSectorsTool.ts
@@ -16,7 +16,7 @@ export type DebugLoadedSectorsToolOptions = {
   showSimpleSectors?: boolean;
   showDetailedSectors?: boolean;
   showDiscardedSectors?: boolean;
-  colorBy?: 'depth' | 'lod';
+  colorBy?: 'depth' | 'lod' | 'loadedTimestamp';
   leafsOnly?: boolean;
 };
 
@@ -65,29 +65,35 @@ export class DebugLoadedSectorsTool extends Cognite3DViewerToolBase {
     shouldShowLod[LevelOfDetail.Simple] = this._options.showSimpleSectors;
     shouldShowLod[LevelOfDetail.Detailed] = this._options.showDetailedSectors;
 
+    const selectedSectorNodes: SectorNode[] = [];
     this._model.cadNode.traverse(node => {
       if (isSectorNode(node)) {
         const sectorNode = node as SectorNode;
 
         if (shouldShowLod[sectorNode.levelOfDetail] && (!this._options.leafsOnly || isLeaf(sectorNode))) {
-          const bboxNode = this.createBboxNodeFor(sectorNode);
-          this._boundingBoxes.add(bboxNode);
+          selectedSectorNodes.push(sectorNode);
         }
       }
+    });
+
+    selectedSectorNodes.forEach(sectorNode => {
+      const bboxNode = this.createBboxNodeFor(sectorNode, selectedSectorNodes);
+      this._boundingBoxes.add(bboxNode);
     });
     this._boundingBoxes.updateMatrixWorld(true);
 
     this._viewer.forceRerender();
   }
 
-  private createBboxNodeFor(node: SectorNode) {
+  private createBboxNodeFor(node: SectorNode, allSelectedNodes: SectorNode[]) {
     const options = this._options;
     function determineColor() {
       switch (options.colorBy) {
-        case 'depth':
+        case 'depth': {
           const s = Math.min(1.0, node.depth / 8);
           return new THREE.Color(Colors.green).lerpHSL(Colors.red, s);
-        case 'lod':
+        }
+        case 'lod': {
           switch (node.levelOfDetail) {
             case LevelOfDetail.Simple:
               return Colors.yellow;
@@ -98,6 +104,19 @@ export class DebugLoadedSectorsTool extends Cognite3DViewerToolBase {
             default:
               assertNever(node.levelOfDetail);
           }
+        }
+        case 'loadedTimestamp': {
+          debugger;
+          const timestampRange = allSelectedNodes.reduce(
+            (v, p) => ({ min: Math.min(p.updatedTimestamp, v.min), max: Math.max(p.updatedTimestamp, v.max) }),
+            { min: Infinity, max: -Infinity }
+          );
+          // Give more precision to recently loaded sectors
+          const s =
+            1.0 - Math.pow((node.updatedTimestamp - timestampRange.min) / (timestampRange.max - timestampRange.min), 4);
+          return new THREE.Color(Colors.green).lerpHSL(Colors.red, s);
+        }
+
         default:
           assertNever(options.colorBy);
       }

--- a/viewer/src/tools/DebugLoadedSectorsTool.ts
+++ b/viewer/src/tools/DebugLoadedSectorsTool.ts
@@ -17,7 +17,6 @@ export type DebugLoadedSectorsToolOptions = {
   showDetailedSectors?: boolean;
   showDiscardedSectors?: boolean;
   colorBy?: 'depth' | 'lod' | 'loadedTimestamp';
-  oldSectorThreshold: number;
   leafsOnly?: boolean;
 };
 
@@ -41,7 +40,6 @@ export class DebugLoadedSectorsTool extends Cognite3DViewerToolBase {
       showDiscardedSectors: false,
       showSimpleSectors: true,
       colorBy: 'lod',
-      oldSectorThreshold: 10000,
       leafsOnly: false,
       ...options
     };


### PR DESCRIPTION
Recently loaded sectors are colored green, old sectors red.
![image](https://user-images.githubusercontent.com/6741854/113935480-e8e4f480-97f6-11eb-8e42-e2f8da91b6eb.png)
