### PR TITLE
refac: add prefer-readonly eslint rule and fix

### DIFF
--- a/viewer/.eslintrc.js
+++ b/viewer/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/prefer-readonly': 2,
     'unused-imports/no-unused-imports-ts': 'error',
 
     // TODO: maksnester 26-06-2020 we need to fix our codebase to play well with these rules

--- a/viewer/.eslintrc.js
+++ b/viewer/.eslintrc.js
@@ -72,7 +72,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
-    '@typescript-eslint/prefer-readonly': 2,
+    '@typescript-eslint/prefer-readonly': 'error',
     'unused-imports/no-unused-imports-ts': 'error',
 
     // TODO: maksnester 26-06-2020 we need to fix our codebase to play well with these rules

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -1449,7 +1449,7 @@ export class Cognite3DViewer {
     return true;
   }
 
-  private startPointerEventListeners = () => {
+  private readonly startPointerEventListeners = () => {
     const canvas = this.canvas;
     const maxMoveDistance = 4;
     const maxClickDuration = 250;

--- a/viewer/core/src/public/migration/RenderController.ts
+++ b/viewer/core/src/public/migration/RenderController.ts
@@ -11,9 +11,9 @@ import * as THREE from 'three';
  */
 export default class RenderController {
   private _needsRedraw: boolean;
-  private _camera: THREE.PerspectiveCamera | THREE.OrthographicCamera;
-  private _lastCameraPosition: THREE.Vector3;
-  private _lastCameraRotation: THREE.Euler;
+  private readonly _camera: THREE.PerspectiveCamera | THREE.OrthographicCamera;
+  private readonly _lastCameraPosition: THREE.Vector3;
+  private readonly _lastCameraRotation: THREE.Euler;
   private _lastCameraZoom: number;
 
   constructor(camera: THREE.PerspectiveCamera | THREE.OrthographicCamera) {

--- a/viewer/core/src/utilities/Spinner.ts
+++ b/viewer/core/src/utilities/Spinner.ts
@@ -12,7 +12,7 @@ export type Corner = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 
 export class Spinner {
   private static readonly stylesId = 'reveal-viewer-spinner-styles';
-  private static classnames = {
+  private static readonly classnames = {
     base: 'reveal-viewer-spinner',
     topLeft: 'reveal-viewer-spinner-top-left',
     topRight: 'reveal-viewer-spinner-top-right',

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/TakenSectorTree.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/TakenSectorTree.ts
@@ -28,7 +28,7 @@ export class TakenSectorTree {
   }[] = [];
   private readonly determineSectorCost: DetermineSectorCostDelegate;
 
-  private _totalCost: SectorCost = { downloadSize: 0, drawCalls: 0, renderCost: 0 };
+  private readonly _totalCost: SectorCost = { downloadSize: 0, drawCalls: 0, renderCost: 0 };
 
   constructor(sectorRoot: SectorMetadata, determineSectorCost: DetermineSectorCostDelegate) {
     this.determineSectorCost = determineSectorCost;

--- a/viewer/packages/cad-styling/src/CombineNodeCollectionBase.ts
+++ b/viewer/packages/cad-styling/src/CombineNodeCollectionBase.ts
@@ -8,7 +8,7 @@ import { NodeCollectionBase, SerializedNodeCollection } from './NodeCollectionBa
  * Node collection that combines the result from multiple underlying node collections.
  */
 export abstract class CombineNodeCollectionBase extends NodeCollectionBase {
-  private _changedUnderlyingNodeCollectionHandler: () => void;
+  private readonly _changedUnderlyingNodeCollectionHandler: () => void;
   private _cachedCombinedIndexSet: IndexSet | undefined = undefined;
   protected _nodeCollections: NodeCollectionBase[] = [];
 

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -71,23 +71,23 @@ export default class ComboControls extends EventDispatcher {
   public orthographicCameraDollyFactor: number = 0.3;
 
   private temporarilyDisableDamping: boolean = false;
-  private camera: PerspectiveCamera | OrthographicCamera;
+  private readonly camera: PerspectiveCamera | OrthographicCamera;
   private firstPersonMode: boolean = false;
-  private reusableCamera: PerspectiveCamera | OrthographicCamera;
-  private reusableVector3: Vector3 = new Vector3();
-  private _accumulatedMouseMove: Vector2 = new Vector2();
-  private domElement: HTMLElement;
-  private target: Vector3 = new Vector3();
-  private targetEnd: Vector3 = new Vector3();
-  private spherical: Spherical = new Spherical();
+  private readonly reusableCamera: PerspectiveCamera | OrthographicCamera;
+  private readonly reusableVector3: Vector3 = new Vector3();
+  private readonly _accumulatedMouseMove: Vector2 = new Vector2();
+  private readonly domElement: HTMLElement;
+  private readonly target: Vector3 = new Vector3();
+  private readonly targetEnd: Vector3 = new Vector3();
+  private readonly spherical: Spherical = new Spherical();
   private sphericalEnd: Spherical = new Spherical();
-  private deltaTarget: Vector3 = new Vector3();
+  private readonly deltaTarget: Vector3 = new Vector3();
   private keyboard: Keyboard = new Keyboard();
 
-  private offsetVector: Vector3 = new Vector3();
-  private panVector: Vector3 = new Vector3();
-  private raycaster: Raycaster = new Raycaster();
-  private targetFPS: number = 30;
+  private readonly offsetVector: Vector3 = new Vector3();
+  private readonly panVector: Vector3 = new Vector3();
+  private readonly raycaster: Raycaster = new Raycaster();
+  private readonly targetFPS: number = 30;
   private targetFPSOverActualFPS: number = 1;
   private isFocused = false;
 
@@ -249,7 +249,7 @@ export default class ComboControls extends EventDispatcher {
     return deltaTheta;
   }
 
-  private onMouseDown = (event: MouseEvent) => {
+  private readonly onMouseDown = (event: MouseEvent) => {
     if (!this.enabled) {
       return;
     }
@@ -274,11 +274,11 @@ export default class ComboControls extends EventDispatcher {
     }
   };
 
-  private onMouseUp = (_event: MouseEvent) => {
+  private readonly onMouseUp = (_event: MouseEvent) => {
     this._accumulatedMouseMove.set(0, 0);
   };
 
-  private onMouseWheel = (event: WheelEvent) => {
+  private readonly onMouseWheel = (event: WheelEvent) => {
     if (!this.enabled) {
       return;
     }
@@ -313,7 +313,7 @@ export default class ComboControls extends EventDispatcher {
     this.dolly(x, y, deltaDistance);
   };
 
-  private onTouchStart = (event: TouchEvent) => {
+  private readonly onTouchStart = (event: TouchEvent) => {
     if (!this.enabled) {
       return;
     }
@@ -337,21 +337,21 @@ export default class ComboControls extends EventDispatcher {
     }
   };
 
-  private onFocusChanged = (event: MouseEvent | TouchEvent | FocusEvent) => {
+  private readonly onFocusChanged = (event: MouseEvent | TouchEvent | FocusEvent) => {
     this.isFocused =
       event.type !== 'blur' && (event.target === this.domElement || document.activeElement === this.domElement);
 
     this.keyboard.disabled = !this.isFocused;
   };
 
-  private onContextMenu = (event: MouseEvent) => {
+  private readonly onContextMenu = (event: MouseEvent) => {
     if (!this.enabled) {
       return;
     }
     event.preventDefault();
   };
 
-  private rotate = (deltaX: number, deltaY: number) => {
+  private readonly rotate = (deltaX: number, deltaY: number) => {
     if (deltaX === 0 && deltaY === 0) {
       return;
     }
@@ -369,7 +369,7 @@ export default class ComboControls extends EventDispatcher {
     }
   };
 
-  private startMouseRotation = (initialEvent: MouseEvent) => {
+  private readonly startMouseRotation = (initialEvent: MouseEvent) => {
     let previousOffset = getHTMLOffset(this.domElement, initialEvent.clientX, initialEvent.clientY);
     const onMouseMove = (event: MouseEvent) => {
       const newOffset = getHTMLOffset(this.domElement, event.clientX, event.clientY);
@@ -387,7 +387,7 @@ export default class ComboControls extends EventDispatcher {
     window.addEventListener('mouseup', onMouseUp, { passive: false });
   };
 
-  private startMousePan = (initialEvent: MouseEvent) => {
+  private readonly startMousePan = (initialEvent: MouseEvent) => {
     let previousOffset = getHTMLOffset(this.domElement, initialEvent.clientX, initialEvent.clientY);
 
     const onMouseMove = (event: MouseEvent) => {
@@ -407,7 +407,7 @@ export default class ComboControls extends EventDispatcher {
     window.addEventListener('mouseup', onMouseUp, { passive: false });
   };
 
-  private startTouchRotation = (initialEvent: TouchEvent) => {
+  private readonly startTouchRotation = (initialEvent: TouchEvent) => {
     const { domElement } = this;
 
     let previousOffset = getHTMLOffset(domElement, initialEvent.touches[0].clientX, initialEvent.touches[0].clientY);
@@ -443,7 +443,7 @@ export default class ComboControls extends EventDispatcher {
     document.addEventListener('touchend', onTouchEnd, { passive: false });
   };
 
-  private startTouchPinch = (initialEvent: TouchEvent) => {
+  private readonly startTouchPinch = (initialEvent: TouchEvent) => {
     const { domElement } = this;
     let previousPinchInfo = getPinchInfo(domElement, initialEvent.touches);
     const initialPinchInfo = getPinchInfo(domElement, initialEvent.touches);
@@ -491,7 +491,7 @@ export default class ComboControls extends EventDispatcher {
     document.addEventListener('touchend', onTouchEnd);
   };
 
-  private handleKeyboard = () => {
+  private readonly handleKeyboard = () => {
     if (!this.enabled || !this.enableKeyboardNavigation || !this.isFocused) {
       return;
     }
@@ -530,7 +530,7 @@ export default class ComboControls extends EventDispatcher {
     }
   };
 
-  private rotateSpherical = (azimuthAngle: number, polarAngle: number) => {
+  private readonly rotateSpherical = (azimuthAngle: number, polarAngle: number) => {
     const { sphericalEnd } = this;
     const theta = MathUtils.clamp(sphericalEnd.theta + azimuthAngle, this.minAzimuthAngle, this.maxAzimuthAngle);
     const phi = MathUtils.clamp(sphericalEnd.phi + polarAngle, this.minPolarAngle, this.maxPolarAngle);
@@ -539,7 +539,7 @@ export default class ComboControls extends EventDispatcher {
     sphericalEnd.makeSafe();
   };
 
-  private rotateFirstPersonMode = (azimuthAngle: number, polarAngle: number) => {
+  private readonly rotateFirstPersonMode = (azimuthAngle: number, polarAngle: number) => {
     const { firstPersonRotationFactor, reusableCamera, reusableVector3, sphericalEnd, targetEnd } = this;
     reusableCamera.position.setFromSpherical(sphericalEnd).add(targetEnd);
     reusableCamera.lookAt(targetEnd);
@@ -554,7 +554,7 @@ export default class ComboControls extends EventDispatcher {
     sphericalEnd.makeSafe();
   };
 
-  private pan = (deltaX: number, deltaY: number) => {
+  private readonly pan = (deltaX: number, deltaY: number) => {
     const { domElement, camera, offsetVector, target } = this;
 
     offsetVector.copy(camera.position).sub(target);
@@ -572,14 +572,14 @@ export default class ComboControls extends EventDispatcher {
     this.panUp((2 * deltaY * targetDistance) / domElement.clientHeight);
   };
 
-  private dollyOrthographicCamera = (_x: number, _y: number, deltaDistance: number) => {
+  private readonly dollyOrthographicCamera = (_x: number, _y: number, deltaDistance: number) => {
     const camera = this.camera as OrthographicCamera;
     camera.zoom *= 1 - deltaDistance;
     camera.zoom = MathUtils.clamp(camera.zoom, this.minZoom, this.maxZoom);
     camera.updateProjectionMatrix();
   };
 
-  private dollyPerspectiveCamera = (x: number, y: number, deltaDistance: number) => {
+  private readonly dollyPerspectiveCamera = (x: number, y: number, deltaDistance: number) => {
     const { dynamicTarget, minDistance, raycaster, reusableVector3, sphericalEnd, targetEnd, camera, reusableCamera } =
       this;
 
@@ -622,7 +622,7 @@ export default class ComboControls extends EventDispatcher {
     targetEnd.add(targetOffset);
   };
 
-  private dolly = (x: number, y: number, deltaDistance: number) => {
+  private readonly dolly = (x: number, y: number, deltaDistance: number) => {
     const { camera } = this;
     // @ts-ignore
     if (camera.isOrthographicCamera) {
@@ -633,7 +633,7 @@ export default class ComboControls extends EventDispatcher {
     }
   };
 
-  private getDollyDeltaDistance = (dollyIn: boolean, steps: number = 1) => {
+  private readonly getDollyDeltaDistance = (dollyIn: boolean, steps: number = 1) => {
     const { sphericalEnd, dollyFactor } = this;
     const zoomFactor = dollyFactor ** steps;
     const factor = dollyIn ? zoomFactor : 1 / zoomFactor;
@@ -641,14 +641,14 @@ export default class ComboControls extends EventDispatcher {
     return distance * (factor - 1);
   };
 
-  private panLeft = (distance: number) => {
+  private readonly panLeft = (distance: number) => {
     const { camera, targetEnd, panVector } = this;
     panVector.setFromMatrixColumn(camera.matrix, 0); // get X column of objectMatrix
     panVector.multiplyScalar(-distance);
     targetEnd.add(panVector);
   };
 
-  private panUp = (distance: number) => {
+  private readonly panUp = (distance: number) => {
     const { camera, targetEnd, panVector } = this;
     panVector.setFromMatrixColumn(camera.matrix, 1); // get X column of objectMatrix
     panVector.multiplyScalar(distance);

--- a/viewer/packages/camera-manager/src/Keyboard.ts
+++ b/viewer/packages/camera-manager/src/Keyboard.ts
@@ -50,7 +50,7 @@ export default class Keyboard {
     return p;
   };
 
-  private addEventListeners = () => {
+  private readonly addEventListeners = () => {
     this.clearPressedKeys();
 
     window.addEventListener('keydown', this.onKeydown);
@@ -58,13 +58,13 @@ export default class Keyboard {
     window.addEventListener('blur', this.clearPressedKeys);
   };
 
-  private removeEventListeners = () => {
+  private readonly removeEventListeners = () => {
     window.removeEventListener('keydown', this.onKeydown);
     window.removeEventListener('keyup', this.onKeyup);
     window.removeEventListener('blur', this.clearPressedKeys);
   };
 
-  private onKeydown = (event: KeyboardEvent) => {
+  private readonly onKeydown = (event: KeyboardEvent) => {
     if (event.metaKey || event.altKey || event.ctrlKey) {
       return;
     }
@@ -77,13 +77,13 @@ export default class Keyboard {
     }
   };
 
-  private onKeyup = (event: KeyboardEvent) => {
+  private readonly onKeyup = (event: KeyboardEvent) => {
     if (event.keyCode in keyMap) {
       this.keys[keyMap[event.keyCode]] = 0;
     }
   };
 
-  private clearPressedKeys = () => {
+  private readonly clearPressedKeys = () => {
     Object.keys(keyMap).forEach((key: string) => {
       this.keys[keyMap[key]] = 0;
     });

--- a/viewer/packages/rendering/src/rendering/EffectRenderManager.ts
+++ b/viewer/packages/rendering/src/rendering/EffectRenderManager.ts
@@ -61,18 +61,18 @@ export class EffectRenderManager {
 
   private _renderOptions: RenderOptions;
 
-  private _combineOutlineDetectionMaterial: THREE.ShaderMaterial;
-  private _fxaaMaterial: THREE.ShaderMaterial;
+  private readonly _combineOutlineDetectionMaterial: THREE.ShaderMaterial;
+  private readonly _fxaaMaterial: THREE.ShaderMaterial;
   private _ssaoMaterial: THREE.ShaderMaterial;
-  private _ssaoBlurMaterial: THREE.ShaderMaterial;
+  private readonly _ssaoBlurMaterial: THREE.ShaderMaterial;
 
-  private _customObjectRenderTarget: THREE.WebGLRenderTarget;
-  private _ghostObjectRenderTarget: THREE.WebGLRenderTarget;
-  private _normalRenderedCadModelTarget: THREE.WebGLRenderTarget;
-  private _inFrontRenderedCadModelTarget: THREE.WebGLRenderTarget;
-  private _compositionTarget: THREE.WebGLRenderTarget;
-  private _ssaoTarget: THREE.WebGLRenderTarget;
-  private _ssaoBlurTarget: THREE.WebGLRenderTarget;
+  private readonly _customObjectRenderTarget: THREE.WebGLRenderTarget;
+  private readonly _ghostObjectRenderTarget: THREE.WebGLRenderTarget;
+  private readonly _normalRenderedCadModelTarget: THREE.WebGLRenderTarget;
+  private readonly _inFrontRenderedCadModelTarget: THREE.WebGLRenderTarget;
+  private readonly _compositionTarget: THREE.WebGLRenderTarget;
+  private readonly _ssaoTarget: THREE.WebGLRenderTarget;
+  private readonly _ssaoBlurTarget: THREE.WebGLRenderTarget;
 
   /**
    * Holds state of how the last frame was rendered by `render()`. This is used to explicit clear

--- a/viewer/packages/rendering/src/transform/NodeTransformTextureBuilder.ts
+++ b/viewer/packages/rendering/src/transform/NodeTransformTextureBuilder.ts
@@ -13,7 +13,7 @@ export class NodeTransformTextureBuilder {
   private readonly _transformOverrideBuffer: TransformOverrideBuffer;
   private readonly _transformOverrideIndexTexture: THREE.DataTexture;
   private _needsUpdate = false;
-  private _handleTransformChangedBound = this.handleTransformChanged.bind(this);
+  private readonly _handleTransformChangedBound = this.handleTransformChanged.bind(this);
 
   constructor(treeIndexCount: number, transformProvider: NodeTransformProvider) {
     const textures = allocateTextures(treeIndexCount);

--- a/viewer/packages/rendering/src/transform/TransformOverrideBuffer.ts
+++ b/viewer/packages/rendering/src/transform/TransformOverrideBuffer.ts
@@ -14,11 +14,11 @@ export class TransformOverrideBuffer {
   private _dataTexture: THREE.DataTexture;
   private _textureBuffer: Uint8Array;
 
-  private _unusedIndices: number[];
+  private readonly _unusedIndices: number[];
 
-  private _treeIndexToOverrideIndex: Map<number, number>;
+  private readonly _treeIndexToOverrideIndex: Map<number, number>;
 
-  private _onGenerateNewDataTextureCallback: (datatexture: THREE.DataTexture) => void;
+  private readonly _onGenerateNewDataTextureCallback: (datatexture: THREE.DataTexture) => void;
 
   get dataTexture(): THREE.DataTexture {
     return this._dataTexture;

--- a/viewer/packages/tools/src/AxisView/AxisViewTool.ts
+++ b/viewer/packages/tools/src/AxisView/AxisViewTool.ts
@@ -38,7 +38,7 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
   private readonly _disposeClickDiv: () => void;
 
   private _dynamicUpdatePosition = () => {};
-  private _updateClickDiv = () => {};
+  private readonly _updateClickDiv = () => {};
 
   constructor(viewer: Cognite3DViewer, config?: AxisBoxConfig) {
     super();

--- a/viewer/packages/tools/src/Geomap/Geomap.ts
+++ b/viewer/packages/tools/src/Geomap/Geomap.ts
@@ -9,7 +9,7 @@ import { LatLongPosition, MapConfig, MapProviders } from './MapConfig';
 
 export class Geomap {
   private readonly _viewer: Cognite3DViewer;
-  private _map: GEOTHREE.MapView;
+  private readonly _map: GEOTHREE.MapView;
   private _intervalId: any = 0;
   private readonly _onCameraChange = this.handleCameraChange.bind(this);
 

--- a/viewer/packages/utilities/src/datastructures/DynamicDefragmentedBuffer.ts
+++ b/viewer/packages/utilities/src/datastructures/DynamicDefragmentedBuffer.ts
@@ -22,9 +22,9 @@ export class DynamicDefragmentedBuffer<T extends TypedArray> {
 
   private _buffer: T;
   private _numFilled: number;
-  private _type: new (length: number) => T;
+  private readonly _type: new (length: number) => T;
 
-  private _batchMap: Map<number, Batch>;
+  private readonly _batchMap: Map<number, Batch>;
   private _currentTail: Batch | undefined;
 
   private _batchIdCounter: number;


### PR DESCRIPTION
Avoids us having `private` variables that only is modified in the constructor.