### PR TITLE
chore(viewer): bump version 2.0.0-beta.1

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "private": true,
   "description": "WebGL based 3D viewer for CAD and point clouds processed in Cognite Data Fusion.",
   "repository": {


### PR DESCRIPTION
any objections if I'll publish the current master as beta-1 for now? Would be easier to align the migration PR preview with the latest changes 

plus we can nudge people to try out the actual pre-release of 2.0 with the latest styling API changes