### PR TITLE
fix: update without color on superset of nodecollection resets color

### DIFF
--- a/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.test.ts
+++ b/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.test.ts
@@ -159,6 +159,52 @@ describe('NodeAppearanceTextureBuilder', () => {
     expect(texelsOf(builder.overrideColorPerTreeIndexTexture)).toEqual([0, 0, 0, 1]);
   });
 
+  test('add custom color then updating superset without color keeps color', () => {
+    // Need to do this here, as we want two elements in our buffer
+    const builder = new NodeAppearanceTextureBuilder(2, styleProvider);
+
+    const customColor: [number, number, number] = [127, 128, 129];
+
+    const set = new TreeIndexNodeCollection(new IndexSet([0]));
+    const style0: NodeAppearance = { color: customColor, visible: true };
+    styleProvider.assignStyledNodeCollection(set, style0);
+
+    jest.runAllTimers();
+    builder.build();
+
+    const superSet = new TreeIndexNodeCollection(new IndexSet([0, 1]));
+    const style1: NodeAppearance = { visible: true };
+    styleProvider.assignStyledNodeCollection(superSet, style1);
+
+    jest.runAllTimers();
+    builder.build();
+
+    expect(texelsOf(builder.overrideColorPerTreeIndexTexture)!.slice(0, 4)).toEqual([...customColor, 1]);
+  });
+
+  test('add custom color then updating superset with color 0, 0, 0 keeps color', () => {
+    // Need to do this here, as we want two elements in our buffer
+    const builder = new NodeAppearanceTextureBuilder(2, styleProvider);
+
+    const customColor: [number, number, number] = [127, 128, 129];
+
+    const set = new TreeIndexNodeCollection(new IndexSet([0]));
+    const style0: NodeAppearance = { color: customColor, visible: true };
+    styleProvider.assignStyledNodeCollection(set, style0);
+
+    jest.runAllTimers();
+    builder.build();
+
+    const superSet = new TreeIndexNodeCollection(new IndexSet([0, 1]));
+    const style1: NodeAppearance = { color: [0, 0, 0] };
+    styleProvider.assignStyledNodeCollection(superSet, style1);
+
+    jest.runAllTimers();
+    builder.build();
+
+    expect(texelsOf(builder.overrideColorPerTreeIndexTexture)!.slice(0, 4)).toEqual([...customColor, 1]);
+  });
+
   test('setDefaultStyle() triggers needs update', () => {
     builder.build(); // Clear needsUpdate
     expect(builder.needsUpdate).toBeFalse();

--- a/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.ts
+++ b/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.ts
@@ -234,7 +234,10 @@ function fillRGBA(rgbaBuffer: Uint8ClampedArray, style: NodeAppearance) {
 function combineRGBA(rgbaBuffer: Uint8ClampedArray, treeIndices: IndexSet, style: NodeAppearance) {
   const [r, g, b, a] = appearanceToColorOverride(style);
   // Create a bit mask for updating color (update if style contains color, don't update if it doesn't)
-  const updateRgbBitmask = style.color !== undefined ? 0b11111111 : 0;
+  const updateRgbBitmask =
+    style.color !== undefined && !(style.color[0] === 0 && style.color[1] === 0 && style.color[2] === 0)
+      ? 0b11111111
+      : 0;
   const keepRgbBitmask = ~updateRgbBitmask;
   const updateR = r & updateRgbBitmask;
   const updateG = g & updateRgbBitmask;
@@ -252,11 +255,15 @@ function combineRGBA(rgbaBuffer: Uint8ClampedArray, treeIndices: IndexSet, style
 
   treeIndices.forEachRange(range => {
     for (let i = range.from; i <= range.toInclusive; ++i) {
+      const oldR = rgbaBuffer[4 * i + 0];
+      const oldG = rgbaBuffer[4 * i + 1];
+      const oldB = rgbaBuffer[4 * i + 2];
+
       // Combine color - this will replace color if the style provided sets color or keep
       // the old color if not
-      rgbaBuffer[4 * i + 0] = (r & keepRgbBitmask) | updateR;
-      rgbaBuffer[4 * i + 1] = (g & keepRgbBitmask) | updateG;
-      rgbaBuffer[4 * i + 2] = (b & keepRgbBitmask) | updateB;
+      rgbaBuffer[4 * i + 0] = (oldR & keepRgbBitmask) | updateR;
+      rgbaBuffer[4 * i + 1] = (oldG & keepRgbBitmask) | updateG;
+      rgbaBuffer[4 * i + 2] = (oldB & keepRgbBitmask) | updateB;
       // Update "settings" - this will override any settings provided by the style,
       // but keep any existing setting that is not provided by the style
       rgbaBuffer[4 * i + 3] = (rgbaBuffer[4 * i + 3] & keepAlphaBitmask) | updateAlpha;

--- a/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.ts
+++ b/viewer/packages/rendering/src/rendering/NodeAppearanceTextureBuilder.ts
@@ -234,10 +234,7 @@ function fillRGBA(rgbaBuffer: Uint8ClampedArray, style: NodeAppearance) {
 function combineRGBA(rgbaBuffer: Uint8ClampedArray, treeIndices: IndexSet, style: NodeAppearance) {
   const [r, g, b, a] = appearanceToColorOverride(style);
   // Create a bit mask for updating color (update if style contains color, don't update if it doesn't)
-  const updateRgbBitmask =
-    style.color !== undefined && !(style.color[0] === 0 && style.color[1] === 0 && style.color[2] === 0)
-      ? 0b11111111
-      : 0;
+  const updateRgbBitmask = style.color !== undefined && !style.color.every(value => value === 0) ? 0b11111111 : 0;
   const keepRgbBitmask = ~updateRgbBitmask;
   const updateR = r & updateRgbBitmask;
   const updateG = g & updateRgbBitmask;


### PR DESCRIPTION
Basically replicates https://github.com/cognitedata/reveal/pull/1816 for the 3.0 alpha branch.

According to Christopher, this should not contribute too much to the pain it is to rebase.