### PR TITLE
chore: fix customScope for 1.x docs

### DIFF
--- a/documentation/docs/components/customScope.ts
+++ b/documentation/docs/components/customScope.ts
@@ -22,5 +22,3 @@ export const customScope: Record<string, any> = {
   },
   ...reveal,
 };
-
-(window as any).reveal = reveal;

--- a/documentation/src/plugins/remark-runnable-reveal-demo.js
+++ b/documentation/src/plugins/remark-runnable-reveal-demo.js
@@ -15,18 +15,26 @@ const transformNode = (node) => {
   ];
 };
 
-const matchNode = (node) => node.type === 'code' && node.meta === 'runnable';
-const nodeForImport = {
-  type: 'import',
-  value:
-    "import { LiveCodeSnippet } from '@site/docs/components/LiveCodeSnippet';",
+const versionedImportNode = {
+  runnable: {
+    type: 'import',
+    value:
+      "import { LiveCodeSnippet } from '@site/docs/components/LiveCodeSnippet';",
+  },
+  'runnable-1x': {
+    type: 'import',
+    value:
+      "import { LiveCodeSnippet } from '@site/versioned_docs/version-1.x/components/LiveCodeSnippet';",
+  },
 };
 
 module.exports = () => {
   let transformed = false;
+  let importNode;
   const transformer = (node) => {
-    if (matchNode(node)) {
+    if (node.type === 'code' && versionedImportNode[node.meta]) {
       transformed = true;
+      importNode = versionedImportNode[node.meta];
       return transformNode(node);
     }
     if (Array.isArray(node.children)) {
@@ -42,7 +50,7 @@ module.exports = () => {
       }
     }
     if (node.type === 'root' && transformed) {
-      node.children.unshift(nodeForImport);
+      node.children.unshift(importNode);
     }
     return null;
   };

--- a/documentation/versioned_docs/version-1.x/examples/cad-2doverlay.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-2doverlay.mdx
@@ -32,7 +32,7 @@ coordinate whenever navigating the viewer.
 There might be "any" number of attached HTML overlays in a viewer, but avoid too many to avoid cluttering the
 view.
 
-```jsx runnable
+```jsx runnable-1x
 // import { HtmlOverlayTool } from '@cognite/reveal/tools';
 
 function createOverlay() {
@@ -77,7 +77,7 @@ from the camera. To do this, provide an `options`-argument with a
 `positionUpdatedCallback` to `HtmlOverlayTool.add`. This
 callback is triggered every time the HTML overlay is updated.
 
-```js runnable
+```jsx runnable-1x
 // import { HtmlOverlayTool } from '@cognite/reveal/tools';
 
 function createOverlay() {

--- a/documentation/versioned_docs/version-1.x/examples/cad-3dobjects.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-3dobjects.mdx
@@ -34,7 +34,7 @@ need lights this needs to be added to the viewer scene.
 
 The following example reacts to clicks in the scene and adds markers to the positions clicked.
 
-```jsx runnable
+```jsx runnable-1x
 const markerGeometry = new THREE.SphereBufferGeometry(1, 10, 10);
 const markerMaterial = new THREE.MeshStandardMaterial({
   emissive: 'white',
@@ -147,7 +147,7 @@ viewer.on('cameraChange', (position, target) => {
 
 Below is the complete code for adding a skybox and ocean to the scene.
 
-```jsx runnable
+```jsx runnable-1x
 // The following has been imported outside this scope:
 // import { Water } from 'three/examples/jsm/objects/Water';
 // const skyUrl = 'https://...'

--- a/documentation/versioned_docs/version-1.x/examples/cad-basic.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-basic.mdx
@@ -44,7 +44,7 @@ main();
 
 Models can be unloaded using `Cognite3DViewer.removeModel()`:
 
-```js runnable
+```jsx runnable-1x
 viewer.removeModel(model)
 ```
 

--- a/documentation/versioned_docs/version-1.x/examples/cad-colors.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-colors.mdx
@@ -15,7 +15,7 @@ Reveal supports updating the color of individual objects by providing [tree indi
 To update the colors of all nodes, loop over all tree indices in the model and update the colors
 accordingly:
 
-```jsx runnable
+```jsx runnable-1x
 model.iterateNodesByTreeIndex(treeIndex => {
   const value = treeIndex % 200;
   model.setNodeColorByTreeIndex(treeIndex, 200, value, 200);
@@ -27,7 +27,7 @@ model.iterateNodesByTreeIndex(treeIndex => {
 Notice how colors are applied in batches using this approach. A more performant choice when a single color is
 to be applied to all nodes is to use `Cognite3DModel.setAllNodeColors`:
 
-```jsx runnable
+```jsx runnable-1x
 model.setAllNodeColors(127, 127, 127);
 ```
 
@@ -35,7 +35,7 @@ model.setAllNodeColors(127, 127, 127);
 
 Color overrides can be reset using `Cognite3DModel.resetNodeColorByTreeIndex`, e.g.
 
-```jsx runnable
+```jsx runnable-1x
 model.iterateNodesByTreeIndex(treeIndex => {
   model.resetNodeColorByTreeIndex(treeIndex);
 });
@@ -44,7 +44,7 @@ model.iterateNodesByTreeIndex(treeIndex => {
 It's also possible (and more performant) to use `Cognite3DModel.resetAllNodeColors()` when
 you want to reset the colors of all nodes:
 
-```jsx runnable
+```jsx runnable-1x
 model.resetAllNodeColors();
 ```
 
@@ -55,6 +55,6 @@ order to update the colors of equipment it's typically necessary to apply the sa
 subtree. Reveal supports this through the use of `Cognite3DModel.setNodesColorsByTreeIndex` with `applyToChildren`
 set to `true`:
 
-```jsx runnable
+```jsx runnable-1x
 model.setNodeColorByTreeIndex(778306, 240, 100, 60, applyToChildren=true);
 ```

--- a/documentation/versioned_docs/version-1.x/examples/cad-explode.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-explode.mdx
@@ -29,7 +29,7 @@ Below is an example that expands a given pipe asset (that has a tree index of `5
 Another good usecase would be to bind the `expand` function to a slider which the user can manipulate to expand the asset.
 
 
-```jsx runnable
+```jsx runnable-1x
 // import { ExplodedViewTool } from '@cognite/reveal/tools';
 
 const rootTreeIndex = 570730;

--- a/documentation/versioned_docs/version-1.x/examples/cad-ghostmode.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-ghostmode.mdx
@@ -23,7 +23,7 @@ for all nodes can be toggled using `Cognite3DModel.ghostAllNodes` and `Cognite3D
 A typical use case for ghosting is to show the location of a piece of equipment. To do this,
 first ghost all nodes and un-ghost the relevant nodes.
 
-```jsx runnable
+```jsx runnable-1x
 model.ghostAllNodes();
 model.unghostNodeByTreeIndex(409228, applyToChildren=true);
 ```
@@ -36,7 +36,7 @@ would be occluded by the ghosted nodes.
 In this example, equipment is made visible through a ghosted model. When the user clicks the equipment
 the other nodes are hidden and the camera is zoomed in to the equipment.
 
-```jsx runnable
+```jsx runnable-1x
 const treeIndex = 409228;
 
 model.showAllNodes();

--- a/documentation/versioned_docs/version-1.x/examples/cad-highlighting.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-highlighting.mdx
@@ -25,7 +25,7 @@ order to highlight equipment it's typically necessary to highlight the entire
 subtree. Reveal supports this through the use of `Cognite3DModel.selectNodeByTreeIndex` with `applyToChildren`
 set to `true`:
 
-```jsx runnable
+```jsx runnable-1x
 model.selectNodeByTreeIndex(778306, applyToChildren=true);
 ```
 
@@ -33,7 +33,7 @@ model.selectNodeByTreeIndex(778306, applyToChildren=true);
 
 Nodes can be deselected using `Cognite3DModel.deselectNodeByTreeIndex`, e.g.
 
-```jsx runnable
+```jsx runnable-1x
 model.iterateNodesByTreeIndex(treeIndex => {
   model.deselectNodeByTreeIndex(treeIndex);
 });
@@ -42,7 +42,7 @@ model.iterateNodesByTreeIndex(treeIndex => {
 It's also possible (and more performant) to use `Cognite3DModel.deselectAllNodes()` when
 you want to deselect all nodes:
 
-```jsx runnable
+```jsx runnable-1x
 model.deselectAllNodes();
 ```
 
@@ -50,7 +50,7 @@ model.deselectAllNodes();
 
 `Cognite3DViewer.on('click', ...)` can be used to handle mouse click events. This example shows how to highlight objects that are clicked.
 
-```jsx runnable
+```jsx runnable-1x
 viewer.on('click', event => {
   const intersection = viewer.getIntersectionFromPixel(
     event.offsetX, event.offsetY
@@ -72,7 +72,7 @@ When the user clicks an object in the 3D model, she or he will click one of the 
 The following example shows how to use node data retrieved from the Cognite SDK to determine to "tagged equipment"
 (i.e. named equipment) and highlighting the full equipment, rather than a single individual part.
 
-```jsx runnable
+```jsx runnable-1x
 viewer.on('click', event => {
   const intersection = viewer.getIntersectionFromPixel(
     event.offsetX, event.offsetY

--- a/documentation/versioned_docs/version-1.x/examples/cad-nodefiltering.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-nodefiltering.mdx
@@ -37,7 +37,7 @@ To query for nodes matching a given attribute value, we use [list3DNodes](https:
 from the [Cognite SDK](https://www.npmjs.com/package/@cognite/sdk) which maps to the [List 3D Nodes API endpoint](https://docs.cognite.com/api/v1/#operation/get3DNodes).
 For this example we query for nodes that are within the 'EP' function and hide all other nodes.
 
-```jsx runnable
+```jsx runnable-1x
 model.hideAllNodes();
 sdk.revisions3D.list3DNodes(model.modelId, model.revisionId,
   {
@@ -54,7 +54,7 @@ For the example model, which is quite small, this performs well. For larger asse
 by avoiding use of `applyToChildren = true` in `Cognite3DModel.showNodeByTreeIndex` which leads to a network request.
 This can be done by using `node.subtreeSize` – a field in the response from `list3DNodes`:
 
-```jsx runnable
+```jsx runnable-1x
 model.hideAllNodes();
 sdk.revisions3D.list3DNodes(model.modelId, model.revisionId,
   {

--- a/documentation/versioned_docs/version-1.x/examples/cad-transform-override.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/cad-transform-override.mdx
@@ -23,7 +23,7 @@ a matrix transformation and a flag if the transformation also should be applied 
 
 
 
-```jsx runnable
+```jsx runnable-1x
 const transform = new THREE.Matrix4();
 transform.setPosition(new THREE.Vector3(10, 10, 0));
 model.setNodeTransformByTreeIndex(532261, transform, true);
@@ -36,7 +36,7 @@ Resetting the transformation is done with `Cognite3DModel.resetNodeTransformByTr
 
 and a flag that determines if the node transform reset also should be applied to any child nodes of the given tree index.
 
-```jsx runnable
+```jsx runnable-1x
 model.resetNodeTransformByTreeIndex(532261, true);
 ```
 
@@ -58,7 +58,7 @@ the following statement:
 
 first applies `worldToModel`, then `rotationMatrix` and finally `modelToWorld`.
 
-```jsx runnable
+```jsx runnable-1x
 model.getBoundingBoxByTreeIndex(533010).then(boundingBox => {
   const center = boundingBox.getCenter(new THREE.Vector3());
 

--- a/documentation/versioned_docs/version-1.x/examples/clipping.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/clipping.mdx
@@ -36,7 +36,7 @@ is used to create slicing planes. This function accepts a direction that defines
 the plane and a point on the plane. For example, the following
 code will create a slicing plane that only accepts geometry below `Y = 55`:
 
-```jsx runnable
+```jsx runnable-1x
 const orientation = new THREE.Vector3(0, -1, 0);
 const point = new THREE.Vector3(0, 55, 0);
 const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(orientation, point);
@@ -51,7 +51,7 @@ triggered after updating the plane before the change will have a visual effect. 
 
 Below is an example animates a slicing plane by ping-ponging the plane in the vertical direction.
 
-```js runnable
+```jsx runnable-1x
 const bbox = model.getModelBoundingBox();
 
 const orientation = new THREE.Vector3(0, -1, 0);
@@ -87,7 +87,7 @@ to manipulate the slicing planes.
 
 After running this snippet the slicing plane can be manipulated by dragging the white manipulator.
 
-```js runnable
+```jsx runnable-1x
 // import { DragControls } from 'three/examples/jsm/controls/DragControls';
 
 const bounds = model.getModelBoundingBox();

--- a/documentation/versioned_docs/version-1.x/examples/combine-models.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/combine-models.mdx
@@ -22,7 +22,7 @@ should also be applied to ensure that the axis system is correct.
 
 The following example shows how to modify the coordinate system of a point cloud model to make it fit with a CAD model.
 
-```js runnable
+```jsx runnable-1x
 viewer.addModel({
   modelId: 5564365369975452 ,
   revisionId: 2817572261344477,

--- a/documentation/versioned_docs/version-1.x/examples/node-visiting.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/node-visiting.mdx
@@ -18,7 +18,7 @@ interactive page while the action is being applied.
 This example only demonstrates how iteration over model nodes performed gradually.
 For more efficient coloring consult our [coloring examples](./cad-colors.mdx).
 
-```jsx runnable
+```jsx runnable-1x
 model
   .iterateNodesByTreeIndex(
     treeIndex => model.setNodeColorByTreeIndex(treeIndex, 127, 127, 127)
@@ -33,7 +33,7 @@ tree index is included in the set of visited nodes. The following example sets t
 a node. This mimics the functionality of `Cognite3DModel.setNodesColorsByTreeIndex` with `applyToChildren`
 set to `true`.
 
-```jsx runnable
+```jsx runnable-1x
 model.iterateSubtreeByTreeIndex(917985, treeIndex => {
   model.setNodeColorByTreeIndex(treeIndex, 127, 255, 127);
 });

--- a/documentation/versioned_docs/version-1.x/examples/pointcloud-intersections.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/pointcloud-intersections.mdx
@@ -17,7 +17,7 @@ import { DemoWrapper } from '@site/versioned_docs/version-1.x/components/DemoWra
 The following example detects intersections at clicked positions and marks the intersected positions
 using a red sphere.
 
-```js runnable
+```jsx runnable-1x
 viewer.on('click', event => {
   const intersection = viewer.getIntersectionFromPixel(
     event.offsetX, event.offsetY

--- a/documentation/versioned_docs/version-1.x/examples/pointcloud.mdx
+++ b/documentation/versioned_docs/version-1.x/examples/pointcloud.mdx
@@ -48,7 +48,7 @@ main();
 
 You can use `pointSize` property to set the size of each rendered point in a point cloud model.
 
-```js runnable
+```jsx runnable-1x
 model.pointSize = 10;
 ```
 
@@ -58,7 +58,7 @@ The point budget limits the number of points loaded and rendered at any given ti
 which helps to adapt performance requirements to the capabilities of different hardware.
 Recommended values are between 500.000 and 10.000.000.
 
-```js runnable
+```jsx runnable-1x
 model.pointBudget = 500000;
 ```
 
@@ -66,7 +66,7 @@ model.pointBudget = 500000;
 
 You can set the point shape of each rendered point in the point cloud. Values are defined by `PotreePointShape` enum.
 
-```js runnable
+```jsx runnable-1x
 // import { PotreePointShape } from '@cognite/reveal';
 model.pointShape = PotreePointShape.Square;
 ```
@@ -75,7 +75,7 @@ model.pointShape = PotreePointShape.Square;
 
 You can specify in which way points should be colored. Values are defined by `PotreePointColorType` enum.
 
-```js runnable
+```jsx runnable-1x
 // import { PotreePointColorType } from '@cognite/reveal'
 model.pointColorType = PotreePointColorType.Depth;
 ```
@@ -122,6 +122,6 @@ const visible = model.isClassVisible(WellKnownAsprsPointClassCodes.Ground);
 
 Point clouds (and CAD models) can be unloaded using `Cognite3DViewer.removeModel()`:
 
-```js runnable
+```jsx runnable-1x
 viewer.removeModel(model)
 ```


### PR DESCRIPTION
In our docs we use direct import for demo wrappers

```
import { DemoWrapper } from '@site/versioned_docs/version-1.x/components/DemoWrapper';
<DemoWrapper name="Cognite3DViewerDemo" />
```

That's why docs work OK now for 1.x and next. Different versions of reveal used correctly.

But customScope passed to live examples wasn't versioned. Because to create live example we use custom markdown syntax in our docs. 

```md
  ```jsx runnable
  code goes here
```

That `runnable` part is transformed by our `documentation/src/plugins/remark-runnable-reveal-demo.js`. Its responsibility is to convert `jsx runnable` into 

```jsx
import { LiveCodeSnippet } from '...';

<LiveCodeSnippet>{`code goes here`}</LiveCodeSnippet>
```

And LiveCodeSnippet is the component that passes `customScope` to live examples. So for 1.x version we need its own reveal version, customScope version, LiveCodeSnippet version. So I had to add different versioned syntax for live examples, to be able to determine which import must be used.


For 1.x version docs it should be like this now:

```md
  ```jsx runnable-1x
  code goes here
```

For `next` there are no changes, keep using `jsx runnable`.