### PR TITLE
fix: certain models cause computer crashes

### DIFF
--- a/viewer/packages/rendering/src/GeometryBatchingManager.ts
+++ b/viewer/packages/rendering/src/GeometryBatchingManager.ts
@@ -106,7 +106,13 @@ export class GeometryBatchingManager {
     const offset = interleavedBufferView.byteOffset;
 
     const interleavedAttributesView = new Uint8Array(interleavedArrayBuffer, offset, length);
+
     const { batchId, bufferIsReallocated, updateRange } = defragBuffer.add(interleavedAttributesView);
+
+    const inputBufferByteStride = interleavedBufferView.BYTES_PER_ELEMENT * instanceAttributes[0].attribute.data.stride;
+
+    assert(updateRange.byteCount % inputBufferByteStride === 0);
+    assert(updateRange.byteOffset % inputBufferByteStride === 0);
 
     for (let i = 0; i < treeIndexInterleavedAttribute.count; i++) {
       incrementOrInsertIndex(mesh.userData.treeIndices, treeIndexInterleavedAttribute.getX(i));

--- a/viewer/packages/sector-loader/src/GltfSectorRepository.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorRepository.ts
@@ -89,7 +89,7 @@ export class GltfSectorRepository implements SectorRepository {
             geometryBatchingQueue.push({
               type,
               geometryBuffer: filteredGeometryBuffer,
-              instanceId: `primitive_${type.toString()}`
+              instanceId: `${RevealGeometryCollectionType[type].toString()}`
             });
             break;
           case RevealGeometryCollectionType.InstanceMesh:

--- a/viewer/packages/sector-loader/src/GltfSectorRepository.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorRepository.ts
@@ -86,7 +86,11 @@ export class GltfSectorRepository implements SectorRepository {
           case RevealGeometryCollectionType.TorusSegmentCollection:
           case RevealGeometryCollectionType.TrapeziumCollection:
           case RevealGeometryCollectionType.NutCollection:
-            geometryBatchingQueue.push({ type, geometryBuffer: filteredGeometryBuffer, instanceId: type.toString() });
+            geometryBatchingQueue.push({
+              type,
+              geometryBuffer: filteredGeometryBuffer,
+              instanceId: `primitive_${type.toString()}`
+            });
             break;
           case RevealGeometryCollectionType.InstanceMesh:
             geometryBatchingQueue.push({

--- a/viewer/packages/sector-loader/src/GltfSectorRepository.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorRepository.ts
@@ -89,7 +89,7 @@ export class GltfSectorRepository implements SectorRepository {
             geometryBatchingQueue.push({
               type,
               geometryBuffer: filteredGeometryBuffer,
-              instanceId: `${RevealGeometryCollectionType[type].toString()}`
+              instanceId: RevealGeometryCollectionType[type].toString()
             });
             break;
           case RevealGeometryCollectionType.InstanceMesh:


### PR DESCRIPTION
The `GeometryBatchingManager` maintains a number of buffer arrays representing instance meshes and different primitive types, stored in a map using some string ID as key. In some cases, the key for an instance mesh, which is always a number stored as a string, would coincide with the key for a primitive, which is also a number (but seemingly is thought not to be).

A fix is therefore to always make sure the primitive array buffer ID does not contain just a number.