### PR TITLE
chore: add eslint naming rule

### DIFF
--- a/viewer/.eslintrc.js
+++ b/viewer/.eslintrc.js
@@ -57,6 +57,12 @@ module.exports = {
     'default-case': 'error',
     'no-console': ['warn', { allow: ['warn', 'error', 'assert'] }],
 
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
+    '@typescript-eslint/naming-convention': [
+      'warn',
+      { selector: 'typeLike', format: ['PascalCase'] },
+      { selector: 'method', format: ['camelCase'], leadingUnderscore: 'allow' }
+    ],
     '@typescript-eslint/unbound-method': 'error',
     '@typescript-eslint/prefer-for-of': 'off',
     '@typescript-eslint/no-explicit-any': 'off',

--- a/viewer/src/datamodels/cad/styling/ByAssetNodeSet.ts
+++ b/viewer/src/datamodels/cad/styling/ByAssetNodeSet.ts
@@ -38,6 +38,8 @@ export class ByAssetNodeSet extends NodeSet {
    * Updates the node set to hold nodes associated with the asset given, or
    * assets within the bounding box or all assets associated with the 3D model.
    * @param filter
+   * @param filter.assetId
+   * @param filter.boundingBox
    */
   async executeFilter(filter: { assetId?: number; boundingBox?: THREE.Box3 }): Promise<void> {
     const model = this._model;


### PR DESCRIPTION
noticed class methods camelCase vs PascalCase related comments in one of the review, so added eslint rule to enforce that convention.