### PR TITLE
fix: metrics tracing for geomap tool usage

### DIFF
--- a/viewer/packages/tools/src/Geomap/GeomapTool.ts
+++ b/viewer/packages/tools/src/Geomap/GeomapTool.ts
@@ -22,7 +22,7 @@ export class GeomapTool extends Cognite3DViewerToolBase {
     this._viewer = viewer;
     this._maps = new Geomap(this._viewer, config);
 
-    MetricsLogger.trackCreateTool('AxisViewTool');
+    MetricsLogger.trackCreateTool('GeomapTool');
   }
 
   /**


### PR DESCRIPTION
# Description

Fixed geomap tool metrics, the usage was zero as this tool was tracing `AxisViewTool` rather than itself.


# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I have performed a self-review of my own code.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
[REV-394](https://cognitedata.atlassian.net/browse/REV-394)
