### PR TITLE
fix: remove @internal from serialize() implementations

### DIFF
--- a/viewer/src/datamodels/cad/styling/AssetNodeCollection.ts
+++ b/viewer/src/datamodels/cad/styling/AssetNodeCollection.ts
@@ -103,7 +103,6 @@ export class AssetNodeCollection extends NodeCollectionBase {
     return this._indexSet;
   }
 
-  /** @internal */
   serialize(): SerializedNodeCollection {
     return {
       token: this.classToken,

--- a/viewer/src/datamodels/cad/styling/IntersectionNodeCollection.ts
+++ b/viewer/src/datamodels/cad/styling/IntersectionNodeCollection.ts
@@ -17,7 +17,6 @@ export class IntersectionNodeCollection extends CombineNodeCollectionBase {
     super(UnionNodeCollection.classToken, nodeCollections);
   }
 
-  /** @internal */
   serialize(): SerializedNodeCollection {
     return {
       token: this.classToken,

--- a/viewer/src/datamodels/cad/styling/InvertedNodeCollection.ts
+++ b/viewer/src/datamodels/cad/styling/InvertedNodeCollection.ts
@@ -42,7 +42,6 @@ export class InvertedNodeCollection extends NodeCollectionBase {
     return this._cachedIndexSet;
   }
 
-  /** @internal */
   serialize(): SerializedNodeCollection {
     return { token: this.classToken, state: { innerCollection: this._innerCollection.serialize() } };
   }

--- a/viewer/src/datamodels/cad/styling/PropertyFilterNodeCollection.ts
+++ b/viewer/src/datamodels/cad/styling/PropertyFilterNodeCollection.ts
@@ -116,7 +116,6 @@ export class PropertyFilterNodeCollection extends NodeCollectionBase {
     return this._indexSet;
   }
 
-  /** @internal */
   serialize() {
     return {
       token: this.classToken,

--- a/viewer/src/datamodels/cad/styling/SinglePropertyFilterNodeCollection.ts
+++ b/viewer/src/datamodels/cad/styling/SinglePropertyFilterNodeCollection.ts
@@ -124,7 +124,6 @@ export class SinglePropertyFilterNodeCollection extends NodeCollectionBase {
     }/revisions/${this._revisionId}/nodes/list`;
   }
 
-  /** @internal */
   serialize() {
     return {
       token: this.classToken,

--- a/viewer/src/datamodels/cad/styling/TreeIndexNodeCollection.ts
+++ b/viewer/src/datamodels/cad/styling/TreeIndexNodeCollection.ts
@@ -48,7 +48,6 @@ export class TreeIndexNodeCollection extends NodeCollectionBase {
     return false;
   }
 
-  /** @internal */
   serialize(): SerializedNodeCollection {
     return {
       token: this.classToken,

--- a/viewer/src/datamodels/cad/styling/UnionNodeCollection.ts
+++ b/viewer/src/datamodels/cad/styling/UnionNodeCollection.ts
@@ -16,7 +16,6 @@ export class UnionNodeCollection extends CombineNodeCollectionBase {
     super(UnionNodeCollection.classToken, nodeCollections);
   }
 
-  /** @internal */
   serialize(): SerializedNodeCollection {
     return {
       token: this.classToken,


### PR DESCRIPTION
This issue causes import to cause compile errors because serialize() is exported in base class, but not implementations.