### PR TITLE
chore: remove sdk-core from dev deps

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@cognite/sdk": "^3.4.0",
-    "@cognite/sdk-core": "^1.0.0",
     "@types/gl-matrix": "^3.2.0",
     "@types/jest": "^26.0.15",
     "@types/jsdom": "^16.2.10",
@@ -97,7 +96,7 @@
   "dependencies": {
     "@cognite/potree-core": "1.2.0",
     "@cognite/reveal-parser-worker": "1.1.1",
-    "@cognite/sdk-core": "^2.1.2",
+    "@cognite/sdk-core": ">=1",
     "@tweenjs/tween.js": "^18.6.4",
     "@types/three": "0.128.0",
     "comlink": "4.3.1",

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -335,10 +335,10 @@
   dependencies:
     comlink "4.3.1"
 
-"@cognite/sdk-core@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-1.2.0.tgz#919a664b73c074de9558bcf8cf91e9cecd3f028b"
-  integrity sha512-RcrvPFUotytag3jfb8frYKGEmpfns34p/RpVQgyshxWcrKwu7tMA3k3lhCTwkVd/mfUsrG1J9ZDvRn2HH4D9nA==
+"@cognite/sdk-core@>=1":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-2.1.2.tgz#fd456988cb6b5921fd2f5b1366c531e5d8d4ef1f"
+  integrity sha512-L+nJzKBoRjkDPVuI33i4Xn5gHttPsGoOYWqAHkH/sy9FuI+d1l2rIg3Vuwr5ZryD3Gb9snXcDCCq9QsT9D3lEw==
   dependencies:
     "@azure/msal-browser" "^2.11.0"
     cross-fetch "^3.0.4"
@@ -347,10 +347,10 @@
     query-string "^5.1.1"
     url "^0.11.0"
 
-"@cognite/sdk-core@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-2.1.2.tgz#fd456988cb6b5921fd2f5b1366c531e5d8d4ef1f"
-  integrity sha512-L+nJzKBoRjkDPVuI33i4Xn5gHttPsGoOYWqAHkH/sy9FuI+d1l2rIg3Vuwr5ZryD3Gb9snXcDCCq9QsT9D3lEw==
+"@cognite/sdk-core@^1.2.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-1.2.2.tgz#be6378ffee45c5da6d0186ce97246eb19a9d9dd4"
+  integrity sha512-ePu4q1UGa4mIKDz0cxR2WzBjImtLlLQRwWY7R38IHfBXOFMJuFUxgHcKgoSP5bonGPGLHWP7UaTW+41+IsyGOw==
   dependencies:
     "@azure/msal-browser" "^2.11.0"
     cross-fetch "^3.0.4"


### PR DESCRIPTION
we need any version that has HttpError and that's it. So I put `>=1` as range, maybe even `*` would be ok, but I didn't want to check since it's not really important imo. 