### PR TITLE
fix: model format priority

### DIFF
--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.test.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.test.ts
@@ -1,0 +1,112 @@
+/*!
+ * Copyright 2022 Cognite AS
+ */
+
+import { BlobOutputMetadata } from 'extensions/datasource';
+import { CadModelMetadataRepository } from './CadModelMetadataRepository';
+import { File3dFormat, ModelDataProvider, ModelMetadataProvider } from '@reveal/modeldata-api';
+
+import * as THREE from 'three';
+import { createV8SceneSectorMetadata, createV9SceneSectorMetadata } from '../../../../test-utilities';
+import { CadSceneRootMetadata } from './parsers/types';
+
+export interface ModelId {
+  readonly revealInternalId: symbol;
+}
+
+function urlFromBlobId(blobId: number) {
+  return `some_url/${blobId}`;
+}
+
+const v9BlobOutputMetadata: BlobOutputMetadata = {
+  blobId: 1,
+  format: File3dFormat.GltfCadModel,
+  version: 9
+};
+
+const v8BlobOutputMetadata: BlobOutputMetadata = {
+  blobId: 0,
+  format: File3dFormat.RevealCadModel,
+  version: 8
+};
+
+const v8SceneSectorMetadata: CadSceneRootMetadata = {
+  version: 8,
+  maxTreeIndex: 800,
+  unit: 'Meters',
+  sectors: [createV8SceneSectorMetadata(0)]
+};
+
+const v9SceneSectorMetadata: CadSceneRootMetadata = {
+  version: 9,
+  maxTreeIndex: 800,
+  unit: 'Meters',
+  sectors: [createV9SceneSectorMetadata(0)]
+};
+
+function createMockedMetadataProvider(outputList: BlobOutputMetadata[]): ModelMetadataProvider {
+  return {
+    getModelOutputs: async (_id: ModelId) => {
+      return outputList;
+    },
+    getModelUri: async (_id: ModelId, cadOutput: BlobOutputMetadata) => {
+      return urlFromBlobId(cadOutput.blobId);
+    },
+    getModelCamera: async () => {
+      return { position: new THREE.Vector3(), target: new THREE.Vector3() };
+    },
+    getModelMatrix: async () => {
+      return new THREE.Matrix4();
+    }
+  };
+}
+
+function createMockedModelDataProvider(): ModelDataProvider {
+  return {
+    getJsonFile: async (url: string) => {
+      const isGltf = url === urlFromBlobId(v9BlobOutputMetadata.blobId);
+      if (isGltf) {
+        return v9SceneSectorMetadata;
+      } else {
+        return v8SceneSectorMetadata;
+      }
+    },
+    getBinaryFile: async () => {
+      return new ArrayBuffer(1);
+    },
+    headers: {}
+  };
+}
+
+describe(CadModelMetadataRepository.name, () => {
+  test('output v8 is returned if v9 is not available', async () => {
+    // Arrange
+
+    /* Only return v8 from model metadata provider */
+    const availableOutputs = [v8BlobOutputMetadata];
+    const mockedMetadataProvider = createMockedMetadataProvider(availableOutputs);
+
+    const mockedModelDataProvider = createMockedModelDataProvider();
+
+    const cadModelMetadataRepository = new CadModelMetadataRepository(mockedMetadataProvider, mockedModelDataProvider);
+
+    // Act
+    const cadModelMetadata = await cadModelMetadataRepository.loadData({ revealInternalId: Symbol('some_model_id') });
+
+    // Assert
+    expect(cadModelMetadata.formatVersion).toBe(8);
+  });
+
+  test('output v9 is returned even if not first in output list', async () => {
+    const availableOutputs = [v8BlobOutputMetadata, v9BlobOutputMetadata];
+    const mockedMetadataProvider = createMockedMetadataProvider(availableOutputs);
+
+    const mockedModelDataProvider = createMockedModelDataProvider();
+
+    const cadModelMetadataRepository = new CadModelMetadataRepository(mockedMetadataProvider, mockedModelDataProvider);
+
+    const cadModelMetadata = await cadModelMetadataRepository.loadData({ revealInternalId: Symbol('some_model_id') });
+
+    expect(cadModelMetadata.formatVersion).toBe(9);
+  });
+});

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.test.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.test.ts
@@ -14,6 +14,39 @@ export interface ModelId {
   readonly revealInternalId: symbol;
 }
 
+describe(CadModelMetadataRepository.name, () => {
+  test('output v8 is returned if v9 is not available', async () => {
+    // Arrange
+
+    /* Only return v8 from model metadata provider */
+    const availableOutputs = [v8BlobOutputMetadata];
+    const mockedMetadataProvider = createMockedMetadataProvider(availableOutputs);
+
+    const mockedModelDataProvider = createMockedModelDataProvider();
+
+    const cadModelMetadataRepository = new CadModelMetadataRepository(mockedMetadataProvider, mockedModelDataProvider);
+
+    // Act
+    const cadModelMetadata = await cadModelMetadataRepository.loadData({ revealInternalId: Symbol('some_model_id') });
+
+    // Assert
+    expect(cadModelMetadata.formatVersion).toBe(8);
+  });
+
+  test('output v9 is returned even if not first in output list', async () => {
+    const availableOutputs = [v8BlobOutputMetadata, v9BlobOutputMetadata];
+    const mockedMetadataProvider = createMockedMetadataProvider(availableOutputs);
+
+    const mockedModelDataProvider = createMockedModelDataProvider();
+
+    const cadModelMetadataRepository = new CadModelMetadataRepository(mockedMetadataProvider, mockedModelDataProvider);
+
+    const cadModelMetadata = await cadModelMetadataRepository.loadData({ revealInternalId: Symbol('some_model_id') });
+
+    expect(cadModelMetadata.formatVersion).toBe(9);
+  });
+});
+
 function urlFromBlobId(blobId: number) {
   return `some_url/${blobId}`;
 }
@@ -77,36 +110,3 @@ function createMockedModelDataProvider(): ModelDataProvider {
     headers: {}
   };
 }
-
-describe(CadModelMetadataRepository.name, () => {
-  test('output v8 is returned if v9 is not available', async () => {
-    // Arrange
-
-    /* Only return v8 from model metadata provider */
-    const availableOutputs = [v8BlobOutputMetadata];
-    const mockedMetadataProvider = createMockedMetadataProvider(availableOutputs);
-
-    const mockedModelDataProvider = createMockedModelDataProvider();
-
-    const cadModelMetadataRepository = new CadModelMetadataRepository(mockedMetadataProvider, mockedModelDataProvider);
-
-    // Act
-    const cadModelMetadata = await cadModelMetadataRepository.loadData({ revealInternalId: Symbol('some_model_id') });
-
-    // Assert
-    expect(cadModelMetadata.formatVersion).toBe(8);
-  });
-
-  test('output v9 is returned even if not first in output list', async () => {
-    const availableOutputs = [v8BlobOutputMetadata, v9BlobOutputMetadata];
-    const mockedMetadataProvider = createMockedMetadataProvider(availableOutputs);
-
-    const mockedModelDataProvider = createMockedModelDataProvider();
-
-    const cadModelMetadataRepository = new CadModelMetadataRepository(mockedMetadataProvider, mockedModelDataProvider);
-
-    const cadModelMetadata = await cadModelMetadataRepository.loadData({ revealInternalId: Symbol('some_model_id') });
-
-    expect(cadModelMetadata.formatVersion).toBe(9);
-  });
-});

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
@@ -72,22 +72,24 @@ export class CadModelMetadataRepository implements MetadataRepository<Promise<Ca
       { format: File3dFormat.RevealCadModel, version: 8 }
     ];
 
-    for (const preferredOutput of preferredOutputs) {
-      const acceptableOutput = outputs.find(
-        supportedOutput =>
-          supportedOutput.format === preferredOutput.format && supportedOutput.version === preferredOutput.version
-      );
+    const supportedOutputs = preferredOutputs
+      .map(preferredOutput =>
+        outputs.find(
+          supportedOutput =>
+            supportedOutput.format === preferredOutput.format && supportedOutput.version === preferredOutput.version
+        )
+      )
+      .filter(supportedOutput => supportedOutput !== undefined);
 
-      if (acceptableOutput) {
-        return acceptableOutput;
-      }
+    if (supportedOutputs.length === 0) {
+      const cadModelOutputsString = outputs.map(output => `${output.format} v${output.version}`).join(', ');
+      const supportedOutputsString = preferredOutputs.map(output => `${output.format} v${output.version}`).join(', ');
+      throw new Error(
+        `Model does not contain any supported CAD model outputs, got [${cadModelOutputsString}], but only supports [${supportedOutputsString}]`
+      );
     }
 
-    const cadModelOutputsString = outputs.map(output => `${output.format} v${output.version}`).join(', ');
-    const supportedOutputsString = preferredOutputs.map(output => `${output.format} v${output.version}`).join(', ');
-    throw new Error(
-      `Model does not contain any supported CAD model outputs, got [${cadModelOutputsString}], but only supports [${supportedOutputsString}]`
-    );
+    return supportedOutputs[0]!;
   }
 }
 

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
@@ -72,21 +72,22 @@ export class CadModelMetadataRepository implements MetadataRepository<Promise<Ca
       { format: File3dFormat.RevealCadModel, version: 8 }
     ];
 
-    const supportedModelOutputs = outputs.filter(modelOutput => {
-      return preferredOutputs.some(supportedOutput => {
-        return supportedOutput.format === modelOutput.format && supportedOutput.version === modelOutput.version;
-      });
-    });
-
-    if (supportedModelOutputs.length === 0) {
-      const cadModelOutputsString = outputs.map(output => `${output.format} v${output.version}`).join(', ');
-      const supportedOutputsString = preferredOutputs.map(output => `${output.format} v${output.version}`).join(', ');
-      throw new Error(
-        `Model does not contain any supported CAD model outputs, got [${cadModelOutputsString}], but only supports [${supportedOutputsString}]`
+    for (const preferredOutput of preferredOutputs) {
+      const acceptableOutput = outputs.find(
+        supportedOutput =>
+          supportedOutput.format === preferredOutput.format && supportedOutput.version === preferredOutput.version
       );
+
+      if (acceptableOutput) {
+        return acceptableOutput;
+      }
     }
 
-    return supportedModelOutputs[0];
+    const cadModelOutputsString = outputs.map(output => `${output.format} v${output.version}`).join(', ');
+    const supportedOutputsString = preferredOutputs.map(output => `${output.format} v${output.version}`).join(', ');
+    throw new Error(
+      `Model does not contain any supported CAD model outputs, got [${cadModelOutputsString}], but only supports [${supportedOutputsString}]`
+    );
   }
 }
 

--- a/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserGltf.test.ts
+++ b/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserGltf.test.ts
@@ -7,7 +7,9 @@ import * as THREE from 'three';
 import { traverseDepthFirst } from '@reveal/utilities';
 import { V9SectorMetadata } from '../types';
 import { parseCadMetadataGltf } from './CadMetadataParserGltf';
-import { CadSceneRootMetadata, V9SceneSectorMetadata } from './types';
+import { CadSceneRootMetadata } from './types';
+
+import { createV9SceneSectorMetadata } from '../../../../../test-utilities';
 
 describe('CadMetadataParserGltf', () => {
   test('Metadata without sectors, throws', () => {
@@ -25,14 +27,14 @@ describe('CadMetadataParserGltf', () => {
       version: 9,
       maxTreeIndex: 103350,
       unit: 'Meters',
-      sectors: [createSectorMetadata(1)]
+      sectors: [createV9SceneSectorMetadata(1)]
     };
     expect(() => parseCadMetadataGltf(metadata)).toThrow();
   });
 
   test('Metadata with single root, return valid scene', () => {
     // Arrange
-    const sectorRoot = createSectorMetadata(0);
+    const sectorRoot = createV9SceneSectorMetadata(0);
     const metadata: CadSceneRootMetadata = {
       version: 9,
       maxTreeIndex: 8000,
@@ -73,11 +75,11 @@ describe('CadMetadataParserGltf', () => {
       maxTreeIndex: 8000,
       unit: 'Meters',
       sectors: [
-        createSectorMetadata(0),
-        createSectorMetadata(1, 0),
-        createSectorMetadata(2, 0),
-        createSectorMetadata(3, 1),
-        createSectorMetadata(4, 3)
+        createV9SceneSectorMetadata(0),
+        createV9SceneSectorMetadata(1, 0),
+        createV9SceneSectorMetadata(2, 0),
+        createV9SceneSectorMetadata(3, 1),
+        createV9SceneSectorMetadata(4, 3)
       ]
     };
 
@@ -107,10 +109,10 @@ describe('CadMetadataParserGltf', () => {
           /
          3
          */
-        createSectorMetadata(2, 0),
-        createSectorMetadata(0),
-        createSectorMetadata(3, 1),
-        createSectorMetadata(1, 0)
+        createV9SceneSectorMetadata(2, 0),
+        createV9SceneSectorMetadata(0),
+        createV9SceneSectorMetadata(3, 1),
+        createV9SceneSectorMetadata(1, 0)
       ]
     };
 
@@ -142,7 +144,7 @@ describe('CadMetadataParserGltf', () => {
       version: 9,
       maxTreeIndex: 4,
       unit: 'AU',
-      sectors: [createSectorMetadata(0)]
+      sectors: [createV9SceneSectorMetadata(0)]
     };
 
     // Act
@@ -152,31 +154,3 @@ describe('CadMetadataParserGltf', () => {
     expect(result.unit).toBe('AU');
   });
 });
-
-function createSectorMetadata(id: number, parentId: number = -1): V9SceneSectorMetadata {
-  const metadata: V9SceneSectorMetadata = {
-    id,
-    parentId,
-    path: '0/',
-    depth: 0,
-    estimatedDrawCallCount: 10,
-    estimatedTriangleCount: 10,
-    boundingBox: {
-      min: {
-        x: 0.0,
-        y: 0.0,
-        z: 0.0
-      },
-      max: {
-        x: 1.0,
-        y: 1.0,
-        z: 1.0
-      }
-    },
-    downloadSize: 1000,
-    maxDiagonalLength: 10,
-    minDiagonalLength: 5,
-    sectorFileName: `${id}.glb`
-  };
-  return metadata;
-}

--- a/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserV8.test.ts
+++ b/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserV8.test.ts
@@ -10,6 +10,8 @@ import { traverseDepthFirst } from '@reveal/utilities';
 import { Mutable } from '../../../../../test-utilities/src/reflection';
 import { CadSceneRootMetadata, V8SceneSectorMetadata } from './types';
 
+import { createV8SceneSectorMetadata } from '../../../../../test-utilities';
+
 describe('parseCadMetadataV8', () => {
   test('Metadata without sectors, throws', () => {
     const metadata: CadSceneRootMetadata = {
@@ -26,14 +28,14 @@ describe('parseCadMetadataV8', () => {
       version: 8,
       maxTreeIndex: 103350,
       unit: 'Meters',
-      sectors: [createSectorMetadata(1)]
+      sectors: [createV8SceneSectorMetadata(1)]
     };
     expect(() => parseCadMetadataV8(metadata)).toThrow();
   });
 
   test('Metadata with single root, return valid scene', () => {
     // Arrange
-    const sectorRoot = createSectorMetadata(0);
+    const sectorRoot = createV8SceneSectorMetadata(0);
     const metadata: CadSceneRootMetadata = {
       version: 8,
       maxTreeIndex: 8000,
@@ -70,7 +72,7 @@ describe('parseCadMetadataV8', () => {
 
   test('Metadata with missing recursiveCoverageFactors, falls back to coverageFactors', () => {
     // Arrange
-    const sectorRoot = createSectorMetadata(0);
+    const sectorRoot = createV8SceneSectorMetadata(0);
     const metadata: CadSceneRootMetadata = {
       version: 8,
       maxTreeIndex: 8000,
@@ -110,11 +112,11 @@ describe('parseCadMetadataV8', () => {
       maxTreeIndex: 8000,
       unit: 'Meters',
       sectors: [
-        createSectorMetadata(0),
-        createSectorMetadata(1, 0),
-        createSectorMetadata(2, 0),
-        createSectorMetadata(3, 1),
-        createSectorMetadata(4, 3)
+        createV8SceneSectorMetadata(0),
+        createV8SceneSectorMetadata(1, 0),
+        createV8SceneSectorMetadata(2, 0),
+        createV8SceneSectorMetadata(3, 1),
+        createV8SceneSectorMetadata(4, 3)
       ]
     };
 
@@ -144,10 +146,10 @@ describe('parseCadMetadataV8', () => {
           /
          3
          */
-        createSectorMetadata(2, 0),
-        createSectorMetadata(0),
-        createSectorMetadata(3, 1),
-        createSectorMetadata(1, 0)
+        createV8SceneSectorMetadata(2, 0),
+        createV8SceneSectorMetadata(0),
+        createV8SceneSectorMetadata(3, 1),
+        createV8SceneSectorMetadata(1, 0)
       ]
     };
 
@@ -175,7 +177,7 @@ describe('parseCadMetadataV8', () => {
 
   test('Single sector without facesFile, creates dummy faces section', () => {
     // Arrange
-    const root: Mutable<V8SceneSectorMetadata> = createSectorMetadata(0, -1);
+    const root: Mutable<V8SceneSectorMetadata> = createV8SceneSectorMetadata(0, -1);
     root.facesFile = null;
     const metadata: CadSceneRootMetadata = {
       version: 8,
@@ -198,9 +200,9 @@ describe('parseCadMetadataV8', () => {
 
   test('Metadata is missing facesFile from leafs, creates dummy facesFile with coverage factors from parent', () => {
     // Arrange
-    const leaf2: Mutable<V8SceneSectorMetadata> = createSectorMetadata(3, 1);
+    const leaf2: Mutable<V8SceneSectorMetadata> = createV8SceneSectorMetadata(3, 1);
     leaf2.facesFile = null;
-    const leaf3: Mutable<V8SceneSectorMetadata> = createSectorMetadata(2, 0);
+    const leaf3: Mutable<V8SceneSectorMetadata> = createV8SceneSectorMetadata(2, 0);
     leaf3.facesFile = null;
     const metadata: CadSceneRootMetadata = {
       version: 8,
@@ -215,9 +217,9 @@ describe('parseCadMetadataV8', () => {
          3
          */
         leaf2,
-        createSectorMetadata(0),
+        createV8SceneSectorMetadata(0),
         leaf3,
-        createSectorMetadata(1, 0)
+        createV8SceneSectorMetadata(1, 0)
       ]
     };
 
@@ -248,10 +250,10 @@ describe('parseCadMetadataV8', () => {
   test('No sectors has faces files, provides dummy values for all', () => {
     // Arrange
     const sectors: Mutable<V8SceneSectorMetadata>[] = [
-      createSectorMetadata(2, 0),
-      createSectorMetadata(0),
-      createSectorMetadata(3, 1),
-      createSectorMetadata(1, 0)
+      createV8SceneSectorMetadata(2, 0),
+      createV8SceneSectorMetadata(0),
+      createV8SceneSectorMetadata(3, 1),
+      createV8SceneSectorMetadata(1, 0)
     ];
     sectors.forEach(x => (x.facesFile = null));
     const metadata: CadSceneRootMetadata = {
@@ -281,7 +283,7 @@ describe('parseCadMetadataV8', () => {
       version: 8,
       maxTreeIndex: 4,
       unit: 'AU',
-      sectors: [createSectorMetadata(0)]
+      sectors: [createV8SceneSectorMetadata(0)]
     };
 
     // Act
@@ -291,47 +293,3 @@ describe('parseCadMetadataV8', () => {
     expect(result.unit).toBe('AU');
   });
 });
-
-function createSectorMetadata(id: number, parentId: number = -1): V8SceneSectorMetadata {
-  const metadata: V8SceneSectorMetadata = {
-    id,
-    parentId,
-    path: '0/',
-    depth: 0,
-    estimatedDrawCallCount: 10,
-    estimatedTriangleCount: 10,
-    boundingBox: {
-      min: {
-        x: 0.0,
-        y: 0.0,
-        z: 0.0
-      },
-      max: {
-        x: 1.0,
-        y: 1.0,
-        z: 1.0
-      }
-    },
-    indexFile: {
-      fileName: `sector_${id}.i3d`,
-      peripheralFiles: [],
-      downloadSize: 19996
-    },
-    facesFile: {
-      fileName: `sector_${id}.f3d`,
-      quadSize: 0.5,
-      coverageFactors: {
-        xy: 0.5,
-        xz: 0.5,
-        yz: 0.5
-      },
-      recursiveCoverageFactors: {
-        xy: 0.6,
-        xz: 0.7,
-        yz: 0.8
-      },
-      downloadSize: 1000
-    }
-  };
-  return metadata;
-}

--- a/viewer/test-utilities/index.ts
+++ b/viewer/test-utilities/index.ts
@@ -10,6 +10,8 @@ export {
   SectorTree
 } from './src/createSectorMetadata';
 
+export { createV8SceneSectorMetadata, createV9SceneSectorMetadata } from './src/createSceneSectorMetadata';
+
 export { createCadModelMetadata } from './src/createCadModelMetadata';
 export { createCadModel } from './src/createCadModel';
 export { createDetermineSectorInput } from './src/createDetermineSectorInput';

--- a/viewer/test-utilities/src/createSceneSectorMetadata.ts
+++ b/viewer/test-utilities/src/createSceneSectorMetadata.ts
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2022 Cognite AS
+ */
+
+import { V9SceneSectorMetadata, V8SceneSectorMetadata } from '../../packages/cad-parsers/src/metadata/parsers/types';
+
+export function createV9SceneSectorMetadata(id: number, parentId: number = -1): V9SceneSectorMetadata {
+  const metadata: V9SceneSectorMetadata = {
+    id,
+    parentId,
+    path: '0/',
+    depth: 0,
+    estimatedDrawCallCount: 10,
+    estimatedTriangleCount: 10,
+    boundingBox: {
+      min: {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0
+      },
+      max: {
+        x: 1.0,
+        y: 1.0,
+        z: 1.0
+      }
+    },
+    downloadSize: 1000,
+    maxDiagonalLength: 10,
+    minDiagonalLength: 5,
+    sectorFileName: `${id}.glb`
+  };
+  return metadata;
+}
+
+export function createV8SceneSectorMetadata(id: number, parentId: number = -1): V8SceneSectorMetadata {
+  const metadata: V8SceneSectorMetadata = {
+    id,
+    parentId,
+    path: '0/',
+    depth: 0,
+    estimatedDrawCallCount: 10,
+    estimatedTriangleCount: 10,
+    boundingBox: {
+      min: {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0
+      },
+      max: {
+        x: 1.0,
+        y: 1.0,
+        z: 1.0
+      }
+    },
+    indexFile: {
+      fileName: `sector_${id}.i3d`,
+      peripheralFiles: [],
+      downloadSize: 19996
+    },
+    facesFile: {
+      fileName: `sector_${id}.f3d`,
+      quadSize: 0.5,
+      coverageFactors: {
+        xy: 0.5,
+        xz: 0.5,
+        yz: 0.5
+      },
+      recursiveCoverageFactors: {
+        xy: 0.6,
+        xz: 0.7,
+        yz: 0.8
+      },
+      downloadSize: 1000
+    }
+  };
+  return metadata;
+}


### PR DESCRIPTION
Reveal is supposed to choose geometry file format depending on the priority given in CadModelMetadataRepository. Instead, it chooses the first output in the output list that matches one of the two formats (v8 / v9). 

In practice, this seems to virtually never be an issue since v9 is often (always?) first, but anyway.