### PR TITLE
refac: standardize event listeners to always accept one "event" argument

### DIFF
--- a/documentation/docs/examples/cad-3dobjects.mdx
+++ b/documentation/docs/examples/cad-3dobjects.mdx
@@ -131,7 +131,7 @@ updateOcean();
 The user is available to move below sea level. Let's restrict the movement to avoid this.
 
 ```js
-viewer.on('cameraChange', (position, target) => {
+viewer.on('cameraChange', ({position, target}) => {
   // Keep camera above sea level
   if (position.y < 20) {
     position.y = 21;
@@ -199,7 +199,7 @@ updateOcean();
 
 // Restrict camera movement
 const boundingSphere = new THREE.Sphere(modelCenterAtSeaLevel, 2000);
-viewer.on('cameraChange', (position, target) => {
+viewer.on('cameraChange', ({position, target}) => {
   // Keep camera above sea level
   if (position.y < 20) {
     position.y = 21;

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -1260,13 +1260,6 @@
   dependencies:
     comlink "4.3.1"
 
-"@cognite/reveal-parser-worker@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@cognite/reveal-parser-worker/-/reveal-parser-worker-1.3.0.tgz#9910121ba90cad684a91b3b04e6df0528ea671f5"
-  integrity sha512-39wuqtdogmZfTmnQhigNpgU/nfYG3POpUFKFO/FMKJKJ+pAsCCZfu4IPEXCDAevJS6/K+mEViPSLL6+Gagi1HQ==
-  dependencies:
-    comlink "4.3.1"
-
 "@cognite/reveal@link:../viewer/dist":
   version "0.0.0"
   uid ""

--- a/examples/src/pages/Geomap.tsx
+++ b/examples/src/pages/Geomap.tsx
@@ -175,7 +175,7 @@ export function Geomap() {
       const selectedSet = new TreeIndexNodeCollection([]);
 
       new AxisViewTool(viewer);
-      viewer.on('click', async (event: PointerEvent) => {
+      viewer.on('click', async event => {
         const { offsetX, offsetY } = event;
         console.log('2D coordinates', event);
         const intersection = await viewer.getIntersectionFromPixel(offsetX, offsetY);

--- a/examples/src/pages/Geomap.tsx
+++ b/examples/src/pages/Geomap.tsx
@@ -16,7 +16,8 @@ import {
   PotreePointColorType, 
   PotreePointShape,
   TreeIndexNodeCollection,
-  IndexSet
+  IndexSet,
+  PointerEvent
 } from '@cognite/reveal';
 import { DebugCameraTool, DebugLoadedSectorsTool, DebugLoadedSectorsToolOptions, AxisViewTool, GeomapTool, MapConfig,
   MapboxMode, MapboxStyle, MapProviders, MapboxImageFormat, BingMapType, HereMapType, HereMapScheme, HereMapImageFormat } from '@cognite/reveal/tools';
@@ -174,7 +175,7 @@ export function Geomap() {
       const selectedSet = new TreeIndexNodeCollection([]);
 
       new AxisViewTool(viewer);
-      viewer.on('click', async event => {
+      viewer.on('click', async (event: PointerEvent) => {
         const { offsetX, offsetY } = event;
         console.log('2D coordinates', event);
         const intersection = await viewer.getIntersectionFromPixel(offsetX, offsetY);

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -17,7 +17,9 @@ import {
   PotreePointColorType,
   PotreePointShape,
   TreeIndexNodeCollection,
-  IndexSet
+  IndexSet,
+  SceneRenderedEvent,
+  PointerEvent
 } from '@cognite/reveal';
 import { DebugCameraTool, DebugLoadedSectorsTool, DebugLoadedSectorsToolOptions, ExplodedViewTool, AxisViewTool, HtmlOverlayTool } from '@cognite/reveal/tools';
 import * as reveal from '@cognite/reveal';
@@ -297,7 +299,7 @@ export function Migration() {
       debugStatsGui.add(guiState.debug.stats, 'textures').name('Textures');
       debugStatsGui.add(guiState.debug.stats, 'renderTime').name('Ms/frame');
 
-      viewer.on('sceneRendered', sceneRenderedEventArgs => {
+      viewer.on('sceneRendered', (sceneRenderedEventArgs: SceneRenderedEvent) => {
         guiState.debug.stats.drawCalls = sceneRenderedEventArgs.renderer.info.render.calls;
         guiState.debug.stats.points = sceneRenderedEventArgs.renderer.info.render.points;
         guiState.debug.stats.triangles = sceneRenderedEventArgs.renderer.info.render.triangles;
@@ -482,7 +484,7 @@ export function Migration() {
 
       new AxisViewTool(viewer);
 
-      viewer.on('click', async event => {
+      viewer.on('click', async (event: PointerEvent) => {
         const { offsetX, offsetY } = event;
         console.log('2D coordinates', event);
         const intersection = await viewer.getIntersectionFromPixel(offsetX, offsetY);

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -299,7 +299,7 @@ export function Migration() {
       debugStatsGui.add(guiState.debug.stats, 'textures').name('Textures');
       debugStatsGui.add(guiState.debug.stats, 'renderTime').name('Ms/frame');
 
-      viewer.on('sceneRendered', (sceneRenderedEventArgs: SceneRenderedEvent) => {
+      viewer.on('sceneRendered', sceneRenderedEventArgs => {
         guiState.debug.stats.drawCalls = sceneRenderedEventArgs.renderer.info.render.calls;
         guiState.debug.stats.points = sceneRenderedEventArgs.renderer.info.render.points;
         guiState.debug.stats.triangles = sceneRenderedEventArgs.renderer.info.render.triangles;

--- a/examples/src/pages/e2e/TestViewer.tsx
+++ b/examples/src/pages/e2e/TestViewer.tsx
@@ -70,8 +70,9 @@ export function TestViewer(props: Props) {
     revealManager: reveal.RevealManager
   ) => {
     let skipFirstLoadingState = true;
-    revealManager.on('loadingStateChanged', (loadingState) => {
+    revealManager.on('loadingStateChanged', (event: reveal.LoadingStateChangedEvent) => {
       // Ignore isLoading updates untill we see that we are starting to download data
+      const loadingState = event as reveal.utilities.LoadingState;
       if (skipFirstLoadingState) {
         if (loadingState.isLoading) {
           skipFirstLoadingState = false;

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1337,6 +1337,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@gltf-transform/core@^0.12.11", "@gltf-transform/core@^0.12.16":
+  version "0.12.16"
+  resolved "https://registry.yarnpkg.com/@gltf-transform/core/-/core-0.12.16.tgz#6736185dfac20cecc6ea535b11c6967bb6c1c3b9"
+  integrity sha512-InPsteALt1rXFzL9MyHywEhZ5pXEOGDrJbhRqzse8AxoFHbXG5/euQKFedXadFs01ZkkiEAXHvFAasae2Lplzg==
+  dependencies:
+    gl-matrix "~3.3.0"
+
+"@gltf-transform/extensions@^0.12.11":
+  version "0.12.16"
+  resolved "https://registry.yarnpkg.com/@gltf-transform/extensions/-/extensions-0.12.16.tgz#e568930ab2ca25b20233c5d98f1ad43bc201b0e5"
+  integrity sha512-phftmyXd8qSPHVqQjQVrECxdNTRORumI9Of7bLHTZ0gXcQSkCKMTYBnmVL0fHi6ZhsayoccCPgzQiK0LpkzMYQ==
+  dependencies:
+    "@gltf-transform/core" "^0.12.16"
+    ktx-parse "^0.2.1"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -2234,11 +2249,6 @@
   version "0.133.0"
   resolved "https://registry.yarnpkg.com/@types/three/-/three-0.133.0.tgz#2e344ce10bc81dc89295b79a98c09932b3f0c294"
   integrity sha512-neDN9L64GK1fhT2raWXYIFvIr6ktM6XYgssfTh4zZp+XRgowD1qJ4/w79hLrLQ0w87u1E91ZfvHB0198wBsuHg==
-
-"@types/three@0.135.0":
-  version "0.135.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.135.0.tgz#db7f9d9699b60aba844fc5b2893adf6dd6811665"
-  integrity sha512-l7WLhIHjhHMtlpyTSltPPAKLpiMwgMD1hXHj59AVUpYRoZP7Fd9NNOSRSvZBCPLpTHPYojgQvSJCoza9zoL7bg==
 
 "@types/uglify-js@*":
   version "3.13.1"
@@ -6126,6 +6136,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gl-matrix@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.3.0.tgz#232eef60b1c8b30a28cbbe75b2caf6c48fd6358b"
+  integrity sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -8112,6 +8127,11 @@ klona@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+
+ktx-parse@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.2.2.tgz#b037b66044855215b332cb73104590af49e47791"
+  integrity sha512-cFBc1jnGG2WlUf52NbDUXK2obJ+Mo9WUkBRvr6tP6CKxRMvZwDDFNV3JAS4cewETp5KyexByfWm9sm+O8AffiQ==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -12178,11 +12198,6 @@ three@0.133.0:
   version "0.133.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.133.0.tgz#41427306c731a89407221b7be48c7a63580400e7"
   integrity sha512-1p8xTXnJD4hMM2Ktm7+FqOOBoImBoftKnKtAZT/b9AQeL3LhRkVu/HnIJhWA69qIMvUYpjfnunNsO4WdObw1ZQ==
-
-three@0.135.0:
-  version "0.135.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.135.0.tgz#cff4ec8edd3c51ce9bc7e88d13e8eafed4d0ddfc"
-  integrity sha512-kuEpuuxRzLv0MDsXai9huCxOSQPZ4vje6y0gn80SRmQvgz6/+rI0NAvCRAw56zYaWKMGMfqKWsxF9Qa2Z9xymQ==
 
 throat@^5.0.0:
   version "5.0.0"

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1237,13 +1237,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@choojs/findup@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@choojs/findup/-/findup-0.2.1.tgz#ac13c59ae7be6e1da64de0779a0a7f03d75615a3"
-  integrity sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==
-  dependencies:
-    commander "^2.15.1"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1256,18 +1249,6 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.5.0.tgz#7b288a12358b2ef2b2ae51195a4ecace396822be"
   integrity sha512-/XhfPYlPIK7LxT0czUIGMWLcUjGfVmf3Nzcf+6FaG+sExr6S8Yqayeid9FdYgi7y+LFmvYSJrZyXgF5LL8ZMrg==
-
-"@cognite/potree-core@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.5.1.tgz#b61bc4ed905757701c8d2074b153890974857bb3"
-  integrity sha512-T0+MIDd3ebZDjRbddiLF1KhMeW0JCunbvaxpseZdgAjXx6S/W4EiIFJqjP0g9KXOn09DLSAIS8DVtKKfKtyhAA==
-
-"@cognite/reveal-parser-worker@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@cognite/reveal-parser-worker/-/reveal-parser-worker-1.3.0.tgz#9910121ba90cad684a91b3b04e6df0528ea671f5"
-  integrity sha512-39wuqtdogmZfTmnQhigNpgU/nfYG3POpUFKFO/FMKJKJ+pAsCCZfu4IPEXCDAevJS6/K+mEViPSLL6+Gagi1HQ==
-  dependencies:
-    comlink "4.3.1"
 
 "@cognite/reveal@link:../viewer/dist":
   version "0.0.0"
@@ -1336,21 +1317,6 @@
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
-
-"@gltf-transform/core@^0.12.11", "@gltf-transform/core@^0.12.16":
-  version "0.12.16"
-  resolved "https://registry.yarnpkg.com/@gltf-transform/core/-/core-0.12.16.tgz#6736185dfac20cecc6ea535b11c6967bb6c1c3b9"
-  integrity sha512-InPsteALt1rXFzL9MyHywEhZ5pXEOGDrJbhRqzse8AxoFHbXG5/euQKFedXadFs01ZkkiEAXHvFAasae2Lplzg==
-  dependencies:
-    gl-matrix "~3.3.0"
-
-"@gltf-transform/extensions@^0.12.11":
-  version "0.12.16"
-  resolved "https://registry.yarnpkg.com/@gltf-transform/extensions/-/extensions-0.12.16.tgz#e568930ab2ca25b20233c5d98f1ad43bc201b0e5"
-  integrity sha512-phftmyXd8qSPHVqQjQVrECxdNTRORumI9Of7bLHTZ0gXcQSkCKMTYBnmVL0fHi6ZhsayoccCPgzQiK0LpkzMYQ==
-  dependencies:
-    "@gltf-transform/core" "^0.12.16"
-    ktx-parse "^0.2.1"
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -1942,11 +1908,6 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
-
-"@tweenjs/tween.js@^18.6.4":
-  version "18.6.4"
-  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-18.6.4.tgz#40a3d0a93647124872dec8e0fd1bd5926695b6ca"
-  integrity sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==
 
 "@types/aria-query@^4.2.0":
   version "4.2.2"
@@ -2896,16 +2857,6 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
-assert@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
-  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
-  dependencies:
-    es6-object-assign "^1.1.0"
-    is-nan "^1.2.1"
-    object-is "^1.0.1"
-    util "^0.12.0"
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -2965,11 +2916,6 @@ autoprefixer@^9.6.1:
     num2fraction "^1.2.2"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
-
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -3272,14 +3218,6 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-bl@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
-  integrity sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
 
 bl@^4.0.3:
   version "4.1.0"
@@ -3931,12 +3869,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comlink@4.3.1, comlink@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
-  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
-
-commander@^2.15.1, commander@^2.20.0:
+commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4003,7 +3936,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@^1.5.2:
+concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -4898,7 +4831,7 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-duplexify@^3.4.2, duplexify@^3.4.5, duplexify@^3.6.0:
+duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
   integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
@@ -5051,32 +4984,6 @@ es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
-es-abstract@^1.18.5:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
-  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
-  dependencies:
-    call-bind "^1.0.2"
-    es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
-    get-intrinsic "^1.1.1"
-    get-symbol-description "^1.0.0"
-    has "^1.0.3"
-    has-symbols "^1.0.2"
-    internal-slot "^1.0.3"
-    is-callable "^1.2.4"
-    is-negative-zero "^2.0.1"
-    is-regex "^1.1.4"
-    is-shared-array-buffer "^1.0.1"
-    is-string "^1.0.7"
-    is-weakref "^1.0.1"
-    object-inspect "^1.11.0"
-    object-keys "^1.1.1"
-    object.assign "^4.1.2"
-    string.prototype.trimend "^1.0.4"
-    string.prototype.trimstart "^1.0.4"
-    unbox-primitive "^1.0.1"
-
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -5103,11 +5010,6 @@ es6-iterator@2.0.3, es6-iterator@~2.0.3:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
-
-es6-object-assign@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
-  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
@@ -5141,18 +5043,6 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
-escodegen@^1.11.1:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
-  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
-  dependencies:
-    esprima "^4.0.1"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.6.1"
 
 escodegen@^2.0.0:
   version "2.0.0"
@@ -5398,7 +5288,7 @@ esrecurse@^4.1.0, esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -5446,7 +5336,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0, events@^3.2.0:
+events@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -5653,16 +5543,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-falafel@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/falafel/-/falafel-2.2.4.tgz#b5d86c060c2412a43166243cb1bce44d1abd2819"
-  integrity sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==
-  dependencies:
-    acorn "^7.1.1"
-    foreach "^2.0.5"
-    isarray "^2.0.1"
-    object-keys "^1.0.6"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -5902,11 +5782,6 @@ for-own@^0.1.3:
   dependencies:
     for-in "^1.0.1"
 
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
-  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
-
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -5960,7 +5835,7 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-from2@^2.1.0, from2@^2.3.0:
+from2@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
   integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
@@ -6116,14 +5991,6 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-get-symbol-description@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
-  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.1"
-
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -6135,11 +6002,6 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
-
-gl-matrix@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.3.0.tgz#232eef60b1c8b30a28cbbe75b2caf6c48fd6358b"
-  integrity sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -6249,142 +6111,6 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-glsl-inject-defines@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz#dd1aacc2c17fcb2bd3fc32411c6633d0d7b60fd4"
-  integrity sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=
-  dependencies:
-    glsl-token-inject-block "^1.0.0"
-    glsl-token-string "^1.0.1"
-    glsl-tokenizer "^2.0.2"
-
-glsl-resolve@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/glsl-resolve/-/glsl-resolve-0.0.1.tgz#894bef73910d792c81b5143180035d0a78af76d3"
-  integrity sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=
-  dependencies:
-    resolve "^0.6.1"
-    xtend "^2.1.2"
-
-glsl-token-assignments@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz#a5d82ab78499c2e8a6b83cb69495e6e665ce019f"
-  integrity sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8=
-
-glsl-token-defines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz#cb892aa959936231728470d4f74032489697fa9d"
-  integrity sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=
-  dependencies:
-    glsl-tokenizer "^2.0.0"
-
-glsl-token-depth@^1.1.0, glsl-token-depth@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz#23c5e30ee2bd255884b4a28bc850b8f791e95d84"
-  integrity sha1-I8XjDuK9JViEtKKLyFC495HpXYQ=
-
-glsl-token-descope@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz#0fc90ab326186b82f597b2e77dc9e21efcd32076"
-  integrity sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=
-  dependencies:
-    glsl-token-assignments "^2.0.0"
-    glsl-token-depth "^1.1.0"
-    glsl-token-properties "^1.0.0"
-    glsl-token-scope "^1.1.0"
-
-glsl-token-inject-block@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz#e1015f5980c1091824adaa2625f1dfde8bd00034"
-  integrity sha1-4QFfWYDBCRgkraomJfHf3ovQADQ=
-
-glsl-token-properties@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz#483dc3d839f0d4b5c6171d1591f249be53c28a9e"
-  integrity sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4=
-
-glsl-token-scope@^1.1.0, glsl-token-scope@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz#a1728e78df24444f9cb93fd18ef0f75503a643b1"
-  integrity sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E=
-
-glsl-token-string@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/glsl-token-string/-/glsl-token-string-1.0.1.tgz#59441d2f857de7c3449c945666021ece358e48ec"
-  integrity sha1-WUQdL4V958NEnJRWZgIezjWOSOw=
-
-glsl-token-whitespace-trim@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz#46d1dfe98c75bd7d504c05d7d11b1b3e9cc93b10"
-  integrity sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA=
-
-glsl-tokenizer@^2.0.0, glsl-tokenizer@^2.0.2:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz#1c2e78c16589933c274ba278d0a63b370c5fee1a"
-  integrity sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==
-  dependencies:
-    through2 "^0.6.3"
-
-glslify-bundle@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glslify-bundle/-/glslify-bundle-5.1.1.tgz#30d2ddf2e6b935bf44d1299321e3b729782c409a"
-  integrity sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==
-  dependencies:
-    glsl-inject-defines "^1.0.1"
-    glsl-token-defines "^1.0.0"
-    glsl-token-depth "^1.1.1"
-    glsl-token-descope "^1.0.2"
-    glsl-token-scope "^1.1.1"
-    glsl-token-string "^1.0.1"
-    glsl-token-whitespace-trim "^1.0.0"
-    glsl-tokenizer "^2.0.2"
-    murmurhash-js "^1.0.0"
-    shallow-copy "0.0.1"
-
-glslify-deps@^1.2.5:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/glslify-deps/-/glslify-deps-1.3.2.tgz#c09ee945352bfc07ac2d8a1cc9e3de776328c72b"
-  integrity sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==
-  dependencies:
-    "@choojs/findup" "^0.2.0"
-    events "^3.2.0"
-    glsl-resolve "0.0.1"
-    glsl-tokenizer "^2.0.0"
-    graceful-fs "^4.1.2"
-    inherits "^2.0.1"
-    map-limit "0.0.1"
-    resolve "^1.0.0"
-
-glslify-import@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glslify-import/-/glslify-import-3.1.0.tgz#3dc745a667bb80e14aaba2f4c9294463f96ab18c"
-  integrity sha512-3n7gI7mDcpkpGMFrbCEFhbyUU70sNrih5OrU6oN6EcgTsTVjrbHpQVjjG78Ta2kzZGEqQX0OD2BgFgglm2DZPg==
-  dependencies:
-    glsl-resolve "0.0.1"
-    glsl-token-string "^1.0.1"
-    glsl-tokenizer "^2.0.2"
-
-glslify@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glslify/-/glslify-7.1.1.tgz#454d9172b410cb49864029c86d5613947fefd30b"
-  integrity sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==
-  dependencies:
-    bl "^2.2.1"
-    concat-stream "^1.5.2"
-    duplexify "^3.4.5"
-    falafel "^2.1.0"
-    from2 "^2.3.0"
-    glsl-resolve "0.0.1"
-    glsl-token-whitespace-trim "^1.0.0"
-    glslify-bundle "^5.0.0"
-    glslify-deps "^1.2.5"
-    minimist "^1.2.5"
-    resolve "^1.1.5"
-    stack-trace "0.0.9"
-    static-eval "^2.0.5"
-    through2 "^2.0.1"
-    xtend "^4.0.0"
-
 glur@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/glur/-/glur-1.1.2.tgz#f20ea36db103bfc292343921f1f91e83c3467689"
@@ -6457,13 +6183,6 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
-
-has-tostringtag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
-  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
-  dependencies:
-    has-symbols "^1.0.2"
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -7024,11 +6743,6 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
-is-callable@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
-  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
-
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -7134,13 +6848,6 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-generator-function@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
-  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -7159,14 +6866,6 @@ is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
   integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
-
-is-nan@^1.2.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
-  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -7249,14 +6948,6 @@ is-regex@^1.0.4, is-regex@^1.1.3:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
-is-regex@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
-  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -7271,11 +6962,6 @@ is-root@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
-
-is-shared-array-buffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
-  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -7292,13 +6978,6 @@ is-string@^1.0.5, is-string@^1.0.6:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
   integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
 
-is-string@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
-  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
@@ -7306,28 +6985,10 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
-is-typed-array@^1.1.3, is-typed-array@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.8.tgz#cbaa6585dc7db43318bc5b89523ea384a6f65e79"
-  integrity sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    es-abstract "^1.18.5"
-    foreach "^2.0.5"
-    has-tostringtag "^1.0.0"
-
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-
-is-weakref@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.1.tgz#842dba4ec17fa9ac9850df2d6efbc1737274f2a2"
-  integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
-  dependencies:
-    call-bind "^1.0.0"
 
 is-windows@^0.2.0:
   version "0.2.0"
@@ -7360,11 +7021,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-
-isarray@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -8121,11 +7777,6 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
-ktx-parse@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.2.1.tgz#6805c0929eae0a1f571ab3ce789e860e9135b432"
-  integrity sha512-I+2mYJ6nQdWGmOlE3m9d9idKfhn2MCw04zaVpgtzyuc19uQ8OwRmmYLf/TP5ueVFfYmHbdpM8mPmId2X5PBLEw==
-
 language-subtag-registry@~0.3.2:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz#04ac218bea46f04cb039084602c6da9e788dd45a"
@@ -8312,11 +7963,6 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-loglevel@^1.7.1:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
-  integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
-
 loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -8388,13 +8034,6 @@ map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
-
-map-limit@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/map-limit/-/map-limit-0.0.1.tgz#eb7961031c0f0e8d001bf2d56fab685d58822f38"
-  integrity sha1-63lhAxwPDo0AG/LVb6toXViCLzg=
-  dependencies:
-    once "~1.3.0"
 
 map-stream@~0.1.0:
   version "0.1.0"
@@ -8657,11 +8296,6 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mixpanel-browser@^2.39.0:
-  version "2.42.0"
-  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.42.0.tgz#85c056577875f6624358bf0d7dcd13678c8277db"
-  integrity sha512-9IC/+BYVIG3PfLn1ubkLsQdXc5dKot3sIXHf56GqssyLCOPPwlZfwhZqg1t8HC/sxGqLCL/HON3YbR7oiXMbeg==
-
 mkdirp-classic@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
@@ -8723,11 +8357,6 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
-
-murmurhash-js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
-  integrity sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=
 
 nan@^2.12.1:
   version "2.15.0"
@@ -8974,7 +8603,7 @@ object-is@^1.0.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-object-keys@^1.0.12, object-keys@^1.0.6, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -9072,13 +8701,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
-  dependencies:
-    wrappy "1"
-
-once@~1.3.0:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
-  integrity sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=
   dependencies:
     wrappy "1"
 
@@ -10693,7 +10315,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -10705,16 +10327,6 @@ read-pkg@^5.2.0:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-"readable-stream@>=1.0.33-1 <1.1.0-0":
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
@@ -10983,12 +10595,7 @@ resolve@1.18.1:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
 
-resolve@^0.6.1:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
-  integrity sha1-3ZV5gufnNt699TtYpN2RdUV13UY=
-
-resolve@^1.0.0, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -11373,11 +10980,6 @@ shallow-clone@^0.1.2:
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
 
-shallow-copy@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
-  integrity sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=
-
 shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
@@ -11442,11 +11044,6 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
-
-skmeans@^0.11.3:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/skmeans/-/skmeans-0.11.3.tgz#6d4dafb8058520a792c10bae9d9b953a6b6379f4"
-  integrity sha512-nccEnlSeOMNAYM9ETMSq+m15u8g0KRCIvH2an/ROTx4Igmci/j3oYHBPGdAeGjhR7knAVoIIQwr/wy2dN/eKQA==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -11699,11 +11296,6 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
-stack-trace@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
-  integrity sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=
-
 stack-utils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
@@ -11728,13 +11320,6 @@ start-server-and-test@^1.12.3:
     lazy-ass "1.6.0"
     ps-tree "1.2.0"
     wait-on "6.0.0"
-
-static-eval@^2.0.5:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.1.0.tgz#a16dbe54522d7fa5ef1389129d813fd47b148014"
-  integrity sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==
-  dependencies:
-    escodegen "^1.11.1"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -11860,11 +11445,6 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -12183,15 +11763,7 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-through2@^0.6.3:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
-  integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
-  dependencies:
-    readable-stream ">=1.0.33-1 <1.1.0-0"
-    xtend ">=4.0.0 <4.1.0-0"
-
-through2@^2.0.0, through2@^2.0.1:
+through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -12669,18 +12241,6 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-util@^0.12.0:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
-  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    safe-buffer "^5.1.2"
-    which-typed-array "^1.1.2"
-
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -13000,18 +12560,6 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which-typed-array@^1.1.2:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.7.tgz#2761799b9a22d4b8660b3c1b40abaa7739691793"
-  integrity sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    es-abstract "^1.18.5"
-    foreach "^2.0.5"
-    has-tostringtag "^1.0.0"
-    is-typed-array "^1.1.7"
-
 which@^1.2.12, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -13258,15 +12806,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
-
-xtend@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.2.0.tgz#eef6b1f198c1c8deafad8b1765a04dad4a01c5a9"
-  integrity sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=
 
 y18n@^4.0.0:
   version "4.0.3"

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1237,6 +1237,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@choojs/findup@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@choojs/findup/-/findup-0.2.1.tgz#ac13c59ae7be6e1da64de0779a0a7f03d75615a3"
+  integrity sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==
+  dependencies:
+    commander "^2.15.1"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1249,6 +1256,18 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.5.0.tgz#7b288a12358b2ef2b2ae51195a4ecace396822be"
   integrity sha512-/XhfPYlPIK7LxT0czUIGMWLcUjGfVmf3Nzcf+6FaG+sExr6S8Yqayeid9FdYgi7y+LFmvYSJrZyXgF5LL8ZMrg==
+
+"@cognite/potree-core@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@cognite/potree-core/-/potree-core-1.5.1.tgz#b61bc4ed905757701c8d2074b153890974857bb3"
+  integrity sha512-T0+MIDd3ebZDjRbddiLF1KhMeW0JCunbvaxpseZdgAjXx6S/W4EiIFJqjP0g9KXOn09DLSAIS8DVtKKfKtyhAA==
+
+"@cognite/reveal-parser-worker@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@cognite/reveal-parser-worker/-/reveal-parser-worker-1.3.0.tgz#9910121ba90cad684a91b3b04e6df0528ea671f5"
+  integrity sha512-39wuqtdogmZfTmnQhigNpgU/nfYG3POpUFKFO/FMKJKJ+pAsCCZfu4IPEXCDAevJS6/K+mEViPSLL6+Gagi1HQ==
+  dependencies:
+    comlink "4.3.1"
 
 "@cognite/reveal@link:../viewer/dist":
   version "0.0.0"
@@ -1909,6 +1928,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tweenjs/tween.js@^18.6.4":
+  version "18.6.4"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-18.6.4.tgz#40a3d0a93647124872dec8e0fd1bd5926695b6ca"
+  integrity sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -2210,6 +2234,11 @@
   version "0.133.0"
   resolved "https://registry.yarnpkg.com/@types/three/-/three-0.133.0.tgz#2e344ce10bc81dc89295b79a98c09932b3f0c294"
   integrity sha512-neDN9L64GK1fhT2raWXYIFvIr6ktM6XYgssfTh4zZp+XRgowD1qJ4/w79hLrLQ0w87u1E91ZfvHB0198wBsuHg==
+
+"@types/three@0.135.0":
+  version "0.135.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.135.0.tgz#db7f9d9699b60aba844fc5b2893adf6dd6811665"
+  integrity sha512-l7WLhIHjhHMtlpyTSltPPAKLpiMwgMD1hXHj59AVUpYRoZP7Fd9NNOSRSvZBCPLpTHPYojgQvSJCoza9zoL7bg==
 
 "@types/uglify-js@*":
   version "3.13.1"
@@ -2857,6 +2886,16 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
+  dependencies:
+    es6-object-assign "^1.1.0"
+    is-nan "^1.2.1"
+    object-is "^1.0.1"
+    util "^0.12.0"
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -2916,6 +2955,11 @@ autoprefixer@^9.6.1:
     num2fraction "^1.2.2"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -3218,6 +3262,14 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bl@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
+  integrity sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
 
 bl@^4.0.3:
   version "4.1.0"
@@ -3869,7 +3921,12 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+comlink@4.3.1, comlink@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
+  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
+
+commander@^2.15.1, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3936,7 +3993,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -4831,7 +4888,7 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-duplexify@^3.4.2, duplexify@^3.6.0:
+duplexify@^3.4.2, duplexify@^3.4.5, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
   integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
@@ -4984,6 +5041,32 @@ es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
+es-abstract@^1.18.5:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -5010,6 +5093,11 @@ es6-iterator@2.0.3, es6-iterator@~2.0.3:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
+
+es6-object-assign@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
@@ -5043,6 +5131,18 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escodegen@^1.11.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
 
 escodegen@^2.0.0:
   version "2.0.0"
@@ -5288,7 +5388,7 @@ esrecurse@^4.1.0, esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -5336,7 +5436,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0:
+events@^3.0.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -5543,6 +5643,16 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+falafel@^2.1.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/falafel/-/falafel-2.2.4.tgz#b5d86c060c2412a43166243cb1bce44d1abd2819"
+  integrity sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==
+  dependencies:
+    acorn "^7.1.1"
+    foreach "^2.0.5"
+    isarray "^2.0.1"
+    object-keys "^1.0.6"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -5782,6 +5892,11 @@ for-own@^0.1.3:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -5835,7 +5950,7 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-from2@^2.1.0:
+from2@^2.1.0, from2@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
   integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
@@ -5991,6 +6106,14 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -6111,6 +6234,142 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+glsl-inject-defines@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz#dd1aacc2c17fcb2bd3fc32411c6633d0d7b60fd4"
+  integrity sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=
+  dependencies:
+    glsl-token-inject-block "^1.0.0"
+    glsl-token-string "^1.0.1"
+    glsl-tokenizer "^2.0.2"
+
+glsl-resolve@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/glsl-resolve/-/glsl-resolve-0.0.1.tgz#894bef73910d792c81b5143180035d0a78af76d3"
+  integrity sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=
+  dependencies:
+    resolve "^0.6.1"
+    xtend "^2.1.2"
+
+glsl-token-assignments@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz#a5d82ab78499c2e8a6b83cb69495e6e665ce019f"
+  integrity sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8=
+
+glsl-token-defines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz#cb892aa959936231728470d4f74032489697fa9d"
+  integrity sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=
+  dependencies:
+    glsl-tokenizer "^2.0.0"
+
+glsl-token-depth@^1.1.0, glsl-token-depth@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz#23c5e30ee2bd255884b4a28bc850b8f791e95d84"
+  integrity sha1-I8XjDuK9JViEtKKLyFC495HpXYQ=
+
+glsl-token-descope@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz#0fc90ab326186b82f597b2e77dc9e21efcd32076"
+  integrity sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=
+  dependencies:
+    glsl-token-assignments "^2.0.0"
+    glsl-token-depth "^1.1.0"
+    glsl-token-properties "^1.0.0"
+    glsl-token-scope "^1.1.0"
+
+glsl-token-inject-block@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz#e1015f5980c1091824adaa2625f1dfde8bd00034"
+  integrity sha1-4QFfWYDBCRgkraomJfHf3ovQADQ=
+
+glsl-token-properties@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz#483dc3d839f0d4b5c6171d1591f249be53c28a9e"
+  integrity sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4=
+
+glsl-token-scope@^1.1.0, glsl-token-scope@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz#a1728e78df24444f9cb93fd18ef0f75503a643b1"
+  integrity sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E=
+
+glsl-token-string@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/glsl-token-string/-/glsl-token-string-1.0.1.tgz#59441d2f857de7c3449c945666021ece358e48ec"
+  integrity sha1-WUQdL4V958NEnJRWZgIezjWOSOw=
+
+glsl-token-whitespace-trim@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz#46d1dfe98c75bd7d504c05d7d11b1b3e9cc93b10"
+  integrity sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA=
+
+glsl-tokenizer@^2.0.0, glsl-tokenizer@^2.0.2:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz#1c2e78c16589933c274ba278d0a63b370c5fee1a"
+  integrity sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==
+  dependencies:
+    through2 "^0.6.3"
+
+glslify-bundle@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glslify-bundle/-/glslify-bundle-5.1.1.tgz#30d2ddf2e6b935bf44d1299321e3b729782c409a"
+  integrity sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==
+  dependencies:
+    glsl-inject-defines "^1.0.1"
+    glsl-token-defines "^1.0.0"
+    glsl-token-depth "^1.1.1"
+    glsl-token-descope "^1.0.2"
+    glsl-token-scope "^1.1.1"
+    glsl-token-string "^1.0.1"
+    glsl-token-whitespace-trim "^1.0.0"
+    glsl-tokenizer "^2.0.2"
+    murmurhash-js "^1.0.0"
+    shallow-copy "0.0.1"
+
+glslify-deps@^1.2.5:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/glslify-deps/-/glslify-deps-1.3.2.tgz#c09ee945352bfc07ac2d8a1cc9e3de776328c72b"
+  integrity sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==
+  dependencies:
+    "@choojs/findup" "^0.2.0"
+    events "^3.2.0"
+    glsl-resolve "0.0.1"
+    glsl-tokenizer "^2.0.0"
+    graceful-fs "^4.1.2"
+    inherits "^2.0.1"
+    map-limit "0.0.1"
+    resolve "^1.0.0"
+
+glslify-import@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glslify-import/-/glslify-import-3.1.0.tgz#3dc745a667bb80e14aaba2f4c9294463f96ab18c"
+  integrity sha512-3n7gI7mDcpkpGMFrbCEFhbyUU70sNrih5OrU6oN6EcgTsTVjrbHpQVjjG78Ta2kzZGEqQX0OD2BgFgglm2DZPg==
+  dependencies:
+    glsl-resolve "0.0.1"
+    glsl-token-string "^1.0.1"
+    glsl-tokenizer "^2.0.2"
+
+glslify@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glslify/-/glslify-7.1.1.tgz#454d9172b410cb49864029c86d5613947fefd30b"
+  integrity sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==
+  dependencies:
+    bl "^2.2.1"
+    concat-stream "^1.5.2"
+    duplexify "^3.4.5"
+    falafel "^2.1.0"
+    from2 "^2.3.0"
+    glsl-resolve "0.0.1"
+    glsl-token-whitespace-trim "^1.0.0"
+    glslify-bundle "^5.0.0"
+    glslify-deps "^1.2.5"
+    minimist "^1.2.5"
+    resolve "^1.1.5"
+    stack-trace "0.0.9"
+    static-eval "^2.0.5"
+    through2 "^2.0.1"
+    xtend "^4.0.0"
+
 glur@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/glur/-/glur-1.1.2.tgz#f20ea36db103bfc292343921f1f91e83c3467689"
@@ -6183,6 +6442,13 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -6743,6 +7009,11 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
+is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -6766,6 +7037,13 @@ is-core-module@^2.0.0, is-core-module@^2.2.0, is-core-module@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
   integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
 
@@ -6848,6 +7126,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -6866,6 +7151,14 @@ is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
   integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
+is-nan@^1.2.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -6948,6 +7241,14 @@ is-regex@^1.0.4, is-regex@^1.1.3:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -6962,6 +7263,11 @@ is-root@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
+
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -6978,6 +7284,13 @@ is-string@^1.0.5, is-string@^1.0.6:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
   integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
 
+is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
@@ -6985,10 +7298,28 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
+is-typed-array@^1.1.3, is-typed-array@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.8.tgz#cbaa6585dc7db43318bc5b89523ea384a6f65e79"
+  integrity sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.5"
+    foreach "^2.0.5"
+    has-tostringtag "^1.0.0"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-weakref@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-windows@^0.2.0:
   version "0.2.0"
@@ -7021,6 +7352,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isarray@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -7963,6 +8299,11 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
+loglevel@^1.7.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
+  integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
+
 loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -8034,6 +8375,13 @@ map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
+
+map-limit@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/map-limit/-/map-limit-0.0.1.tgz#eb7961031c0f0e8d001bf2d56fab685d58822f38"
+  integrity sha1-63lhAxwPDo0AG/LVb6toXViCLzg=
+  dependencies:
+    once "~1.3.0"
 
 map-stream@~0.1.0:
   version "0.1.0"
@@ -8296,6 +8644,11 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
+mixpanel-browser@^2.39.0:
+  version "2.43.0"
+  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.43.0.tgz#a4d4f97f5a7ca85411697ef70fa833177e67eb95"
+  integrity sha512-6zOjFXaRRWYo7YdcBwa9Z6nk9zRkkxPd9Qa/KNRcjSJ0OkMv7ka/p8rR+6VqMeY93pia/7X31c/HU5YhqAXnEQ==
+
 mkdirp-classic@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
@@ -8357,6 +8710,11 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+murmurhash-js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
+  integrity sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=
 
 nan@^2.12.1:
   version "2.15.0"
@@ -8603,7 +8961,7 @@ object-is@^1.0.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.0.6, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -8701,6 +9059,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+once@~1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
+  integrity sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=
   dependencies:
     wrappy "1"
 
@@ -8982,7 +9347,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -10315,7 +10680,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -10327,6 +10692,16 @@ read-pkg@^5.2.0:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+"readable-stream@>=1.0.33-1 <1.1.0-0":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
@@ -10594,6 +10969,20 @@ resolve@1.18.1:
   dependencies:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
+
+resolve@^0.6.1:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
+  integrity sha1-3ZV5gufnNt699TtYpN2RdUV13UY=
+
+resolve@^1.0.0, resolve@^1.1.5:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.21.0.tgz#b51adc97f3472e6a5cf4444d34bc9d6b9037591f"
+  integrity sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==
+  dependencies:
+    is-core-module "^2.8.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.20.0"
@@ -10980,6 +11369,11 @@ shallow-clone@^0.1.2:
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
 
+shallow-copy@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+  integrity sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=
+
 shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
@@ -11044,6 +11438,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+skmeans@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/skmeans/-/skmeans-0.11.3.tgz#6d4dafb8058520a792c10bae9d9b953a6b6379f4"
+  integrity sha512-nccEnlSeOMNAYM9ETMSq+m15u8g0KRCIvH2an/ROTx4Igmci/j3oYHBPGdAeGjhR7knAVoIIQwr/wy2dN/eKQA==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -11296,6 +11695,11 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stack-trace@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
+  integrity sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=
+
 stack-utils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
@@ -11320,6 +11724,13 @@ start-server-and-test@^1.12.3:
     lazy-ass "1.6.0"
     ps-tree "1.2.0"
     wait-on "6.0.0"
+
+static-eval@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.1.0.tgz#a16dbe54522d7fa5ef1389129d813fd47b148014"
+  integrity sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==
+  dependencies:
+    escodegen "^1.11.1"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -11445,6 +11856,11 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -11589,6 +12005,11 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 svg-parser@^2.0.2:
   version "2.0.4"
@@ -11758,12 +12179,25 @@ three@0.133.0:
   resolved "https://registry.yarnpkg.com/three/-/three-0.133.0.tgz#41427306c731a89407221b7be48c7a63580400e7"
   integrity sha512-1p8xTXnJD4hMM2Ktm7+FqOOBoImBoftKnKtAZT/b9AQeL3LhRkVu/HnIJhWA69qIMvUYpjfnunNsO4WdObw1ZQ==
 
+three@0.135.0:
+  version "0.135.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.135.0.tgz#cff4ec8edd3c51ce9bc7e88d13e8eafed4d0ddfc"
+  integrity sha512-kuEpuuxRzLv0MDsXai9huCxOSQPZ4vje6y0gn80SRmQvgz6/+rI0NAvCRAw56zYaWKMGMfqKWsxF9Qa2Z9xymQ==
+
 throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-through2@^2.0.0:
+through2@^0.6.3:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
+  integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
+
+through2@^2.0.0, through2@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -12241,6 +12675,18 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.0:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
+  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    safe-buffer "^5.1.2"
+    which-typed-array "^1.1.2"
+
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -12560,6 +13006,18 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
+which-typed-array@^1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.7.tgz#2761799b9a22d4b8660b3c1b40abaa7739691793"
+  integrity sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.5"
+    foreach "^2.0.5"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.7"
+
 which@^1.2.12, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -12806,10 +13264,15 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xtend@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.2.0.tgz#eef6b1f198c1c8deafad8b1765a04dad4a01c5a9"
+  integrity sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=
 
 y18n@^4.0.0:
   version "4.0.3"

--- a/viewer/core/src/public/RevealManager.test.ts
+++ b/viewer/core/src/public/RevealManager.test.ts
@@ -5,11 +5,12 @@ import * as THREE from 'three';
 
 import { createRevealManager } from './createRevealManager';
 import { RevealManager } from './RevealManager';
-import { LoadingStateChangeListener } from '..';
 import { createGlContext } from '../../../test-utilities';
 
 import { ModelDataProvider, ModelMetadataProvider } from '@reveal/modeldata-api';
 import { SectorCuller } from '@reveal/cad-geometry-loaders';
+import { LoadingStateChangedEvent } from '@reveal/cad-styling';
+import { EventListener } from '@reveal/utilities';
 
 describe('RevealManager', () => {
   const stubMetadataProvider: ModelMetadataProvider = {} as any;
@@ -84,7 +85,7 @@ describe('RevealManager', () => {
 
   test('loadingStateChanged is not triggered if loading state doesnt change', () => {
     const camera = new THREE.PerspectiveCamera(60, 1, 0.5, 100);
-    const loadingStateChangedCb: LoadingStateChangeListener = jest.fn();
+    const loadingStateChangedCb: EventListener<LoadingStateChangedEvent> = jest.fn();
     manager.on('loadingStateChanged', loadingStateChangedCb);
 
     manager.update(camera);

--- a/viewer/core/src/public/RevealManager.test.ts
+++ b/viewer/core/src/public/RevealManager.test.ts
@@ -10,7 +10,6 @@ import { createGlContext } from '../../../test-utilities';
 import { ModelDataProvider, ModelMetadataProvider } from '@reveal/modeldata-api';
 import { SectorCuller } from '@reveal/cad-geometry-loaders';
 import { LoadingStateChangedEvent } from '@reveal/cad-styling';
-import { EventListener } from '@reveal/utilities';
 
 describe('RevealManager', () => {
   const stubMetadataProvider: ModelMetadataProvider = {} as any;
@@ -85,7 +84,7 @@ describe('RevealManager', () => {
 
   test('loadingStateChanged is not triggered if loading state doesnt change', () => {
     const camera = new THREE.PerspectiveCamera(60, 1, 0.5, 100);
-    const loadingStateChangedCb: EventListener<LoadingStateChangedEvent> = jest.fn();
+    const loadingStateChangedCb: (event: LoadingStateChangedEvent) => void = jest.fn();
     manager.on('loadingStateChanged', loadingStateChangedCb);
 
     manager.update(camera);

--- a/viewer/core/src/public/RevealManager.ts
+++ b/viewer/core/src/public/RevealManager.ts
@@ -19,7 +19,7 @@ import { CadModelSectorBudget, LoadingState } from '@reveal/cad-geometry-loaders
 import { LoadingStateChangedEvent, NodeAppearanceProvider } from '@reveal/cad-styling';
 import { RenderOptions, EffectRenderManager, CadNode, defaultRenderOptions, RenderMode } from '@reveal/rendering';
 import { MetricsLogger } from '@reveal/metrics';
-import { assertNever, EventTrigger, EventListener } from '@reveal/utilities';
+import { assertNever, EventTrigger } from '@reveal/utilities';
 
 import { ModelIdentifier } from '@reveal/modeldata-api';
 
@@ -157,7 +157,7 @@ export class RevealManager {
     return this._cadManager.clippingPlanes;
   }
 
-  public on(event: 'loadingStateChanged', listener: EventListener<LoadingStateChangedEvent>): void {
+  public on(event: 'loadingStateChanged', listener: (event: LoadingStateChangedEvent) => void): void {
     switch (event) {
       case 'loadingStateChanged':
         this._events.loadingStateChanged.subscribe(listener);
@@ -168,7 +168,7 @@ export class RevealManager {
     }
   }
 
-  public off(event: 'loadingStateChanged', listener: EventListener<LoadingStateChangedEvent>): void {
+  public off(event: 'loadingStateChanged', listener: (event: LoadingStateChangedEvent) => void): void {
     switch (event) {
       case 'loadingStateChanged':
         this._events.loadingStateChanged.unsubscribe(listener);

--- a/viewer/core/src/public/RevealManager.ts
+++ b/viewer/core/src/public/RevealManager.ts
@@ -9,17 +9,17 @@ import { map, observeOn, subscribeOn, tap, auditTime, distinctUntilChanged } fro
 
 import { CadManager } from '../datamodels/cad/CadManager';
 import { PointCloudManager } from '../datamodels/pointcloud/PointCloudManager';
-import { LoadingStateChangeListener, PointCloudBudget } from './types';
+import { PointCloudBudget } from './types';
 import { SupportedModelTypes } from '../datamodels/base';
 import { PointCloudNode } from '../datamodels/pointcloud/PointCloudNode';
 import { CadModelSectorLoadStatistics } from '../datamodels/cad/CadModelSectorLoadStatistics';
 import { GeometryFilter } from '..';
 
 import { CadModelSectorBudget, LoadingState } from '@reveal/cad-geometry-loaders';
-import { NodeAppearanceProvider } from '@reveal/cad-styling';
+import { LoadingStateChangedEvent, NodeAppearanceProvider } from '@reveal/cad-styling';
 import { RenderOptions, EffectRenderManager, CadNode, defaultRenderOptions, RenderMode } from '@reveal/rendering';
 import { MetricsLogger } from '@reveal/metrics';
-import { assertNever, EventTrigger } from '@reveal/utilities';
+import { assertNever, EventTrigger, EventListener } from '@reveal/utilities';
 
 import { ModelIdentifier } from '@reveal/modeldata-api';
 
@@ -44,7 +44,7 @@ export class RevealManager {
   private _isDisposed = false;
   private readonly _subscriptions = new Subscription();
   private readonly _events = {
-    loadingStateChanged: new EventTrigger<LoadingStateChangeListener>()
+    loadingStateChanged: new EventTrigger<LoadingStateChangedEvent>()
   };
 
   private readonly _updateSubject: Subject<void>;
@@ -157,10 +157,10 @@ export class RevealManager {
     return this._cadManager.clippingPlanes;
   }
 
-  public on(event: 'loadingStateChanged', listener: LoadingStateChangeListener): void {
+  public on(event: 'loadingStateChanged', listener: EventListener<LoadingStateChangedEvent>): void {
     switch (event) {
       case 'loadingStateChanged':
-        this._events.loadingStateChanged.subscribe(listener as LoadingStateChangeListener);
+        this._events.loadingStateChanged.subscribe(listener);
         break;
 
       default:
@@ -168,10 +168,10 @@ export class RevealManager {
     }
   }
 
-  public off(event: 'loadingStateChanged', listener: LoadingStateChangeListener): void {
+  public off(event: 'loadingStateChanged', listener: EventListener<LoadingStateChangedEvent>): void {
     switch (event) {
       case 'loadingStateChanged':
-        this._events.loadingStateChanged.unsubscribe(listener as LoadingStateChangeListener);
+        this._events.loadingStateChanged.unsubscribe(listener);
         break;
 
       default:

--- a/viewer/core/src/public/migration/Cognite3DViewer.test.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.test.ts
@@ -5,13 +5,15 @@
 import * as THREE from 'three';
 import TWEEN from '@tweenjs/tween.js';
 import { CogniteClient } from '@cognite/sdk';
+
 import { SectorCuller } from '@reveal/cad-geometry-loaders';
+import { EventListener, EmptyEvent } from '@reveal/utilities';
 
 import { Cognite3DViewer } from './Cognite3DViewer';
+import { createGlContext, mockClientAuthentication } from '../../../../test-utilities';
 
 import nock from 'nock';
-import { DisposedDelegate, SceneRenderedDelegate } from '../types';
-import { createGlContext, mockClientAuthentication } from '../../../../test-utilities';
+import { SceneRenderedEvent } from '../types';
 
 const sceneJson = require('./Cognite3DViewer.test-scene.json');
 
@@ -70,7 +72,7 @@ describe('Cognite3DViewer', () => {
   });
 
   test('dispose raises disposed-event', () => {
-    const disposedListener: DisposedDelegate = jest.fn();
+    const disposedListener: EventListener<EmptyEvent> = jest.fn();
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
     viewer.on('disposed', disposedListener);
 
@@ -80,7 +82,7 @@ describe('Cognite3DViewer', () => {
   });
   test('on cameraChange triggers when position and target is changed', () => {
     // Arrange
-    const onCameraChange: (position: THREE.Vector3, target: THREE.Vector3) => void = jest.fn();
+    const onCameraChange: (event: { position: THREE.Vector3; target: THREE.Vector3 }) => void = jest.fn();
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
     viewer.on('cameraChange', onCameraChange);
 
@@ -113,7 +115,7 @@ describe('Cognite3DViewer', () => {
       .get(/.*\/scene.json/)
       .reply(200, sceneJson);
 
-    const onCameraChange: (position: THREE.Vector3, target: THREE.Vector3) => void = jest.fn();
+    const onCameraChange: (event: { position: THREE.Vector3; target: THREE.Vector3 }) => void = jest.fn();
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
     viewer.on('cameraChange', onCameraChange);
 
@@ -184,7 +186,7 @@ describe('Cognite3DViewer', () => {
       });
     let requestAnimationFrameCallback: FrameRequestCallback | undefined;
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
-    const onRendered: SceneRenderedDelegate = jest.fn();
+    const onRendered: EventListener<SceneRenderedEvent> = jest.fn();
     if (!requestAnimationFrameCallback) throw new Error('Animation frame not triggered');
 
     try {

--- a/viewer/core/src/public/migration/Cognite3DViewer.test.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.test.ts
@@ -7,7 +7,6 @@ import TWEEN from '@tweenjs/tween.js';
 import { CogniteClient } from '@cognite/sdk';
 
 import { SectorCuller } from '@reveal/cad-geometry-loaders';
-import { EventListener, EmptyEvent } from '@reveal/utilities';
 
 import { Cognite3DViewer } from './Cognite3DViewer';
 import { createGlContext, mockClientAuthentication } from '../../../../test-utilities';
@@ -72,7 +71,7 @@ describe('Cognite3DViewer', () => {
   });
 
   test('dispose raises disposed-event', () => {
-    const disposedListener: EventListener<EmptyEvent> = jest.fn();
+    const disposedListener: () => void = jest.fn();
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
     viewer.on('disposed', disposedListener);
 
@@ -186,7 +185,7 @@ describe('Cognite3DViewer', () => {
       });
     let requestAnimationFrameCallback: FrameRequestCallback | undefined;
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
-    const onRendered: EventListener<SceneRenderedEvent> = jest.fn();
+    const onRendered: (event: SceneRenderedEvent) => void = jest.fn();
     if (!requestAnimationFrameCallback) throw new Error('Animation frame not triggered');
 
     try {

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -14,7 +14,6 @@ import { defaultRenderOptions, SsaoParameters, SsaoSampleQuality, AntiAliasingMo
 import {
   assertNever,
   EventTrigger,
-  EventListener,
   InputHandler,
   disposeOfAllEventListeners,
   EmptyEvent,
@@ -359,7 +358,7 @@ export class Cognite3DViewer {
    * Triggered when the viewer is disposed. Listeners should clean up any
    * resources held and remove the reference to the viewer.
    */
-  on(event: 'disposed', listener: EventListener<EmptyEvent>): void;
+  on(event: 'disposed', listener: () => void): void;
 
   /**
    * @example
@@ -368,7 +367,7 @@ export class Cognite3DViewer {
    * viewer.on('click', onClick);
    * ```
    */
-  on(event: 'click' | 'hover', listener: EventListener<PointerEvent>): void;
+  on(event: 'click' | 'hover', listener: (event: PointerEvent) => void): void;
   /**
    * @example
    * ```js
@@ -377,13 +376,13 @@ export class Cognite3DViewer {
    * });
    * ```
    */
-  on(event: 'cameraChange', listener: EventListener<CameraChangedEvent>): void;
+  on(event: 'cameraChange', listener: (event: CameraChangedEvent) => void): void;
   /**
    * Event that is triggered immediately after the scene has been rendered.
    * @param event Metadata about the rendering frame.
    * @param callback Callback to trigger when the event occurs.
    */
-  on(event: 'sceneRendered', listener: EventListener<SceneRenderedEvent>): void;
+  on(event: 'sceneRendered', listener: (event: SceneRenderedEvent) => void): void;
   /**
    * Add event listener to the viewer.
    * Call {@link Cognite3DViewer.off} to remove an event listener.
@@ -393,30 +392,30 @@ export class Cognite3DViewer {
   on(
     event: Cognite3DViewerEvents,
     listener:
-      | EventListener<PointerEvent>
-      | EventListener<CameraChangedEvent>
-      | EventListener<SceneRenderedEvent>
-      | EventListener<EmptyEvent>
+      | ((event: PointerEvent) => void)
+      | ((event: CameraChangedEvent) => void)
+      | ((event: SceneRenderedEvent) => void)
+      | ((event: EmptyEvent) => void)
   ): void {
     switch (event) {
       case 'click':
-        this._events.click.subscribe(listener as EventListener<PointerEvent>);
+        this._events.click.subscribe(listener as (event: PointerEvent) => void);
         break;
 
       case 'hover':
-        this._events.hover.subscribe(listener as EventListener<PointerEvent>);
+        this._events.hover.subscribe(listener as (event: PointerEvent) => void);
         break;
 
       case 'cameraChange':
-        this._events.cameraChange.subscribe(listener as EventListener<CameraChangedEvent>);
+        this._events.cameraChange.subscribe(listener as (event: CameraChangedEvent) => void);
         break;
 
       case 'sceneRendered':
-        this._events.sceneRendered.subscribe(listener as EventListener<SceneRenderedEvent>);
+        this._events.sceneRendered.subscribe(listener as (event: SceneRenderedEvent) => void);
         break;
 
       case 'disposed':
-        this._events.disposed.subscribe(listener as EventListener<EmptyEvent>);
+        this._events.disposed.subscribe(listener as (event: EmptyEvent) => void);
         break;
 
       default:
@@ -430,37 +429,44 @@ export class Cognite3DViewer {
    * viewer.off('click', onClick);
    * ```
    */
-  off(event: 'click' | 'hover', listener: EventListener<PointerEvent>): void;
-  off(event: 'cameraChange', listener: EventListener<CameraChangedEvent>): void;
-  off(event: 'sceneRendered', listener: EventListener<SceneRenderedEvent>): void;
-  off(event: 'disposed', listener: EventListener<EmptyEvent>): void;
+  off(event: 'click' | 'hover', listener: (event: PointerEvent) => void): void;
+  off(event: 'cameraChange', listener: (event: CameraChangedEvent) => void): void;
+  off(event: 'sceneRendered', listener: (event: SceneRenderedEvent) => void): void;
+  off(event: 'disposed', listener: () => void): void;
 
   /**
    * Remove event listener from the viewer.
    * Call {@link Cognite3DViewer.on} to add event listener.
    * @param event
-   * @param callback
+   * @param listener
    */
-  off(event: Cognite3DViewerEvents, callback: any): void {
+  off(
+    event: Cognite3DViewerEvents,
+    listener:
+      | ((event: PointerEvent) => void)
+      | ((event: CameraChangedEvent) => void)
+      | ((event: SceneRenderedEvent) => void)
+      | ((event: EmptyEvent) => void)
+  ): void {
     switch (event) {
       case 'click':
-        this._events.click.unsubscribe(callback);
+        this._events.click.unsubscribe(listener as (event: PointerEvent) => void);
         break;
 
       case 'hover':
-        this._events.hover.unsubscribe(callback);
+        this._events.hover.unsubscribe(listener as (event: PointerEvent) => void);
         break;
 
       case 'cameraChange':
-        this._events.cameraChange.unsubscribe(callback);
+        this._events.cameraChange.unsubscribe(listener as (event: CameraChangedEvent) => void);
         break;
 
       case 'sceneRendered':
-        this._events.sceneRendered.unsubscribe(callback);
+        this._events.sceneRendered.unsubscribe(listener as (event: SceneRenderedEvent) => void);
         break;
 
       case 'disposed':
-        this._events.disposed.unsubscribe(callback);
+        this._events.disposed.unsubscribe(listener as (event: EmptyEvent) => void);
         break;
 
       default:

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -113,6 +113,7 @@ export class Cognite3DViewer {
     sceneRendered: new EventTrigger<SceneRenderedDelegate>(),
     disposed: new EventTrigger<DisposedDelegate>()
   };
+  private readonly _mouseHandler: InputHandler;
 
   private readonly _models: CogniteModelBase[] = [];
   private readonly _extraObjects: THREE.Object3D[] = [];
@@ -255,7 +256,8 @@ export class Cognite3DViewer {
       );
     }
     this.renderController = new RenderController(this.camera);
-
+    
+    this._mouseHandler = new InputHandler(this.domElement);
     this.startPointerEventListeners();
 
     this.revealManager.setRenderTarget(
@@ -350,6 +352,7 @@ export class Cognite3DViewer {
 
     this._events.disposed.fire();
     this.disposeOfAllEventListeners();
+    this._mouseHandler.dispose();
   }
 
   /**
@@ -1333,13 +1336,11 @@ export class Cognite3DViewer {
   }
 
   private readonly startPointerEventListeners = () => {
-    const mouseHandler = new InputHandler(this.domElement);
-
-    mouseHandler.on('click', e => {
+    this._mouseHandler.on('click', e => {
       this._events.click.fire(e);
     });
 
-    mouseHandler.on('hover', e => {
+    this._mouseHandler.on('hover', e => {
       this._events.hover.fire(e);
     });
   };

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -11,7 +11,7 @@ import { LoadingState } from '@reveal/cad-geometry-loaders';
 
 import { defaultRenderOptions, SsaoParameters, SsaoSampleQuality, AntiAliasingMode } from '@reveal/rendering';
 
-import { assertNever, EventTrigger, InputHandler } from '@reveal/utilities';
+import { assertNever, EventTrigger, InputHandler, disposeOfAllEventListeners } from '@reveal/utilities';
 import { MetricsLogger } from '@reveal/metrics';
 
 import { worldToNormalizedViewportCoordinates, worldToViewportCoordinates } from '../../utilities/worldToViewport';
@@ -351,7 +351,7 @@ export class Cognite3DViewer {
     this.spinner.dispose();
 
     this._events.disposed.fire();
-    this.disposeOfAllEventListeners();
+    disposeOfAllEventListeners(this._events);
     this._mouseHandler.dispose();
   }
 
@@ -1323,16 +1323,6 @@ export class Cognite3DViewer {
     adjustCamera(this.camera, width, height);
 
     return true;
-  }
-
-  /**
-   * Method for deleting all external events that are associated with current instance of Cognite3DViewer.
-   */
-  private disposeOfAllEventListeners() {
-    const cognite3DViewerEvents = ['click', 'hover', 'cameraChange', 'sceneRendered', 'disposed'];
-    for (const event of cognite3DViewerEvents) {
-      this._events[event as Cognite3DViewerEvents].unsubscribeAll();
-    }
   }
 
   private readonly startPointerEventListeners = () => {

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -349,6 +349,7 @@ export class Cognite3DViewer {
     this.spinner.dispose();
 
     this._events.disposed.fire();
+    this.disposeOfAllEventListeners();
   }
 
   /**
@@ -1319,6 +1320,16 @@ export class Cognite3DViewer {
     adjustCamera(this.camera, width, height);
 
     return true;
+  }
+
+  /**
+   * Method for deleting all external events that are associated with current instance of Cognite3DViewer.
+   */
+  private disposeOfAllEventListeners() {
+    const cognite3DViewerEvents = ['click', 'hover', 'cameraChange', 'sceneRendered', 'disposed'];
+    for (const event of cognite3DViewerEvents) {
+      this._events[event as Cognite3DViewerEvents].unsubscribeAll();
+    }
   }
 
   private readonly startPointerEventListeners = () => {

--- a/viewer/core/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/core/src/public/migration/Cognite3DViewer.ts
@@ -256,7 +256,7 @@ export class Cognite3DViewer {
       );
     }
     this.renderController = new RenderController(this.camera);
-    
+
     this._mouseHandler = new InputHandler(this.domElement);
     this.startPointerEventListeners();
 

--- a/viewer/core/src/public/migration/types.ts
+++ b/viewer/core/src/public/migration/types.ts
@@ -277,31 +277,31 @@ export { CameraConfiguration } from '@reveal/utilities';
  * @module @cognite/reveal
  * @see {@link Cognite3DViewer.on}.
  */
-export type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
+export type PointerEvent = { offsetX: number; offsetY: number };
 
 /**
  * Delegate for camera update events.
  * @module @cognite/reveal
  * @see {@link Cognite3DViewer.on}.
  */
-export type CameraChangeDelegate = (position: THREE.Vector3, target: THREE.Vector3) => void;
+export type CameraChangedEvent = { position: THREE.Vector3; target: THREE.Vector3 };
 
 /**
  * Delegate for disposal events.
  */
-export type DisposedDelegate = () => void;
+export type DisposedEvent = never;
 
 /**
  * Delegate for rendering events.
  * @module @cognite/reveal
  * @see {@link Cognite3DViewer.on}.
  */
-export type SceneRenderedDelegate = (event: {
+export type SceneRenderedEvent = {
   frameNumber: number;
   renderTime: number;
   renderer: THREE.WebGLRenderer;
   camera: THREE.PerspectiveCamera;
-}) => void;
+};
 
 export * from './NotSupportedInMigrationWrapperError';
 export { CogniteModelBase } from './CogniteModelBase';

--- a/viewer/core/src/public/types.ts
+++ b/viewer/core/src/public/types.ts
@@ -5,6 +5,7 @@
 import { LoadingState, SectorCuller } from '@reveal/cad-geometry-loaders';
 import { SectorQuads, RenderOptions } from '@reveal/rendering';
 import { SectorGeometry } from '@reveal/cad-parsers';
+export { EventListener, PointerEvent } from '@reveal/utilities';
 
 /**
  * @property logMetrics Might be used to disable usage statistics.

--- a/viewer/core/src/public/types.ts
+++ b/viewer/core/src/public/types.ts
@@ -5,7 +5,7 @@
 import { LoadingState, SectorCuller } from '@reveal/cad-geometry-loaders';
 import { SectorQuads, RenderOptions } from '@reveal/rendering';
 import { SectorGeometry } from '@reveal/cad-parsers';
-export { EventListener, PointerEvent } from '@reveal/utilities';
+export { PointerEvent } from '@reveal/utilities';
 
 /**
  * @property logMetrics Might be used to disable usage statistics.

--- a/viewer/core/src/public/types.ts
+++ b/viewer/core/src/public/types.ts
@@ -42,7 +42,7 @@ export interface GeometryFilter {
 /**
  * Handler for events about data being loaded.
  */
-export type LoadingStateChangeListener = (loadingState: LoadingState) => any;
+export type LoadingStateEvent = { loadingState: LoadingState };
 
 export * from '../datamodels/pointcloud/types';
 export * from './migration/types';

--- a/viewer/internals.ts
+++ b/viewer/internals.ts
@@ -14,5 +14,5 @@ export {
 } from './packages/cad-geometry-loaders';
 
 export { CadNode, SuggestedCameraConfig, RenderOptions, defaultRenderOptions } from './packages/rendering';
-export { NodeAppearanceProvider } from './packages/cad-styling';
+export { NodeAppearanceProvider, LoadingStateChangedEvent } from './packages/cad-styling';
 export { revealEnv } from './packages/utilities';

--- a/viewer/packages/cad-styling/index.ts
+++ b/viewer/packages/cad-styling/index.ts
@@ -8,3 +8,4 @@ export { TreeIndexNodeCollection } from './src/TreeIndexNodeCollection';
 export { UnionNodeCollection } from './src/UnionNodeCollection';
 export { NodeAppearance, DefaultNodeAppearance, NodeOutlineColor } from './src/NodeAppearance';
 export { NodeAppearanceProvider } from './src/NodeAppearanceProvider';
+export { LoadingStateChangedEvent } from './src/types';

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
@@ -116,12 +116,12 @@ describe('NodeAppearanceProvider', () => {
     nodeCollection.isLoading = true;
     nodeCollection.triggerChanged();
     jest.runAllTimers();
-    expect(isLoadingChangedListener).toBeCalledWith(true);
+    expect(isLoadingChangedListener).toBeCalledWith({ isLoading: true });
     isLoadingChangedListener.mockReset();
 
     nodeCollection.isLoading = false;
     nodeCollection.triggerChanged();
     jest.runAllTimers();
-    expect(isLoadingChangedListener).toBeCalledWith(false);
+    expect(isLoadingChangedListener).toBeCalledWith({ isLoading: false });
   });
 });

--- a/viewer/packages/cad-styling/src/NodeCollectionBase.ts
+++ b/viewer/packages/cad-styling/src/NodeCollectionBase.ts
@@ -3,7 +3,7 @@
  */
 
 import assert from 'assert';
-import { EventTrigger, IndexSet } from '@reveal/utilities';
+import { EmptyEvent, EventTrigger, IndexSet } from '@reveal/utilities';
 
 export type SerializedNodeCollection = {
   token: string;
@@ -15,7 +15,7 @@ export type SerializedNodeCollection = {
  * Abstract class for implementing a set of nodes to be styled.
  */
 export abstract class NodeCollectionBase {
-  private readonly _changedEvent = new EventTrigger<() => void>();
+  private readonly _changedEvent = new EventTrigger<EmptyEvent>();
   private readonly _classToken: string;
 
   protected constructor(classToken: string) {
@@ -64,7 +64,7 @@ export abstract class NodeCollectionBase {
    * Triggers the changed-event.
    */
   protected notifyChanged(): void {
-    this._changedEvent.fire();
+    this._changedEvent.fire(null);
   }
 
   abstract serialize(): SerializedNodeCollection;

--- a/viewer/packages/cad-styling/src/types.ts
+++ b/viewer/packages/cad-styling/src/types.ts
@@ -1,0 +1,4 @@
+/*!
+ * Copyright 2022 Cognite AS
+ */
+export type LoadingStateChangedEvent = { isLoading: boolean };

--- a/viewer/packages/camera-manager/src/CameraManager.ts
+++ b/viewer/packages/camera-manager/src/CameraManager.ts
@@ -565,7 +565,7 @@ export class CameraManager {
     return { x, y };
   }
 
-   private disposeOfAllEventListeners() {
+  private disposeOfAllEventListeners() {
     const cameraManagerEvents = ['cameraChange'];
     for (const event of cameraManagerEvents) {
       this._events[event as CameraManagerEvents].unsubscribeAll();

--- a/viewer/packages/camera-manager/src/CameraManager.ts
+++ b/viewer/packages/camera-manager/src/CameraManager.ts
@@ -5,18 +5,19 @@
 import * as THREE from 'three';
 import TWEEN from '@tweenjs/tween.js';
 import { ComboControls } from './ComboControls';
+import { CameraChangedEvent, CameraManagerCallbackData, CameraControlsOptions, ControlsState } from './types';
 import {
-  CameraManagerCallbackData,
-  CameraControlsOptions,
-  CameraChangeData,
-  PointerEventDelegate,
-  ControlsState
-} from './types';
-import { assertNever, EventTrigger, InputHandler, disposeOfAllEventListeners } from '@reveal/utilities';
+  assertNever,
+  EventListener,
+  EventTrigger,
+  PointerEvent,
+  InputHandler,
+  disposeOfAllEventListeners
+} from '@reveal/utilities';
 import range from 'lodash/range';
 export class CameraManager {
   private readonly _events = {
-    cameraChange: new EventTrigger<CameraChangeData>()
+    cameraChange: new EventTrigger<CameraChangedEvent>()
   };
 
   private readonly _controls: ComboControls;
@@ -97,20 +98,20 @@ export class CameraManager {
     }
   }
 
-  on(event: 'cameraChange', callback: CameraChangeData): void {
+  on(event: 'cameraChange', listener: EventListener<CameraChangedEvent>): void {
     switch (event) {
       case 'cameraChange':
-        this._events.cameraChange.subscribe(callback as CameraChangeData);
+        this._events.cameraChange.subscribe(listener);
         break;
       default:
         assertNever(event);
     }
   }
 
-  off(event: 'cameraChange', callback: CameraChangeData): void {
+  off(event: 'cameraChange', listener: EventListener<CameraChangedEvent>): void {
     switch (event) {
       case 'cameraChange':
-        this._events.cameraChange.subscribe(callback as CameraChangeData);
+        this._events.cameraChange.subscribe(listener);
         break;
       default:
         assertNever(event);
@@ -480,7 +481,7 @@ export class CameraManager {
    */
   private teardownControls() {
     if (this._onClick !== undefined) {
-      this._inputHandler.off('click', this._onClick as PointerEventDelegate);
+      this._inputHandler.off('click', this._onClick as EventListener<PointerEvent>);
       this._onClick = undefined;
     }
     if (this._onWheel !== undefined) {

--- a/viewer/packages/camera-manager/src/CameraManager.ts
+++ b/viewer/packages/camera-manager/src/CameraManager.ts
@@ -12,10 +12,8 @@ import {
   PointerEventDelegate,
   ControlsState
 } from './types';
-import { assertNever, EventTrigger, InputHandler } from '@reveal/utilities';
+import { assertNever, EventTrigger, InputHandler, disposeOfAllEventListeners } from '@reveal/utilities';
 import range from 'lodash/range';
-
-type CameraManagerEvents = 'cameraChange';
 export class CameraManager {
   private readonly _events = {
     cameraChange: new EventTrigger<CameraChangeData>()
@@ -358,7 +356,7 @@ export class CameraManager {
     this.isDisposed = true;
     this._controls.dispose();
     this.teardownControls();
-    this.disposeOfAllEventListeners();
+    disposeOfAllEventListeners(this._events);
     this._inputHandler.dispose();
   }
 
@@ -563,13 +561,6 @@ export class CameraManager {
     const y = (pixelY / this._domElement.clientHeight) * -2 + 1;
 
     return { x, y };
-  }
-
-  private disposeOfAllEventListeners() {
-    const cameraManagerEvents = ['cameraChange'];
-    for (const event of cameraManagerEvents) {
-      this._events[event as CameraManagerEvents].unsubscribeAll();
-    }
   }
 
   private calculateDefaultDuration(distanceToCamera: number): number {

--- a/viewer/packages/camera-manager/src/CameraManager.ts
+++ b/viewer/packages/camera-manager/src/CameraManager.ts
@@ -6,14 +6,7 @@ import * as THREE from 'three';
 import TWEEN from '@tweenjs/tween.js';
 import { ComboControls } from './ComboControls';
 import { CameraChangedEvent, CameraManagerCallbackData, CameraControlsOptions, ControlsState } from './types';
-import {
-  assertNever,
-  EventListener,
-  EventTrigger,
-  PointerEvent,
-  InputHandler,
-  disposeOfAllEventListeners
-} from '@reveal/utilities';
+import { assertNever, EventTrigger, InputHandler, disposeOfAllEventListeners, PointerEvent } from '@reveal/utilities';
 import range from 'lodash/range';
 export class CameraManager {
   private readonly _events = {
@@ -98,7 +91,7 @@ export class CameraManager {
     }
   }
 
-  on(event: 'cameraChange', listener: EventListener<CameraChangedEvent>): void {
+  on(event: 'cameraChange', listener: (event: CameraChangedEvent) => void): void {
     switch (event) {
       case 'cameraChange':
         this._events.cameraChange.subscribe(listener);
@@ -108,7 +101,7 @@ export class CameraManager {
     }
   }
 
-  off(event: 'cameraChange', listener: EventListener<CameraChangedEvent>): void {
+  off(event: 'cameraChange', listener: (event: CameraChangedEvent) => void): void {
     switch (event) {
       case 'cameraChange':
         this._events.cameraChange.subscribe(listener);
@@ -481,7 +474,7 @@ export class CameraManager {
    */
   private teardownControls() {
     if (this._onClick !== undefined) {
-      this._inputHandler.off('click', this._onClick as EventListener<PointerEvent>);
+      this._inputHandler.off('click', this._onClick as (event: PointerEvent) => void);
       this._onClick = undefined;
     }
     if (this._onWheel !== undefined) {

--- a/viewer/packages/camera-manager/src/CameraManager.ts
+++ b/viewer/packages/camera-manager/src/CameraManager.ts
@@ -15,6 +15,7 @@ import {
 import { assertNever, EventTrigger, InputHandler } from '@reveal/utilities';
 import range from 'lodash/range';
 
+type CameraManagerEvents = 'cameraChange';
 export class CameraManager {
   private readonly _events = {
     cameraChange: new EventTrigger<CameraChangeData>()
@@ -357,6 +358,8 @@ export class CameraManager {
     this.isDisposed = true;
     this._controls.dispose();
     this.teardownControls();
+    this.disposeOfAllEventListeners();
+    this._inputHandler.dispose();
   }
 
   private calculateAnimationStartTarget(newTarget: THREE.Vector3): THREE.Vector3 {
@@ -560,6 +563,13 @@ export class CameraManager {
     const y = (pixelY / this._domElement.clientHeight) * -2 + 1;
 
     return { x, y };
+  }
+
+   private disposeOfAllEventListeners() {
+    const cameraManagerEvents = ['cameraChange'];
+    for (const event of cameraManagerEvents) {
+      this._events[event as CameraManagerEvents].unsubscribeAll();
+    }
   }
 
   private calculateDefaultDuration(distanceToCamera: number): number {

--- a/viewer/packages/camera-manager/src/types.ts
+++ b/viewer/packages/camera-manager/src/types.ts
@@ -80,12 +80,6 @@ export type CameraManagerCallbackData = {
 };
 
 /**
- * Delegate for pointer events.
- * @module @cognite/reveal
- */
-export type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
-
-/**
  * Type defining camera change event data.
  */
-export type CameraChangeData = (event: { camera: { position: THREE.Vector3; target: THREE.Vector3 } }) => void;
+export type CameraChangedEvent = { camera: { position: THREE.Vector3; target: THREE.Vector3 } };

--- a/viewer/packages/rendering/src/CadMaterialManager.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.ts
@@ -11,7 +11,7 @@ import { createMaterials, Materials } from './rendering/materials';
 import { RenderMode } from './rendering/RenderMode';
 
 import { NodeAppearance, NodeAppearanceProvider } from '@reveal/cad-styling';
-import { IndexSet, EventTrigger, assertNever } from '@reveal/utilities';
+import { IndexSet, EventTrigger, assertNever, EmptyEvent } from '@reveal/utilities';
 
 import throttle from 'lodash/throttle';
 
@@ -28,7 +28,7 @@ interface MaterialsWrapper {
 
 export class CadMaterialManager {
   private readonly _events = {
-    materialsChanged: new EventTrigger<() => void>()
+    materialsChanged: new EventTrigger<EmptyEvent>()
   };
 
   get clippingPlanes(): THREE.Plane[] {
@@ -241,7 +241,7 @@ export class CadMaterialManager {
   }
 
   private triggerMaterialsChanged() {
-    this._events.materialsChanged.fire();
+    this._events.materialsChanged.fire(null);
   }
 }
 

--- a/viewer/packages/rendering/src/transform/NodeTransformProvider.ts
+++ b/viewer/packages/rendering/src/transform/NodeTransformProvider.ts
@@ -4,35 +4,35 @@
 
 import * as THREE from 'three';
 
-import { assertNever, EventTrigger, NumericRange } from '@reveal/utilities';
+import { assertNever, EventListener, EventTrigger, NumericRange } from '@reveal/utilities';
 
 const identityTransform = new THREE.Matrix4().identity();
 
-export type NodeTransformChangeEventDelegate = (
-  change: 'set' | 'reset',
-  treeIndices: NumericRange,
-  transform: THREE.Matrix4
-) => void;
+export type NodeTransformChangedEvent = {
+  change: 'set' | 'reset';
+  treeIndices: NumericRange;
+  transform: THREE.Matrix4;
+};
 
 export class NodeTransformProvider {
   private readonly _events = {
-    changed: new EventTrigger<NodeTransformChangeEventDelegate>()
+    changed: new EventTrigger<NodeTransformChangedEvent>()
   };
 
-  on(event: 'changed', listener: NodeTransformChangeEventDelegate): void {
+  on(event: 'changed', listener: EventListener<NodeTransformChangedEvent>): void {
     switch (event) {
       case 'changed':
-        this._events.changed.subscribe(listener as NodeTransformChangeEventDelegate);
+        this._events.changed.subscribe(listener);
         break;
       default:
         assertNever(event, `Unsupported event: '${event}'`);
     }
   }
 
-  off(event: 'changed', listener: NodeTransformChangeEventDelegate): void {
+  off(event: 'changed', listener: EventListener<NodeTransformChangedEvent>): void {
     switch (event) {
       case 'changed':
-        this._events.changed.unsubscribe(listener as NodeTransformChangeEventDelegate);
+        this._events.changed.unsubscribe(listener);
         break;
       default:
         assertNever(event, `Unsupported event: '${event}'`);
@@ -40,10 +40,10 @@ export class NodeTransformProvider {
   }
 
   setNodeTransform(treeIndices: NumericRange, transform: THREE.Matrix4): void {
-    this._events.changed.fire('set', treeIndices, transform);
+    this._events.changed.fire({ change: 'set', treeIndices, transform });
   }
 
   resetNodeTransform(treeIndices: NumericRange): void {
-    this._events.changed.fire('reset', treeIndices, identityTransform);
+    this._events.changed.fire({ change: 'reset', treeIndices, transform: identityTransform });
   }
 }

--- a/viewer/packages/rendering/src/transform/NodeTransformProvider.ts
+++ b/viewer/packages/rendering/src/transform/NodeTransformProvider.ts
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 
-import { assertNever, EventListener, EventTrigger, NumericRange } from '@reveal/utilities';
+import { assertNever, EventTrigger, NumericRange } from '@reveal/utilities';
 
 const identityTransform = new THREE.Matrix4().identity();
 
@@ -19,7 +19,7 @@ export class NodeTransformProvider {
     changed: new EventTrigger<NodeTransformChangedEvent>()
   };
 
-  on(event: 'changed', listener: EventListener<NodeTransformChangedEvent>): void {
+  on(event: 'changed', listener: (event: NodeTransformChangedEvent) => void): void {
     switch (event) {
       case 'changed':
         this._events.changed.subscribe(listener);
@@ -29,7 +29,7 @@ export class NodeTransformProvider {
     }
   }
 
-  off(event: 'changed', listener: EventListener<NodeTransformChangedEvent>): void {
+  off(event: 'changed', listener: (event: NodeTransformChangedEvent) => void): void {
     switch (event) {
       case 'changed':
         this._events.changed.unsubscribe(listener);

--- a/viewer/packages/rendering/src/transform/NodeTransformTextureBuilder.ts
+++ b/viewer/packages/rendering/src/transform/NodeTransformTextureBuilder.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import { TransformOverrideBuffer } from './TransformOverrideBuffer';
 
 import { determinePowerOfTwoDimensions, assertNever, NumericRange } from '@reveal/utilities';
-import { NodeTransformProvider } from './NodeTransformProvider';
+import { NodeTransformChangedEvent, NodeTransformProvider } from './NodeTransformProvider';
 
 export class NodeTransformTextureBuilder {
   private readonly _transformProvider: NodeTransformProvider;
@@ -70,7 +70,8 @@ export class NodeTransformTextureBuilder {
     this._needsUpdate = true;
   }
 
-  private handleTransformChanged(change: 'set' | 'reset', treeIndices: NumericRange, transform: THREE.Matrix4) {
+  private handleTransformChanged(event: NodeTransformChangedEvent) {
+    const { change, treeIndices, transform } = event;
     switch (change) {
       case 'set':
         this.setNodeTransform(treeIndices, transform);

--- a/viewer/packages/tools/index.ts
+++ b/viewer/packages/tools/index.ts
@@ -37,6 +37,6 @@ export {
 } from './src/Geomap/MapConfig';
 export { TimelineTool } from './src/Timeline/TimelineTool';
 export { Keyframe } from './src/Timeline/Keyframe';
-export { TimelineDateUpdateDelegate } from './src/Timeline/types';
+export { TimelineDateUpdatedEvent } from './src/Timeline/types';
 export { Cognite3DViewerToolBase } from './src/Cognite3DViewerToolBase';
 export { DebugLoadedSectorsTool, DebugLoadedSectorsToolOptions } from './src/DebugLoadedSectorsTool';

--- a/viewer/packages/tools/src/Cognite3DViewerToolBase.test.ts
+++ b/viewer/packages/tools/src/Cognite3DViewerToolBase.test.ts
@@ -2,8 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import { DisposedDelegate } from './types';
 import { Cognite3DViewerToolBase } from './Cognite3DViewerToolBase';
+import { EventListener, EmptyEvent } from '@reveal/utilities';
 
 describe('Cognite3DViewerToolBase', () => {
   class MockedCognite3DViewerToolBase extends Cognite3DViewerToolBase {
@@ -17,7 +17,7 @@ describe('Cognite3DViewerToolBase', () => {
     tool = new MockedCognite3DViewerToolBase();
   });
   test('dispose() triggers disposed event', () => {
-    const handler: DisposedDelegate = jest.fn();
+    const handler: EventListener<EmptyEvent> = jest.fn();
     tool.on('disposed', handler);
 
     tool.dispose();

--- a/viewer/packages/tools/src/Cognite3DViewerToolBase.test.ts
+++ b/viewer/packages/tools/src/Cognite3DViewerToolBase.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { Cognite3DViewerToolBase } from './Cognite3DViewerToolBase';
-import { EventListener, EmptyEvent } from '@reveal/utilities';
 
 describe('Cognite3DViewerToolBase', () => {
   class MockedCognite3DViewerToolBase extends Cognite3DViewerToolBase {
@@ -17,7 +16,7 @@ describe('Cognite3DViewerToolBase', () => {
     tool = new MockedCognite3DViewerToolBase();
   });
   test('dispose() triggers disposed event', () => {
-    const handler: EventListener<EmptyEvent> = jest.fn();
+    const handler: () => void = jest.fn();
     tool.on('disposed', handler);
 
     tool.dispose();

--- a/viewer/packages/tools/src/Cognite3DViewerToolBase.ts
+++ b/viewer/packages/tools/src/Cognite3DViewerToolBase.ts
@@ -3,7 +3,7 @@
  */
 
 import { assertNever, EventTrigger } from '@reveal/core/utilities';
-import { EventListener, EmptyEvent } from '@reveal/utilities';
+import { EmptyEvent } from '@reveal/utilities';
 
 /**
  * Base class for tools attaching to a {@see Cognite3DViewer}.
@@ -19,7 +19,7 @@ export abstract class Cognite3DViewerToolBase {
    * @param listener
    * @internal
    */
-  on(event: 'disposed', listener: EventListener<EmptyEvent>): void {
+  on(event: 'disposed', listener: () => void): void {
     switch (event) {
       case 'disposed':
         this._disposedEvent.subscribe(listener);
@@ -35,10 +35,10 @@ export abstract class Cognite3DViewerToolBase {
    * @param event
    * @param handler
    */
-  off(event: 'disposed', handler: EventListener<EmptyEvent>): void {
+  off(event: 'disposed', listener: () => void): void {
     switch (event) {
       case 'disposed':
-        this._disposedEvent.unsubscribe(handler);
+        this._disposedEvent.unsubscribe(listener);
         break;
 
       default:

--- a/viewer/packages/tools/src/Cognite3DViewerToolBase.ts
+++ b/viewer/packages/tools/src/Cognite3DViewerToolBase.ts
@@ -3,25 +3,26 @@
  */
 
 import { assertNever, EventTrigger } from '@reveal/core/utilities';
+import { EventListener, EmptyEvent } from '@reveal/utilities';
 
 /**
  * Base class for tools attaching to a {@see Cognite3DViewer}.
  */
 export abstract class Cognite3DViewerToolBase {
-  private readonly _disposedEvent = new EventTrigger<() => void>();
+  private readonly _disposedEvent = new EventTrigger<EmptyEvent>();
   private _disposed = false;
 
   /**
    * Registers an event handler that is triggered when {@see Cognite3DViewerToolBase.dispose} is
    * called.
    * @param event
-   * @param handler
+   * @param listener
    * @internal
    */
-  on(event: 'disposed', handler: () => void): void {
+  on(event: 'disposed', listener: EventListener<EmptyEvent>): void {
     switch (event) {
       case 'disposed':
-        this._disposedEvent.subscribe(handler);
+        this._disposedEvent.subscribe(listener);
         break;
 
       default:
@@ -34,7 +35,7 @@ export abstract class Cognite3DViewerToolBase {
    * @param event
    * @param handler
    */
-  off(event: 'disposed', handler: () => void): void {
+  off(event: 'disposed', handler: EventListener<EmptyEvent>): void {
     switch (event) {
       case 'disposed':
         this._disposedEvent.unsubscribe(handler);
@@ -46,15 +47,15 @@ export abstract class Cognite3DViewerToolBase {
   }
 
   /**
-   * Disposes the element and triggeres the 'disposed' event before clearing the list
-   * of dipose-listeners.
+   * Disposes the element and triggers the 'disposed' event before clearing the list
+   * of dispose-listeners.
    */
   dispose(): void {
     if (this._disposed) {
       throw new Error('Already disposed');
     }
     this._disposed = true;
-    this._disposedEvent.fire();
+    this._disposedEvent.fire(null);
     this._disposedEvent.unsubscribeAll();
   }
 

--- a/viewer/packages/tools/src/DebugCameraTool.ts
+++ b/viewer/packages/tools/src/DebugCameraTool.ts
@@ -4,13 +4,13 @@
 
 import * as THREE from 'three';
 import { Cognite3DViewer } from '@reveal/core';
-import { DisposedDelegate } from './types';
+import { EventListener, EmptyEvent } from '@reveal/utilities';
 
 import { Cognite3DViewerToolBase } from './Cognite3DViewerToolBase';
 
 export class DebugCameraTool extends Cognite3DViewerToolBase {
   private readonly _viewer: Cognite3DViewer;
-  private readonly _onViewerDisposedHandler: DisposedDelegate;
+  private readonly _onViewerDisposedHandler: EventListener<EmptyEvent>;
   private _cameraHelper?: THREE.CameraHelper;
 
   private get viewerCamera(): THREE.PerspectiveCamera {

--- a/viewer/packages/tools/src/DebugCameraTool.ts
+++ b/viewer/packages/tools/src/DebugCameraTool.ts
@@ -4,13 +4,12 @@
 
 import * as THREE from 'three';
 import { Cognite3DViewer } from '@reveal/core';
-import { EventListener, EmptyEvent } from '@reveal/utilities';
 
 import { Cognite3DViewerToolBase } from './Cognite3DViewerToolBase';
 
 export class DebugCameraTool extends Cognite3DViewerToolBase {
   private readonly _viewer: Cognite3DViewer;
-  private readonly _onViewerDisposedHandler: EventListener<EmptyEvent>;
+  private readonly _onViewerDisposedHandler: () => void;
   private _cameraHelper?: THREE.CameraHelper;
 
   private get viewerCamera(): THREE.PerspectiveCamera {

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -8,7 +8,7 @@ import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
 import { BucketGrid2D } from './BucketGrid2D';
 
 import { MetricsLogger } from '@reveal/metrics';
-import { assertNever, EventListener, EmptyEvent } from '@reveal/utilities';
+import { assertNever } from '@reveal/utilities';
 import { Cognite3DViewer, SceneRenderedEvent } from '@reveal/core';
 import { worldToViewportCoordinates } from '@reveal/core/utilities';
 
@@ -136,8 +136,8 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   private readonly _htmlOverlays: Map<HTMLElement, HtmlOverlayElement> = new Map();
   private readonly _compositeOverlays: HTMLElement[] = [];
 
-  private readonly _onSceneRenderedHandler: EventListener<SceneRenderedEvent>;
-  private readonly _onViewerDisposedHandler: EventListener<EmptyEvent>;
+  private readonly _onSceneRenderedHandler: (event: SceneRenderedEvent) => void;
+  private readonly _onViewerDisposedHandler: () => void;
   // Allocate variables needed for processing once to avoid allocations
   private readonly _preallocatedVariables = {
     camPos: new THREE.Vector3(),

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -8,8 +8,10 @@ import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
 import { BucketGrid2D } from './BucketGrid2D';
 
 import { MetricsLogger } from '@reveal/metrics';
-import { assertNever, worldToViewportCoordinates } from '@reveal/core/utilities';
-import { Cognite3DViewer, DisposedDelegate, SceneRenderedDelegate } from '@reveal/core';
+import { assertNever, EventListener, EmptyEvent } from '@reveal/utilities';
+import { Cognite3DViewer, SceneRenderedEvent } from '@reveal/core';
+import { worldToViewportCoordinates } from '@reveal/core/utilities';
+
 import debounce from 'lodash/debounce';
 
 /**
@@ -134,8 +136,8 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   private readonly _htmlOverlays: Map<HTMLElement, HtmlOverlayElement> = new Map();
   private readonly _compositeOverlays: HTMLElement[] = [];
 
-  private readonly _onSceneRenderedHandler: SceneRenderedDelegate;
-  private readonly _onViewerDisposedHandler: DisposedDelegate;
+  private readonly _onSceneRenderedHandler: EventListener<SceneRenderedEvent>;
+  private readonly _onViewerDisposedHandler: EventListener<EmptyEvent>;
   // Allocate variables needed for processing once to avoid allocations
   private readonly _preallocatedVariables = {
     camPos: new THREE.Vector3(),

--- a/viewer/packages/tools/src/Timeline/TimelineTool.ts
+++ b/viewer/packages/tools/src/Timeline/TimelineTool.ts
@@ -7,8 +7,8 @@ import TWEEN from '@tweenjs/tween.js';
 import { Cognite3DModel } from '@reveal/core';
 import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
 import { Keyframe } from './Keyframe';
-import { TimelineDateUpdateDelegate } from './types';
-import { EventTrigger, assertNever } from '@reveal/core/utilities';
+import { TimelineDateUpdatedEvent } from './types';
+import { EventListener, EventTrigger, assertNever } from '@reveal/utilities';
 
 /**
  * Tool to applying styles to nodes based on date to play them over in Timeline
@@ -17,7 +17,9 @@ export class TimelineTool extends Cognite3DViewerToolBase {
   private readonly _model: Cognite3DModel;
   private readonly _keyframes: Keyframe[];
   private _playback: TWEEN.Tween | undefined = undefined;
-  private readonly _events = { dateChanged: new EventTrigger<TimelineDateUpdateDelegate>() };
+  private readonly _events = {
+    dateChanged: new EventTrigger<TimelineDateUpdatedEvent>()
+  };
 
   constructor(cadModel: Cognite3DModel) {
     super();
@@ -31,7 +33,7 @@ export class TimelineTool extends Cognite3DViewerToolBase {
    * @param event `dateChanged` event
    * @param listener Listen to Timeline date Update during Playback
    */
-  public subscribe(event: 'dateChanged', listener: TimelineDateUpdateDelegate): void {
+  public subscribe(event: 'dateChanged', listener: EventListener<TimelineDateUpdatedEvent>): void {
     switch (event) {
       case 'dateChanged':
         this._events.dateChanged.subscribe(listener);
@@ -46,7 +48,7 @@ export class TimelineTool extends Cognite3DViewerToolBase {
    * @param event `dateChanged` event
    * @param listener Remove Listen to Timeline date Update
    */
-  public unsubscribe(event: 'dateChanged', listener: TimelineDateUpdateDelegate): void {
+  public unsubscribe(event: 'dateChanged', listener: EventListener<TimelineDateUpdatedEvent>): void {
     switch (event) {
       case 'dateChanged':
         this._events.dateChanged.unsubscribe(listener);

--- a/viewer/packages/tools/src/Timeline/TimelineTool.ts
+++ b/viewer/packages/tools/src/Timeline/TimelineTool.ts
@@ -8,7 +8,7 @@ import { Cognite3DModel } from '@reveal/core';
 import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
 import { Keyframe } from './Keyframe';
 import { TimelineDateUpdatedEvent } from './types';
-import { EventListener, EventTrigger, assertNever } from '@reveal/utilities';
+import { EventTrigger, assertNever } from '@reveal/utilities';
 
 /**
  * Tool to applying styles to nodes based on date to play them over in Timeline
@@ -33,7 +33,7 @@ export class TimelineTool extends Cognite3DViewerToolBase {
    * @param event `dateChanged` event
    * @param listener Listen to Timeline date Update during Playback
    */
-  public subscribe(event: 'dateChanged', listener: EventListener<TimelineDateUpdatedEvent>): void {
+  public subscribe(event: 'dateChanged', listener: (event: TimelineDateUpdatedEvent) => void): void {
     switch (event) {
       case 'dateChanged':
         this._events.dateChanged.subscribe(listener);
@@ -48,7 +48,7 @@ export class TimelineTool extends Cognite3DViewerToolBase {
    * @param event `dateChanged` event
    * @param listener Remove Listen to Timeline date Update
    */
-  public unsubscribe(event: 'dateChanged', listener: EventListener<TimelineDateUpdatedEvent>): void {
+  public unsubscribe(event: 'dateChanged', listener: (event: TimelineDateUpdatedEvent) => void): void {
     switch (event) {
       case 'dateChanged':
         this._events.dateChanged.unsubscribe(listener);

--- a/viewer/packages/tools/src/Timeline/types.ts
+++ b/viewer/packages/tools/src/Timeline/types.ts
@@ -5,9 +5,9 @@ import { Keyframe } from './Keyframe';
 /**
  * Delegate for Timeline Date update
  */
-export type TimelineDateUpdateDelegate = (event: {
+export type TimelineDateUpdatedEvent = {
   date: Date;
   activeKeyframe: Keyframe | undefined;
   startDate: Date;
   endDate: Date;
-}) => void;
+};

--- a/viewer/packages/tools/src/types.ts
+++ b/viewer/packages/tools/src/types.ts
@@ -1,4 +1,0 @@
-/*!
- * Copyright 2021 Cognite AS
- */
-export type DisposedDelegate = () => void;

--- a/viewer/packages/utilities/index.ts
+++ b/viewer/packages/utilities/index.ts
@@ -7,7 +7,7 @@ export { transformCameraConfiguration } from './src/transformCameraConfiguration
 
 export { RandomColors } from './src/RandomColors';
 export { CameraConfiguration } from './src/CameraConfiguration';
-export { EventTrigger, clickOrTouchEventOffset, InputHandler } from './src/events';
+export { EventTrigger, clickOrTouchEventOffset, InputHandler, disposeOfAllEventListeners } from './src/events';
 export { assertNever } from './src/assertNever';
 export { NumericRange } from './src/NumericRange';
 export { determinePowerOfTwoDimensions } from './src/determinePowerOfTwoDimensions';

--- a/viewer/packages/utilities/index.ts
+++ b/viewer/packages/utilities/index.ts
@@ -9,7 +9,6 @@ export { RandomColors } from './src/RandomColors';
 export { CameraConfiguration } from './src/CameraConfiguration';
 export {
   EventTrigger,
-  EventListener,
   EmptyEvent,
   PointerEvent,
   clickOrTouchEventOffset,

--- a/viewer/packages/utilities/index.ts
+++ b/viewer/packages/utilities/index.ts
@@ -7,7 +7,15 @@ export { transformCameraConfiguration } from './src/transformCameraConfiguration
 
 export { RandomColors } from './src/RandomColors';
 export { CameraConfiguration } from './src/CameraConfiguration';
-export { EventTrigger, clickOrTouchEventOffset, InputHandler, disposeOfAllEventListeners } from './src/events';
+export {
+  EventTrigger,
+  EventListener,
+  EmptyEvent,
+  PointerEvent,
+  clickOrTouchEventOffset,
+  InputHandler,
+  disposeOfAllEventListeners
+} from './src/events';
 export { assertNever } from './src/assertNever';
 export { NumericRange } from './src/NumericRange';
 export { determinePowerOfTwoDimensions } from './src/determinePowerOfTwoDimensions';

--- a/viewer/packages/utilities/src/events/EventTrigger.test.ts
+++ b/viewer/packages/utilities/src/events/EventTrigger.test.ts
@@ -2,26 +2,27 @@
  * Copyright 2021 Cognite AS
  */
 
+import { EmptyEvent } from '.';
 import { EventTrigger } from './EventTrigger';
 
 describe('EventTrigger', () => {
   test('fire() triggers subscribed listeners', () => {
-    const listener: (arg1: string, arg2: number) => void = jest.fn();
+    const listener: (event: { arg1: string; arg2: number }) => void = jest.fn();
 
-    const source = new EventTrigger<(arg1: string, arg2: number) => void>();
+    const source = new EventTrigger<{ arg1: string; arg2: number }>();
     source.subscribe(listener);
-    source.fire('hei', 1);
+    source.fire({ arg1: 'hei', arg2: 1 });
 
-    expect(listener).toBeCalledWith('hei', 1);
+    expect(listener).toBeCalledWith({ arg1: 'hei', arg2: 1 });
   });
 
   test('fire() doesnt trigger unsubscribed listener', () => {
     const listener: () => void = jest.fn();
 
-    const source = new EventTrigger<() => void>();
+    const source = new EventTrigger<EmptyEvent>();
     source.subscribe(listener);
     source.unsubscribe(listener);
-    source.fire();
+    source.fire(null);
 
     expect(listener).not.toBeCalled();
   });
@@ -29,10 +30,10 @@ describe('EventTrigger', () => {
   test('fire() doesnt trigger after unsubscribeAll()', () => {
     const listener: () => void = jest.fn();
 
-    const source = new EventTrigger<() => void>();
+    const source = new EventTrigger<EmptyEvent>();
     source.subscribe(listener);
     source.unsubscribeAll();
-    source.fire();
+    source.fire(null);
 
     expect(listener).not.toBeCalled();
   });

--- a/viewer/packages/utilities/src/events/EventTrigger.ts
+++ b/viewer/packages/utilities/src/events/EventTrigger.ts
@@ -5,14 +5,14 @@
 /**
  * Subscribable event source.
  */
-export class EventTrigger<TListener extends (...args: any[]) => void> {
-  private readonly _listeners: TListener[] = [];
+export class EventTrigger<TEventArgs> {
+  private readonly _listeners: ((eventArgs: TEventArgs) => void)[] = [];
 
-  subscribe(listener: TListener): void {
+  subscribe(listener: (eventArgs: TEventArgs) => void): void {
     this._listeners.push(listener);
   }
 
-  unsubscribe(listener: TListener): void {
+  unsubscribe(listener: (eventArgs: TEventArgs) => void): void {
     const index = this._listeners.indexOf(listener);
     if (index !== -1) {
       this._listeners.splice(index, 1);
@@ -23,7 +23,7 @@ export class EventTrigger<TListener extends (...args: any[]) => void> {
     this._listeners.splice(0);
   }
 
-  fire(...args: Parameters<TListener>): void {
-    this._listeners.forEach(listener => listener(...args));
+  fire(eventArgs: TEventArgs): void {
+    this._listeners.forEach(listener => listener(eventArgs));
   }
 }

--- a/viewer/packages/utilities/src/events/InputHandler.ts
+++ b/viewer/packages/utilities/src/events/InputHandler.ts
@@ -1,21 +1,23 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import { clickOrTouchEventOffset } from './clickOrTouchEventOffset';
-import { EventTrigger } from './EventTrigger';
-import debounce from 'lodash/debounce';
-import { assertNever } from '@reveal/utilities';
 import { Vector2 } from 'three';
 
-type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
+import { clickOrTouchEventOffset } from './clickOrTouchEventOffset';
+import { EventListener, PointerEvent } from './types';
+import { EventTrigger } from './EventTrigger';
+import { assertNever } from '../assertNever';
+
+import debounce from 'lodash/debounce';
+
 export class InputHandler {
   private readonly domElement: HTMLElement;
   private static readonly maxMoveDistance = 8;
   private static readonly maxClickDuration = 250;
 
   private readonly _events = {
-    click: new EventTrigger<PointerEventDelegate>(),
-    hover: new EventTrigger<PointerEventDelegate>()
+    click: new EventTrigger<PointerEvent>(),
+    hover: new EventTrigger<PointerEvent>()
   };
 
   constructor(domElement: HTMLElement) {
@@ -30,28 +32,28 @@ export class InputHandler {
    * viewer.on('click', onClick);
    * ```
    */
-  on(event: 'click' | 'hover', callback: PointerEventDelegate): void {
+  on(event: 'click' | 'hover', listener: EventListener<PointerEvent>): void {
     switch (event) {
       case 'click':
-        this._events.click.subscribe(callback as PointerEventDelegate);
+        this._events.click.subscribe(listener);
         break;
 
       case 'hover':
-        this._events.hover.subscribe(callback as PointerEventDelegate);
+        this._events.hover.subscribe(listener);
         break;
       default:
         assertNever(event);
     }
   }
 
-  off(event: 'click' | 'hover', callback: PointerEventDelegate): void {
+  off(event: 'click' | 'hover', callback: EventListener<PointerEvent>): void {
     switch (event) {
       case 'click':
-        this._events.click.unsubscribe(callback as PointerEventDelegate);
+        this._events.click.unsubscribe(callback);
         break;
 
       case 'hover':
-        this._events.hover.unsubscribe(callback as PointerEventDelegate);
+        this._events.hover.unsubscribe(callback);
         break;
       default:
         assertNever(event);
@@ -150,7 +152,7 @@ export class InputHandler {
 /**
  * Method for deleting all external events that are associated with current instance of a class.
  */
-export function disposeOfAllEventListeners(eventList: any): void {
+export function disposeOfAllEventListeners(eventList: { [eventName: string]: EventTrigger<any> }): void {
   for (const eventType of Object.keys(eventList)) {
     eventList[eventType].unsubscribeAll();
   }

--- a/viewer/packages/utilities/src/events/InputHandler.ts
+++ b/viewer/packages/utilities/src/events/InputHandler.ts
@@ -8,8 +8,6 @@ import { assertNever } from '@reveal/utilities';
 import { Vector2 } from 'three';
 
 type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
-
-type InputHandlerEvents = 'click' | 'hover';
 export class InputHandler {
   private readonly domElement: HTMLElement;
   private static readonly maxMoveDistance = 8;
@@ -61,7 +59,7 @@ export class InputHandler {
   }
 
   dispose(): void {
-    this.disposeOfAllEventListeners();
+    disposeOfAllEventListeners(this._events);
   }
 
   private setupEventListeners() {
@@ -148,10 +146,13 @@ export class InputHandler {
     this._events.hover.fire(clickOrTouchEventOffset(e, this.domElement));
   }, 100);
 
-  private disposeOfAllEventListeners() {
-    const inputHandlerEvents = ['click', 'hover'];
-    for (const event of inputHandlerEvents) {
-      this._events[event as InputHandlerEvents].unsubscribeAll();
-    }
+}
+
+ /**
+   * Method for deleting all external events that are associated with current instance of a class.
+   */
+export function disposeOfAllEventListeners(eventList: any) {
+  for (const eventType of Object.keys(eventList)) {
+    eventList[eventType].unsubscribeAll();
   }
 }

--- a/viewer/packages/utilities/src/events/InputHandler.ts
+++ b/viewer/packages/utilities/src/events/InputHandler.ts
@@ -9,6 +9,7 @@ import { Vector2 } from 'three';
 
 type PointerEventDelegate = (event: { offsetX: number; offsetY: number }) => void;
 
+type InputHandlerEvents = 'click' | 'hover';
 export class InputHandler {
   private readonly domElement: HTMLElement;
   private static readonly maxMoveDistance = 8;
@@ -57,6 +58,10 @@ export class InputHandler {
       default:
         assertNever(event);
     }
+  }
+
+  dispose() {
+    this.disposeOfAllEventListeners();
   }
 
   private setupEventListeners() {
@@ -142,4 +147,11 @@ export class InputHandler {
   private readonly onHoverCallback = debounce((e: MouseEvent) => {
     this._events.hover.fire(clickOrTouchEventOffset(e, this.domElement));
   }, 100);
+
+  private disposeOfAllEventListeners() {
+    const inputHandlerEvents = ['click', 'hover'];
+    for (const event of inputHandlerEvents) {
+      this._events[event as InputHandlerEvents].unsubscribeAll();
+    }
+  }
 }

--- a/viewer/packages/utilities/src/events/InputHandler.ts
+++ b/viewer/packages/utilities/src/events/InputHandler.ts
@@ -4,7 +4,7 @@
 import { Vector2 } from 'three';
 
 import { clickOrTouchEventOffset } from './clickOrTouchEventOffset';
-import { EventListener, PointerEvent } from './types';
+import { PointerEvent } from './types';
 import { EventTrigger } from './EventTrigger';
 import { assertNever } from '../assertNever';
 
@@ -32,7 +32,7 @@ export class InputHandler {
    * viewer.on('click', onClick);
    * ```
    */
-  on(event: 'click' | 'hover', listener: EventListener<PointerEvent>): void {
+  on(event: 'click' | 'hover', listener: (event: PointerEvent) => void): void {
     switch (event) {
       case 'click':
         this._events.click.subscribe(listener);
@@ -46,7 +46,7 @@ export class InputHandler {
     }
   }
 
-  off(event: 'click' | 'hover', callback: EventListener<PointerEvent>): void {
+  off(event: 'click' | 'hover', callback: (event: PointerEvent) => void): void {
     switch (event) {
       case 'click':
         this._events.click.unsubscribe(callback);

--- a/viewer/packages/utilities/src/events/InputHandler.ts
+++ b/viewer/packages/utilities/src/events/InputHandler.ts
@@ -145,13 +145,12 @@ export class InputHandler {
   private readonly onHoverCallback = debounce((e: MouseEvent) => {
     this._events.hover.fire(clickOrTouchEventOffset(e, this.domElement));
   }, 100);
-
 }
 
- /**
-   * Method for deleting all external events that are associated with current instance of a class.
-   */
-export function disposeOfAllEventListeners(eventList: any) {
+/**
+ * Method for deleting all external events that are associated with current instance of a class.
+ */
+export function disposeOfAllEventListeners(eventList: any): void {
   for (const eventType of Object.keys(eventList)) {
     eventList[eventType].unsubscribeAll();
   }

--- a/viewer/packages/utilities/src/events/InputHandler.ts
+++ b/viewer/packages/utilities/src/events/InputHandler.ts
@@ -60,7 +60,7 @@ export class InputHandler {
     }
   }
 
-  dispose() {
+  dispose(): void {
     this.disposeOfAllEventListeners();
   }
 

--- a/viewer/packages/utilities/src/events/clickOrTouchEventOffset.ts
+++ b/viewer/packages/utilities/src/events/clickOrTouchEventOffset.ts
@@ -1,6 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
+import { PointerEvent } from './types';
 
 /**
  * Determines clicked or touched coordinate as offset
@@ -8,10 +9,7 @@
  * @param target    HTML element to find coordinates relative to.
  * @returns A struct containing coordinates relative to the HTML element provided.
  */
-export function clickOrTouchEventOffset(
-  ev: MouseEvent | TouchEvent,
-  target: HTMLElement
-): { offsetX: number; offsetY: number } {
+export function clickOrTouchEventOffset(ev: MouseEvent | TouchEvent, target: HTMLElement): PointerEvent {
   const rect = target.getBoundingClientRect();
 
   if (ev instanceof MouseEvent) {

--- a/viewer/packages/utilities/src/events/index.ts
+++ b/viewer/packages/utilities/src/events/index.ts
@@ -3,4 +3,4 @@
  */
 export { clickOrTouchEventOffset } from './clickOrTouchEventOffset';
 export { EventTrigger } from './EventTrigger';
-export { InputHandler } from './InputHandler';
+export { InputHandler, disposeOfAllEventListeners } from './InputHandler';

--- a/viewer/packages/utilities/src/events/index.ts
+++ b/viewer/packages/utilities/src/events/index.ts
@@ -4,3 +4,4 @@
 export { clickOrTouchEventOffset } from './clickOrTouchEventOffset';
 export { EventTrigger } from './EventTrigger';
 export { InputHandler, disposeOfAllEventListeners } from './InputHandler';
+export { EmptyEvent, EventListener, PointerEvent } from './types';

--- a/viewer/packages/utilities/src/events/index.ts
+++ b/viewer/packages/utilities/src/events/index.ts
@@ -4,4 +4,4 @@
 export { clickOrTouchEventOffset } from './clickOrTouchEventOffset';
 export { EventTrigger } from './EventTrigger';
 export { InputHandler, disposeOfAllEventListeners } from './InputHandler';
-export { EmptyEvent, EventListener, PointerEvent } from './types';
+export { EmptyEvent, PointerEvent } from './types';

--- a/viewer/packages/utilities/src/events/types.ts
+++ b/viewer/packages/utilities/src/events/types.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright 2022 Cognite AS
+ */
+export type EmptyEvent = null;
+
+/**
+ * Delegate for pointer events.
+ * @module @cognite/reveal
+ */
+export type PointerEvent = { offsetX: number; offsetY: number };
+
+/**
+ * Listener for events.
+ */
+export type EventListener<TEventArgs> = (event: TEventArgs) => void;

--- a/viewer/packages/utilities/src/events/types.ts
+++ b/viewer/packages/utilities/src/events/types.ts
@@ -8,8 +8,3 @@ export type EmptyEvent = null;
  * @module @cognite/reveal
  */
 export type PointerEvent = { offsetX: number; offsetY: number };
-
-/**
- * Listener for events.
- */
-export type EventListener<TEventArgs> = (event: TEventArgs) => void;


### PR DESCRIPTION
Reduces flexibility in what an event looks like, but makes it easier to implement general functionality around events.

To me, less flexibility is acceptable - I believe that event handlers always should have maximum one argument with an object providing necessary context for the given event.