### PR TITLE
chore: only deploy preview docs from one PR concurrently

### DIFF
--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -4,9 +4,8 @@ on:
   pull_request:
     branches-ignore:
       - 'dependabot/**'
-
 jobs:
-  build-and-deploy:
+  build:
     name: Publish documentation preview
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +46,12 @@ jobs:
           yarn install --immutable
           yarn build:fast
 
+  deploy:
+    name: Deploy preview documentation
+    concurrency: deploy-preview-documentation
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy documentation preview 🚀
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -47,7 +47,7 @@ jobs:
           yarn build:fast
 
   deploy:
-    name: Publish preview documentation
+    name: Publish documentation preview
     concurrency: deploy-preview-documentation
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -6,7 +6,7 @@ on:
       - 'dependabot/**'
 jobs:
   build:
-    name: Publish documentation preview
+    name: Build preview documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -47,7 +47,7 @@ jobs:
           yarn build:fast
 
   deploy:
-    name: Deploy preview documentation
+    name: Publish preview documentation
     concurrency: deploy-preview-documentation
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -48,6 +48,8 @@ jobs:
 
   deploy:
     name: Publish documentation preview
+    # Ensures that there only will be executed one "instance" of this operation
+    # across all ongoing Github Action executions
     concurrency: deploy-preview-documentation
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
This ensures that only one job is publishing preview docs at the same time, avoiding CI to fail because multiple PRs are deploying docs at the same time.