### PR TITLE
fix: too little geometry was culled during load when a geometry filter was active

### DIFF
--- a/viewer/packages/cad-geometry-loaders/src/sector/sectorUtilities.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/sectorUtilities.ts
@@ -49,7 +49,7 @@ export function consumeSectorDetailed(
 ): { sectorMeshes: AutoDisposeGroup; instancedMeshes: InstancedMeshFile[] } {
   const bounds = metadata.bounds;
 
-  if (geometryClipBox !== null && geometryClipBox.containsBox(bounds)) {
+  if (geometryClipBox !== null && fuzzyContainsBox(geometryClipBox, bounds)) {
     // If sector bounds is fully inside clip Box, nothing will be clipped so don't go the extra mile
     // to check
     geometryClipBox = null;
@@ -128,4 +128,24 @@ export function findSectorMetadata(root: SectorMetadata, sectorId: number): Sect
     throw new Error(`Could not find metadata for sector ${sectorId} - invalid id?`);
   }
   return foundSector;
+}
+
+/**
+ * Like THREE.Box3.containsBox(), but with fuzziness added.
+ */
+function fuzzyContainsBox(
+  boxToCheckIfCovers: THREE.Box3,
+  possiblyCovered: THREE.Box3,
+  fuzziness: number = 1e-4
+): boolean {
+  const big = boxToCheckIfCovers;
+  const small = possiblyCovered;
+  return (
+    big.min.x - small.min.x >= fuzziness &&
+    small.max.x - big.max.x >= fuzziness &&
+    big.min.y - small.min.y >= fuzziness &&
+    small.max.y - big.max.y >= fuzziness &&
+    big.min.z - small.min.z >= fuzziness &&
+    small.max.z - big.max.z >= fuzziness
+  );
 }

--- a/viewer/packages/cad-geometry-loaders/src/sector/sectorUtilities.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/sectorUtilities.ts
@@ -49,7 +49,7 @@ export function consumeSectorDetailed(
 ): { sectorMeshes: AutoDisposeGroup; instancedMeshes: InstancedMeshFile[] } {
   const bounds = metadata.bounds;
 
-  if (geometryClipBox !== null && fuzzyContainsBox(geometryClipBox, bounds)) {
+  if (geometryClipBox !== null && isSectorBoundsFullyInsideClipBox(geometryClipBox, bounds)) {
     // If sector bounds is fully inside clip Box, nothing will be clipped so don't go the extra mile
     // to check
     geometryClipBox = null;
@@ -131,9 +131,14 @@ export function findSectorMetadata(root: SectorMetadata, sectorId: number): Sect
 }
 
 /**
- * Like THREE.Box3.containsBox(), but with fuzziness added.
+ * Checks if sector bounds is partially outside clip box, and hence
+ * if it should be clipped (as opposition to clipping). Since model
+ * sectors are clipped to fit within the clip box on load, we
+ * consider sectors on the boundary to be outside. Worst case, this
+ * causes geometry within some sectors to be unnecessary clipped
+ * towards to clip box, but will not lead to any lost geometry.
  */
-function fuzzyContainsBox(
+function isSectorBoundsFullyInsideClipBox(
   boxToCheckIfCovers: THREE.Box3,
   possiblyCovered: THREE.Box3,
   fuzziness: number = 1e-4


### PR DESCRIPTION
In a regression introduced in #1513, geometry filter culling of geometry didn't correctly work, causing too much clipped geometry to be loaded (and processed/rendered), reducing performance and visual quality.

See below for a comparison of the same view point (the blue box is the active geometry filter, but we disable clipping filters to also show loaded geometry outside this box).

Before fix:
![image](https://user-images.githubusercontent.com/6741854/143944196-8a476fec-7f18-4c64-abe1-f45a6cff691e.png)
2420 draw calls

After fix:
![image](https://user-images.githubusercontent.com/6741854/143943134-a86b9851-bcde-4439-b867-892c1d83f7a2.png)
670 draw calls

Fixes REV-259.