### PR TITLE
feat: add support for limiting loaded geometry by "render cost"

### DIFF
--- a/examples/src/utils/CadBudgetUi.ts
+++ b/examples/src/utils/CadBudgetUi.ts
@@ -13,19 +13,22 @@ export function initialCadBudgetUi(viewer: Cognite3DViewer, uiFolder: dat.GUI) {
   const state = {
     factor: 100.0,
     limitDownloadedBytes: true,
-    limitDrawcalls: true
+    limitDrawCalls: true,
+    limitRenderCost: true
   };
   const defaultCadBudget = { ...viewer.cadBudget };
   const onCadBudgetSettingsChanged = () => {
     const scale = state.factor / 100.0;
-    const { limitDownloadedBytes, limitDrawcalls } = state;
+    const { limitDownloadedBytes, limitDrawCalls, limitRenderCost } = state;
     viewer.cadBudget = {
       highDetailProximityThreshold: defaultCadBudget.highDetailProximityThreshold * scale,
       geometryDownloadSizeBytes:  limitDownloadedBytes ? defaultCadBudget.geometryDownloadSizeBytes * scale : Infinity,
-      maximumNumberOfDrawCalls: limitDrawcalls ? defaultCadBudget.maximumNumberOfDrawCalls * scale : Infinity
+      maximumNumberOfDrawCalls: limitDrawCalls ? defaultCadBudget.maximumNumberOfDrawCalls * scale : Infinity,
+      maximumRenderCost: limitRenderCost ? defaultCadBudget.maximumRenderCost * scale : Infinity,
     };
   };
   uiFolder.add(state, 'factor', 1, 500, 5).name('Budget factor (%)').onChange(onCadBudgetSettingsChanged);
   uiFolder.add(state, 'limitDownloadedBytes').name('Limit bytesize').onChange(onCadBudgetSettingsChanged);
-  uiFolder.add(state, 'limitDrawcalls').name('Limit draw calls').onChange(onCadBudgetSettingsChanged);
+  uiFolder.add(state, 'limitDrawCalls').name('Limit draw calls').onChange(onCadBudgetSettingsChanged);
+  uiFolder.add(state, 'limitRenderCost').name('Limit render cost').onChange(onCadBudgetSettingsChanged);
 }

--- a/viewer/core/src/__testutilities__/createSectorMetadata.ts
+++ b/viewer/core/src/__testutilities__/createSectorMetadata.ts
@@ -23,6 +23,7 @@ export function createSectorMetadata(tree: SectorTree, depth: number = 0, path: 
     depth,
     bounds,
     estimatedDrawCallCount: 100,
+    estimatedRenderCost: 1000,
     indexFile: {
       fileName: `sector_${id}.i3d`,
       peripheralFiles: [],

--- a/viewer/core/src/datamodels/cad/CadModelSectorBudget.ts
+++ b/viewer/core/src/datamodels/cad/CadModelSectorBudget.ts
@@ -19,9 +19,15 @@ export type CadModelSectorBudget = {
   readonly geometryDownloadSizeBytes: number;
 
   /**
-   * Maximum number of estimated drawcalls of geometry to load.
+   * Maximum number of estimated draw calls of geometry to load.
    */
   readonly maximumNumberOfDrawCalls: number;
+
+  /**
+   * Maximum render cost. This number can be thought of as triangle count, although the number
+   * doesn't match this directly.
+   */
+  readonly maximumRenderCost: number;
 };
 
 export const defaultCadModelSectorBudget: CadModelSectorBudget = isMobileOrTablet()
@@ -29,11 +35,13 @@ export const defaultCadModelSectorBudget: CadModelSectorBudget = isMobileOrTable
     {
       highDetailProximityThreshold: 5,
       geometryDownloadSizeBytes: 20 * 1024 * 1024,
-      maximumNumberOfDrawCalls: 700
+      maximumNumberOfDrawCalls: 700,
+      maximumRenderCost: Infinity
     }
   : // Desktop
     {
       highDetailProximityThreshold: 10,
       geometryDownloadSizeBytes: 35 * 1024 * 1024,
-      maximumNumberOfDrawCalls: 2000
+      maximumNumberOfDrawCalls: 2000,
+      maximumRenderCost: Infinity
     };

--- a/viewer/core/src/datamodels/cad/CadModelUpdateHandler.ts
+++ b/viewer/core/src/datamodels/cad/CadModelUpdateHandler.ts
@@ -44,6 +44,7 @@ export class CadModelUpdateHandler {
     this._lastSpent = {
       downloadSize: 0,
       drawCalls: 0,
+      renderCost: 0,
       loadedSectorCount: 0,
       simpleSectorCount: 0,
       detailedSectorCount: 0,

--- a/viewer/core/src/datamodels/cad/parsers/CadMetadataParserV8.test.ts
+++ b/viewer/core/src/datamodels/cad/parsers/CadMetadataParserV8.test.ts
@@ -53,7 +53,8 @@ describe('parseCadMetadataV8', () => {
         recursiveCoverageFactors: sectorRoot.facesFile!.recursiveCoverageFactors!
       },
       children: [],
-      estimatedDrawCallCount: 10
+      estimatedDrawCallCount: 10,
+      estimatedRenderCost: 10
     };
 
     // Act
@@ -86,7 +87,8 @@ describe('parseCadMetadataV8', () => {
       indexFile: sectorRoot.indexFile,
       facesFile: { ...sectorRoot.facesFile!, recursiveCoverageFactors: sectorRoot.facesFile!.coverageFactors },
       children: [],
-      estimatedDrawCallCount: 10
+      estimatedDrawCallCount: 10,
+      estimatedRenderCost: 10
     };
 
     // Act

--- a/viewer/core/src/datamodels/cad/parsers/CadMetadataParserV8.ts
+++ b/viewer/core/src/datamodels/cad/parsers/CadMetadataParserV8.ts
@@ -13,6 +13,7 @@ export interface CadSectorMetadataV8 {
   readonly path: string;
   readonly depth: number;
   readonly estimatedDrawCallCount: number;
+  readonly estimatedTriangleCount: number;
 
   readonly boundingBox: {
     readonly min: {
@@ -111,6 +112,7 @@ function createSectorMetadata(metadata: CadSectorMetadataV8): SectorMetadata {
     depth: metadata.depth,
     bounds: new THREE.Box3(new THREE.Vector3(min_x, min_y, min_z), new THREE.Vector3(max_x, max_y, max_z)),
     estimatedDrawCallCount: metadata.estimatedDrawCallCount,
+    estimatedRenderCost: metadata.estimatedTriangleCount || 0,
 
     // I3D
     indexFile: { ...metadata.indexFile },

--- a/viewer/core/src/datamodels/cad/sector/CadModelClipper.test.ts
+++ b/viewer/core/src/datamodels/cad/sector/CadModelClipper.test.ts
@@ -48,7 +48,7 @@ describe('CadModelClipper', () => {
     });
   });
 
-  test('createClippedModel() reduces estimated draw calls for clipped sectors', () => {
+  test('createClippedModel() reduces estimated draw calls and render cost for clipped sectors', () => {
     const box = new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.5, 0.5, 0.5));
     const clipper = new CadModelClipper(box);
 
@@ -58,6 +58,7 @@ describe('CadModelClipper', () => {
     sectors.forEach(s => {
       const original = modelDepth2.scene.getSectorById(s.id)!;
       expect(s.estimatedDrawCallCount).toBeLessThan(original.estimatedDrawCallCount);
+      expect(s.estimatedRenderCost).toBeLessThan(original.estimatedRenderCost);
     });
   });
 });

--- a/viewer/core/src/datamodels/cad/sector/CadModelClipper.ts
+++ b/viewer/core/src/datamodels/cad/sector/CadModelClipper.ts
@@ -68,6 +68,7 @@ function clipSector(sector: SectorMetadata, geometryClipBox: THREE.Box3): Sector
       ...sector,
       children: intersectingChildren,
       estimatedDrawCallCount: Math.ceil(keptDrawCallsRatio * sector.estimatedDrawCallCount),
+      estimatedRenderCost: Math.ceil(keptDrawCallsRatio * sector.estimatedRenderCost),
       bounds
     };
     return clippedSector;

--- a/viewer/core/src/datamodels/cad/sector/SectorLoader.test.ts
+++ b/viewer/core/src/datamodels/cad/sector/SectorLoader.test.ts
@@ -170,6 +170,7 @@ const noBudget: SectorLoadingSpent = {
   accumulatedPriority: 0,
   detailedSectorCount: 0,
   drawCalls: 0,
+  renderCost: 0,
   forcedDetailedSectorCount: 0,
   loadedSectorCount: 0,
   simpleSectorCount: 0,

--- a/viewer/core/src/datamodels/cad/sector/culling/TakenSectorTree.ts
+++ b/viewer/core/src/datamodels/cad/sector/culling/TakenSectorTree.ts
@@ -27,7 +27,7 @@ export class TakenSectorTree {
   }[] = [];
   private readonly determineSectorCost: DetermineSectorCostDelegate;
 
-  private _totalCost: SectorCost = { downloadSize: 0, drawCalls: 0 };
+  private _totalCost: SectorCost = { downloadSize: 0, drawCalls: 0, renderCost: 0 };
 
   constructor(sectorRoot: SectorMetadata, determineSectorCost: DetermineSectorCostDelegate) {
     this.determineSectorCost = determineSectorCost;
@@ -38,7 +38,7 @@ export class TakenSectorTree {
         sector: x,
         parentIndex: -1,
         priority: -1,
-        cost: { downloadSize: 0, drawCalls: 0 },
+        cost: { downloadSize: 0, drawCalls: 0, renderCost: 0 },
         lod: LevelOfDetail.Discarded
       };
       return true;

--- a/viewer/core/src/datamodels/cad/sector/culling/types.ts
+++ b/viewer/core/src/datamodels/cad/sector/culling/types.ts
@@ -29,6 +29,11 @@ export type SectorLoadingSpent = {
    * Estimated number of draw calls required to draw the sectors.
    */
   readonly drawCalls: number;
+  /**
+   * Estimated "render cost" which can be compared to triangle count (but
+   * due to how Reveal renders primitives doesn't map directly to triangles).
+   */
+  readonly renderCost: number;
 
   /**
    * Total number of sectors to load.
@@ -59,16 +64,19 @@ export type SectorLoadingSpent = {
 export type SectorCost = {
   downloadSize: number;
   drawCalls: number;
+  renderCost: number;
 };
 
 export function addSectorCost(sum: SectorCost, cost: SectorCost) {
   sum.downloadSize += cost.downloadSize;
   sum.drawCalls += cost.drawCalls;
+  sum.renderCost += cost.renderCost;
 }
 
 export function reduceSectorCost(sum: SectorCost, cost: SectorCost) {
   sum.downloadSize -= cost.downloadSize;
   sum.drawCalls -= cost.drawCalls;
+  sum.renderCost -= cost.renderCost;
 }
 
 export type PrioritizedWantedSector = WantedSector & { priority: number };

--- a/viewer/core/src/datamodels/cad/sector/sectorUtilities.test.ts
+++ b/viewer/core/src/datamodels/cad/sector/sectorUtilities.test.ts
@@ -29,6 +29,7 @@ describe('sectorUtilities', () => {
       bounds: new THREE.Box3(new THREE.Vector3(1, 2, 3), new THREE.Vector3(3, 4, 5)),
       children: [],
       estimatedDrawCallCount: 10,
+      estimatedRenderCost: 1000,
       indexFile: {
         fileName: 'sector_1.i3d',
         peripheralFiles: [],

--- a/viewer/core/src/datamodels/cad/sector/types.ts
+++ b/viewer/core/src/datamodels/cad/sector/types.ts
@@ -138,6 +138,7 @@ export interface SectorMetadata {
   readonly facesFile: SectorMetadataFacesFileSection;
   readonly children: SectorMetadata[];
   readonly estimatedDrawCallCount: number;
+  readonly estimatedRenderCost: number;
 }
 
 export interface SectorGeometry {

--- a/viewer/core/src/public/migration/types.ts
+++ b/viewer/core/src/public/migration/types.ts
@@ -258,6 +258,12 @@ export type CadModelBudget = {
    * are very important for the framerate.
    */
   readonly maximumNumberOfDrawCalls: number;
+
+  /**
+   * Maximum render cost. This number can be thought of as triangle count, although the number
+   * doesn't match this directly.
+   */
+  readonly maximumRenderCost: number;
 };
 
 /**


### PR DESCRIPTION
Note that the default budget for render cost is Infinity, so this doesn't affect the default behaviour.