### PR TITLE
doc: remove version tags as they are not relevant in v3 docs

### DIFF
--- a/viewer/core/src/public/migration/Cognite3DModel.ts
+++ b/viewer/core/src/public/migration/Cognite3DModel.ts
@@ -38,7 +38,6 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
    * Returns the unit the coordinates for the model is stored. Returns an empty string
    * if no unit has been stored.
    * Note that coordinates in Reveal always are converted to meters using {@see modelUnitToMetersFactor}.
-   * @version New since 2.1
    */
   get modelUnit(): WellKnownUnit | '' {
     // Note! Returns union type, because we expect it to be a value in WellKnownUnit, but we
@@ -49,7 +48,6 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase {
   /**
    * Returns the conversion factor that converts from model coordinates to meters. Note that this can
    * return undefined if the model has been stored in an unsupported unit.
-   * @version New since 2.1
    */
   get modelUnitToMetersFactor(): number | undefined {
     return WellKnownDistanceToMeterConversionFactors.get(this.modelUnit);

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -796,7 +796,6 @@ export class Cognite3DViewer {
 
   /**
    * Returns the current active clipping planes.
-   * @version New in 2.1
    */
   getClippingPlanes(): THREE.Plane[] {
     return this.revealManager.clippingPlanes;

--- a/viewer/packages/data-source/src/DataSource.ts
+++ b/viewer/packages/data-source/src/DataSource.ts
@@ -8,7 +8,6 @@ import { ModelDataProvider, ModelMetadataProvider } from '@reveal/modeldata-api'
 /**
  * Describes how Reveal data is stored, and provides means to create custom storage providers
  * that Reveal will fetch data from.
- * @version New since 2.2
  */
 export interface DataSource {
   /**

--- a/viewer/packages/modeldata-api/src/ModelMetadataProvider.ts
+++ b/viewer/packages/modeldata-api/src/ModelMetadataProvider.ts
@@ -7,7 +7,6 @@ import { BlobOutputMetadata, File3dFormat } from './types';
 
 /**
  * Provides metadata for 3D models.
- * @version New since 2.2
  */
 export interface ModelMetadataProvider {
   getModelOutputs(modelIdentifier: ModelIdentifier): Promise<BlobOutputMetadata[]>;

--- a/viewer/packages/modeldata-api/src/types.ts
+++ b/viewer/packages/modeldata-api/src/types.ts
@@ -13,7 +13,6 @@ export interface BinaryFileProvider {
 
 /**
  * Provides data for 3D models.
- * @version New since 2.2
  */
 export interface ModelDataProvider extends HttpHeadersProvider, JsonFileProvider, BinaryFileProvider {
   /**

--- a/viewer/packages/nodes-api/src/NodesApiClient.ts
+++ b/viewer/packages/nodes-api/src/NodesApiClient.ts
@@ -8,7 +8,6 @@ import { CogniteInternalId } from '@cognite/sdk';
 
 /**
  * Client for retrieving metadata information about CAD nodes.
- * @version New since 2.2
  */
 export interface NodesApiClient {
   /**

--- a/viewer/packages/tools/src/Geomap/GeomapTool.ts
+++ b/viewer/packages/tools/src/Geomap/GeomapTool.ts
@@ -11,7 +11,6 @@ import { MetricsLogger } from '@reveal/metrics';
 
 /**
  * The `GeomapTool` is a geolocation for the models and allow the user to place them on the maps.
- * @version New since 2.1.
  */
 export class GeomapTool extends Cognite3DViewerToolBase {
   private readonly _viewer: Cognite3DViewer;


### PR DESCRIPTION
These are used to indicate which minor version features were added, and since all of the 2.x features are available in 3.0 we can remove them.