### PR TITLE
chore: change eslint 'header' rule to allow 2021 and 2022 copyright notice

### DIFF
--- a/viewer/.eslintrc.js
+++ b/viewer/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
       'block',
       [
         {
-          pattern: `(Copyright ${new Date().getFullYear()}|istanbul ignore)`,
+          pattern: `(Copyright 20\\d{2}|istanbul ignore)`,
           template: `!\n * Copyright ${new Date().getFullYear()} Cognite AS\n `
         }
       ]


### PR DESCRIPTION
Cherry picked from ec6a9ff