### PR TITLE
fix: clearing wrong render target

### DIFF
--- a/viewer/packages/cad-model/src/PickingHandler.ts
+++ b/viewer/packages/cad-model/src/PickingHandler.ts
@@ -188,7 +188,6 @@ export class PickingHandler {
     const stateHelper = new WebGLRendererStateHelper(renderer);
     try {
       stateHelper.setClearColor(clearColor, clearAlpha);
-      renderer.clearColor();
       this._pipelineExecutor.render(renderPipeline, pickCamera);
       renderer.readRenderTargetPixels(renderTarget, 0, 0, 1, 1, pixelBuffer);
     } finally {


### PR DESCRIPTION
Fixes the "white screen" issue when picking / mouse scrolling