### PR TITLE
improvement: apply all node style changes within same 'tick' at the same time

### DIFF
--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
@@ -14,7 +14,7 @@ describe('NodeAppearanceProvider', () => {
 
   beforeEach(() => {
     provider = new NodeAppearanceProvider();
-    jest.useFakeTimers('modern');
+    jest.useFakeTimers();
   });
 
   afterEach(() => {

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
@@ -14,7 +14,7 @@ describe('NodeAppearanceProvider', () => {
 
   beforeEach(() => {
     provider = new NodeAppearanceProvider();
-    jest.useFakeTimers();
+    jest.useFakeTimers('modern');
   });
 
   afterEach(() => {
@@ -67,12 +67,15 @@ describe('NodeAppearanceProvider', () => {
     provider.on('changed', listener);
 
     provider.assignStyledNodeCollection(nodeCollection, {});
+    jest.runAllTimers();
     expect(listener).toBeCalledTimes(1);
 
     provider.assignStyledNodeCollection(nodeCollection, { visible: false });
+    jest.runAllTimers();
     expect(listener).toBeCalledTimes(2);
 
     provider.unassignStyledNodeCollection(nodeCollection);
+    jest.runAllTimers();
     expect(listener).toBeCalledTimes(3);
   });
 
@@ -94,6 +97,7 @@ describe('NodeAppearanceProvider', () => {
     const style: NodeAppearance = { visible: false };
     provider.assignStyledNodeCollection(nodeCollection, style);
     provider.unassignStyledNodeCollection(nodeCollection);
+    jest.runAllTimers();
     const listener = jest.fn();
     provider.on('changed', listener);
 

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
@@ -6,6 +6,7 @@ import { NodeAppearance } from './NodeAppearance';
 import { NodeCollectionBase } from './NodeCollectionBase';
 
 import { IndexSet, assertNever, EventTrigger } from '@reveal/utilities';
+import debounce from 'lodash/debounce';
 
 /**
  * Delegate for applying styles in {@see NodeStyleProvider}.
@@ -77,7 +78,7 @@ export class NodeAppearanceProvider {
 
       this._styledCollections.push(styledCollection);
       nodeCollection.on('changed', styledCollection.handleNodeCollectionChangedListener);
-      this.notifyChanged();
+      this.scheduleNotifyChanged();
     }
   }
 
@@ -90,7 +91,7 @@ export class NodeAppearanceProvider {
 
     this._styledCollections.splice(index, 1);
     nodeCollection.off('changed', styledCollection.handleNodeCollectionChangedListener);
-    this.notifyChanged();
+    this.scheduleNotifyChanged();
   }
 
   applyStyles(applyCb: ApplyStyleDelegate) {
@@ -106,7 +107,7 @@ export class NodeAppearanceProvider {
       nodeCollection.off('changed', styledSet.handleNodeCollectionChangedListener);
     }
     this._styledCollections.splice(0);
-    this.notifyChanged();
+    this.scheduleNotifyChanged();
   }
 
   get isLoading(): boolean {
@@ -116,6 +117,10 @@ export class NodeAppearanceProvider {
   private notifyChanged() {
     this._events.changed.fire();
   }
+  /**
+   * Schedules event 'changed' to trigger at the next tick.
+   */
+  private readonly scheduleNotifyChanged = debounce(() => this.notifyChanged(), 0);
 
   private notifyLoadingStateChanged() {
     if (this._lastFiredLoadingState === this.isLoading) return;
@@ -124,7 +129,7 @@ export class NodeAppearanceProvider {
   }
 
   private handleNodeCollectionChanged(_styledSet: StyledNodeCollection) {
-    this.notifyChanged();
+    this.scheduleNotifyChanged();
     this.notifyLoadingStateChanged();
   }
 }

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
@@ -117,6 +117,7 @@ export class NodeAppearanceProvider {
   private notifyChanged() {
     this._events.changed.fire();
   }
+
   /**
    * Schedules event 'changed' to trigger at the next tick.
    */

--- a/viewer/packages/rendering/src/CadMaterialManager.test.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.test.ts
@@ -18,7 +18,12 @@ describe('CadMaterialManager', () => {
   let manager: CadMaterialManager;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     manager = new CadMaterialManager();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   test('addModelMaterials creates material and initializes collections for model', () => {
@@ -62,6 +67,7 @@ describe('CadMaterialManager', () => {
     manager.on('materialsChanged', listener);
 
     provider.assignStyledNodeCollection(new TreeIndexNodeCollection(new IndexSet([1, 2, 3])), { renderGhosted: true });
+    jest.runAllTimers();
 
     expect(manager.getModelBackTreeIndices('model')).toEqual(new IndexSet([0, 4]));
     expect(manager.getModelGhostedTreeIndices('model')).toEqual(new IndexSet([1, 2, 3]));

--- a/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.test.ts
+++ b/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.test.ts
@@ -24,7 +24,7 @@ describe('NodeAppearanceTextureBuilder', () => {
   });
 
   afterEach(() => {
-    jest.useRealTimers;
+    jest.useRealTimers();
   });
 
   test('needsUpdate is initially true', () => {

--- a/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.test.ts
+++ b/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.test.ts
@@ -17,9 +17,14 @@ describe('NodeAppearanceTextureBuilder', () => {
   let nodeCollection: TreeIndexNodeCollection;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     styleProvider = new NodeAppearanceProvider();
     builder = new NodeAppearanceTextureBuilder(1, styleProvider);
     nodeCollection = new TreeIndexNodeCollection([0]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers;
   });
 
   test('needsUpdate is initially true', () => {
@@ -34,11 +39,13 @@ describe('NodeAppearanceTextureBuilder', () => {
   test('needsUpdate() is true after style provider is changed', () => {
     builder.build(); // Reset needsUpdate
     styleProvider.assignStyledNodeCollection(nodeCollection, { renderGhosted: true });
+    jest.runAllTimers();
     expect(builder.needsUpdate).toBeTrue();
   });
 
   test('build() applies color override', () => {
     styleProvider.assignStyledNodeCollection(nodeCollection, { color: [128, 255, 64] });
+    jest.runAllTimers();
     builder.build();
 
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([128, 255, 64, 1]);
@@ -46,6 +53,7 @@ describe('NodeAppearanceTextureBuilder', () => {
 
   test('build() applies hidden', () => {
     styleProvider.assignStyledNodeCollection(nodeCollection, { visible: false });
+    jest.runAllTimers();
     builder.build();
 
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([0, 0, 0, 0]);
@@ -53,6 +61,7 @@ describe('NodeAppearanceTextureBuilder', () => {
 
   test('build() applies in front', () => {
     styleProvider.assignStyledNodeCollection(nodeCollection, { renderInFront: true });
+    jest.runAllTimers();
     builder.build();
 
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([0, 0, 0, 3]);
@@ -60,6 +69,7 @@ describe('NodeAppearanceTextureBuilder', () => {
 
   test('build() applies ghost mode', () => {
     styleProvider.assignStyledNodeCollection(nodeCollection, { renderGhosted: true });
+    jest.runAllTimers();
     builder.build();
 
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([0, 0, 0, 5]);
@@ -67,6 +77,7 @@ describe('NodeAppearanceTextureBuilder', () => {
 
   test('build() applies outline', () => {
     styleProvider.assignStyledNodeCollection(nodeCollection, { outlineColor: NodeOutlineColor.Orange });
+    jest.runAllTimers();
     builder.build();
 
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([0, 0, 0, 1 + (NodeOutlineColor.Orange << 5)]);
@@ -78,6 +89,7 @@ describe('NodeAppearanceTextureBuilder', () => {
     expect(builder.ghostedNodeTreeIndices).toEqual(new IndexSet([]));
 
     styleProvider.assignStyledNodeCollection(nodeCollection, { renderGhosted: true });
+    jest.runAllTimers();
     builder.build();
 
     expect(builder.regularNodeTreeIndices).toEqual(new IndexSet([]));
@@ -90,6 +102,7 @@ describe('NodeAppearanceTextureBuilder', () => {
     expect(builder.infrontNodeTreeIndices).toEqual(new IndexSet([]));
 
     styleProvider.assignStyledNodeCollection(nodeCollection, { renderInFront: true });
+    jest.runAllTimers();
     builder.build();
 
     expect(builder.regularNodeTreeIndices).toEqual(new IndexSet([]));
@@ -99,11 +112,13 @@ describe('NodeAppearanceTextureBuilder', () => {
   test('build() resets styles of removed node collections', () => {
     // Arrange
     styleProvider.assignStyledNodeCollection(nodeCollection, { renderGhosted: true });
+    jest.runAllTimers();
     builder.build();
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([0, 0, 0, 5]); // Alpha = 5 -> visible, ghosted
 
     // Act
     styleProvider.unassignStyledNodeCollection(nodeCollection);
+    jest.runAllTimers();
     builder.build();
 
     // Assert
@@ -115,11 +130,13 @@ describe('NodeAppearanceTextureBuilder', () => {
     builder.build();
     const originalTexels = texelsOf(builder.overrideColorPerTreeIndexTexture);
     styleProvider.assignStyledNodeCollection(nodeCollection, { renderGhosted: true });
+    jest.runAllTimers();
     builder.build();
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).not.toEqual(originalTexels);
 
     // Act
     styleProvider.unassignStyledNodeCollection(nodeCollection);
+    jest.runAllTimers();
     builder.build();
 
     // Assert
@@ -130,11 +147,13 @@ describe('NodeAppearanceTextureBuilder', () => {
     const set = new TreeIndexNodeCollection(new IndexSet([0]));
     const style: NodeAppearance = { color: [127, 128, 192], visible: false };
     styleProvider.assignStyledNodeCollection(set, style);
+    jest.runAllTimers();
 
     builder.build();
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([127, 128, 192, 0]);
 
     set.updateSet(new IndexSet([]));
+    jest.runAllTimers();
     builder.build();
 
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([0, 0, 0, 1]);
@@ -158,6 +177,7 @@ describe('NodeAppearanceTextureBuilder', () => {
   test('setDefaultStyle() has effect for unset fields in styled sets', () => {
     builder.setDefaultAppearance({ color: [1, 2, 3], renderGhosted: true });
     styleProvider.assignStyledNodeCollection(new TreeIndexNodeCollection([0]), { renderGhosted: false });
+    jest.runAllTimers();
     builder.build();
 
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([1, 2, 3, 1]); // Color is from default style, but 'renderGhosted' from styled set
@@ -174,6 +194,7 @@ describe('NodeAppearanceTextureBuilder', () => {
     // Override settings for node 1+2, moving these into ghosted and infront sets
     styleProvider.assignStyledNodeCollection(new TreeIndexNodeCollection([1]), { renderGhosted: true });
     styleProvider.assignStyledNodeCollection(new TreeIndexNodeCollection([2]), { renderInFront: true });
+    jest.runAllTimers();
     builder.build();
     expect(builder.regularNodeTreeIndices).toEqual(new IndexSet([0]));
     expect(builder.ghostedNodeTreeIndices).toEqual(new IndexSet([1]));


### PR DESCRIPTION
Fixes an issue with timeline where the styling intermittently would be reset to the default styling