### PR TITLE
chore: dont use force_orphan option, it wipes out everything

### DIFF
--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -54,7 +54,6 @@ jobs:
           publish_dir: documentation/build
           destination_dir: ${{ env.PR_NUMBER }}
           keep_files: false
-          force_orphan: true
 
       - name: Add comment about preview URL
         uses: unsplash/comment-on-pr@master


### PR DESCRIPTION
sorry I wiped out all the existing PR previews. Just rerun preview workflow to get them back. 

I guess `force_orphan` option doesn't work as I expected, but I guess it will once [v4 will be published](https://github.com/peaceiris/actions-gh-pages/issues/455). I expected commit history to be squashed but contents must be kept. 