### PR TITLE
fix: error when saving viewer state

### DIFF
--- a/viewer/core/src/utilities/ViewStateHelper.ts
+++ b/viewer/core/src/utilities/ViewStateHelper.ts
@@ -73,7 +73,12 @@ export class ViewStateHelper {
   }
 
   public async setState(viewerState: ViewerState): Promise<void> {
-    this._cameraControls.setState(viewerState.camera.position, viewerState.camera.target);
+    const camPos = viewerState.camera.position;
+    const camTarget = viewerState.camera.target;
+    this._cameraControls.setState(
+      new THREE.Vector3(camPos.x, camPos.y, camPos.z),
+      new THREE.Vector3(camTarget.x, camTarget.y, camTarget.z)
+    );
 
     const cadModels = this._viewer.models
       .filter(model => model instanceof Cognite3DModel)


### PR DESCRIPTION
There is a bug in the documentation about viewer state. The second example throws an error when run: https://cognitedata.github.io/reveal-docs/docs/examples/cad-save-viewerstate/ It stems from an attempt at calling `clone` on the input vector objects, but they only contain data and not member methods.

This change converts the input data to actual `THREE.Vector3`s, solving the problem.