### PR TITLE
fix: primitive filtering bounding boxes being bogus

### DIFF
--- a/viewer/packages/cad-parsers/src/cad/filterPrimitivesCommon.ts
+++ b/viewer/packages/cad-parsers/src/cad/filterPrimitivesCommon.ts
@@ -16,7 +16,11 @@ export function filterPrimitivesOutsideClipBox(
   ) => void
 ): Uint8Array {
   const elementCount = attributesByteValues.length / elementSize;
-  const attributeFloatValues = new Float32Array(attributesByteValues.buffer);
+  const attributeFloatValues = new Float32Array(
+    attributesByteValues.buffer,
+    attributesByteValues.byteOffset,
+    attributesByteValues.byteLength / Float32Array.BYTES_PER_ELEMENT
+  );
 
   const instanceBbox = new THREE.Box3();
 

--- a/viewer/packages/cad-parsers/src/cad/filterPrimitivesV9.test.ts
+++ b/viewer/packages/cad-parsers/src/cad/filterPrimitivesV9.test.ts
@@ -366,24 +366,6 @@ describe(filterGeometryOutsideClipBox.name, () => {
   });
 
   test('Two different primitive types in same buffer: one of each accepted', () => {
-    const mat0 = new THREE.Matrix4()
-      .makeTranslation(10, -10, 0)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
-    const mat1 = new THREE.Matrix4()
-      .makeTranslation(-10, 5, 10)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
-
-    const circles: Circle[] = [
-      {
-        instanceMatrix: mat0.toArray(),
-        normal: [0, 1, 0]
-      },
-      {
-        instanceMatrix: mat1.toArray(),
-        normal: [0, 1, 0]
-      }
-    ];
-
     const ellipsoids: Ellipsoid[] = [
       {
         horizontalRadius: 1,
@@ -399,8 +381,31 @@ describe(filterGeometryOutsideClipBox.name, () => {
       }
     ];
 
-    const primitives = [circles, ellipsoids];
-    const primitiveTypes = [PrimitiveName.Circle, PrimitiveName.Ellipsoid];
+    const cylinders: GeneralCylinder[] = [
+      {
+        angle: 0,
+        arcAngle: Math.PI,
+        centerA: [10, -10, -0.5],
+        centerB: [10, -10, 0.5],
+        localXAxis: [1, 0, 0],
+        planeA: [0, 1, 0, 1],
+        planeB: [0, -1, 0, 1],
+        radius: 0.5
+      },
+      {
+        angle: 0,
+        arcAngle: Math.PI,
+        centerA: [-10, 5, -0.5],
+        centerB: [-10, 5, 0.5],
+        localXAxis: [1, 0, 0],
+        planeA: [0, 1, 0, 1],
+        planeB: [0, -1, 0, 1],
+        radius: 0.5
+      }
+    ];
+
+    const primitives = [ellipsoids, cylinders];
+    const primitiveTypes = [PrimitiveName.Ellipsoid, PrimitiveName.GeneralCylinder];
     const collectionTypes = primitiveTypes.map(getCollectionType);
 
     const geometries = createPrimitiveInterleavedGeometriesSharingBuffer(primitiveTypes, primitives);


### PR DESCRIPTION
There was a problem with many primitives being rendered outside the geometry clipping box. The issue turned out to be caused by a `Float32Array` which uses an already-existing buffer holding primitive values. The array was not constructed using the correct offset into the underlying buffer, which becomes a problem when the buffer contains different primitive types (which it generally does).

We did have one test that was supposed to catch problems like this (`Two different primitive types in same buffer: one of each accepted` in the `filterGeometryOutsideClipBox` suite), but it seems like it succeeded by chance because the erroneously read primitive values happened to yield a bounding box intersecting the geometry filter. This test has now been changed to a combination that fails on this error.