### PR TITLE
fix: add a force override overload for updating the camera state

### DIFF
--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -141,7 +141,7 @@ export class ComboControls extends EventDispatcher {
     };
   }
 
-  public update = (deltaTime: number): boolean => {
+  public update = (deltaTime: number, forceUpdate = false): boolean => {
     const {
       _camera,
       _target,
@@ -157,7 +157,7 @@ export class ComboControls extends EventDispatcher {
       enabled
     } = this;
 
-    if (!enabled) {
+    if (!forceUpdate && !enabled) {
       return false;
     }
 
@@ -242,7 +242,7 @@ export class ComboControls extends EventDispatcher {
     this._target.copy(this._targetEnd);
     this._scrollTarget.copy(target);
     this._spherical.copy(this._sphericalEnd);
-    this.update(1000 / this._targetFPS);
+    this.update(1000 / this._targetFPS, true);
     this.triggerCameraChangeEvent();
   };
 

--- a/viewer/packages/camera-manager/tests/ComboControls.test.ts
+++ b/viewer/packages/camera-manager/tests/ComboControls.test.ts
@@ -3,16 +3,16 @@
  */
 
 import * as THREE from 'three';
-import 'jest-extended';
 import { ComboControls } from '../src/ComboControls';
+import { It, Mock } from 'moq.ts';
 
 describe('Combo Controls', () => {
   let controls: ComboControls;
 
   beforeEach(() => {
     const camera = new THREE.PerspectiveCamera();
-    const domElement = document.createElement('div');
-    controls = new ComboControls(camera, domElement);
+    const domElementMock = new Mock<HTMLDivElement>().setup(p => p.addEventListener(It.IsAny(), It.IsAny())).returns();
+    controls = new ComboControls(camera, domElementMock.object());
   });
 
   test('Getting a state should return the same as the state that was set', () => {


### PR DESCRIPTION
# Description
Adds a override in the update of the camera controls to allow for setting the camera state even though the controls are disabled.


# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [ ] I am proud of this feature.

- **I am not proud of this due to having to implement this in the controls though setting the camera state should not touch the controls. Also virtually impossible to test due to the tight coupling with DOM events.**
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.

- **Tried my best but had to give up due to the horrible coupling of logic and DOM.**
- [ ] I have refactored the code for readability to the best of my ability.

- **I have not, but that would require a large amount of work, almost to the point of totally re-designing the entire controls.**
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking cabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- **I have, and my conclusion is that it is awful.** 
- [x] I have asked peers to test this feature.
