### PR TITLE
chore: add lodash eslint plugin

### DIFF
--- a/viewer/.eslintrc.js
+++ b/viewer/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module' // Allows for the use of imports
   },
-  plugins: ['header', '@typescript-eslint', 'jsdoc', 'unused-imports'],
+  plugins: ['header', '@typescript-eslint', 'jsdoc', 'unused-imports', 'lodash'],
 
   extends: [
     'plugin:@typescript-eslint/recommended',
@@ -47,6 +47,10 @@ module.exports = {
         }
       ]
     ],
+
+    // see relevant discussion https://github.com/cognitedata/cognite-sdk-js/pull/386
+    'lodash/import-scope': ['error', 'method'],
+
     'no-return-await': 'error',
     'no-empty': 'off',
     'object-literal-sort-keys': 'off',

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -62,6 +62,7 @@
     "eslint-config-prettier": "^6.14.0",
     "eslint-plugin-header": "^3.1.0",
     "eslint-plugin-jsdoc": "^30.5.1",
+    "eslint-plugin-lodash": "^7.2.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-unused-imports": "^0.1.3",
     "file-loader": "^6.2.0",

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -3703,6 +3703,13 @@ eslint-plugin-jsdoc@^30.5.1:
     semver "^7.3.4"
     spdx-expression-parse "^3.0.1"
 
+eslint-plugin-lodash@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-7.2.0.tgz#160b0996bda6dd0592e83eab86d099e1982d6fa8"
+  integrity sha512-7Wf7SOCK90OFgPd8LleVQa8uCWBZDLjPKxaFdwM/aINDyXhley0nRKSKL6TESGFCCMduYPox5VLttvqV2Vfbig==
+  dependencies:
+    lodash ">=4"
+
 eslint-plugin-prettier@^3.1.4:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
@@ -6389,7 +6396,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.x, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@4.x, lodash@>=4, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
helps to avoid accidental imports of the whole lodash package which increases bundle size a bit more than necessary