### PR TITLE
chore: add workflow to cleanup docs previews

### DIFF
--- a/.github/workflows/preview-documentation-cleanup.yml
+++ b/.github/workflows/preview-documentation-cleanup.yml
@@ -1,0 +1,35 @@
+name: preview-documentation-cleanup
+
+# only trigger on pull request closed events both merged or not
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  build-and-deploy:
+    name: Publish documentation preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+
+      - name: Create empty folder for override
+        working-directory: documentation
+        run: mkdir build
+
+      - name: Deploy empty folder to override preview
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.REVEAL_DOCS_PREVIEW_DEPLOY_KEY }}
+          external_repository: cognitedata/reveal-docs-preview
+          publish_branch: master
+          publish_dir: documentation/build
+          destination_dir: ${{ env.PR_NUMBER }}
+
+      - name: Add comment about preview URL
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: |
+            🧹 Documentation preview is deleted.

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -53,6 +53,8 @@ jobs:
           publish_branch: master
           publish_dir: documentation/build
           destination_dir: ${{ env.PR_NUMBER }}
+          keep_files: false
+          force_orphan: true
 
       - name: Add comment about preview URL
         uses: unsplash/comment-on-pr@master


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4989157/123623370-a0454200-d80d-11eb-8c27-af5f636cbd46.png)

That's how the current docs preview repo looks like. It's huge, I think that's why it's slow, not because of git history. I'll do manual cleanup there, but I hope that little workflow will remove each PR preview once it merged.

UPD: @larsmoa actually I got a second thought on it, and maybe history still matters the most here. If something ever were committed to the git it remains in the git, so I have doubts that this cleanup will help anyhow 🙁  but let's see still