### PR TITLE
feat: add UI for storing and restoring camera from/to URL

### DIFF
--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -26,6 +26,7 @@ import { NodeStylingUI } from '../utils/NodeStylingUI';
 import { initialCadBudgetUi } from '../utils/CadBudgetUi';
 import { authenticateSDKWithEnvironment } from '../utils/example-helpers';
 import { InspectNodeUI } from '../utils/InspectNodeUi';
+import { CameraUI } from '../utils/CameraUI';
 
 window.THREE = THREE;
 (window as any).reveal = reveal;
@@ -376,6 +377,7 @@ export function Migration() {
       });
 
       const clippingUi = new ClippingUI(gui.addFolder('Slicing'), planes => viewer.setSlicingPlanes(planes));
+      new CameraUI(viewer, gui.addFolder('Camera'));
 
       const pcSettings = gui.addFolder('Point clouds');
       pcSettings.add(pointCloudParams, 'budget', 0, 20_000_000, 100_000).onFinishChange(() => pointCloudParams.apply());

--- a/examples/src/utils/CameraUI.ts
+++ b/examples/src/utils/CameraUI.ts
@@ -1,0 +1,73 @@
+import * as THREE from 'three';
+import { Cognite3DViewer } from "@cognite/reveal";
+import dat from 'dat.gui';
+
+export class CameraUI {
+  private readonly _viewer: Cognite3DViewer;
+
+  constructor(viewer: Cognite3DViewer, ui: dat.GUI) {
+    this._viewer = viewer;
+    const actions = {
+      saveCameraToUrl: () => this.saveCameraToUrl(),
+      restoreCameraFromUrl: () => this.restoreCameraFromUrl()
+    };
+
+    ui.add(actions, 'saveCameraToUrl').name('Save camera to URL');
+    ui.add(actions, 'restoreCameraFromUrl').name('Restore camera from URL');
+
+    if (this.hasCameraInUrl()) {
+      // Hack - since adding a model will load a camera in our examples
+      // we just wait a second before applying it.
+      setTimeout(() => this.restoreCameraFromUrl(), 1000);
+    }
+  }
+
+  private saveCameraToUrl(): void {
+    const position = this._viewer.getCameraPosition();
+    const target = this._viewer.getCameraTarget();
+
+    const url = new URL(window.location.href);
+    url.searchParams.set('camPos', vector3ToString(position));
+    url.searchParams.set('camTarget', vector3ToString(target));
+
+    window.history.replaceState(null, document.title, url.toString());
+  }
+
+  private hasCameraInUrl(): boolean {
+    const url = new URL(window.location.href);
+    return url.searchParams.get('camPos') !== null && url.searchParams.get('camTarget') !== null;
+  }
+
+  private restoreCameraFromUrl(): void {
+    try {
+      if (!this.hasCameraInUrl()) {
+        throw new Error('Must provide URL parameters "camPos" and "camTarget"');
+      }
+
+      const url = new URL(window.location.href);
+      const camPosParam = url.searchParams.get('camPos')!;
+      const camTargetParam = url.searchParams.get('camTarget')!;
+      const camPos = stringToVector3(camPosParam);
+      const camTarget = stringToVector3(camTargetParam);
+
+      this._viewer.setCameraPosition(camPos);
+      this._viewer.setCameraTarget(camTarget);
+    }
+    catch (error) {
+      alert('Could not restore camera from URL: ' + error);
+    }
+  }
+}
+
+function vector3ToString(v: THREE.Vector3): string {
+  return `${v.x},${v.y},${v.z}`;
+}
+
+function stringToVector3(s: string): THREE.Vector3 {
+  const tokens = s.split(',');
+  if (tokens.length !== 3) {
+    throw new Error(`Invalid vector3 string: "${s}"`);
+  }
+  const components = tokens.map(Number.parseFloat);
+  return new THREE.Vector3(components[0], components[1], components[2]);
+}

--- a/examples/src/utils/CameraUI.ts
+++ b/examples/src/utils/CameraUI.ts
@@ -29,7 +29,7 @@ export class CameraUI {
     const url = new URL(window.location.href);
     url.searchParams.set('camPos', vector3ToString(position));
     url.searchParams.set('camTarget', vector3ToString(target));
-
+    // Update URL without reloading
     window.history.replaceState(null, document.title, url.toString());
   }
 


### PR DESCRIPTION
This is very useful when debugging and you want to store an exact camera position to share or to use for reproducing an issue. Produces URLs ala https://localhost:8080/migration?project=3d-test&env=greenfield-3d&modelId=5244774438818744&revisionId=2249063501234508&camPos=238.93704593199658%2C65.7797568736406%2C-338.87591274763025&camTarget=193.05550578419502%2C42.334793193169986%2C-275.8093275879768

(notice parameters camPos and camTarget).

![image](https://user-images.githubusercontent.com/6741854/150426190-f73a8dd2-442c-4303-a52e-2904c872b52f.png)
