### PR TITLE
fix: issue causing loading indicator to not update while camera was moving

### DIFF
--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
@@ -117,7 +117,6 @@ export class CadModelUpdateHandler {
 
   updateCamera(camera: THREE.PerspectiveCamera): void {
     this._cameraSubject.next(camera);
-    this._progressSubject.next(notLoadingState);
   }
 
   set clippingPlanes(value: THREE.Plane[]) {


### PR DESCRIPTION
Dont trigger 'not loading' whenever camera moves as we now support loading while camera moves