### PR TITLE
Fix off-by-one-error in IndexSet

### DIFF
--- a/viewer/packages/utilities/src/indexset/IndexSet.test.ts
+++ b/viewer/packages/utilities/src/indexset/IndexSet.test.ts
@@ -160,7 +160,7 @@ describe('IndexSet', () => {
 
     const invertedRanges = set1.invertedRanges();
 
-    const expectedInvertedRanges = [new NumericRange(4, 4), new NumericRange(7, 9)];
+    const expectedInvertedRanges = [new NumericRange(4, 1), new NumericRange(7, 3)];
 
     expect(invertedRanges).toBeArrayOfSize(expectedInvertedRanges.length);
     for (const expectedRange of expectedInvertedRanges) {

--- a/viewer/packages/utilities/src/indexset/IndexSet.test.ts
+++ b/viewer/packages/utilities/src/indexset/IndexSet.test.ts
@@ -152,6 +152,27 @@ describe('IndexSet', () => {
     expect(Array.from(set1.toIndexArray()).sort()).toEqual([1, 2]);
   });
 
+  test('invertedRanges returns just ranges between added ranges', () => {
+    const set1 = new IndexSet();
+    set1.addRange(new NumericRange(1, 3));
+    set1.addRange(new NumericRange(5, 2));
+    set1.addRange(new NumericRange(10, 3));
+
+    const invertedRanges = set1.invertedRanges();
+
+    const expectedInvertedRanges = [new NumericRange(4, 4), new NumericRange(7, 9)];
+
+    expect(invertedRanges).toBeArrayOfSize(expectedInvertedRanges.length);
+    for (const expectedRange of expectedInvertedRanges) {
+      expect(invertedRanges).toSatisfy(ranges =>
+        ranges.some(
+          (invertedRange: NumericRange) =>
+            invertedRange.from === expectedRange.from && invertedRange.toInclusive === expectedRange.toInclusive
+        )
+      );
+    }
+  });
+
   function runAddTest(params: { ranges: [number, number][]; add: [number, number]; expected: [number, number][] }) {
     const { ranges, add, expected } = params;
     const set = new IndexSet();

--- a/viewer/packages/utilities/src/indexset/IndexSet.ts
+++ b/viewer/packages/utilities/src/indexset/IndexSet.ts
@@ -112,7 +112,9 @@ export class IndexSet {
         // Should not happen, but let's be safe
         continue;
       }
-      newRanges.push(NumericRange.createFromInterval(originalRanges[i].toInclusive + 1, originalRanges[i + 1].from));
+      newRanges.push(
+        NumericRange.createFromInterval(originalRanges[i].toInclusive + 1, originalRanges[i + 1].from - 1)
+      );
     }
 
     return newRanges;


### PR DESCRIPTION
In index set inversion, specifically

Wish that we had just used the first-inclusive-last-exclusive convention for NumericRanges to begin with :/ 