### PR TITLE
fix: remove-batch needs to update until end of defrag buffer

### DIFF
--- a/viewer/packages/rendering/src/GeometryBatchingManager.ts
+++ b/viewer/packages/rendering/src/GeometryBatchingManager.ts
@@ -69,11 +69,18 @@ export class GeometryBatchingManager {
 
       const { defragBuffer, mesh } = geometry;
 
-      const updateRange = defragBuffer.getRangeForBatchId(batchId);
+      const batchUpdateRange = defragBuffer.getRangeForBatchId(batchId);
 
-      this.removeTreeIndicesFromMeshUserData(mesh, updateRange);
+      this.removeTreeIndicesFromMeshUserData(mesh, batchUpdateRange);
 
       defragBuffer.remove(batchId);
+
+      const defragBufferEnd = defragBuffer.length;
+
+      const updateRange = {
+        byteOffset: batchUpdateRange.byteOffset,
+        byteCount: defragBufferEnd - batchUpdateRange.byteOffset
+      };
 
       this.updateInstanceAttributes(mesh, updateRange);
 


### PR DESCRIPTION
When removing batch from defrag buffer it needs to extend all the way to the end of buffer since every consecutive batch is shifted down in the buffer. 