### PR TITLE
fix: GltfSectorRepository fails on small cache size

### DIFF
--- a/viewer/packages/utilities/src/cache/MemoryRequestCache.test.ts
+++ b/viewer/packages/utilities/src/cache/MemoryRequestCache.test.ts
@@ -41,5 +41,21 @@ describe('MemoryRequestCache', () => {
     expect(() => cache.forceInsert(4, 'test')).not.toThrow();
   });
 
+  test('cache does not fail on insertion when initialized to size 0', () => {
+    const cache = new MemoryRequestCache<number, string>(0);
+
+    expect(() => cache.insert(1, 'test')).not.toThrow();
+    expect(() => cache.forceInsert(2, 'test')).not.toThrow();
+  });
+
+  test('cache does not fail on insertion when given cleanup count 0', () => {
+    const cache = new MemoryRequestCache<number, string>(2, () => {}, 0);
+
+    cache.insert(1, 'test');
+    cache.insert(2, 'test');
+
+    expect(() => cache.forceInsert(3, 'test')).not.toThrow();
+  });
+
   // TODO add test that requires data
 });

--- a/viewer/packages/utilities/src/cache/MemoryRequestCache.test.ts
+++ b/viewer/packages/utilities/src/cache/MemoryRequestCache.test.ts
@@ -31,5 +31,15 @@ describe('MemoryRequestCache', () => {
     jest.resetAllMocks();
   });
 
+  test('cache is correctly cleaned up on forceInsert after resize with small size', () => {
+    const cache = new MemoryRequestCache<number, string>(10);
+    cache.resize(2);
+
+    cache.insert(2, 'test');
+    cache.insert(3, 'test');
+
+    expect(() => cache.forceInsert(4, 'test')).not.toThrow();
+  });
+
   // TODO add test that requires data
 });

--- a/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
+++ b/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
@@ -110,7 +110,7 @@ export class MemoryRequestCache<Key, Data> implements RequestCache<Key, Data> {
 
   resize(cacheSize: number): void {
     this._maxElementsInCache = cacheSize;
-    this._defaultCleanupCount = Math.ceil(cacheSize * MemoryRequestCache.CLEANUP_COUNT_TO_CAPACITY_RATIO);
+    this._defaultCleanupCount = Math.max(cacheSize * MemoryRequestCache.CLEANUP_COUNT_TO_CAPACITY_RATIO, 1);
 
     if (this.isFull()) {
       this.cleanCache(this._data.size - this._maxElementsInCache);

--- a/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
+++ b/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
@@ -110,7 +110,7 @@ export class MemoryRequestCache<Key, Data> implements RequestCache<Key, Data> {
 
   resize(cacheSize: number): void {
     this._maxElementsInCache = cacheSize;
-    this._defaultCleanupCount = Math.floor(cacheSize * MemoryRequestCache.CLEANUP_COUNT_TO_CAPACITY_RATIO);
+    this._defaultCleanupCount = Math.ceil(cacheSize * MemoryRequestCache.CLEANUP_COUNT_TO_CAPACITY_RATIO);
 
     if (this.isFull()) {
       this.cleanCache(this._data.size - this._maxElementsInCache);

--- a/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
+++ b/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
@@ -90,7 +90,7 @@ export class MemoryRequestCache<Key, Data> implements RequestCache<Key, Data> {
   }
 
   isFull(): boolean {
-    return !(this._data.size < this._maxElementsInCache);
+    return this._data.size >= this._maxElementsInCache;
   }
 
   cleanCache(count: number): void {

--- a/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
+++ b/viewer/packages/utilities/src/cache/MemoryRequestCache.ts
@@ -46,7 +46,7 @@ export class MemoryRequestCache<Key, Data> implements RequestCache<Key, Data> {
   ) {
     this._data = new Map();
     this._maxElementsInCache = maxElementsInCache;
-    this._defaultCleanupCount = defaultCleanupCount;
+    this._defaultCleanupCount = Math.max(defaultCleanupCount, 1);
     this._removeCallback = removeCallback;
   }
 
@@ -64,7 +64,7 @@ export class MemoryRequestCache<Key, Data> implements RequestCache<Key, Data> {
   insert(id: Key, data: Data): void {
     if (this._data.size < this._maxElementsInCache) {
       this._data.set(id, new TimestampedContainer(data));
-    } else {
+    } else if (this._maxElementsInCache > 0) {
       throw new Error('Cache full, please clean Cache and retry adding data');
     }
   }


### PR DESCRIPTION
This is because the default number of sectors to remove on cleanup is 0 for small cache sizes, so that the cache remains full after cleanup.