### PR TITLE
fix: improve test speed

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -29,7 +29,7 @@
     "build:prod": "yarn run clean && webpack --env.production && tsc-alias -p tsconfig.webpack.json",
     "mkdist": "shx mkdir -p dist && shx cp README.md LICENSE dist",
     "clean": "shx rm -rf dist/ && yarn run mkdist",
-    "test": "jest",
+    "test": "jest --maxWorkers=4",
     "coverage": "jest --coverage",
     "lint": "yarn workspaces foreach -p run lint",
     "prebump": "yarn version --no-git-tag-version && yarn && cd ../documentation && yarn replace-latest-by-next",
@@ -39,7 +39,7 @@
     "bump:push": "git push -u origin head && git push --tags",
     "release": "yarn build:prod && cd dist && yarn publish --non-interactive",
     "ws:start": "cd $INIT_CWD && webpack-dev-server --open --env.dir=$INIT_CWD",
-    "ws:test": "cd $INIT_CWD && jest --maxWorkers=1",
+    "ws:test": "cd $INIT_CWD && jest --runInBand",
     "ws:lint": "cd $INIT_CWD && eslint . --ext .ts,.js --max-warnings 0 --cache"
   },
   "dependencies": {


### PR DESCRIPTION
Setting maxWorkers to 4 magically makes tests faster and watching single test files faster with runInBand option.

I have no idea why but it watching a single (simple) file went from >10sec per change to < 2 sec.

When running all tests I got about 50% improvement.

Found this nugget at: https://itnext.io/how-to-make-your-sluggish-jest-v23-tests-go-faster-1d4f3388bcdd