### PR TITLE
feat: add support for transparency in custom objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install NPM dependencies
       working-directory: viewer
-      run: yarn
+      run: yarn cache clean && yarn cache clean --mirror && yarn
 
     - name: Lint
       working-directory: viewer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install NPM dependencies
       working-directory: viewer
-      run: yarn cache clean && yarn cache clean --mirror && yarn
+      run: yarn
 
     - name: Lint
       working-directory: viewer

--- a/documentation/docs/examples/cad-3dobjects.mdx
+++ b/documentation/docs/examples/cad-3dobjects.mdx
@@ -40,9 +40,10 @@ The following example reacts to clicks in the scene and adds markers to the posi
 
 ```jsx runnable
 const markerGeometry = new THREE.SphereBufferGeometry(1, 10, 10);
-const markerMaterial = new THREE.MeshStandardMaterial({
-  emissive: 'white',
-  wireframe: true,
+const markerMaterial = new THREE.MeshBasicMaterial({
+  color: 'blue',
+  transparent: true,
+  opacity: 0.7
 });
 viewer.on('click', (event) => {
   const intersection = viewer.getIntersectionFromPixel(

--- a/documentation/docs/examples/cad-3dobjects.mdx
+++ b/documentation/docs/examples/cad-3dobjects.mdx
@@ -20,7 +20,11 @@ need lights this needs to be added to the viewer scene.
 [`THREE.Material.depthWrite`](https://threejs.org/docs/#api/en/materials/Material.depthWrite) must  `true` and
 [`THREE.Material.depthFunc`](https://threejs.org/docs/#api/en/materials/Material.depthFunc) must be `LessEqualDepth`.
 You might experience unexpected results if you are using materials where this doesn't hold.
-- Transparency is not fully supported. Transparent objects will not blend correctly with Reveal models.
+- Objects with opacity less than 1.0 will appear transparent regardless of if 
+[`THREE.Material.transparent`](https://threejs.org/docs/?q=Material#api/en/materials/Material.transparent) is `true` or
+`false`. The final composited image is always blended as if 
+[`THREE.Material.blendDst`](https://threejs.org/docs/?q=Material#api/en/materials/Material.blendDst) is 
+`OneMinusSrcAlphaFactor` and the blending settings on the material won't have any effect on the composition.
 :::
 
 <!-- :::tip

--- a/viewer/src/glsl/post-processing/outline-detect-combine.frag
+++ b/viewer/src/glsl/post-processing/outline-detect-combine.frag
@@ -112,12 +112,12 @@ void main() {
 
     if( any(equal(backNeighborIndices, vec4(0.0))) && backOutlineIndex > 0.0) 
     { 
-        float borderColorIndex = max(max(backNeighborIndices.x, backNeighborIndices.y), max(backNeighborIndices.z, backNeighborIndices.w));
-        gl_FragColor = texture2D(tOutlineColors, vec2(0.125 * borderColorIndex + (0.125 / 2.0), 0.5));
+      float borderColorIndex = max(max(backNeighborIndices.x, backNeighborIndices.y), max(backNeighborIndices.z, backNeighborIndices.w));
+      gl_FragColor = texture2D(tOutlineColors, vec2(0.125 * borderColorIndex + (0.125 / 2.0), 0.5));
 #if defined(gl_FragDepthEXT) || defined(GL_EXT_frag_depth)
-        gl_FragDepthEXT = texture2D(tBackDepth, vUv).r;
+      gl_FragDepthEXT = texture2D(tBackDepth, vUv).r;
 #endif
-        return;
+      return;
     }
   }
 
@@ -127,23 +127,33 @@ void main() {
     discard;
   }
   
-  float edgeStrength = 0.0;
-  if(customDepth < backDepth){
-    backDepth = customDepth;
-    backAlbedo = customAlbedo;
+  // Combine color from ghost, back and custom object
+  vec4 color = backAlbedo;
+  float depth = backDepth;
+  if (customDepth < backDepth && ghostDepth == 1.0) {
+    color = vec4(customAlbedo.rgb * customAlbedo.a + (1.0 - customAlbedo.a) * backAlbedo.rgb, 1.0);
+    depth = customDepth;
+  } else if (customDepth < backDepth && ghostDepth < 1.0) {
+    float s = (1.0 - step(backDepth, ghostDepth)) * clampedGhostAlbedo.a;
+    vec3 modelAlbedo = mix(backAlbedo.rgb, clampedGhostAlbedo.rgb, s);
+    color = vec4(customAlbedo.rgb * customAlbedo.a + (1.0 - customAlbedo.a) * modelAlbedo.rgb, 1.0);
+    depth = customDepth;
   } else {
-#if defined(EDGES)
-      if(!any(equal(computeNeighborAlphas(tBack), vec4(0.0)))){
-        float depthEdge = toViewZ(backDepth, cameraNear, cameraFar);
-        edgeStrength = (1.0 - smoothstep(10.0, 40.0, depthEdge)) * edgeDetectionFilter(tBack, vUv, resolution) * edgeStrengthMultiplier;
-      }
-#endif
+    float s = (1.0 - step(backDepth, ghostDepth)) * clampedGhostAlbedo.a;
+    color = vec4(mix(backAlbedo.rgb, clampedGhostAlbedo.rgb, s), backAlbedo.a);
+    depth = mix(backDepth, ghostDepth, s);
   }
+
+  float edgeStrength = 0.0;
+#if defined(EDGES)
+  if (!any(equal(computeNeighborAlphas(tBack), vec4(0.0)))) {
+    float depthEdge = toViewZ(backDepth, cameraNear, cameraFar);
+    edgeStrength = (1.0 - smoothstep(10.0, 40.0, depthEdge)) * edgeDetectionFilter(tBack, vUv, resolution) * edgeStrengthMultiplier;
+  }
+#endif
   
-  float s = (1.0 - step(backDepth, ghostDepth)) * clampedGhostAlbedo.a;
-  vec4 outAlbedo = vec4(mix(backAlbedo.rgb, clampedGhostAlbedo.rgb, s), 1.0);
-  gl_FragColor = outAlbedo * (1.0 - edgeStrength) + vec4(vec3(edgeGrayScaleIntensity) * edgeStrength, 1.0);
+  gl_FragColor = color * (1.0 - edgeStrength) + vec4(vec3(edgeGrayScaleIntensity) * edgeStrength, 1.0);
 #if defined(gl_FragDepthEXT) || defined(GL_EXT_frag_depth)  
-  gl_FragDepthEXT = mix(backDepth, ghostDepth, s);
+  gl_FragDepthEXT = depth;
 #endif
 }


### PR DESCRIPTION
Combined with regular geometry (0.7 opacity):
![image](https://user-images.githubusercontent.com/6741854/117278018-ad266480-ae60-11eb-85b7-140304dafeb6.png)

Combined with ghosted geometry (0.3 opacity):
![image](https://user-images.githubusercontent.com/6741854/117278230-e068f380-ae60-11eb-9d3c-5f646172d19b.png)

Combined with highlighted object (0.3 opacity):
![image](https://user-images.githubusercontent.com/6741854/117278402-08f0ed80-ae61-11eb-9317-dcf2b81feb48.png)
