### PR TITLE
doc: fix broken preview docs

### DIFF
--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -26,7 +26,7 @@ jobs:
           yarn build:prod
 
       - name: Update Docosaurus base URL
-        uses: jacobtomlinson/gha-find-replace@master
+        uses: jacobtomlinson/gha-find-replace@v1
         with:
           find: "baseUrl: .*"
           replace: "baseUrl: '/reveal-docs-preview/${{ env.PR_NUMBER }}/',"


### PR DESCRIPTION
Caused by broken Github Actions step - set version to v1.