### PR TITLE
fix: focus lost when clicked outside canvas

### DIFF
--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -1192,11 +1192,6 @@
   dependencies:
     commander "^2.15.1"
 
-"@cognite/potree-core@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.5.0.tgz#7b288a12358b2ef2b2ae51195a4ecace396822be"
-  integrity sha512-/XhfPYlPIK7LxT0czUIGMWLcUjGfVmf3Nzcf+6FaG+sExr6S8Yqayeid9FdYgi7y+LFmvYSJrZyXgF5LL8ZMrg==
-
 "@cognite/potree-core@^1.1.6":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.2.0.tgz#29d42606e2dd4b4ef0ad82c97c0a23ca94f0ff65"
@@ -1262,6 +1257,13 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@cognite/reveal-parser-worker/-/reveal-parser-worker-1.2.0.tgz#0606ddccddd40e7809ef52e78c36d96e7af9b11c"
   integrity sha512-l3B+PCZjOFTdbc9aC8YqF76DktJaNeqvOhF7Xpno2Y4rST69SpWQjl/g1RE4fgOAoAltoQ8k5UIAv7E/iGNQkQ==
+  dependencies:
+    comlink "4.3.1"
+
+"@cognite/reveal-parser-worker@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@cognite/reveal-parser-worker/-/reveal-parser-worker-1.3.0.tgz#9910121ba90cad684a91b3b04e6df0528ea671f5"
+  integrity sha512-39wuqtdogmZfTmnQhigNpgU/nfYG3POpUFKFO/FMKJKJ+pAsCCZfu4IPEXCDAevJS6/K+mEViPSLL6+Gagi1HQ==
   dependencies:
     comlink "4.3.1"
 

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -373,7 +373,7 @@ export class ComboControls extends EventDispatcher {
 
   private readonly isDescendant = (parent: HTMLElement, child: HTMLElement) => {
     let node = child.parentNode;
-    while (node) {
+    while (node !== null) {
       if (node === parent) {
         return true;
       }

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -369,7 +369,7 @@ export class ComboControls extends EventDispatcher {
         document.activeElement === this._domElement);
 
     this._keyboard.disabled = !this._isFocused;
-  }
+  };
 
   private readonly isDescendant = (parent: HTMLElement, child: HTMLElement) => {
     let node = child.parentNode;
@@ -380,14 +380,14 @@ export class ComboControls extends EventDispatcher {
       node = node.parentNode;
     }
     return false;
-  }
+  };
 
   private readonly onContextMenu = (event: MouseEvent) => {
     if (!this.enabled) {
       return;
     }
     event.preventDefault();
-  }
+  };
 
   private readonly rotate = (deltaX: number, deltaY: number) => {
     if (deltaX === 0 && deltaY === 0) {

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -362,16 +362,16 @@ export class ComboControls extends EventDispatcher {
     }
   };
 
-  private onFocusChanged(event: MouseEvent | TouchEvent | FocusEvent): void {
+  private readonly onFocusChanged = (event: MouseEvent | TouchEvent | FocusEvent) => {
     this._isFocused =
       event.type !== 'blur' &&
       (this.isDescendant(this._domElement.parentElement!, event.target as HTMLElement) ||
         document.activeElement === this._domElement);
 
     this._keyboard.disabled = !this._isFocused;
-  };
+  }
 
-  private isDescendant(parent: HTMLElement, child: HTMLElement): boolean {
+  private readonly isDescendant = (parent: HTMLElement, child: HTMLElement) => {
     let node = child.parentNode;
     while (node !== null) {
       if (node === parent) {
@@ -380,14 +380,14 @@ export class ComboControls extends EventDispatcher {
       node = node.parentNode;
     }
     return false;
-  };
+  }
 
-  private onContextMenu(event: MouseEvent): void{
+  private readonly onContextMenu = (event: MouseEvent) => {
     if (!this.enabled) {
       return;
     }
     event.preventDefault();
-  };
+  }
 
   private readonly rotate = (deltaX: number, deltaY: number) => {
     if (deltaX === 0 && deltaY === 0) {

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -364,9 +364,23 @@ export class ComboControls extends EventDispatcher {
 
   private readonly onFocusChanged = (event: MouseEvent | TouchEvent | FocusEvent) => {
     this._isFocused =
-      event.type !== 'blur' && (event.target === this._domElement || document.activeElement === this._domElement);
+      event.type !== 'blur' &&
+      (this.isDescendant(this._domElement.parentElement!, event.target as HTMLElement) ||
+        document.activeElement === this._domElement);
+    event.type !== 'blur' && (event.target === this._domElement || document.activeElement === this._domElement);
 
     this._keyboard.disabled = !this._isFocused;
+  };
+
+  private readonly isDescendant = (parent: HTMLElement, child: HTMLElement) => {
+    let node = child.parentNode;
+    while (node) {
+      if (node === parent) {
+        return true;
+      }
+      node = node.parentNode;
+    }
+    return false;
   };
 
   private readonly onContextMenu = (event: MouseEvent) => {

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -367,7 +367,6 @@ export class ComboControls extends EventDispatcher {
       event.type !== 'blur' &&
       (this.isDescendant(this._domElement.parentElement!, event.target as HTMLElement) ||
         document.activeElement === this._domElement);
-    event.type !== 'blur' && (event.target === this._domElement || document.activeElement === this._domElement);
 
     this._keyboard.disabled = !this._isFocused;
   };

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -362,7 +362,7 @@ export class ComboControls extends EventDispatcher {
     }
   };
 
-  private readonly onFocusChanged = (event: MouseEvent | TouchEvent | FocusEvent) => {
+  private onFocusChanged(event: MouseEvent | TouchEvent | FocusEvent): void {
     this._isFocused =
       event.type !== 'blur' &&
       (this.isDescendant(this._domElement.parentElement!, event.target as HTMLElement) ||

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -382,7 +382,7 @@ export class ComboControls extends EventDispatcher {
     return false;
   };
 
-  private readonly onContextMenu = (event: MouseEvent) => {
+  private onContextMenu(event: MouseEvent): void{
     if (!this.enabled) {
       return;
     }

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -371,7 +371,7 @@ export class ComboControls extends EventDispatcher {
     this._keyboard.disabled = !this._isFocused;
   };
 
-  private readonly isDescendant = (parent: HTMLElement, child: HTMLElement) => {
+  private isDescendant(parent: HTMLElement, child: HTMLElement): boolean {
     let node = child.parentNode;
     while (node !== null) {
       if (node === parent) {


### PR DESCRIPTION
When clicking any UI element like Spinner logo or other UI elements in Reveal, keyboard controls doesn’t work until the 3D canvas is left or right clicked. Jira reference https://cognitedata.atlassian.net/browse/REV-278

