### PR TITLE
chore: don't check worker version in tests

### DIFF
--- a/viewer/src/utilities/workers/WorkerPool.ts
+++ b/viewer/src/utilities/workers/WorkerPool.ts
@@ -42,7 +42,9 @@ export class WorkerPool {
       this.workerList.push(newWorker);
     }
 
-    checkWorkerVersion(this.workerList[0].worker).catch(console.error);
+    if (process.env.NODE_ENV !== 'test') {
+      checkWorkerVersion(this.workerList[0].worker).catch(console.error);
+    }
 
     if (this.workerObjUrl) {
       URL.revokeObjectURL(this.workerObjUrl);


### PR DESCRIPTION
There is no real worker instance in tests so it falls back to the default version which is 1.1.0.

I'll also cherry-pick it into 1.x after merge 