### PR TITLE
docs: fix example in cad-styling-custom.mdx

### DIFF
--- a/documentation/docs/examples/cad-styling-custom.mdx
+++ b/documentation/docs/examples/cad-styling-custom.mdx
@@ -56,7 +56,7 @@ mySet.getIndexSet = () => {
   }
   return indexSet;
 };
-mySet.clear = () => throw new Error('Not supported');
+mySet.clear = () => { throw new Error('Not supported'); }
 
 model.setDefaultNodeAppearance(DefaultNodeAppearance.Ghosted);
 model.addStyledNodeSet(mySet, { renderGhosted: false, color: [40, 200, 20] } );


### PR DESCRIPTION
react-live doesn't play well with arrow function that starts with `throw` without brackets