### PR TITLE
fix: reduce constant to shave of a few nanoseconds in the rendering loop

### DIFF
--- a/viewer/core/src/glsl/math/floatBitsSubset.glsl
+++ b/viewer/core/src/glsl/math/floatBitsSubset.glsl
@@ -1,21 +1,16 @@
-const int MAX_ITER = 24;
+const int MAX_ITER = 8;
 
 float floatBitsSubset(float inNumber, int fromLeastSignificantBitIndex,  int toMostSignificantBitIndex) {
     float lsbif = float(fromLeastSignificantBitIndex);
-    
     int a = int(toMostSignificantBitIndex - fromLeastSignificantBitIndex);
-
     float denominator = pow(2.0, lsbif);
-    
     float outNumber = 0.0;
     for(int i = 0; i < MAX_ITER; i++)
     {
       if(i >= a) break;
-
       float backBits = pow(2.0, lsbif + float(i));
       outNumber += (mod(inNumber, backBits * 2.0) - mod(inNumber, backBits)) / denominator;
     }
-
     return outNumber;
 }
 


### PR DESCRIPTION
We only work with bits 0-7 so no need to have more iterations.