### PR TITLE
fix: revert change from output 'gltf-directory' to 'reveal-directory' because of bugs in Reveal < 3.0 causing problems if we add new output versions for reveal-directory         

### DIFF
--- a/viewer/core/src/datamodels/cad/CadModelFactory.ts
+++ b/viewer/core/src/datamodels/cad/CadModelFactory.ts
@@ -54,12 +54,8 @@ export class CadModelFactory {
   private getSectorRepository(format: File3dFormat, formatVersion: number): SectorRepository {
     if (format === File3dFormat.RevealCadModel && formatVersion === 8) {
       return this._v8SectorRepository;
-    } else if (format === File3dFormat.RevealCadModel && formatVersion === 9) {
+    } else if (format === File3dFormat.GltfCadModel && formatVersion === 9) {
       return this._gltfSectorRepository;
-    } else if (format === File3dFormat.GltfCadModel) {
-      return this._gltfSectorRepository;
-    } else if (format !== File3dFormat.RevealCadModel) {
-      throw new Error(`Model format [${format}] is not a valid CAD model format`);
     } else {
       throw new Error(
         `Model format [${format} v${formatVersion}] is not supported (only version 8 and 9 is supported)`

--- a/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.ts
@@ -183,8 +183,6 @@ function isLegacyModelFormat(model: CadModelMetadata): boolean {
 }
 
 function isGltfModelFormat(model: CadModelMetadata): boolean {
-  return (
-    (model.format === File3dFormat.RevealCadModel && model.formatVersion >= 9) ||
-    model.format === File3dFormat.GltfCadModel
-  );
+  // Add new versions here as support is added to Reveal
+  return model.format === File3dFormat.GltfCadModel && model.formatVersion === 9;
 }

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
@@ -66,29 +66,27 @@ export class CadModelMetadataRepository implements MetadataRepository<Promise<Ca
 
   private async getSupportedOutput(modelIdentifier: ModelIdentifier): Promise<BlobOutputMetadata> {
     const outputs = await this._modelMetadataProvider.getModelOutputs(modelIdentifier);
+    // Supported output formats in order of preference (first format is most preferred)
+    const preferredOutputs = [
+      { format: File3dFormat.GltfCadModel, version: 9 },
+      { format: File3dFormat.RevealCadModel, version: 8 }
+    ];
 
-    const cadModelOutputs = outputs.filter(
-      output =>
-        // V8
-        output.format === File3dFormat.RevealCadModel ||
-        // V9
-        output.format === File3dFormat.GltfCadModel
-    );
+    const supportedModelOutputs = outputs.filter(modelOutput => {
+      return preferredOutputs.some(supportedOutput => {
+        return supportedOutput.format === modelOutput.format && supportedOutput.version === modelOutput.version;
+      });
+    });
 
-    if (cadModelOutputs.length === 0) {
-      throw new Error(`Model does not contain any supported cad model output ${File3dFormat.RevealCadModel}`);
-    }
-
-    const v9output = cadModelOutputs.find(x => x.version === 9);
-    const v8output = cadModelOutputs.find(x => x.version === 8);
-    if (v8output === undefined && v9output === undefined) {
+    if (supportedModelOutputs.length === 0) {
+      const cadModelOutputsString = outputs.map(output => `${output.format} v${output.version}`).join(',');
+      const supportedOutputsString = outputs.map(output => `${output.format} v${output.version}`).join(',');
       throw new Error(
-        `Model does not contain any supported CAD model output for versions in [8,9], ` +
-          `only got ${cadModelOutputs.map(x => x.version).join(',')}`
+        `Model does not contain any supported CAD model outputs, got ${cadModelOutputsString}, but only supports ${supportedOutputsString}`
       );
     }
 
-    return (v9output ?? v8output)!;
+    return supportedModelOutputs[0];
   }
 }
 

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
@@ -69,9 +69,9 @@ export class CadModelMetadataRepository implements MetadataRepository<Promise<Ca
 
     const cadModelOutputs = outputs.filter(
       output =>
+        // V8
         output.format === File3dFormat.RevealCadModel ||
-        // TODO 2021-12-14 larsmoa: Remove after 3.0 release
-        // This is in place to support "pre-release" GLTF models that had a different output name
+        // V9
         output.format === File3dFormat.GltfCadModel
     );
 
@@ -83,7 +83,7 @@ export class CadModelMetadataRepository implements MetadataRepository<Promise<Ca
     const v8output = cadModelOutputs.find(x => x.version === 8);
     if (v8output === undefined && v9output === undefined) {
       throw new Error(
-        `Model does not contain any supported cad model output ${File3dFormat.RevealCadModel} for versions in [8,9], ` +
+        `Model does not contain any supported CAD model output for versions in [8,9], ` +
           `only got ${cadModelOutputs.map(x => x.version).join(',')}`
       );
     }

--- a/viewer/packages/modeldata-api/src/types.ts
+++ b/viewer/packages/modeldata-api/src/types.ts
@@ -36,9 +36,12 @@ export interface HttpHeadersProvider {
 
 export enum File3dFormat {
   EptPointCloud = 'ept-pointcloud',
+  /**
+   * V8 models only due to bug for version checks in Reveal <3.0
+   */
   RevealCadModel = 'reveal-directory',
   /**
-   * @deprecated Use {@link RevealCadModel}
+   * Reveal v9 and above (GLTF based output)
    */
   GltfCadModel = 'gltf-directory',
   AnyFormat = 'all-outputs'

--- a/viewer/packages/sector-loader/app/index.ts
+++ b/viewer/packages/sector-loader/app/index.ts
@@ -105,7 +105,7 @@ async function loadSectors(
   client: CogniteClient
 ) {
   const output = outputs.find(
-    output => output.format === File3dFormat.RevealCadModel && output.version === formatVersion
+    output => output.format === File3dFormat.GltfCadModel && output.version === formatVersion
   );
   const sceneJson = await modelDataClient.getJsonFile(
     `${client.getBaseUrl()}/api/v1/projects/${client.project}/3d/files/${output?.blobId}`,


### PR DESCRIPTION
Partially reverts b312880

This was necessary as Reveal 1.x and 2.x has a bug causing it to pick up unsupported version from 'reveal-directory`.