### PR TITLE
chore: bump cognite SDK and SDK-core

### DIFF
--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -1566,6 +1566,7 @@
 
 "@cognite/reveal@link:../viewer/dist":
   version "0.0.0"
+  uid ""
 
 "@cognite/sdk-1.x@npm:@cognite/sdk@^3.4.0":
   version "3.5.2"
@@ -1627,8 +1628,20 @@
     query-string "^5.1.1"
     url "^0.11.0"
 
+"@cognite/sdk-core@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.4.0.tgz#73ff6332006256e63da69d669af35c9eb8f27f5f"
+  integrity sha512-lAW43TKWevDIjcqFThlQRch2Qh+K+ZyrpNbVAUdlE8ZoqWzyvtsHoCf8WCtyAvUgtksr4biFdZ7oyf2ZigKR8g==
+  dependencies:
+    cross-fetch "^3.0.4"
+    is-buffer "^2.0.5"
+    lodash "^4.17.11"
+    query-string "^5.1.1"
+    url "^0.11.0"
+
 "@cognite/sdk@link:../viewer/node_modules/@cognite/sdk":
   version "0.0.0"
+  uid ""
 
 "@cognite/three-combo-controls@^1.4.3":
   version "1.4.3"
@@ -2364,7 +2377,7 @@
   dependencies:
     "@types/draco3d" "*"
 
-"@types/geojson@^7946.0.8":
+"@types/geojson@7946.0.8", "@types/geojson@^7946.0.8":
   version "7946.0.8"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
   integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
@@ -2529,6 +2542,11 @@
   version "0.138.0"
   resolved "https://registry.yarnpkg.com/@types/three/-/three-0.138.0.tgz#ec9f1d1fd8dffea2e0572f9d815ff5a35cf4dc6b"
   integrity sha512-D8AoV7h2kbCfrv/DcebHOFh1WDwyus3HdooBkAwcBikXArdqnsQ38PQ85JCunnvun160oA9jz53GszF3zch3tg==
+
+"@types/three@0.140.0":
+  version "0.140.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.140.0.tgz#3b74a021a69a6e2cd0e2550def15aa4c1c20e924"
+  integrity sha512-YPJLSIY6uKUOp1k6BZYDq5GtEIdhfeK04UCbc9IPAVbdn/RNjkfrbnyd7smrsNkJhc0IFASLpd3AAYgwqgXKVQ==
 
 "@types/uglify-js@*":
   version "3.13.1"
@@ -5815,6 +5833,11 @@ geo-three@^0.0.15:
   dependencies:
     "@types/offscreencanvas" "^2019.6.3"
 
+geojson@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/geojson/-/geojson-0.5.0.tgz#3cd6c96399be65b56ee55596116fe9191ce701c0"
+  integrity sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -7959,6 +7982,11 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+mgrs@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mgrs/-/mgrs-1.0.0.tgz#fb91588e78c90025672395cb40b25f7cd6ad1829"
+  integrity sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==
+
 microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
@@ -9697,6 +9725,14 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
+proj4@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.8.0.tgz#b2cb8f3ccd56d4dcc7c3e46155cd02caa804b170"
+  integrity sha512-baC+YcD4xsSqJ+CpCZljj2gcQDhlKb+J+Zjv/2KSBwWNjk4M0pafgQsE+mWurd84tflMIsP+7j7mtIpFDHzQfQ==
+  dependencies:
+    mgrs "1.0.0"
+    wkt-parser "^1.3.1"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -11575,6 +11611,11 @@ three@0.138.3:
   resolved "https://registry.yarnpkg.com/three/-/three-0.138.3.tgz#7be5153d79dcbf9e9baad82e7faf8c29edda4ed0"
   integrity sha512-4t1cKC8gimNyJChJbaklg8W/qj3PpsLJUIFm5LIuAy/hVxxNm1ru2FGTSfbTSsuHmC/7ipsyuGKqrSAKLNtkzg==
 
+three@0.140.2:
+  version "0.140.2"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.140.2.tgz#ca0b7390d1ce4f7f2850e80afd00ef48fc244491"
+  integrity sha512-DdT/AHm/TbZXEhQKQpGt5/iSgBrmXpjU26FNtj1KhllVPTKj1eG4X/ShyD5W2fngE+I1s1wa4ttC4C3oCJt7Ag==
+
 through2@^0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
@@ -12620,6 +12661,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+wkt-parser@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.3.2.tgz#deeff04a21edc5b170a60da418e9ed1d1ab0e219"
+  integrity sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ==
 
 word-wrap@~1.2.3:
   version "1.2.3"

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -64,8 +64,8 @@
   },
   "devDependencies": {
     "@azure/msal-browser": "2.24.0",
-    "@cognite/sdk": "7.5.1",
-    "@cognite/sdk-core": "^4.1.1",
+    "@cognite/sdk": "7.6.1",
+    "@cognite/sdk-core": "4.4.0",
     "@types/dat.gui": "0.7.7",
     "@types/jest": "27.5.2",
     "@types/jsdom": "16.2.14",

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -698,8 +698,8 @@ __metadata:
   dependencies:
     "@azure/msal-browser": 2.24.0
     "@cognite/reveal-parser-worker": 1.3.0
-    "@cognite/sdk": 7.5.1
-    "@cognite/sdk-core": ^4.1.1
+    "@cognite/sdk": 7.6.1
+    "@cognite/sdk-core": 4.4.0
     "@tweenjs/tween.js": 18.6.4
     "@types/dat.gui": 0.7.7
     "@types/draco3dgltf": 1.4.0
@@ -777,40 +777,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cognite/sdk-core@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "@cognite/sdk-core@npm:4.1.1"
+"@cognite/sdk-core@npm:4.4.0, @cognite/sdk-core@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@cognite/sdk-core@npm:4.4.0"
   dependencies:
     cross-fetch: ^3.0.4
     is-buffer: ^2.0.5
     lodash: ^4.17.11
     query-string: ^5.1.1
     url: ^0.11.0
-  checksum: 5009dfda18388178ccb10a66e7ad0d1723bc7e00e0a2fdc73b9353379f879d131ad73c5a0286dc24b15cdc117e9560ad66e961d6174a94f48b000423aa7e9c40
+  checksum: ad9708580b7c3a12685c0dbb1e696a55441f65d7f19a3bb06e732e543893e2efa814039f87795fec0538de5c6a6c6d8acdb91f1b9510020d59840398b7706450
   languageName: node
   linkType: hard
 
-"@cognite/sdk-core@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@cognite/sdk-core@npm:4.2.0"
+"@cognite/sdk@npm:7.6.1":
+  version: 7.6.1
+  resolution: "@cognite/sdk@npm:7.6.1"
   dependencies:
-    cross-fetch: ^3.0.4
-    is-buffer: ^2.0.5
-    lodash: ^4.17.11
-    query-string: ^5.1.1
-    url: ^0.11.0
-  checksum: b6ebbe6b7579d4a62b04af09eda800b39de7e0b4684a8bca9265559e8f7519aac473779a15f8d90c87f7f0c6f0294588bdafa46e10115e7217bc72ec5e0ae5e9
-  languageName: node
-  linkType: hard
-
-"@cognite/sdk@npm:7.5.1":
-  version: 7.5.1
-  resolution: "@cognite/sdk@npm:7.5.1"
-  dependencies:
-    "@cognite/sdk-core": ^4.2.0
+    "@cognite/sdk-core": ^4.4.0
     geojson: ^0.5.0
     lodash: ^4.17.11
-  checksum: f74cc64e086baeb8988282a83d433e48ac73bb861b7c33a4e008c05bda56e4ac2b551269125946ea72863b38aebc3a609114c95e7da159d4e79da49227e7b78c
+  checksum: 10510f22efb60c6291488a51e40ee283a2177c17947a878187c25132456daa359bb314d664ecbf52d54b1e07863595d8f6719414881c70886533eb0b2587cc4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Bump SDK version, current version seems to break in the browser due to certain nodejs dependencies. This causes issues when running documentation locally.
