### PR TITLE
improvement: simplify CAD model budget by only controlling "renderCost"

### DIFF
--- a/documentation/versioned_docs/version-2.x/API Reference.md
+++ b/documentation/versioned_docs/version-2.x/API Reference.md
@@ -9843,7 +9843,7 @@ Represents a measurement of how much geometry can be loaded.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `maximumRenderCost` | `number` | Maximum render cost. This number can be thought of as triangle count, although the number doesn't match this directly. |
-| `highDetailProximityThreshold` | `number` | For 3D models processed before Q1 20202, sectors within this distance from the camera will always be loaded in high details (deprecated). |
+| `highDetailProximityThreshold` | `number` | For 3D models processed before Q1 2022, sectors within this distance from the camera will always be loaded in high details (deprecated). |
 
 ##### Defined in
 

--- a/documentation/versioned_docs/version-2.x/API Reference.md
+++ b/documentation/versioned_docs/version-2.x/API Reference.md
@@ -9842,10 +9842,8 @@ Represents a measurement of how much geometry can be loaded.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `geometryDownloadSizeBytes` | `number` | Number of bytes of the geometry that must be downloaded. |
-| `highDetailProximityThreshold` | `number` | Sectors within this distance from the camera will always be loaded in high details. |
-| `maximumNumberOfDrawCalls` | `number` | Estimated maximum number of WebGL draw calls to download geometry for. Draw calls are very important for the framerate. |
 | `maximumRenderCost` | `number` | Maximum render cost. This number can be thought of as triangle count, although the number doesn't match this directly. |
+| `highDetailProximityThreshold` | `number` | For 3D models processed before Q1 20202, sectors within this distance from the camera will always be loaded in high details (deprecated). |
 
 ##### Defined in
 

--- a/examples/src/utils/CadBudgetUi.ts
+++ b/examples/src/utils/CadBudgetUi.ts
@@ -11,24 +11,15 @@ import dat from 'dat.gui';
  */
 export function initialCadBudgetUi(viewer: Cognite3DViewer, uiFolder: dat.GUI) {
   const state = {
-    factor: 100.0,
-    limitDownloadedBytes: true,
-    limitDrawCalls: true,
-    limitRenderCost: true
+    factor: 100.0
   };
   const defaultCadBudget = { ...viewer.cadBudget };
   const onCadBudgetSettingsChanged = () => {
     const scale = state.factor / 100.0;
-    const { limitDownloadedBytes, limitDrawCalls, limitRenderCost } = state;
     viewer.cadBudget = {
       highDetailProximityThreshold: defaultCadBudget.highDetailProximityThreshold * scale,
-      geometryDownloadSizeBytes:  limitDownloadedBytes ? defaultCadBudget.geometryDownloadSizeBytes * scale : Infinity,
-      maximumNumberOfDrawCalls: limitDrawCalls ? defaultCadBudget.maximumNumberOfDrawCalls * scale : Infinity,
-      maximumRenderCost: limitRenderCost ? defaultCadBudget.maximumRenderCost * scale : Infinity,
+      maximumRenderCost: defaultCadBudget.maximumRenderCost * scale,
     };
   };
   uiFolder.add(state, 'factor', 1, 500, 1).name('Budget factor (%)').onChange(onCadBudgetSettingsChanged);
-  uiFolder.add(state, 'limitDownloadedBytes').name('Limit bytesize').onChange(onCadBudgetSettingsChanged);
-  uiFolder.add(state, 'limitDrawCalls').name('Limit draw calls').onChange(onCadBudgetSettingsChanged);
-  uiFolder.add(state, 'limitRenderCost').name('Limit render cost').onChange(onCadBudgetSettingsChanged);
 }

--- a/viewer/core/src/datamodels/cad/CadManager.ts
+++ b/viewer/core/src/datamodels/cad/CadManager.ts
@@ -11,7 +11,7 @@ import { CadModelSectorLoadStatistics } from './CadModelSectorLoadStatistics';
 import { GeometryFilter } from '../../public/types';
 
 import { LevelOfDetail, ConsumedSector } from '@reveal/cad-parsers';
-import { CadModelUpdateHandler, CadModelSectorBudget, LoadingState } from '@reveal/cad-geometry-loaders';
+import { CadModelUpdateHandler, CadModelBudget, LoadingState } from '@reveal/cad-geometry-loaders';
 import { CadNode, CadMaterialManager, RenderMode } from '@reveal/rendering';
 import { ModelIdentifier } from '@reveal/modeldata-api';
 import { MetricsLogger } from '@reveal/metrics';
@@ -33,11 +33,11 @@ export class CadManager {
     return this._materialManager;
   }
 
-  get budget(): CadModelSectorBudget {
+  get budget(): CadModelBudget {
     return this._cadModelUpdateHandler.budget;
   }
 
-  set budget(budget: CadModelSectorBudget) {
+  set budget(budget: CadModelBudget) {
     this._cadModelUpdateHandler.budget = budget;
   }
 

--- a/viewer/core/src/public/RevealManager.ts
+++ b/viewer/core/src/public/RevealManager.ts
@@ -15,7 +15,7 @@ import { PointCloudNode } from '../datamodels/pointcloud/PointCloudNode';
 import { CadModelSectorLoadStatistics } from '../datamodels/cad/CadModelSectorLoadStatistics';
 import { GeometryFilter } from '..';
 
-import { CadModelSectorBudget, LoadingState } from '@reveal/cad-geometry-loaders';
+import { CadModelBudget, LoadingState } from '@reveal/cad-geometry-loaders';
 import { NodeAppearanceProvider } from '@reveal/cad-styling';
 import { RenderOptions, EffectRenderManager, CadNode, defaultRenderOptions, RenderMode } from '@reveal/rendering';
 import { MetricsLogger } from '@reveal/metrics';
@@ -120,11 +120,11 @@ export class RevealManager {
     }
   }
 
-  public get cadBudget(): CadModelSectorBudget {
+  public get cadBudget(): CadModelBudget {
     return this._cadManager.budget;
   }
 
-  public set cadBudget(budget: CadModelSectorBudget) {
+  public set cadBudget(budget: CadModelBudget) {
     this._cadManager.budget = budget;
   }
 

--- a/viewer/core/src/public/migration/types.ts
+++ b/viewer/core/src/public/migration/types.ts
@@ -4,7 +4,7 @@
 
 import { CogniteClient } from '@cognite/sdk';
 
-import { SectorCuller } from '@reveal/cad-geometry-loaders';
+import { CadModelBudget, SectorCuller } from '@reveal/cad-geometry-loaders';
 import { Cognite3DModel } from './Cognite3DModel';
 import { CognitePointCloudModel } from './CognitePointCloudModel';
 
@@ -306,34 +306,7 @@ export type SceneRenderedDelegate = (event: {
 export * from './NotSupportedInMigrationWrapperError';
 export { CogniteModelBase } from './CogniteModelBase';
 
-/**
- * Represents a measurement of how much geometry can be loaded.
- */
-export type CadModelBudget = {
-  // TODO 2020-11-04 larsmoa: Merge this type with CadModelSectorBudget.
-
-  /**
-   * Sectors within this distance from the camera will always be loaded in high details.
-   */
-  readonly highDetailProximityThreshold: number;
-
-  /**
-   * Number of bytes of the geometry that must be downloaded.
-   */
-  readonly geometryDownloadSizeBytes: number;
-
-  /**
-   * Estimated maximum number of WebGL draw calls to download geometry for. Draw calls
-   * are very important for the framerate.
-   */
-  readonly maximumNumberOfDrawCalls: number;
-
-  /**
-   * Maximum render cost. This number can be thought of as triangle count, although the number
-   * doesn't match this directly.
-   */
-  readonly maximumRenderCost: number;
-};
+export { CadModelBudget };
 
 /**
  * Represents a budget of how many point from point clouds can be

--- a/viewer/packages/cad-geometry-loaders/app/index.ts
+++ b/viewer/packages/cad-geometry-loaders/app/index.ts
@@ -56,9 +56,7 @@ async function init() {
   const cadManager = new CadManager(materialManager, cadModelFactory, cadModelUpdateHandler);
 
   cadManager.budget = {
-    geometryDownloadSizeBytes: Infinity,
     highDetailProximityThreshold: cadManager.budget.highDetailProximityThreshold,
-    maximumNumberOfDrawCalls: Infinity,
     maximumRenderCost: cadManager.budget.maximumRenderCost
   };
 

--- a/viewer/packages/cad-geometry-loaders/index.ts
+++ b/viewer/packages/cad-geometry-loaders/index.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-export { CadModelSectorBudget } from './src/CadModelSectorBudget';
+export { CadModelBudget } from './src/CadModelBudget';
 
 export { CadLoadingHints } from './src/CadLoadingHints';
 

--- a/viewer/packages/cad-geometry-loaders/src/CadModelBudget.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelBudget.ts
@@ -7,21 +7,12 @@ import { isMobileOrTablet } from '@reveal/utilities';
 /**
  * Represents a measurement of how much geometry can be loaded.
  */
-export type CadModelSectorBudget = {
+export type CadModelBudget = {
   /**
    * Sectors within this distance from the camera will always be loaded in high details.
+   * @deprecated This is only used for 3D models processed prior to the Reveal 3.0 release (Q1 2022).
    */
   readonly highDetailProximityThreshold: number;
-
-  /**
-   * Number of bytes of the geometry that must be downloaded.
-   */
-  readonly geometryDownloadSizeBytes: number;
-
-  /**
-   * Maximum number of estimated draw calls of geometry to load.
-   */
-  readonly maximumNumberOfDrawCalls: number;
 
   /**
    * Maximum render cost. This number can be thought of as triangle count, although the number
@@ -30,18 +21,14 @@ export type CadModelSectorBudget = {
   readonly maximumRenderCost: number;
 };
 
-export const defaultCadModelSectorBudget: CadModelSectorBudget = isMobileOrTablet()
+export const defaultCadModelBudget: CadModelBudget = isMobileOrTablet()
   ? // Mobile/tablet
     {
       highDetailProximityThreshold: 5,
-      geometryDownloadSizeBytes: 20 * 1024 * 1024,
-      maximumNumberOfDrawCalls: 700,
-      maximumRenderCost: 10_000_000
+      maximumRenderCost: 7_000_000
     }
   : // Desktop
     {
       highDetailProximityThreshold: 10,
-      geometryDownloadSizeBytes: 35 * 1024 * 1024,
-      maximumNumberOfDrawCalls: 2000,
-      maximumRenderCost: 20_000_000
+      maximumRenderCost: 15_000_000
     };

--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
@@ -17,7 +17,7 @@ import { LoadingState } from './utilities/types';
 import { emissionLastMillis } from './utilities/rxOperations';
 import { loadingEnabled } from './sector/rxSectorUtilities';
 import { SectorLoader } from './sector/SectorLoader';
-import { CadModelSectorBudget, defaultCadModelSectorBudget } from './CadModelSectorBudget';
+import { CadModelBudget, defaultCadModelBudget } from './CadModelBudget';
 import { DetermineSectorsPayload, SectorLoadingSpent } from './sector/culling/types';
 import { ModelStateHandler } from './sector/ModelStateHandler';
 
@@ -26,14 +26,14 @@ const notLoadingState: LoadingState = { isLoading: false, itemsLoaded: 0, itemsR
 export class CadModelUpdateHandler {
   private readonly _sectorCuller: SectorCuller;
   private readonly _modelStateHandler: ModelStateHandler;
-  private _budget: CadModelSectorBudget;
+  private _budget: CadModelBudget;
   private _lastSpent: SectorLoadingSpent;
 
   private readonly _cameraSubject: Subject<THREE.PerspectiveCamera> = new Subject();
   private readonly _clippingPlaneSubject: Subject<THREE.Plane[]> = new Subject();
   private readonly _loadingHintsSubject: Subject<CadLoadingHints> = new Subject();
   private readonly _modelSubject: Subject<{ model: CadNode; operation: 'add' | 'remove' }> = new Subject();
-  private readonly _budgetSubject: Subject<CadModelSectorBudget> = new Subject();
+  private readonly _budgetSubject: Subject<CadModelBudget> = new Subject();
   private readonly _progressSubject: Subject<LoadingState> = new BehaviorSubject<LoadingState>(notLoadingState);
 
   private readonly _updateObservable: Observable<ConsumedSector>;
@@ -41,7 +41,7 @@ export class CadModelUpdateHandler {
   constructor(sectorCuller: SectorCuller) {
     this._sectorCuller = sectorCuller;
     this._modelStateHandler = new ModelStateHandler();
-    this._budget = defaultCadModelSectorBudget;
+    this._budget = defaultCadModelBudget;
     this._lastSpent = {
       downloadSize: 0,
       drawCalls: 0,
@@ -123,10 +123,10 @@ export class CadModelUpdateHandler {
     this._clippingPlaneSubject.next(value);
   }
 
-  get budget(): CadModelSectorBudget {
+  get budget(): CadModelBudget {
     return this._budget;
   }
-  set budget(b: CadModelSectorBudget) {
+  set budget(b: CadModelBudget) {
     this._budget = b;
     this._budgetSubject.next(b);
   }
@@ -181,7 +181,7 @@ export class CadModelUpdateHandler {
 
 type SettingsInput = {
   loadingHints: CadLoadingHints;
-  budget: CadModelSectorBudget;
+  budget: CadModelBudget;
 };
 type CameraInput = {
   camera: THREE.PerspectiveCamera;
@@ -191,7 +191,7 @@ type ClippingInput = {
   clippingPlanes: THREE.Plane[] | never[];
 };
 
-function makeSettingsInput([loadingHints, budget]: [CadLoadingHints, CadModelSectorBudget]): SettingsInput {
+function makeSettingsInput([loadingHints, budget]: [CadLoadingHints, CadModelBudget]): SettingsInput {
   return { loadingHints, budget };
 }
 function makeCameraInput([camera, cameraInMotion]: [THREE.PerspectiveCamera, boolean]): CameraInput {

--- a/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.test.ts
@@ -60,9 +60,7 @@ describe('SectorLoader', () => {
     input = {
       camera: new THREE.PerspectiveCamera(),
       budget: {
-        geometryDownloadSizeBytes: 0,
         highDetailProximityThreshold: 0,
-        maximumNumberOfDrawCalls: 0,
         maximumRenderCost: 0
       },
       cameraInMotion: false,

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/ByScreenSizeSectorCuller.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/ByScreenSizeSectorCuller.test.ts
@@ -7,7 +7,6 @@ import * as THREE from 'three';
 import { ByScreenSizeSectorCuller } from './ByScreenSizeSectorCuller';
 
 import { CadModelMetadata, LevelOfDetail, WantedSector } from '@reveal/cad-parsers';
-import { CadModelSectorBudget } from '@reveal/cad-geometry-loaders';
 
 import {
   createCadModelMetadata,
@@ -15,11 +14,12 @@ import {
   createV8SectorMetadata,
   createV9SectorMetadata
 } from '../../../../../test-utilities';
+import { CadModelBudget } from '../../CadModelBudget';
 
-describe('ByScreenSizeSectorCuller', () => {
+describe(ByScreenSizeSectorCuller.name, () => {
   let camera: THREE.PerspectiveCamera;
   let model: CadModelMetadata;
-  let budget: CadModelSectorBudget;
+  let budget: CadModelBudget;
   let allSectorsRenderCost: number;
 
   let culler: ByScreenSizeSectorCuller;
@@ -49,8 +49,6 @@ describe('ByScreenSizeSectorCuller', () => {
     culler = new ByScreenSizeSectorCuller();
 
     budget = {
-      geometryDownloadSizeBytes: Infinity,
-      maximumNumberOfDrawCalls: Infinity,
       maximumRenderCost: 0,
       highDetailProximityThreshold: 0
     };

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/ByVisibilityGpuSectorCuller.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/ByVisibilityGpuSectorCuller.test.ts
@@ -101,9 +101,9 @@ describe('ByVisibilityGpuSectorCuller', () => {
       switch (lod) {
         case LevelOfDetail.Detailed:
           return [
-            { downloadSize: 10, drawCalls: 0, renderCost: 0 },
-            { downloadSize: 10, drawCalls: 0, renderCost: 0 },
-            { downloadSize: 100, drawCalls: 0, renderCost: 0 }
+            { downloadSize: 10, drawCalls: 0, renderCost: 5 },
+            { downloadSize: 10, drawCalls: 0, renderCost: 5 },
+            { downloadSize: 100, drawCalls: 0, renderCost: 5 }
           ][sector.id];
         case LevelOfDetail.Simple:
           return { downloadSize: 1, drawCalls: 0, renderCost: 0 };
@@ -129,7 +129,7 @@ describe('ByVisibilityGpuSectorCuller', () => {
     camera.position.set(1000, 1000, 1000);
     const input = createDetermineSectorInput(camera, model, {
       highDetailProximityThreshold: 10,
-      maximumRenderCost: Infinity
+      maximumRenderCost: 8
     });
 
     // Act
@@ -141,14 +141,14 @@ describe('ByVisibilityGpuSectorCuller', () => {
     expect(sectors.filter(x => x.levelOfDetail === LevelOfDetail.Simple).map(x => x.metadata.id)).toEqual([2]);
   });
 
-  test('determineSectors limits sectors by draw calls', () => {
+  test('determineSectors limits sectors by render cost', () => {
     // Arrange
     const determineSectorCost = (_sector: SectorMetadata, lod: LevelOfDetail): SectorCost => {
       switch (lod) {
         case LevelOfDetail.Detailed:
-          return { downloadSize: 0, drawCalls: 5, renderCost: 0 };
+          return { downloadSize: 0, drawCalls: 0, renderCost: 5 };
         case LevelOfDetail.Simple:
-          return { downloadSize: 0, drawCalls: 1, renderCost: 0 };
+          return { downloadSize: 0, drawCalls: 0, renderCost: 1 };
         default:
           return { downloadSize: 0, drawCalls: 0, renderCost: 0 };
       }
@@ -171,7 +171,7 @@ describe('ByVisibilityGpuSectorCuller', () => {
     camera.position.set(1000, 1000, 1000);
     const input = createDetermineSectorInput(camera, model, {
       highDetailProximityThreshold: -1,
-      maximumRenderCost: Infinity
+      maximumRenderCost: 10
     });
 
     // Act

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/ByVisibilityGpuSectorCuller.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/ByVisibilityGpuSectorCuller.test.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import { DetermineSectorsInput, SectorCost } from './types';
 import { OrderSectorsByVisibilityCoverage } from './OrderSectorsByVisibilityCoverage';
 import { ByVisibilityGpuSectorCuller } from './ByVisibilityGpuSectorCuller';
-import { CadModelSectorBudget } from '../../CadModelSectorBudget';
+import { CadModelBudget } from '../../CadModelBudget';
 import { PropType } from '../../utilities/reflection';
 
 import { CadMaterialManager, CadNode } from '@reveal/rendering';
@@ -128,8 +128,6 @@ describe('ByVisibilityGpuSectorCuller', () => {
     // Place camera far away to avoid sectors being loaded because camera is near them
     camera.position.set(1000, 1000, 1000);
     const input = createDetermineSectorInput(camera, model, {
-      geometryDownloadSizeBytes: 20,
-      maximumNumberOfDrawCalls: Infinity,
       highDetailProximityThreshold: 10,
       maximumRenderCost: Infinity
     });
@@ -172,8 +170,6 @@ describe('ByVisibilityGpuSectorCuller', () => {
     // Place camera far away to avoid sectors being loaded because camera is near them
     camera.position.set(1000, 1000, 1000);
     const input = createDetermineSectorInput(camera, model, {
-      geometryDownloadSizeBytes: Infinity,
-      maximumNumberOfDrawCalls: 10,
       highDetailProximityThreshold: -1,
       maximumRenderCost: Infinity
     });
@@ -197,7 +193,7 @@ describe('ByVisibilityGpuSectorCuller', () => {
 function createDetermineSectorInput(
   camera: THREE.PerspectiveCamera,
   models: CadModelMetadata | CadModelMetadata[],
-  budget?: CadModelSectorBudget
+  budget?: CadModelBudget
 ): DetermineSectorsInput {
   const determineSectorsInput: DetermineSectorsInput = {
     camera,
@@ -206,9 +202,7 @@ function createDetermineSectorInput(
     loadingHints: {},
     cameraInMotion: false,
     budget: budget || {
-      geometryDownloadSizeBytes: 20,
       highDetailProximityThreshold: 10,
-      maximumNumberOfDrawCalls: Infinity,
       maximumRenderCost: Infinity
     },
     prioritizedAreas: []

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/ByVisibilityGpuSectorCuller.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/ByVisibilityGpuSectorCuller.ts
@@ -8,7 +8,7 @@ import { OrderSectorsByVisibilityCoverage } from './OrderSectorsByVisibilityCove
 import { SectorCuller } from './SectorCuller';
 import { DetermineSectorCostDelegate, DetermineSectorsInput, SectorCost, SectorLoadingSpent } from './types';
 import { TakenV8SectorMap } from './takensectors';
-import { CadModelSectorBudget } from '../../CadModelSectorBudget';
+import { CadModelBudget } from '../../CadModelBudget';
 
 import { CadModelMetadata, WantedSector, LevelOfDetail, V8SectorMetadata } from '@reveal/cad-parsers';
 
@@ -94,7 +94,7 @@ export class ByVisibilityGpuSectorCuller implements SectorCuller {
     camera: THREE.PerspectiveCamera,
     models: CadModelMetadata[],
     clippingPlanes: THREE.Plane[] | null,
-    budget: CadModelSectorBudget
+    budget: CadModelBudget
   ): TakenV8SectorMap {
     const { coverageUtil } = this.options;
     const takenSectors = this.takenSectors;
@@ -122,10 +122,8 @@ export class ByVisibilityGpuSectorCuller implements SectorCuller {
     this.log(`Retrieving ${i} of ${prioritizedLength} (last: ${prioritized.length > 0 ? prioritized[i - 1] : null})`);
     this.log(
       `Total scheduled: ${takenSectors.getWantedSectorCount()} of ${prioritizedLength} (cost: ${
-        takenSectors.totalCost.downloadSize / 1024 / 1024
-      }/${budget.geometryDownloadSizeBytes / 1024 / 1024}, drawCalls: ${takenSectors.totalCost.drawCalls}/${
-        budget.maximumNumberOfDrawCalls
-      }, priority: ${debugAccumulatedPriority})`
+        takenSectors.totalCost.renderCost
+      }/${budget.maximumRenderCost}, priority: ${debugAccumulatedPriority})`
     );
 
     return takenSectors;
@@ -134,7 +132,7 @@ export class ByVisibilityGpuSectorCuller implements SectorCuller {
   private addHighDetailsForNearSectors(
     camera: THREE.PerspectiveCamera,
     models: CadModelMetadata[],
-    budget: CadModelSectorBudget,
+    budget: CadModelBudget,
     takenSectors: TakenV8SectorMap,
     clippingPlanes: THREE.Plane[] | null
   ) {

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/takensectors/TakenV8SectorMap.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/takensectors/TakenV8SectorMap.ts
@@ -3,7 +3,7 @@
  */
 import { TakenV8SectorTree } from './TakenV8SectorTree';
 import { PrioritizedWantedSector, DetermineSectorCostDelegate, SectorCost, addSectorCost } from '../types';
-import { CadModelSectorBudget } from '../../../CadModelSectorBudget';
+import { CadModelBudget } from '../../../CadModelBudget';
 import { TakenSectorMapBase } from './TakenSectorMapBase';
 
 import { CadModelMetadata, V8SectorMetadata } from '@reveal/cad-parsers';
@@ -66,13 +66,9 @@ export class TakenV8SectorMap extends TakenSectorMapBase {
     sectorTree!.markSectorDetailed(sectorId, priority);
   }
 
-  isWithinBudget(budget: CadModelSectorBudget): boolean {
+  isWithinBudget(budget: CadModelBudget): boolean {
     const currentCost = this.totalCost;
-    return (
-      currentCost.downloadSize < budget.geometryDownloadSizeBytes &&
-      currentCost.drawCalls < budget.maximumNumberOfDrawCalls &&
-      currentCost.renderCost < budget.maximumRenderCost
-    );
+    return currentCost.renderCost < budget.maximumRenderCost;
   }
 
   collectWantedSectors(): PrioritizedWantedSector[] {

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/takensectors/TakenV9SectorMap.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/takensectors/TakenV9SectorMap.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 import { addSectorCost, DetermineSectorCostDelegate, PrioritizedWantedSector, SectorCost } from '../types';
-import { CadModelSectorBudget } from '../../../CadModelSectorBudget';
+import { CadModelBudget } from '../../../CadModelBudget';
 import { TakenSectorMapBase } from './TakenSectorMapBase';
 
 import { CadModelMetadata, V9SectorMetadata, LevelOfDetail, SectorMetadata } from '@reveal/cad-parsers';
@@ -59,12 +59,8 @@ export class TakenV9SectorMap extends TakenSectorMapBase {
     }
   }
 
-  isWithinBudget(budget: CadModelSectorBudget): boolean {
-    return (
-      this._totalCost.downloadSize < budget.geometryDownloadSizeBytes &&
-      this._totalCost.drawCalls < budget.maximumNumberOfDrawCalls &&
-      this._totalCost.renderCost < budget.maximumRenderCost
-    );
+  isWithinBudget(budget: CadModelBudget): boolean {
+    return this._totalCost.renderCost < budget.maximumRenderCost;
   }
 
   collectWantedSectors(): PrioritizedWantedSector[] {

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/types.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/types.ts
@@ -7,7 +7,7 @@ import { PrioritizedArea } from '@reveal/cad-styling';
 import { CadModelMetadata, LevelOfDetail, WantedSector } from '@reveal/cad-parsers';
 
 import { CadLoadingHints } from '../../CadLoadingHints';
-import { CadModelSectorBudget } from '../../CadModelSectorBudget';
+import { CadModelBudget } from '../../CadModelBudget';
 import { CadNode } from '@reveal/rendering';
 
 export interface DetermineSectorsInput {
@@ -16,7 +16,7 @@ export interface DetermineSectorsInput {
   cadModelsMetadata: CadModelMetadata[];
   loadingHints: CadLoadingHints;
   cameraInMotion: boolean;
-  budget: CadModelSectorBudget;
+  budget: CadModelBudget;
   prioritizedAreas: PrioritizedArea[];
 }
 
@@ -26,7 +26,7 @@ export type DetermineSectorsPayload = {
   models: CadNode[];
   loadingHints: CadLoadingHints;
   cameraInMotion: boolean;
-  budget: CadModelSectorBudget;
+  budget: CadModelBudget;
   prioritizedAreas: PrioritizedArea[];
 };
 

--- a/viewer/test-utilities/src/createDetermineSectorInput.ts
+++ b/viewer/test-utilities/src/createDetermineSectorInput.ts
@@ -4,12 +4,12 @@
 
 // Note! In testUtilities we need to use relative imports
 import { CadModelMetadata } from '../../packages/cad-parsers';
-import { CadModelSectorBudget, DetermineSectorsInput } from '../../packages/cad-geometry-loaders';
+import { DetermineSectorsInput, CadModelBudget } from '../../packages/cad-geometry-loaders';
 
 export function createDetermineSectorInput(
   camera: THREE.PerspectiveCamera,
   models: CadModelMetadata | CadModelMetadata[],
-  budget?: CadModelSectorBudget
+  budget?: CadModelBudget
 ): DetermineSectorsInput {
   const determineSectorsInput: DetermineSectorsInput = {
     camera,
@@ -18,9 +18,7 @@ export function createDetermineSectorInput(
     loadingHints: {},
     cameraInMotion: false,
     budget: budget || {
-      geometryDownloadSizeBytes: 20,
       highDetailProximityThreshold: 10,
-      maximumNumberOfDrawCalls: Infinity,
       maximumRenderCost: Infinity
     },
     prioritizedAreas: []


### PR DESCRIPTION
\- Remove draw calls and max download size as it doesn't work well in V9
\- Simplified to only work on a single number which makes things more clear to users
\- Makes it easier to automatically adjust this in the future
\- Adjusted the default budget