### PR TITLE
fix: setting Cognite3DModel.visible has no effect

### DIFF
--- a/documentation/docs/examples/cad-basic.mdx
+++ b/documentation/docs/examples/cad-basic.mdx
@@ -42,14 +42,33 @@ async function main() {
 main();
 ```
 
-Models can be unloaded using `Cognite3DViewer.removeModel()`:
+Models can be temporarily hidden using `Cognite3DModel.visible`. Note that 
+the viewer must be explicitly re-rendered after setting the visibility flag:
+
+```js runnable
+model.visible = false;
+viewer.forceRerender();
+
+setTimeout(() => {
+  model.visible = true;
+  viewer.forceRerender();
+}, 5000);
+```
+
+Hiding models doesn't free any memory occupied by the model and should only be used
+to temporarily hide a model when it's expected that it will shortly be shown again.
+
+To also reclaim memory and permanently unloading the model, use 
+`Cognite3DViewer.removeModel()`:
 
 ```js runnable
 viewer.removeModel(model)
 ```
 
+## Only loading a part of the model
+
 In some cases, it might be useful to restrict the area for which geometry is loaded to only show a partial
-view. This can be done using a `geometryFilter`:
+view. This can be done using a `geometryFilter` which allows only loading geometry within a provided box:
 
 ```js runnable
 viewer.models.forEach(x => viewer.removeModel(x));

--- a/viewer/core/src/datamodels/cad/CadModelUpdateHandler.ts
+++ b/viewer/core/src/datamodels/cad/CadModelUpdateHandler.ts
@@ -12,7 +12,6 @@ import { ConsumedSector } from './sector/types';
 import { Repository } from './sector/Repository';
 
 import { assertNever, emissionLastMillis, LoadingState } from '../../utilities';
-import { CadModelMetadata } from '.';
 import { loadingEnabled } from './sector/rxSectorUtilities';
 import { SectorLoader } from './sector/SectorLoader';
 import { CadModelSectorBudget, defaultCadModelSectorBudget } from './CadModelSectorBudget';
@@ -171,14 +170,14 @@ export class CadModelUpdateHandler {
         const { model, operation } = next;
         switch (operation) {
           case 'add':
-            array.push(model.cadModelMetadata);
+            array.push(model);
             return array;
           case 'remove':
-            return array.filter(x => x.modelIdentifier !== model.cadModelMetadata.modelIdentifier);
+            return array.filter(x => x.cadModelMetadata.modelIdentifier !== model.cadModelMetadata.modelIdentifier);
           default:
             assertNever(operation);
         }
-      }, [] as CadModelMetadata[])
+      }, [] as CadNode[])
     );
   }
 }
@@ -205,16 +204,16 @@ function makeClippingInput([clippingPlanes]: [THREE.Plane[]]): ClippingInput {
   return { clippingPlanes };
 }
 
-function createDetermineSectorsInput([settings, camera, clipping, cadModelsMetadata]: [
+function createDetermineSectorsInput([settings, camera, clipping, models]: [
   SettingsInput,
   CameraInput,
   ClippingInput,
-  CadModelMetadata[]
+  CadNode[]
 ]): DetermineSectorsInput {
   return {
     ...camera,
     ...settings,
     ...clipping,
-    cadModelsMetadata
+    cadModelsMetadata: models.filter(x => x.visible).map(x => x.cadModelMetadata)
   };
 }

--- a/viewer/core/src/datamodels/cad/rendering/EffectRenderManager.ts
+++ b/viewer/core/src/datamodels/cad/rendering/EffectRenderManager.ts
@@ -810,7 +810,10 @@ export class EffectRenderManager {
     while (objectStack.length > 0) {
       const element = objectStack.pop()!;
       if (element instanceof RootSectorNode) {
-        this._rootSectorNodeBuffer.add([element, element.parent! as CadNode]);
+        const cadNode = element.parent! as CadNode;
+        if (cadNode.visible) {
+          this._rootSectorNodeBuffer.add([element, cadNode]);
+        }
       } else if (!(element instanceof THREE.Group)) {
         objectStack.push(...element.children);
       }

--- a/viewer/core/src/public/migration/Cognite3DModel.ts
+++ b/viewer/core/src/public/migration/Cognite3DModel.ts
@@ -75,6 +75,17 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
     this.cadNode = cadNode;
 
     this.add(this.cadNode);
+
+    // Note! As this is defined in ThreeJS we cannot override this using
+    // regular TypeScript getters and setters.
+    // It's necessary to forward this setting to CadNode as Cognite3DModel is
+    // just a wrapper around this and not part of the actual rendered scene.
+    Object.defineProperty(this, 'visible', {
+      get: () => this.cadNode.visible,
+      set: (x: boolean) => {
+        this.cadNode.visible = x;
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Hidden models will no longer be visible on screen and sectors will not be loaded.

Note that we don't unload data associated with hidden models. To also reclaim memory, use `Cognite3DViewer.removeModel()`