### PR TITLE
chore: add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,3 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/typescript-node/.devcontainer/base.Dockerfile
-
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT="16-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -17,4 +17,4 @@ Please see <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote
 
 Once the devcontainer startup is done, open a new terminal, and follow the build steps as explained in the main README.md for Reveal, running yarn build steps.
 
-If you have a (Github Codespaces]<https://github.com/features/codespaces> account, you should be able to load the devcontainer there as well.
+If you have a [Github Codespaces](https://github.com/features/codespaces) account, you should be able to load the devcontainer there as well.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,20 @@
+# Devcontainer setup for Reveal
+
+This devcontainer setup can be utilized in various ways to make it easier to get a development environment for Reveal.
+
+One way is with Visual Studio Code - Remote containers, which will run installation of all Reveal pre-requisites, and allow development of it inside Docker on your machine.
+You need to have Docker and VSCode installed on your machine.
+
+1. Open VSCode
+1. Press Ctrl+Shift-P (or the green "Remote window" in the lower left corner of VSCode)
+1. Choose "Clone repository in container volume"
+1. Choose "Clone a repository from Github in a Container volume"
+1. Type "cognitedata/reveal"
+1. Choose "master" branch (or any other branch)
+
+A new VSCode window should now be opened, and it should start up the devcontainer. You can see the logs by clicking the notification dialog in the lower right.
+Please see <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers> for more instructions.
+
+Once the devcontainer startup is done, open a new terminal, and follow the build steps as explained in the main README.md for Reveal, running yarn build steps.
+
+If you have a (Github Codespaces]<https://github.com/features/codespaces> account, you should be able to load the devcontainer there as well.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-        // The xserver deps is needed for the GL package build needed by Reveal.
+	// The xserver deps is needed for the GL package build needed by Reveal.
 	"postCreateCommand": 
 		"sudo apt-get -y update && sudo apt-get --fix-missing -y install xserver-xorg-dev libxi-dev libxext-dev",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": 
-		"sudo apt-get -y update && sudo apt-get --fix-missing -y install xvfb libgl1-mesa-dev xserver-xorg-dev libxi-dev libxext-dev",
+		"sudo apt-get -y update && sudo apt-get --fix-missing -y install xserver-xorg-dev libxi-dev libxext-dev",
 
 	"postStartCommand": 
 		"yarn install",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,11 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install",
+	"postCreateCommand": 
+		"sudo apt-get -y update && sudo apt-get --fix-missing -y install xvfb libgl1-mesa-dev xserver-xorg-dev libxi-dev libxext-dev",
+
+	"postStartCommand": 
+		"yarn install",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "zsh",
+	},
 
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/typescript-node
+{
+	"name": "Reveal devcontainer",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local on arm64/Apple Silicon.
+		"args": { 
+			"VARIANT": "16-bullseye"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"rust-lang.rust",
+		"cadenas.vscode-glsllint",
+		"mhutchie.git-graph",
+		"eamodio.gitlens"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "yarn install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	"features": {
+		"github-cli": "latest",
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/typescript-node
+// For format details, see https://aka.ms/devcontainer.json For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/main/containers/typescript-node
 {
 	"name": "Reveal devcontainer",
 	"build": {
@@ -31,6 +31,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
+        // The xserver deps is needed for the GL package build needed by Reveal.
 	"postCreateCommand": 
 		"sudo apt-get -y update && sudo apt-get --fix-missing -y install xserver-xorg-dev libxi-dev libxext-dev",
 


### PR DESCRIPTION
This PR adds support to load Reveal as a devcontainer, in VSCode.
