### PR TITLE
fix: variable naming in migration example and some other places

### DIFF
--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -468,8 +468,8 @@ export function Migration() {
       controlsGui.add(guiState.controls, 'mouseWheelAction', mouseWheelActionTypes).name('Mouse wheel action type').onFinishChange(value => {
         viewer.setCameraControlsOptions({ ...viewer.getCameraControlsOptions(), mouseWheelAction: value });
       });
-      controlsGui.add(guiState.controls, 'onClickTargetChange').name('Change camera target on click').onFinishChange(value => {
-        viewer.setCameraControlsOptions({ ...viewer.getCameraControlsOptions(), onClickTargetChange: value });
+      controlsGui.add(guiState.controls, 'changeCameraTargetOnClick').name('Change camera target on click').onFinishChange(value => {
+        viewer.setCameraControlsOptions({ ...viewer.getCameraControlsOptions(), changeCameraTargetOnClick: value });
       });
   
       const overlayTool = new HtmlOverlayTool(viewer,

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -2230,11 +2230,6 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/three@0.133.0":
-  version "0.133.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.133.0.tgz#2e344ce10bc81dc89295b79a98c09932b3f0c294"
-  integrity sha512-neDN9L64GK1fhT2raWXYIFvIr6ktM6XYgssfTh4zZp+XRgowD1qJ4/w79hLrLQ0w87u1E91ZfvHB0198wBsuHg==
-
 "@types/three@0.135.0":
   version "0.135.0"
   resolved "https://registry.yarnpkg.com/@types/three/-/three-0.135.0.tgz#db7f9d9699b60aba844fc5b2893adf6dd6811665"
@@ -12152,11 +12147,6 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
-
-three@0.133.0:
-  version "0.133.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.133.0.tgz#41427306c731a89407221b7be48c7a63580400e7"
-  integrity sha512-1p8xTXnJD4hMM2Ktm7+FqOOBoImBoftKnKtAZT/b9AQeL3LhRkVu/HnIJhWA69qIMvUYpjfnunNsO4WdObw1ZQ==
 
 three@0.135.0:
   version "0.135.0"

--- a/viewer/core/src/public/migration/Cognite3DViewer.test.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.test.ts
@@ -232,7 +232,9 @@ describe('Cognite3DViewer', () => {
     // Assert
     const newCameraControlsOptions = viewer.getCameraControlsOptions();
 
-    expect(newCameraControlsOptions.changeCameraTargetOnClick).not.toEqual(originalCameraControlsOptions.changeCameraTargetOnClick);
+    expect(newCameraControlsOptions.changeCameraTargetOnClick).not.toEqual(
+      originalCameraControlsOptions.changeCameraTargetOnClick
+    );
     expect(newCameraControlsOptions.mouseWheelAction).toEqual('zoomToTarget');
   });
 });

--- a/viewer/core/src/public/migration/Cognite3DViewer.test.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.test.ts
@@ -225,14 +225,14 @@ describe('Cognite3DViewer', () => {
 
     // Act
     viewer.setCameraControlsOptions({
-      onClickTargetChange: !originalCameraControlsOptions.onClickTargetChange,
+      changeCameraTargetOnClick: !originalCameraControlsOptions.changeCameraTargetOnClick,
       mouseWheelAction: 'zoomToTarget'
     });
 
     // Assert
     const newCameraControlsOptions = viewer.getCameraControlsOptions();
 
-    expect(newCameraControlsOptions.onClickTargetChange).not.toEqual(originalCameraControlsOptions.onClickTargetChange);
+    expect(newCameraControlsOptions.changeCameraTargetOnClick).not.toEqual(originalCameraControlsOptions.changeCameraTargetOnClick);
     expect(newCameraControlsOptions.mouseWheelAction).toEqual('zoomToTarget');
   });
 });

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -24,7 +24,7 @@ import {
   CameraChangeDelegate,
   PointerEventDelegate,
   CadModelBudget,
-  PointCloudBudget,
+  PointCloudBudget
 } from './types';
 import { NotSupportedInMigrationWrapperError } from './NotSupportedInMigrationWrapperError';
 import RenderController from './RenderController';
@@ -45,7 +45,7 @@ import { CadModelSectorLoadStatistics } from '../../datamodels/cad/CadModelSecto
 import { ViewerState, ViewStateHelper } from '../../utilities/ViewStateHelper';
 import { RevealManagerHelper } from '../../storage/RevealManagerHelper';
 
-import { CameraManager, ComboControls, CameraControlsOptions} from '@reveal/camera-manager';
+import { CameraManager, ComboControls, CameraControlsOptions } from '@reveal/camera-manager';
 import { CdfModelIdentifier, File3dFormat } from '@reveal/modeldata-api';
 import { DataSource, CdfDataSource, LocalDataSource } from '@reveal/data-source';
 

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -25,7 +25,6 @@ import {
   PointerEventDelegate,
   CadModelBudget,
   PointCloudBudget,
-  CameraControlsOptions
 } from './types';
 import { NotSupportedInMigrationWrapperError } from './NotSupportedInMigrationWrapperError';
 import RenderController from './RenderController';
@@ -46,7 +45,7 @@ import { CadModelSectorLoadStatistics } from '../../datamodels/cad/CadModelSecto
 import { ViewerState, ViewStateHelper } from '../../utilities/ViewStateHelper';
 import { RevealManagerHelper } from '../../storage/RevealManagerHelper';
 
-import { CameraManager, ComboControls } from '@reveal/camera-manager';
+import { CameraManager, ComboControls, CameraControlsOptions} from '@reveal/camera-manager';
 import { CdfModelIdentifier, File3dFormat } from '@reveal/modeldata-api';
 import { DataSource, CdfDataSource, LocalDataSource } from '@reveal/data-source';
 

--- a/viewer/core/src/public/migration/types.ts
+++ b/viewer/core/src/public/migration/types.ts
@@ -199,31 +199,6 @@ export interface AddModelOptions {
   geometryFilter?: GeometryFilter;
 }
 
-export type CameraControlsOptions = {
-  /**
-   * Sets mouse wheel initiated action.
-   *
-   * Modes:
-   *
-   * 'zoomToTarget' - zooms just to the current target (center of the screen) of the camera.
-   *
-   * 'zoomPastCursor' - zooms in the direction of the ray coming from camera through cursor screen position, allows going through objects.
-   *
-   * 'zoomToCursor' - mouse wheel scroll zooms towards the point on the model where cursor is hovering over, doesn't allow going through objects.
-   *
-   * Default is 'zoomPastCursor'.
-   *
-   */
-  mouseWheelAction?: 'zoomToTarget' | 'zoomPastCursor' | 'zoomToCursor';
-  /**
-   * Enables or disables change of camera target on mouse click. New target is then set to the point of the model under current cursor position.
-   *
-   * Default is false.
-   *
-   */
-  onClickTargetChange?: boolean;
-};
-
 export type CadIntersection = {
   /**
    * The intersection type.


### PR DESCRIPTION
Added proper name for CameraControlsOptions type variable in migration example and some other places.