### PR TITLE
fix: Setting default node appearance to ghosted hides "default"-rendered geometry

### DIFF
--- a/viewer/packages/cad-parsers/src/cad/triangleMeshes.ts
+++ b/viewer/packages/cad-parsers/src/cad/triangleMeshes.ts
@@ -3,7 +3,7 @@
  */
 
 import * as THREE from 'three';
-import { disposeAttributeArrayOnUpload } from '@reveal/utilities';
+import { disposeAttributeArrayOnUpload, incrementOrInsertIndex } from '@reveal/utilities';
 import { TriangleMesh } from '@reveal/cad-parsers';
 
 export function createTriangleMeshes(
@@ -37,7 +37,11 @@ export function createTriangleMeshes(
     const obj = new THREE.Mesh(geometry, material);
     obj.name = `Triangle mesh ${mesh.fileId}`;
 
-    obj.userData.treeIndices = new Set(mesh.treeIndices);
+    obj.userData.treeIndices = new Map<number, number>();
+
+    for (const i of mesh.treeIndices) {
+      incrementOrInsertIndex(obj.userData.treeIndices, i);
+    }
 
     result.push(obj);
   }

--- a/viewer/packages/rendering/src/GeometryBatchingManager.ts
+++ b/viewer/packages/rendering/src/GeometryBatchingManager.ts
@@ -242,8 +242,11 @@ export class GeometryBatchingManager {
     const typedArray = treeIndexAttribute.data.array as TypedArray;
     const instanceByteSize = treeIndexAttribute.data.stride * typedArray.BYTES_PER_ELEMENT;
 
-    const firstWholeInstanceIndex = Math.ceil(byteOffset / instanceByteSize);
-    const firstInvalidInstanceIndex = Math.floor((byteOffset + byteCount) / instanceByteSize);
+    assert(byteOffset % instanceByteSize === 0);
+    assert(byteCount % instanceByteSize === 0);
+
+    const firstWholeInstanceIndex = byteOffset / instanceByteSize;
+    const firstInvalidInstanceIndex = (byteOffset + byteCount) / instanceByteSize;
 
     for (let i = firstWholeInstanceIndex; i < firstInvalidInstanceIndex; i++) {
       const treeIndex = treeIndexAttribute.getX(i);

--- a/viewer/packages/rendering/src/GeometryBatchingManager.ts
+++ b/viewer/packages/rendering/src/GeometryBatchingManager.ts
@@ -223,16 +223,11 @@ export class GeometryBatchingManager {
   private getTreeIndexAttribute(
     instanceAttributes: { name: string; attribute: THREE.InterleavedBufferAttribute }[]
   ): THREE.InterleavedBufferAttribute {
-    let treeIndexAttribute: THREE.InterleavedBufferAttribute | undefined = undefined;
-    for (let i = 0; i < instanceAttributes.length; i++) {
-      if (instanceAttributes[i].name == 'a_treeIndex') {
-        treeIndexAttribute = instanceAttributes[i].attribute;
-      }
-    }
+    let treeIndexAttribute = instanceAttributes.filter(att => att.name === 'a_treeIndex');
 
-    assert(treeIndexAttribute !== undefined);
+    assert(treeIndexAttribute.length > 0);
 
-    return treeIndexAttribute;
+    return treeIndexAttribute[0].attribute;
   }
 
   private removeTreeIndicesFromMeshUserData(

--- a/viewer/packages/rendering/src/GeometryBatchingManager.ts
+++ b/viewer/packages/rendering/src/GeometryBatchingManager.ts
@@ -223,7 +223,7 @@ export class GeometryBatchingManager {
   private getTreeIndexAttribute(
     instanceAttributes: { name: string; attribute: THREE.InterleavedBufferAttribute }[]
   ): THREE.InterleavedBufferAttribute {
-    let treeIndexAttribute = instanceAttributes.filter(att => att.name === 'a_treeIndex');
+    const treeIndexAttribute = instanceAttributes.filter(att => att.name === 'a_treeIndex');
 
     assert(treeIndexAttribute.length > 0);
 

--- a/viewer/packages/rendering/src/GeometryBatchingManager.ts
+++ b/viewer/packages/rendering/src/GeometryBatchingManager.ts
@@ -83,12 +83,6 @@ export class GeometryBatchingManager {
     this._sectorMap.delete(sectorId);
   }
 
-  private *getFloatsFromAttribute(attribute: THREE.InterleavedBufferAttribute): Iterable<number> {
-    for (let i = 0; i < attribute.count; i++) {
-      yield attribute.getX(i);
-    }
-  }
-
   private processGeometries(
     sectorBufferGeometry: THREE.BufferGeometry,
     instanceId: string | undefined,
@@ -114,8 +108,8 @@ export class GeometryBatchingManager {
     const interleavedAttributesView = new Uint8Array(interleavedArrayBuffer, offset, length);
     const { batchId, bufferIsReallocated, updateRange } = defragBuffer.add(interleavedAttributesView);
 
-    for (const treeIndex of this.getFloatsFromAttribute(treeIndexInterleavedAttribute)) {
-      incrementOrInsertIndex(mesh.userData.treeIndices, treeIndex);
+    for (let i = 0; i < treeIndexInterleavedAttribute.count; i++) {
+      incrementOrInsertIndex(mesh.userData.treeIndices, treeIndexInterleavedAttribute.getX(i));
     }
 
     const sectorBatches = this._sectorMap.get(sectorId) ?? this.createSectorBatch(sectorId);

--- a/viewer/packages/rendering/src/rendering/EffectRenderManager.ts
+++ b/viewer/packages/rendering/src/rendering/EffectRenderManager.ts
@@ -551,7 +551,7 @@ export class EffectRenderManager {
       const objectStack: THREE.Object3D[] = [rootSectorNodeData[0]];
       while (objectStack.length > 0) {
         const element = objectStack.pop()!;
-        const objectTreeIndices = element.userData.treeIndices as Set<number> | undefined;
+        const objectTreeIndices = element.userData.treeIndices as Map<number, number> | undefined;
 
         if (objectTreeIndices) {
           if (hasInFrontElements && infrontSet.hasIntersectionWith(objectTreeIndices)) {

--- a/viewer/packages/rendering/src/rendering/createSimpleGeometryMesh.ts
+++ b/viewer/packages/rendering/src/rendering/createSimpleGeometryMesh.ts
@@ -5,7 +5,7 @@ import * as THREE from 'three';
 
 import { ParsePrimitiveAttribute } from '@cognite/reveal-parser-worker';
 
-import { disposeAttributeArrayOnUpload } from '@reveal/utilities';
+import { disposeAttributeArrayOnUpload, incrementOrInsertIndex } from '@reveal/utilities';
 import { filterPrimitivesOutsideClipBoxByBaseBoundsAndInstanceMatrix } from '@reveal/cad-parsers';
 
 import { Materials } from './materials';
@@ -96,10 +96,10 @@ export function createSimpleGeometryMesh(
   function setTreeIndicesToUserData() {
     const treeIndexAttributeOffset = 3;
 
-    const treeIndices = new Set();
+    const treeIndices = new Map<number, number>();
 
     for (let i = 0; i < attributeValues.length / stride; i++) {
-      treeIndices.add(attributeValues[i * stride + treeIndexAttributeOffset]);
+      incrementOrInsertIndex(treeIndices, attributeValues[i * stride + treeIndexAttributeOffset]);
     }
     obj.userData.treeIndices = treeIndices;
   }

--- a/viewer/packages/rendering/src/rendering/primitives.ts
+++ b/viewer/packages/rendering/src/rendering/primitives.ts
@@ -22,7 +22,7 @@ import {
   filterPrimitivesOutsideClipBoxByVertices
 } from '@reveal/cad-parsers';
 
-import { BoundingBoxLOD, disposeAttributeArrayOnUpload } from '@reveal/utilities';
+import { BoundingBoxLOD, disposeAttributeArrayOnUpload, incrementOrInsertIndex } from '@reveal/utilities';
 
 import { Materials } from './materials';
 
@@ -165,10 +165,13 @@ function setAttributes(
     const treeIndexAttribute = attributes.get('treeIndex')!;
     const treeIndexAttributeOffset = treeIndexAttribute.offset;
 
-    const treeIndices = new Set();
+    const treeIndices = new Map<number, number>();
 
     for (let i = 0; i < geometry.instanceCount; i++) {
-      treeIndices.add(collectionView.getFloat32(i * attributesByteSize + treeIndexAttributeOffset, true));
+      incrementOrInsertIndex(
+        treeIndices,
+        collectionView.getFloat32(i * attributesByteSize + treeIndexAttributeOffset, true)
+      );
     }
     mesh.userData.treeIndices = treeIndices;
   }

--- a/viewer/packages/sector-loader/src/GltfSectorRepository.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorRepository.ts
@@ -8,7 +8,7 @@ import { BinaryFileProvider } from '@reveal/modeldata-api';
 import { CadMaterialManager } from '@reveal/rendering';
 import { GltfSectorParser, ParsedGeometry, RevealGeometryCollectionType } from '@reveal/sector-parser';
 import { SectorRepository } from '..';
-import { AutoDisposeGroup, assertNever } from '@reveal/utilities';
+import { AutoDisposeGroup, assertNever, incrementOrInsertIndex } from '@reveal/utilities';
 import { filterGeometryOutsideClipBox } from '../../cad-parsers/src/cad/filterPrimitivesV9';
 
 import assert from 'assert';
@@ -110,14 +110,14 @@ export class GltfSectorRepository implements SectorRepository {
     };
   }
 
-  private createTreeIndexSet(geometry: THREE.BufferGeometry): Set<number> {
+  private createTreeIndexSet(geometry: THREE.BufferGeometry): Map<number, number> {
     const treeIndexAttribute = geometry.attributes['treeIndex'];
     assert(treeIndexAttribute !== undefined);
 
-    const treeIndexSet = new Set<number>();
+    const treeIndexSet = new Map<number, number>();
 
     for (let i = 0; i < treeIndexAttribute.count; i++) {
-      treeIndexSet.add(treeIndexAttribute.getX(i));
+      incrementOrInsertIndex(treeIndexSet, treeIndexAttribute.getX(i));
     }
 
     return treeIndexSet;

--- a/viewer/packages/sector-loader/src/GltfSectorRepository.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorRepository.ts
@@ -11,6 +11,8 @@ import { SectorRepository } from '..';
 import { AutoDisposeGroup, assertNever } from '@reveal/utilities';
 import { filterGeometryOutsideClipBox } from '../../cad-parsers/src/cad/filterPrimitivesV9';
 
+import assert from 'assert';
+
 export class GltfSectorRepository implements SectorRepository {
   private readonly _gltfSectorParser: GltfSectorParser;
   private readonly _sectorFileProvider: BinaryFileProvider;
@@ -108,10 +110,25 @@ export class GltfSectorRepository implements SectorRepository {
     };
   }
 
+  private createTreeIndexSet(geometry: THREE.BufferGeometry): Set<number> {
+    const treeIndexAttribute = geometry.attributes['treeIndex'];
+    assert(treeIndexAttribute !== undefined);
+
+    const treeIndexSet = new Set<number>();
+
+    for (let i = 0; i < treeIndexAttribute.count; i++) {
+      treeIndexSet.add(treeIndexAttribute.getX(i));
+    }
+
+    return treeIndexSet;
+  }
+
   private createMesh(group: AutoDisposeGroup, geometry: THREE.BufferGeometry, material: THREE.ShaderMaterial) {
     const mesh = new THREE.Mesh(geometry, material);
     group.add(mesh);
     mesh.frustumCulled = false;
+
+    mesh.userData.treeIndices = this.createTreeIndexSet(geometry);
 
     if (material.uniforms.inverseModelMatrix === undefined) return;
 

--- a/viewer/packages/utilities/index.ts
+++ b/viewer/packages/utilities/index.ts
@@ -32,3 +32,5 @@ export { MostFrequentlyUsedCache } from './src/cache/MostFrequentlyUsedCache';
 export { disposeAttributeArrayOnUpload } from './src/disposeAttributeArrayOnUpload';
 
 export { revealEnv } from './src/revealEnv';
+
+export { incrementOrInsertIndex, decrementOrDeleteIndex } from './src/counterMap';

--- a/viewer/packages/utilities/src/counterMap.ts
+++ b/viewer/packages/utilities/src/counterMap.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 Cognite AS
+ */
+
+import assert from 'assert';
+
+export function incrementOrInsertIndex(indexMap: Map<number, number>, index: number): void {
+  const count = indexMap.get(index);
+
+  if (count === undefined) {
+    indexMap.set(index, 1);
+  } else {
+    indexMap.set(index, count + 1);
+  }
+}
+
+export function decrementOrDeleteIndex(indexMap: Map<number, number>, index: number): void {
+  const count = indexMap.get(index);
+  assert(count !== undefined);
+
+  if (count <= 1) {
+    indexMap.delete(index);
+  } else {
+    indexMap.set(index, count - 1);
+  }
+}

--- a/viewer/packages/utilities/src/datastructures/DynamicDefragmentedBuffer.ts
+++ b/viewer/packages/utilities/src/datastructures/DynamicDefragmentedBuffer.ts
@@ -114,6 +114,16 @@ export class DynamicDefragmentedBuffer<T extends TypedArray> {
     return { updateRange: { byteOffset, byteCount } };
   }
 
+  public getRangeForBatchId(batchId: number): { byteOffset: number; byteCount: number } {
+    const batch = this._batchMap.get(batchId);
+
+    if (!batch) {
+      throw new Error('batch does not exist in buffer');
+    }
+
+    return { byteOffset: batch.from, byteCount: batch.count };
+  }
+
   private createBatch(array: T) {
     const batch: Batch = {
       from: this._numFilled,

--- a/viewer/packages/utilities/src/indexset/IndexSet.ts
+++ b/viewer/packages/utilities/src/indexset/IndexSet.ts
@@ -142,13 +142,21 @@ export class IndexSet {
     return this;
   }
 
-  hasIntersectionWith(otherSet: IndexSet | Set<number>): boolean {
+  hasIntersectionWith(otherSet: IndexSet | Map<number, number> | Set<number>): boolean {
     if (otherSet instanceof IndexSet) {
       if (this.rootNode === undefined || otherSet.rootNode === undefined) {
         return false;
       }
 
       return this.rootNode.hasIntersectionWith(otherSet.rootNode);
+    } else if (otherSet instanceof Map) {
+      for (const index of otherSet.keys()) {
+        if (this.contains(index)) {
+          return true;
+        }
+      }
+
+      return false;
     } else {
       for (const index of otherSet) {
         if (this.contains(index)) {


### PR DESCRIPTION
The fix seems to be to properly add `mesh.userData.treeIndices`.