### PR TITLE
improvement: transfer buffers from parser web worker to main thread

### DIFF
--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1252,10 +1252,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cognite/potree-core@1.5.0", "@cognite/potree-core@^1.5.0":
+"@cognite/potree-core@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.5.0.tgz#7b288a12358b2ef2b2ae51195a4ecace396822be"
   integrity sha512-/XhfPYlPIK7LxT0czUIGMWLcUjGfVmf3Nzcf+6FaG+sExr6S8Yqayeid9FdYgi7y+LFmvYSJrZyXgF5LL8ZMrg==
+
+"@cognite/potree-core@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.5.1.tgz#b61bc4ed905757701c8d2074b153890974857bb3"
+  integrity sha512-T0+MIDd3ebZDjRbddiLF1KhMeW0JCunbvaxpseZdgAjXx6S/W4EiIFJqjP0g9KXOn09DLSAIS8DVtKKfKtyhAA==
 
 "@cognite/reveal-parser-worker@1.2.0":
   version "1.2.0"
@@ -3926,7 +3931,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comlink@4.3.1:
+comlink@4.3.1, comlink@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
   integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==

--- a/parser-worker/RevealParserWorker.ts
+++ b/parser-worker/RevealParserWorker.ts
@@ -2,6 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
+import * as Comlink from "comlink";
+
 import { createDetailedGeometry } from "./createDetailedGeometry";
 import type * as rustTypes from "./pkg/reveal_rs_wrapper";
 
@@ -44,7 +46,34 @@ export class RevealParserWorker {
 
     sectorData.free();
 
-    return parseResult;
+    return Comlink.transfer(parseResult, [
+      parseResult.instanceMeshes.colors.buffer,
+      parseResult.instanceMeshes.fileIds.buffer,
+      parseResult.instanceMeshes.instanceMatrices.buffer,
+      parseResult.instanceMeshes.sizes.buffer,
+      parseResult.instanceMeshes.treeIndices.buffer,
+      parseResult.instanceMeshes.triangleCounts.buffer,
+      parseResult.instanceMeshes.triangleOffsets.buffer,
+
+      parseResult.triangleMeshes.colors.buffer,
+      parseResult.triangleMeshes.fileIds.buffer,
+      parseResult.triangleMeshes.sizes.buffer,
+      parseResult.triangleMeshes.treeIndices.buffer,
+      parseResult.triangleMeshes.triangleCounts.buffer,
+
+      parseResult.primitives.boxCollection.buffer,
+      parseResult.primitives.circleCollection.buffer,
+      parseResult.primitives.coneCollection.buffer,
+      parseResult.primitives.eccentricConeCollection.buffer,
+      parseResult.primitives.ellipsoidSegmentCollection.buffer,
+      parseResult.primitives.generalCylinderCollection.buffer,
+      parseResult.primitives.generalRingCollection.buffer,
+      parseResult.primitives.nutCollection.buffer,
+      parseResult.primitives.quadCollection.buffer,
+      parseResult.primitives.sphericalSegmentCollection.buffer,
+      parseResult.primitives.torusSegmentCollection.buffer,
+      parseResult.primitives.trapeziumCollection.buffer,
+    ]);
   }
 
   public async parseCtm(buffer: Uint8Array): Promise<ParseCtmResult> {
@@ -61,7 +90,10 @@ export class RevealParserWorker {
 
     ctm.free();
 
-    return result;
+    const transferable: Transferable[] = result.normals !== undefined ?
+      [result.indices.buffer, result.normals.buffer, result.vertices.buffer] :
+      [result.indices.buffer, result.vertices.buffer];
+    return Comlink.transfer(result, transferable);
   }
 
   public async parseQuads(buffer: Uint8Array): Promise<SectorQuads> {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -50,7 +50,7 @@
     "@tweenjs/tween.js": "^18.6.4",
     "@types/three": "0.133.0",
     "assert": "^2.0.0",
-    "comlink": "4.3.1",
+    "comlink": "^4.3.1",
     "geo-three": "^0.0.15",
     "glslify": "^7.1.1",
     "glslify-import": "^3.1.0",

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -491,7 +491,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.29.1
     "@typescript-eslint/parser": ^4.29.1
     assert: ^2.0.0
-    comlink: 4.3.1
+    comlink: ^4.3.1
     copy-pkg-json-webpack-plugin: ^0.0.40
     copy-webpack-plugin: ^6.2.1
     core-js: ^3.6.5
@@ -3910,7 +3910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"comlink@npm:4.3.1":
+"comlink@npm:4.3.1, comlink@npm:^4.3.1":
   version: 4.3.1
   resolution: "comlink@npm:4.3.1"
   checksum: 557360a6558708c55aff74a25f834bfb9bfca8a42444682c4d5aead57681534a0206202be2a2760b4de124c3ba6d485b08978b6d5469cb3d26bf1438ee28a4f1


### PR DESCRIPTION
This avoids copying buffers, saving some time when transfering them.

See https://github.com/GoogleChromeLabs/comlink#comlinktransfervalue-transferables-and-comlinkproxyvalue

Note! This PR doesn't really change anything as we will need to release a new parser-worker before it has effect. In order to test this, run it locally and follow procedures in parser-worker/README.md for testing local worker.