### PR TITLE
chore: update direct dependencies

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -82,7 +82,7 @@
     "three": "^0.125.0",
     "ts-jest": "^26.4.3",
     "ts-loader": "8.0.7",
-    "typescript": "4.0.5",
+    "typescript": "4.2.4",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -99,7 +99,7 @@
     "@tweenjs/tween.js": "^18.6.4",
     "@types/lodash": "^4.14.170",
     "@types/skmeans": "^0.11.0",
-    "comlink": "^4.3.1",
+    "comlink": "4.3.0",
     "gl-matrix": "^3.3.0",
     "glslify": "^7.1.1",
     "glslify-import": "^3.1.0",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -94,18 +94,18 @@
   "dependencies": {
     "@cognite/potree-core": "^1.1.6",
     "@cognite/reveal-parser-worker": "1.1.0",
-    "@cognite/sdk-core": "^1.0.0",
+    "@cognite/sdk-core": "^2.1.2",
     "@cognite/three-combo-controls": "^1.4.3",
     "@tweenjs/tween.js": "^18.6.4",
-    "@types/lodash": "^4.14.162",
+    "@types/lodash": "^4.14.170",
     "@types/skmeans": "^0.11.0",
-    "comlink": "^4.3.0",
+    "comlink": "^4.3.1",
     "gl-matrix": "^3.3.0",
     "glslify": "^7.1.1",
     "glslify-import": "^3.1.0",
     "lodash": "^4.17.20",
     "mixpanel-browser": "^2.39.0",
-    "rxjs": "^6.6.3",
+    "rxjs": "^7.1.0",
     "skmeans": "^0.11.3"
   },
   "peerDependencies": {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@cognite/sdk": "^3.0.0",
-    "@cognite/sdk-core": "^1.0.0",
     "@types/gl-matrix": "^3.2.0",
     "@types/jest": "^26.0.15",
     "@types/mixpanel-browser": "^2.35.4",

--- a/viewer/src/datamodels/pointcloud/PotreeGroupWrapper.ts
+++ b/viewer/src/datamodels/pointcloud/PotreeGroupWrapper.ts
@@ -18,7 +18,7 @@ import { PotreeNodeWrapper } from './PotreeNodeWrapper';
 export class PotreeGroupWrapper extends THREE.Object3D {
   private _needsRedraw: boolean = false;
   private _lastDrawPointBuffersHash = -1;
-  private readonly _forceLoadingSubject = new Subject();
+  private readonly _forceLoadingSubject = new Subject<void>();
   private readonly _loadingObservable: Observable<LoadingState>;
 
   get needsRedraw(): boolean {

--- a/viewer/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/src/public/migration/Cognite3DViewer.ts
@@ -8,8 +8,7 @@ import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 import ComboControls from '@cognite/three-combo-controls';
 import { CogniteClient } from '@cognite/sdk';
-import { debounceTime, filter, map } from 'rxjs/operators';
-import { merge, Subject, Subscription, fromEventPattern, Observable } from 'rxjs';
+import { Subscription, fromEventPattern } from 'rxjs';
 
 import { from3DPositionToRelativeViewportCoordinates } from '../../utilities/worldToViewport';
 import { intersectCadNodes } from '../../datamodels/cad/picking';
@@ -104,7 +103,6 @@ export class Cognite3DViewer {
   private readonly scene: THREE.Scene;
   private readonly controls: ComboControls;
   private readonly sdkClient: CogniteClient;
-  private readonly _updateCameraNearAndFarSubject: Subject<{ camera: THREE.PerspectiveCamera; force: boolean }>;
   private readonly _subscription = new Subscription();
   private readonly _revealManager: RevealManager<CdfModelIdentifier>;
   private readonly _domElement: HTMLElement;
@@ -263,7 +261,6 @@ export class Cognite3DViewer {
       )
     );
 
-    this._updateCameraNearAndFarSubject = this.setupUpdateCameraNearAndFar();
     this.animate(0);
 
     trackEvent('construct3dViewer', {
@@ -626,7 +623,7 @@ export class Cognite3DViewer {
     object.updateMatrixWorld(true);
     this.extraObjects.push(object);
     this.renderController.redraw();
-    this.triggerUpdateCameraNearAndFar(true);
+    this.updateCameraNearAndFar(this.camera);
   }
 
   /**
@@ -649,7 +646,7 @@ export class Cognite3DViewer {
       this.extraObjects.splice(index, 1);
     }
     this.renderController.redraw();
-    this.triggerUpdateCameraNearAndFar(true);
+    this.updateCameraNearAndFar(this.camera);
   }
 
   /**
@@ -1246,7 +1243,7 @@ export class Cognite3DViewer {
       if (renderController.needsRedraw || this._revealManager.needsRedraw || this._slicingNeedsUpdate) {
         const frameNumber = this.renderer.info.render.frame;
         const start = Date.now();
-        this.triggerUpdateCameraNearAndFar();
+        this.updateCameraNearAndFar(this.camera);
         this._revealManager.render(this.camera);
         renderController.clearNeedsRedraw();
         this._revealManager.resetRedraw();
@@ -1256,45 +1253,6 @@ export class Cognite3DViewer {
         this._events.sceneRendered.fire({ frameNumber, renderTime, renderer: this.renderer, camera: this.camera });
       }
     }
-  }
-
-  /** @private */
-  private setupUpdateCameraNearAndFar(): Subject<{ camera: THREE.PerspectiveCamera; force: boolean }> {
-    const lastUpdatePosition = new THREE.Vector3(Infinity, Infinity, Infinity);
-    const camPosition = new THREE.Vector3();
-
-    const updateNearFarSubject = new Subject<{ camera: THREE.PerspectiveCamera; force: boolean }>();
-    updateNearFarSubject
-      .pipe(
-        map(state => {
-          if (state.force) {
-            // Emulate camera movement to force update
-            return Infinity;
-          }
-          return lastUpdatePosition.distanceToSquared(state.camera.getWorldPosition(camPosition));
-        }),
-        (source: Observable<number>) => {
-          return merge(
-            // When camera is moved more than 10 meters
-            source.pipe(filter(distanceMoved => distanceMoved > 10.0)),
-            // Or it's been a while since we last update near/far and camera has moved slightly
-            source.pipe(
-              debounceTime(100),
-              filter(distanceMoved => distanceMoved > 0.0)
-            )
-          );
-        }
-      )
-      .subscribe(() => {
-        this.camera.getWorldPosition(lastUpdatePosition);
-        this.updateCameraNearAndFar(this.camera);
-      });
-    return updateNearFarSubject;
-  }
-
-  /** @private */
-  private triggerUpdateCameraNearAndFar(force?: boolean) {
-    this._updateCameraNearAndFarSubject.next({ camera: this.camera, force: !!force });
   }
 
   /** @private */

--- a/viewer/src/public/migration/NodeIdAndTreeIndexMaps.ts
+++ b/viewer/src/public/migration/NodeIdAndTreeIndexMaps.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import { Subject, Observable, lastValueFrom } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { bufferTime, mergeMap, filter, mergeAll, map, share, tap, first } from 'rxjs/operators';
 import { CogniteClient, CogniteInternalId, InternalId } from '@cognite/sdk';
 import { CogniteClientNodeIdAndTreeIndexMapper } from '../../utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
@@ -117,13 +117,15 @@ export class NodeIdAndTreeIndexMaps {
       return treeIndex;
     }
 
-    const result = this.nodeIdResponse.pipe(
-      first(node => node.nodeId === nodeId),
-      map(node => node.treeIndex)
-    );
+    const result = this.nodeIdResponse
+      .pipe(
+        first(node => node.nodeId === nodeId),
+        map(node => node.treeIndex)
+      )
+      .toPromise();
 
     this.nodeIdRequestObservable.next(nodeId);
-    return lastValueFrom(result);
+    return (await result)!;
   }
 
   async getNodeId(treeIndex: number): Promise<number> {
@@ -132,13 +134,15 @@ export class NodeIdAndTreeIndexMaps {
       return nodeId;
     }
 
-    const result = this.treeIndexResponse.pipe(
-      first(node => node.treeIndex === treeIndex),
-      map(node => node.nodeId)
-    );
+    const result = this.treeIndexResponse
+      .pipe(
+        first(node => node.treeIndex === treeIndex),
+        map(node => node.nodeId)
+      )
+      .toPromise();
 
     this.treeIndexRequestObservable.next(treeIndex);
-    return lastValueFrom(result);
+    return (await result)!;
   }
 
   async getSubtreeSize(treeIndex: number): Promise<number> {
@@ -148,13 +152,15 @@ export class NodeIdAndTreeIndexMaps {
     }
 
     const nodeId = await this.getNodeId(treeIndex);
-    const result = this.subtreeSizeResponse.pipe(
-      first(node => node.treeIndex === treeIndex),
-      map(node => node.subtreeSize)
-    );
+    const result = this.subtreeSizeResponse
+      .pipe(
+        first(node => node.treeIndex === treeIndex),
+        map(node => node.subtreeSize)
+      )
+      .toPromise();
     this.subtreeSizeObservable.next({ id: nodeId });
 
-    return lastValueFrom(result);
+    return (await result)!;
   }
 
   async getTreeIndices(nodeIds: number[]): Promise<number[]> {

--- a/viewer/src/public/migration/NodeIdAndTreeIndexMaps.ts
+++ b/viewer/src/public/migration/NodeIdAndTreeIndexMaps.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import { Subject, Observable } from 'rxjs';
+import { Subject, Observable, lastValueFrom } from 'rxjs';
 import { bufferTime, mergeMap, filter, mergeAll, map, share, tap, first } from 'rxjs/operators';
 import { CogniteClient, CogniteInternalId, InternalId } from '@cognite/sdk';
 import { CogniteClientNodeIdAndTreeIndexMapper } from '../../utilities/networking/CogniteClientNodeIdAndTreeIndexMapper';
@@ -117,15 +117,13 @@ export class NodeIdAndTreeIndexMaps {
       return treeIndex;
     }
 
-    const result = this.nodeIdResponse
-      .pipe(
-        first(node => node.nodeId === nodeId),
-        map(node => node.treeIndex)
-      )
-      .toPromise();
+    const result = this.nodeIdResponse.pipe(
+      first(node => node.nodeId === nodeId),
+      map(node => node.treeIndex)
+    );
 
     this.nodeIdRequestObservable.next(nodeId);
-    return result;
+    return lastValueFrom(result);
   }
 
   async getNodeId(treeIndex: number): Promise<number> {
@@ -134,15 +132,13 @@ export class NodeIdAndTreeIndexMaps {
       return nodeId;
     }
 
-    const result = this.treeIndexResponse
-      .pipe(
-        first(node => node.treeIndex === treeIndex),
-        map(node => node.nodeId)
-      )
-      .toPromise();
+    const result = this.treeIndexResponse.pipe(
+      first(node => node.treeIndex === treeIndex),
+      map(node => node.nodeId)
+    );
 
     this.treeIndexRequestObservable.next(treeIndex);
-    return result;
+    return lastValueFrom(result);
   }
 
   async getSubtreeSize(treeIndex: number): Promise<number> {
@@ -152,15 +148,13 @@ export class NodeIdAndTreeIndexMaps {
     }
 
     const nodeId = await this.getNodeId(treeIndex);
-    const result = this.subtreeSizeResponse
-      .pipe(
-        first(node => node.treeIndex === treeIndex),
-        map(node => node.subtreeSize)
-      )
-      .toPromise();
+    const result = this.subtreeSizeResponse.pipe(
+      first(node => node.treeIndex === treeIndex),
+      map(node => node.subtreeSize)
+    );
     this.subtreeSizeObservable.next({ id: nodeId });
 
-    return result;
+    return lastValueFrom(result);
   }
 
   async getTreeIndices(nodeIds: number[]): Promise<number[]> {

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -335,10 +335,22 @@
   dependencies:
     comlink "^4.3.0"
 
-"@cognite/sdk-core@^1.0.0", "@cognite/sdk-core@^1.2.2":
+"@cognite/sdk-core@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-1.2.2.tgz#be6378ffee45c5da6d0186ce97246eb19a9d9dd4"
   integrity sha512-ePu4q1UGa4mIKDz0cxR2WzBjImtLlLQRwWY7R38IHfBXOFMJuFUxgHcKgoSP5bonGPGLHWP7UaTW+41+IsyGOw==
+  dependencies:
+    "@azure/msal-browser" "^2.11.0"
+    cross-fetch "^3.0.4"
+    is-buffer "^2.0.5"
+    lodash "^4.17.11"
+    query-string "^5.1.1"
+    url "^0.11.0"
+
+"@cognite/sdk-core@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-2.1.2.tgz#fd456988cb6b5921fd2f5b1366c531e5d8d4ef1f"
+  integrity sha512-L+nJzKBoRjkDPVuI33i4Xn5gHttPsGoOYWqAHkH/sy9FuI+d1l2rIg3Vuwr5ZryD3Gb9snXcDCCq9QsT9D3lEw==
   dependencies:
     "@azure/msal-browser" "^2.11.0"
     cross-fetch "^3.0.4"
@@ -758,10 +770,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
-"@types/lodash@^4.14.162":
-  version "4.14.168"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
-  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+"@types/lodash@^4.14.170":
+  version "4.14.170"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
+  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
 
 "@types/minimatch@*":
   version "3.0.4"
@@ -2859,6 +2871,11 @@ comlink@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.0.tgz#80b3366baccd87897dab3638ebfcfae28b2f87c7"
   integrity sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==
+
+comlink@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
+  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
 
 commander@^2.15.1, commander@^2.20.0:
   version "2.20.3"
@@ -8156,12 +8173,19 @@ run-script-os@^1.1.3:
   resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
   integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
 
-rxjs@^6.6.0, rxjs@^6.6.3, rxjs@^6.6.7:
+rxjs@^6.6.0, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.1.0.tgz#94202d27b19305ef7b1a4f330277b2065df7039e"
+  integrity sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==
+  dependencies:
+    tslib "~2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -9201,6 +9225,11 @@ tslib@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.21.0"

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -2867,15 +2867,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comlink@^4.3.0:
+comlink@4.3.0, comlink@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.0.tgz#80b3366baccd87897dab3638ebfcfae28b2f87c7"
   integrity sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==
-
-comlink@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
-  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
 
 commander@^2.15.1, commander@^2.20.0:
   version "2.20.3"

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -9314,10 +9314,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+typescript@4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 typescript@^3.6.3:
   version "3.9.9"


### PR DESCRIPTION
I had to defer updating comlink from 4.3.0 -> 4.3.1 as this introduced a regression with parsing sectors.