### PR TITLE
Trigger sector load on assigning priority [REV-295]

### DIFF
--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
@@ -70,7 +70,7 @@ export class CadModelUpdateHandler {
         this._loadingHintsSubject.pipe(startWith({} as CadLoadingHints)),
         this._budgetSubject.pipe(startWith(this._budget))
       ]).pipe(map(makeSettingsInput)),
-      this._prioritizedLoadingHintsSubject,
+      this._prioritizedLoadingHintsSubject.pipe(startWith(undefined as void)),
       combineLatest([
         this._cameraSubject.pipe(auditTime(500)),
         this._cameraSubject.pipe(auditTime(250), emissionLastMillis(600))
@@ -142,8 +142,6 @@ export class CadModelUpdateHandler {
     this._modelStateHandler.addModel(model.cadModelMetadata.modelIdentifier);
     this._modelSubject.next({ model, operation: 'add' });
     model.nodeAppearanceProvider.on('prioritizedAreasChanged', () => this.updatePrioritizedAreas());
-    // Ensure there is at least one call in the line for the model to load
-    this.updatePrioritizedAreas();
   }
 
   removeModel(model: CadNode): void {

--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
@@ -153,7 +153,7 @@ export class CadModelUpdateHandler {
     this._loadingHintsSubject.next(cadLoadingHints);
   }
 
-  updatePrioritizedAreas(): void {
+  private updatePrioritizedAreas(): void {
     this._prioritizedLoadingHintsSubject.next();
   }
 

--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
@@ -142,6 +142,8 @@ export class CadModelUpdateHandler {
     this._modelStateHandler.addModel(model.cadModelMetadata.modelIdentifier);
     this._modelSubject.next({ model, operation: 'add' });
     model.nodeAppearanceProvider.on('prioritizedAreasChanged', () => this.updatePrioritizedAreas());
+    // Ensure there is at least one call in the line for the model to load
+    this.updatePrioritizedAreas();
   }
 
   removeModel(model: CadNode): void {

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.test.ts
@@ -169,4 +169,21 @@ describe('NodeAppearanceProvider', () => {
       expect(isContained).toBeTrue();
     }
   });
+
+  test('assigning priority triggers callback', () => {
+    const nodeCollection0 = new TreeIndexNodeCollection(new IndexSet([1, 3, 5]));
+    const nodeCollection1 = new TreeIndexNodeCollection(new IndexSet([6, 8, 10]));
+    const nodeCollection2 = new TreeIndexNodeCollection(new IndexSet([4, 3, 2]));
+
+    let numCalls = 0;
+    provider.on('prioritizedAreasChanged', () => {
+      numCalls++;
+    });
+
+    provider.assignStyledNodeCollection(nodeCollection0, { prioritizedForLoadingHint: 5 });
+    provider.assignStyledNodeCollection(nodeCollection1, { visible: true });
+    provider.assignStyledNodeCollection(nodeCollection2, { prioritizedForLoadingHint: 5 });
+
+    expect(numCalls).toBe(2);
+  });
 });

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
@@ -30,18 +30,26 @@ export class NodeAppearanceProvider {
 
   private readonly _events = {
     changed: new EventTrigger<() => void>(),
-    loadingStateChanged: new EventTrigger<(isLoading: boolean) => void>()
+    loadingStateChanged: new EventTrigger<(isLoading: boolean) => void>(),
+    prioritizedAreasChanged: new EventTrigger<() => void>()
   };
 
   on(event: 'changed', listener: () => void): void;
   on(event: 'loadingStateChanged', listener: (isLoading: boolean) => void): void;
-  on(event: 'changed' | 'loadingStateChanged', listener: (() => void) | ((isLoading: boolean) => void)): void {
+  on(event: 'prioritizedAreasChanged', listener: () => void): void;
+  on(
+    event: 'changed' | 'loadingStateChanged' | 'prioritizedAreasChanged',
+    listener: (() => void) | ((isLoading: boolean) => void)
+  ): void {
     switch (event) {
       case 'changed':
         this._events.changed.subscribe(listener as () => void);
         break;
       case 'loadingStateChanged':
         this._events.loadingStateChanged.subscribe(listener as (isLoading: boolean) => void);
+        break;
+      case 'prioritizedAreasChanged':
+        this._events.prioritizedAreasChanged.subscribe(listener as () => void);
         break;
 
       default:
@@ -51,13 +59,19 @@ export class NodeAppearanceProvider {
 
   off(event: 'changed', listener: () => void): void;
   off(event: 'loadingStateChanged', listener: (isLoading: boolean) => void): void;
-  off(event: 'changed' | 'loadingStateChanged', listener: (() => void) | ((isLoading: boolean) => void)): void {
+  off(
+    event: 'changed' | 'loadingStateChanged' | 'prioritizedAreasChanged',
+    listener: (() => void) | ((isLoading: boolean) => void)
+  ): void {
     switch (event) {
       case 'changed':
         this._events.changed.unsubscribe(listener as () => void);
         break;
       case 'loadingStateChanged':
         this._events.loadingStateChanged.unsubscribe(listener as (isLoading: boolean) => void);
+        break;
+      case 'prioritizedAreasChanged':
+        this._events.prioritizedAreasChanged.unsubscribe(listener as () => void);
         break;
 
       default:
@@ -82,6 +96,10 @@ export class NodeAppearanceProvider {
       this._styledCollections.push(styledCollection);
       nodeCollection.on('changed', styledCollection.handleNodeCollectionChangedListener);
       this.scheduleNotifyChanged();
+    }
+
+    if (appearance.prioritizedForLoadingHint) {
+      this.notifyPrioritizedAreasChanged();
     }
   }
 
@@ -157,5 +175,9 @@ export class NodeAppearanceProvider {
   private handleNodeCollectionChanged(_styledSet: StyledNodeCollection) {
     this.scheduleNotifyChanged();
     this.notifyLoadingStateChanged();
+  }
+
+  private notifyPrioritizedAreasChanged() {
+    this._events.prioritizedAreasChanged.fire();
   }
 }


### PR DESCRIPTION
Causes setting prioritized hint for node collections to trigger sector loading so that the result becomes visible at once.