### PR TITLE
fix: remove @internal from Cognite3DViewerToolBase

### DIFF
--- a/viewer/src/tools/Cognite3DViewerToolBase.ts
+++ b/viewer/src/tools/Cognite3DViewerToolBase.ts
@@ -7,7 +7,6 @@ import { EventTrigger } from '../utilities/events';
 
 /**
  * Base class for tools attaching to a {@see Cognite3DViewer}.
- * @internal
  */
 export abstract class Cognite3DViewerToolBase {
   private readonly _disposedEvent = new EventTrigger<() => void>();


### PR DESCRIPTION
This should make the class visible in client projects, avoiding error
```
ERROR: node_modules/@cognite/reveal/tools/HtmlOverlayTool.d.ts:6:10 - error TS2305: Module '"./Cognite3DViewerToolBase"' has no exported member 'Cognite3DViewerToolBase'.
```