### PR TITLE
fix: proper version check of parser-worker

### DIFF
--- a/viewer/src/utilities/workers/WorkerPool.ts
+++ b/viewer/src/utilities/workers/WorkerPool.ts
@@ -93,11 +93,14 @@ export class WorkerPool {
 
 export async function checkWorkerVersion(worker: RevealParserWorker) {
   let actualWorkerVersion: string;
-  if ('getVersion' in worker) {
-    // @ts-ignore TS knows when there is no getVersion and forbids to check it (if 1.1.0 is installed)
+  try {
     actualWorkerVersion = await worker.getVersion();
-  } else {
-    actualWorkerVersion = '1.1.0'; // versions below 1.1.1 do not have getVersion method
+  } catch (e) {
+    // versions below 1.1.1 do not have getVersion method
+    // notice also you cannot use 'in' operator on worker object
+    // because it's merely a proxy-wrapper over postmessage('methodname')
+    // so `'getVersion' in worker` - will be always false
+    actualWorkerVersion = '1.1.0';
   }
   const minWorkerVersion = process.env.WORKER_VERSION;
 


### PR DESCRIPTION
I made a mistake with version check, 2 mistakes actually 🤦 

1) `in` operator doesn't work on worker. Comlink magic confused me. 
2) Turned out I accidentally uploaded the parser-worker WIP version to cognite CDN as 1.1.0. That's why if you navigate [here](https://apps-cdn.cogniteapp.com/@cognite/reveal-parser-worker/1.1.0/reveal.parser.worker.js) and search for "getVersion" you will find it, but it was originally planned to be a part of 1.1.1 version. But it's not critical at all. It just confused me when I tried to understand why I see that version mismatch error. Turned out it just never worked (see 1)