### PR TITLE
fix: instanced mesh is not transformed by transform override

### DIFF
--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
@@ -30,7 +30,7 @@ void main()
     v_color = a_color;
 
     vec3 transformed = (a_instanceMatrix * vec4(position, 1.0)).xyz;
-    vec4 modelViewPosition = viewMatrix * modelMatrix * vec4(transformed, 1.0);
+    vec4 modelViewPosition = viewMatrix * treeIndexWorldTransform * modelMatrix * vec4(transformed, 1.0);
     v_viewPosition = modelViewPosition.xyz;
     v_treeIndex = a_treeIndex;
     gl_Position = projectionMatrix * modelViewPosition;


### PR DESCRIPTION
Also transitively fixes the explode tool issue in the documentation. 