### PR TITLE
Add authentication environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ or create `.env` file within the same folder and paste them there, then use sour
 source .env
 ```
 3. Run `yarn` again and be happy!
+
+## Environment for Credentials
+
+Connecting the Cognite SDK client to internal projects through the Cognite API now requires OICD login, meaning that it is no longer sufficient to supply an API key when connecting to these projects. Instead, you need to supply the `tenantId` for the tenant for which the project belongs, as well as the `clientId` for Reveal (or the derived app) within that tenant. This poses a problem when running the examples, which has relied the API keys for authentication.
+
+The examples are configured to run using any environment variables specified in the file `examples/.env`. Specifically, Reveal will use a variable called `REACT_APP_CREDENTIAL_ENVIRONMENT` for authentication. The file `examples/.env.example` shows the expected JSON format of the value contained in this variable. The JSON object may specify several environments. Note that the values provided in `examples/.env.example` are dummy values.
+
+When starting an example that uses the Cognite SDK Client, you can add e.g. `env=example_environment` to use the authentication credential stored in the `example_environment` environment specified in the JSON object.
+
 ## Hosting models locally
 
 If you have locally converted 3D models, these can be viewed locally using the "Simple" example by

--- a/examples/.env
+++ b/examples/.env
@@ -1,2 +1,0 @@
-
-REACT_APP_CREDENTIAL_ENVIRONMENTS={"environments": { "europewest11-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "api" }, "greenfield-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "greenfield" } } }

--- a/examples/.env
+++ b/examples/.env
@@ -1,0 +1,2 @@
+
+REACT_APP_CREDENTIAL_ENVIRONMENTS={"environments": { "europewest11-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "api" }, "greenfield-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "greenfield" } } }

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -15,4 +15,6 @@ REACT_APP_CAD_2_REVISION_ID=012
 REACT_APP_POINTCLOUD_ID=345
 REACT_APP_POINTCLOUD_REVISION_ID=678
 
-REACT_APP_CREDENTIAL_ENVIRONMENTS={"environments": { "europewest11-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "api" }, "greenfield-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "greenfield" } } }
+# Note that the below values for "tenantId" and "clientId" are dummy values
+
+REACT_APP_CREDENTIAL_ENVIRONMENTS={"environments": { "example_environment": { "tenantId": "00000000-0000-0000-0000-000000000000", "clientId": "00000000-0000-0000-0000-000000000000", "cluster": "api" } } }

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -14,3 +14,5 @@ REACT_APP_CAD_2_REVISION_ID=012
 
 REACT_APP_POINTCLOUD_ID=345
 REACT_APP_POINTCLOUD_REVISION_ID=678
+
+REACT_APP_CREDENTIAL_ENVIRONMENTS={"environments": { "europewest11-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "api" }, "greenfield-3d": { "tenantId": "20a88741-8181-4275-99d9-bd4451666d6e", "clientId": "a03a8caf-7611-43ac-87f3-1d493c085579", "cluster": "greenfield" } } }

--- a/examples/src/pages/Clipping.tsx
+++ b/examples/src/pages/Clipping.tsx
@@ -28,10 +28,10 @@ export function Clipping() {
         project: 'publicdata',
         modelUrl: 'primitives',
       });
-      
+
       const client = new CogniteClient({ appId: 'reveal.example.simple' });
       if (project && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
       const scene = new THREE.Scene();

--- a/examples/src/pages/Clipping.tsx
+++ b/examples/src/pages/Clipping.tsx
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import * as reveal from '@cognite/reveal/internals';
 import CameraControls from 'camera-controls';
 import dat from 'dat.gui';
-import { getParamsFromURL } from '../utils/example-helpers';
+import { getParamsFromURL, authenticateSDKWithEnvironment } from '../utils/example-helpers';
 import { CogniteClient } from '@cognite/sdk';
 import { BoundingBoxClipper } from '@cognite/reveal';
 import { CanvasWrapper } from '../components/styled';
@@ -24,13 +24,15 @@ export function Clipping() {
     const animationLoopHandler: AnimationLoopHandler = new AnimationLoopHandler();
 
     async function main() {
-      const { project, modelUrl, modelRevision } = getParamsFromURL({
+      const { project, modelUrl, modelRevision, environmentParam } = getParamsFromURL({
         project: 'publicdata',
         modelUrl: 'primitives',
       });
+      
       const client = new CogniteClient({ appId: 'reveal.example.simple' });
-      await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project } });
-      await client.authenticate();
+      if (project && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
+      }
 
       const scene = new THREE.Scene();
       const renderer = new THREE.WebGLRenderer({

--- a/examples/src/pages/Geomap.tsx
+++ b/examples/src/pages/Geomap.tsx
@@ -4,6 +4,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import { CanvasWrapper } from '../components/styled';
+import { authenticateSDKWithEnvironment } from '../utils/example-helpers';
 import * as THREE from 'three';
 import { CogniteClient } from '@cognite/sdk';
 import dat from 'dat.gui';
@@ -41,6 +42,7 @@ export function Geomap() {
       const urlParams = url.searchParams;
       const project = urlParams.get('project');
       const geometryFilterInput = urlParams.get('geometryFilter');
+      const environmentParam = urlParams.get('env');
       const geometryFilter = createGeometryFilter(geometryFilterInput);
       const baseUrl = urlParams.get('baseUrl') || undefined;
       if (!project) {
@@ -65,9 +67,10 @@ export function Geomap() {
       };
 
       // Login
-      const client = new CogniteClient({ appId: 'cognite.reveal.example', baseUrl });
-      await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project } });
-      await client.authenticate();
+      const client = new CogniteClient({ appId: 'cognite.reveal.example' });
+      if (project && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
+      }
 
       const progress = (itemsLoaded: number, itemsRequested: number, itemsCulled: number) => {
         guiState.debug.loadedSectors.statistics.culledCount = itemsCulled;

--- a/examples/src/pages/Geomap.tsx
+++ b/examples/src/pages/Geomap.tsx
@@ -69,7 +69,7 @@ export function Geomap() {
       // Login
       const client = new CogniteClient({ appId: 'cognite.reveal.example' });
       if (project && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
       const progress = (itemsLoaded: number, itemsRequested: number, itemsCulled: number) => {

--- a/examples/src/pages/Geomap.tsx
+++ b/examples/src/pages/Geomap.tsx
@@ -44,7 +44,6 @@ export function Geomap() {
       const geometryFilterInput = urlParams.get('geometryFilter');
       const environmentParam = urlParams.get('env');
       const geometryFilter = createGeometryFilter(geometryFilterInput);
-      const baseUrl = urlParams.get('baseUrl') || undefined;
       if (!project) {
         throw new Error('Must provide "project"as URL parameter');
       }

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -71,8 +71,8 @@ export function Migration() {
         ssaoQualityHint: (urlParams.get('ssao') || undefined) as any
       };
       
-      if (project !== null && environmentParam !== null) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+      if (project && environmentParam) {
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       } else if (modelUrl !== null) {
         viewerOptions = {
           ...viewerOptions,

--- a/examples/src/pages/SSAO.tsx
+++ b/examples/src/pages/SSAO.tsx
@@ -8,7 +8,7 @@ import * as THREE from 'three';
 import CameraControls from 'camera-controls';
 import * as reveal from '@cognite/reveal/internals';
 import dat from 'dat.gui';
-import { getParamsFromURL } from '../utils/example-helpers';
+import { authenticateSDKWithEnvironment, getParamsFromURL } from '../utils/example-helpers';
 import { CogniteClient } from '@cognite/sdk';
 import { AnimationLoopHandler } from '../utils/AnimationLoopHandler';
 import { defaultRenderOptions } from '@cognite/reveal/internals';
@@ -24,13 +24,14 @@ export function SSAO() {
     let revealManager: reveal.RevealManager;
 
     async function main() {
-      const { project, modelUrl, modelRevision } = getParamsFromURL({
+      const { project, modelUrl, modelRevision, environmentParam } = getParamsFromURL({
         project: 'publicdata',
         modelUrl: 'primitives',
       });
       const client = new CogniteClient({ appId: 'reveal.example.ssao' });
-      await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project }});
-      await client.authenticate();
+      if (project && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
+      }
 
       const scene = new THREE.Scene();
 

--- a/examples/src/pages/SSAO.tsx
+++ b/examples/src/pages/SSAO.tsx
@@ -30,7 +30,7 @@ export function SSAO() {
       });
       const client = new CogniteClient({ appId: 'reveal.example.ssao' });
       if (project && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
       const scene = new THREE.Scene();

--- a/examples/src/pages/SectorWithPointcloud.tsx
+++ b/examples/src/pages/SectorWithPointcloud.tsx
@@ -133,7 +133,7 @@ export function SectorWithPointcloud() {
         appId: 'reveal.example.hybrid-cad-pointcloud',
       });
       if ((modelRevision || pointCloudModelRevision) && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
       const scene = new THREE.Scene();

--- a/examples/src/pages/SectorWithPointcloud.tsx
+++ b/examples/src/pages/SectorWithPointcloud.tsx
@@ -18,7 +18,7 @@ import {
   createDefaultRenderOptions,
 } from '../utils/renderer-debug-widget';
 import { CogniteClient } from '@cognite/sdk';
-import { getParamsFromURL } from '../utils/example-helpers';
+import { getParamsFromURL, authenticateSDKWithEnvironment } from '../utils/example-helpers';
 import { AnimationLoopHandler } from '../utils/AnimationLoopHandler';
 import { createManagerAndLoadModel } from '../utils/createManagerAndLoadModel';
 
@@ -119,7 +119,7 @@ export function SectorWithPointcloud() {
     const animationLoopHandler: AnimationLoopHandler = new AnimationLoopHandler();
 
     async function main() {
-      const { project, modelUrl, modelRevision } = getParamsFromURL({
+      const { project, modelUrl, modelRevision, environmentParam } = getParamsFromURL({
         project: 'publicdata',
         modelUrl: 'primitives',
       });
@@ -132,9 +132,8 @@ export function SectorWithPointcloud() {
       const client = new CogniteClient({
         appId: 'reveal.example.hybrid-cad-pointcloud',
       });
-      if (modelRevision || pointCloudModelRevision) {
-        await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project }});
-        await client.authenticate()
+      if ((modelRevision || pointCloudModelRevision) && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
       const scene = new THREE.Scene();

--- a/examples/src/pages/Simple.tsx
+++ b/examples/src/pages/Simple.tsx
@@ -34,7 +34,7 @@ export function Simple() {
       const client = new CogniteClient({ appId: 'reveal.example.simple' });
 
       if (project && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
       const renderer = new THREE.WebGLRenderer({

--- a/examples/src/pages/Simple.tsx
+++ b/examples/src/pages/Simple.tsx
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import CameraControls from 'camera-controls';
-import { getParamsFromURL } from '../utils/example-helpers';
+import { getParamsFromURL, authenticateSDKWithEnvironment } from '../utils/example-helpers';
 import { CogniteClient } from '@cognite/sdk';
 import * as reveal from '@cognite/reveal/internals';
 import React, { useEffect, useRef, useState } from 'react';
@@ -27,13 +27,15 @@ export function Simple() {
       if (!canvas.current) {
         return;
       }
-      const { project, modelUrl, modelRevision } = getParamsFromURL({
+      const { project, modelUrl, modelRevision, environmentParam } = getParamsFromURL({
         project: 'publicdata',
         modelUrl: 'primitives',
       });
       const client = new CogniteClient({ appId: 'reveal.example.simple' });
-      await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project }});
-      await client.authenticate();
+
+      if (project && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
+      }
 
       const renderer = new THREE.WebGLRenderer({
         canvas: canvas.current,

--- a/examples/src/pages/SimplePointcloud.tsx
+++ b/examples/src/pages/SimplePointcloud.tsx
@@ -11,7 +11,7 @@ import { CogniteClient } from '@cognite/sdk';
 
 import CameraControls from 'camera-controls';
 import dat, { GUI } from 'dat.gui';
-import { getParamsFromURL } from '../utils/example-helpers';
+import { authenticateSDKWithEnvironment, getParamsFromURL } from '../utils/example-helpers';
 import { AnimationLoopHandler } from '../utils/AnimationLoopHandler';
 import { ClippingUI } from '../utils/ClippingUI';
 import { createManagerAndLoadModel } from '../utils/createManagerAndLoadModel';
@@ -75,14 +75,16 @@ export function SimplePointcloud() {
     const gui = new dat.GUI();
 
     async function main() {
-      const { project, modelUrl, modelRevision } = getParamsFromURL({
+      const { project, modelUrl, modelRevision, environmentParam } = getParamsFromURL({
         project: 'publicdata',
       });
       const client = new CogniteClient({
         appId: 'reveal.example.simple-pointcloud',
       });
-      await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project }});
-      await client.authenticate();
+
+      if (project && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
+      }
       
       const scene = new THREE.Scene();
       const renderer = new THREE.WebGLRenderer({

--- a/examples/src/pages/SimplePointcloud.tsx
+++ b/examples/src/pages/SimplePointcloud.tsx
@@ -83,7 +83,7 @@ export function SimplePointcloud() {
       });
 
       if (project && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
       
       const scene = new THREE.Scene();

--- a/examples/src/pages/TwoModels.tsx
+++ b/examples/src/pages/TwoModels.tsx
@@ -40,7 +40,7 @@ export function TwoModels() {
       
       const client = new CogniteClient({ appId: 'reveal.example.two-models' });
       if (project && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
 

--- a/examples/src/pages/TwoModels.tsx
+++ b/examples/src/pages/TwoModels.tsx
@@ -7,7 +7,7 @@ import { CanvasWrapper } from '../components/styled';
 import * as THREE from 'three';
 
 import CameraControls from 'camera-controls';
-import { getParamsFromURL } from '../utils/example-helpers';
+import { authenticateSDKWithEnvironment, getParamsFromURL } from '../utils/example-helpers';
 import { CogniteClient } from '@cognite/sdk';
 import * as reveal from '@cognite/reveal/internals';
 import { AnimationLoopHandler } from '../utils/AnimationLoopHandler';
@@ -32,14 +32,17 @@ export function TwoModels() {
     const animationLoopHandler: AnimationLoopHandler = new AnimationLoopHandler();
     let revealManager: reveal.RevealManager;
     async function main() {
-      const { project, modelUrl, modelRevision } = getParamsFromURL({
+      const { project, modelUrl, modelRevision, environmentParam } = getParamsFromURL({
         project: 'publicdata',
         modelUrl: 'primitives',
       });
       const { modelUrl: modelUrl2, modelRevision: modelRevision2 } = getModel2Params();
+      
       const client = new CogniteClient({ appId: 'reveal.example.two-models' });
-      await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project }});
-      await client.authenticate();
+      if (project && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
+      }
+
 
       const renderer = new THREE.WebGLRenderer({
         canvas: canvasRef.current!,

--- a/examples/src/pages/WalkablePath.tsx
+++ b/examples/src/pages/WalkablePath.tsx
@@ -9,7 +9,7 @@ import CameraControls from 'camera-controls';
 import { CogniteClient, HttpError } from '@cognite/sdk';
 import * as reveal from '@cognite/reveal/internals';
 import { GUI, GUIController } from 'dat.gui';
-import { getParamsFromURL } from '../utils/example-helpers';
+import { authenticateSDKWithEnvironment, getParamsFromURL } from '../utils/example-helpers';
 import { AnimationLoopHandler } from '../utils/AnimationLoopHandler';
 import { createManagerAndLoadModel } from '../utils/createManagerAndLoadModel';
 
@@ -62,15 +62,17 @@ export function WalkablePath() {
     const animationLoopHandler: AnimationLoopHandler = new AnimationLoopHandler();
     let revealManager: reveal.RevealManager;
     async function main() {
-      const { project, modelUrl, modelRevision } = getParamsFromURL({
+      const { project, modelUrl, modelRevision, environmentParam } = getParamsFromURL({
         project: 'publicdata',
         modelUrl: 'primitives',
       });
+      
       const client = new CogniteClient({
         appId: 'reveal.example.walkable-path',
       });
-      await client.loginWithOAuth({ type: 'CDF_OAUTH', options: { project }});
-      await client.authenticate();
+      if (project && environmentParam) {
+        authenticateSDKWithEnvironment(client, project, environmentParam);
+      }
 
       const scene = new THREE.Scene();
       const renderer = new THREE.WebGLRenderer({

--- a/examples/src/pages/WalkablePath.tsx
+++ b/examples/src/pages/WalkablePath.tsx
@@ -71,7 +71,7 @@ export function WalkablePath() {
         appId: 'reveal.example.walkable-path',
       });
       if (project && environmentParam) {
-        authenticateSDKWithEnvironment(client, project, environmentParam);
+        await authenticateSDKWithEnvironment(client, project, environmentParam);
       }
 
       const scene = new THREE.Scene();

--- a/examples/src/routes.tsx
+++ b/examples/src/routes.tsx
@@ -48,6 +48,8 @@ const cad2RevisionId = getEnv('REACT_APP_CAD_2_REVISION_ID');
 const pointCloudId = getEnv('REACT_APP_POINTCLOUD_ID');
 const pointCloudRevisionId = getEnv('REACT_APP_POINTCLOUD_REVISION_ID');
 
+const defaultEnvironmentParam = 'europewest11-3d';
+
 function menuTitleAz(a: ExampleRoute, b: ExampleRoute): number {
   return a.menuTitle < b.menuTitle ? -1 : a.menuTitle === b.menuTitle ? 0 : 1;
 }
@@ -69,15 +71,17 @@ export const exampleRoutes: Array<ExampleRoute> = [
     name: 'default',
     path:
       `/migration?project=${project}` +
+      `&env=${defaultEnvironmentParam}` +
       `&modelId=${cadId}` +
       `&revisionId=${cadRevisionId}`,
-    menuTitle: 'Default',
+    menuTitle: 'Abandon all hope ye who enter here',
     component: <Migration />,
   },
   {
     name: 'geomap',
     path:
       `/geomap?project=${project}` +
+      `&env=${defaultEnvironmentParam}` +
       `&modelId=${cadId}` +
       `&revisionId=${cadRevisionId}`,
     menuTitle: 'Geomap',
@@ -87,6 +91,7 @@ export const exampleRoutes: Array<ExampleRoute> = [
     name: 'cad-pointcloud',
     path:
       `/sector-with-pointcloud?project=${project}` +
+      `&env=${defaultEnvironmentParam}` +
       `&modelId=${cadId}` +
       `&revisionId=${cadRevisionId}` +
       `&pointCloudModelId=${pointCloudId}` +
@@ -96,7 +101,11 @@ export const exampleRoutes: Array<ExampleRoute> = [
   },
   {
     name: 'pointcloud',
-    path: `/simple-point-cloud?project=${project}&modelId=${pointCloudId}&revisionId=${pointCloudRevisionId}`,
+    path:
+      `/simple-point-cloud?project=${project}` +
+      `&env=${defaultEnvironmentParam}` +
+      `&modelId=${pointCloudId}` +
+      `&revisionId=${pointCloudRevisionId}`,
     menuTitle: 'Simple Point Cloud',
     component: <SimplePointcloud />,
   },
@@ -111,6 +120,7 @@ export const exampleRoutes: Array<ExampleRoute> = [
     // not really good defaults, provide something more meaningful
     path:
       `/two-models?project=${project}` +
+      `&env=${defaultEnvironmentParam}` +
       `&modelId=${cadId}&revisionId=${cadRevisionId}` +
       `&modelId2=${cad2Id}&revisionId2=${cad2RevisionId}`,
     menuTitle: 'Two models',

--- a/examples/src/routes.tsx
+++ b/examples/src/routes.tsx
@@ -74,7 +74,7 @@ export const exampleRoutes: Array<ExampleRoute> = [
       `&env=${defaultEnvironmentParam}` +
       `&modelId=${cadId}` +
       `&revisionId=${cadRevisionId}`,
-    menuTitle: 'Abandon all hope ye who enter here',
+    menuTitle: 'Default',
     component: <Migration />,
   },
   {


### PR DESCRIPTION
Allows for easier switching between projects. URLs for using the test examples now have the form

```
https://localhost:3000/migration?env=europewest11-3d&project=3ddemo&modelId=2890599736800729&revisionId=8160779262643447
https://localhost:3000/migration?env=greenfield-3d&project=3ddemo&modelId=4304523256471874&revisionId=1692652455232986
```