### PR TITLE
chore: Fix triple import error and sdk-playground version from latest master rebase

### DIFF
--- a/examples/src/utils/InspectNodeUi.ts
+++ b/examples/src/utils/InspectNodeUi.ts
@@ -1,6 +1,5 @@
 import * as dat from 'dat.gui';
-import * as THREE from 'three';
-import { Cognite3DModel, Cognite3DViewer, DefaultCameraManager } from "@cognite/reveal";
+import { Cognite3DModel, Cognite3DViewer, DefaultCameraManager, THREE } from "@cognite/reveal";
 import { CogniteClient, Node3D } from "@cognite/sdk";
 import { TreeIndexNodeCollection } from '@cognite/reveal';
 import { NumericRange } from '@cognite/reveal';

--- a/examples/src/utils/PointCloudObjectStylingUI.ts
+++ b/examples/src/utils/PointCloudObjectStylingUI.ts
@@ -2,8 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import { CognitePointCloudModel } from '@cognite/reveal';
-import * as THREE from 'three';
+import { CognitePointCloudModel, THREE } from '@cognite/reveal';
 
 export class PointCloudObjectStylingUI {
 

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1274,10 +1274,10 @@
     query-string "^5.1.1"
     url "^0.11.0"
 
-"@cognite/sdk-core@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.1.3.tgz#e2dc84159ffc1f71397d3ced8d55d6a868bafef3"
-  integrity sha512-6vywOs6yR1GCM4V0Z+YsStw0DPh2UZ/neGjWkbGR5ff9X367LgnCxXrtskWRCVVdmkoWKiaf6Z+jkJoeTVr6lA==
+"@cognite/sdk-core@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.5.0.tgz#d93c128f552aed124128345adc8f35ce1cbba3a5"
+  integrity sha512-HwurP2XfkTQcPgKI5R+90i5vpRNI2EyZf7Qvvauw5VCXmn7iOgOgEJD1BaXCmP/Oz280VySPBwhSLih/6Ffbvg==
   dependencies:
     cross-fetch "^3.0.4"
     is-buffer "^2.0.5"
@@ -1289,60 +1289,12 @@
   version "0.0.0"
   uid ""
 
-"@cognite/sdk@^7.2.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk/-/sdk-7.2.5.tgz#e3be4a835eab00c2765089bdfaf7992e4fbbe7ae"
-  integrity sha512-rLVHvODP0lVacs+5dyngLcnngBFtlnS7FBy09AQbP5EM30LBppJBvSwKNRi/XjYbxM010Dx2AwYgo8LBIPoL0Q==
+"@cognite/sdk@^7.6.1":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk/-/sdk-7.7.0.tgz#91080a08173c64d72cfecac2a55ef59a5770a7a1"
+  integrity sha512-W4fhpowZqE4asb0wS0H7MpwwSWVjb0P+IutMqSSgRZz1uPtlXIjeZFXeGm0QNXHbR7C8wLxXubam7ke+cEVcjA==
   dependencies:
-    "@cognite/sdk-core" "^4.1.3"
-    geojson "^0.5.0"
-    lodash "^4.17.11"
-
-"@cognite/sdk-core@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.1.3.tgz#e2dc84159ffc1f71397d3ced8d55d6a868bafef3"
-  integrity sha512-6vywOs6yR1GCM4V0Z+YsStw0DPh2UZ/neGjWkbGR5ff9X367LgnCxXrtskWRCVVdmkoWKiaf6Z+jkJoeTVr6lA==
-  dependencies:
-    cross-fetch "^3.0.4"
-    is-buffer "^2.0.5"
-    lodash "^4.17.11"
-    query-string "^5.1.1"
-    url "^0.11.0"
-
-"@cognite/sdk-playground@link:../viewer/node_modules/@cognite/sdk-playground":
-  version "0.0.0"
-  uid ""
-
-"@cognite/sdk@^7.2.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk/-/sdk-7.2.5.tgz#e3be4a835eab00c2765089bdfaf7992e4fbbe7ae"
-  integrity sha512-rLVHvODP0lVacs+5dyngLcnngBFtlnS7FBy09AQbP5EM30LBppJBvSwKNRi/XjYbxM010Dx2AwYgo8LBIPoL0Q==
-  dependencies:
-    "@cognite/sdk-core" "^4.1.3"
-    geojson "^0.5.0"
-    lodash "^4.17.11"
-
-"@cognite/sdk-core@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.1.3.tgz#e2dc84159ffc1f71397d3ced8d55d6a868bafef3"
-  integrity sha512-6vywOs6yR1GCM4V0Z+YsStw0DPh2UZ/neGjWkbGR5ff9X367LgnCxXrtskWRCVVdmkoWKiaf6Z+jkJoeTVr6lA==
-  dependencies:
-    cross-fetch "^3.0.4"
-    is-buffer "^2.0.5"
-    lodash "^4.17.11"
-    query-string "^5.1.1"
-    url "^0.11.0"
-
-"@cognite/sdk-playground@link:../viewer/node_modules/@cognite/sdk-playground":
-  version "0.0.0"
-  uid ""
-
-"@cognite/sdk@^7.2.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk/-/sdk-7.2.5.tgz#e3be4a835eab00c2765089bdfaf7992e4fbbe7ae"
-  integrity sha512-rLVHvODP0lVacs+5dyngLcnngBFtlnS7FBy09AQbP5EM30LBppJBvSwKNRi/XjYbxM010Dx2AwYgo8LBIPoL0Q==
-  dependencies:
-    "@cognite/sdk-core" "^4.1.3"
+    "@cognite/sdk-core" "^4.5.0"
     geojson "^0.5.0"
     lodash "^4.17.11"
 
@@ -7128,7 +7080,7 @@ is-core-module@^2.0.0, is-core-module@^2.2.0, is-core-module@^2.4.0:
   dependencies:
     has "^1.0.3"
 
-is-core-module@^2.8.1:
+is-core-module@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
@@ -11089,11 +11041,11 @@ resolve@^0.6.1:
   integrity sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==
 
 resolve@^1.0.0, resolve@^1.1.5:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
-  integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
-    is-core-module "^2.8.1"
+    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -66,7 +66,7 @@
     "@azure/msal-browser": "2.26.0",
     "@cognite/sdk": "7.6.1",
     "@cognite/sdk-core": "4.4.0",
-    "@cognite/sdk-playground": "^5.5.0",
+    "@cognite/sdk-playground": "5.4.0",
     "@types/dat.gui": "0.7.7",
     "@types/jest": "27.5.2",
     "@types/jsdom": "16.2.14",

--- a/viewer/packages/pointclouds/src/PointCloudNode.ts
+++ b/viewer/packages/pointclouds/src/PointCloudNode.ts
@@ -15,12 +15,6 @@ import { PickPoint, PotreePointColorType, PotreePointShape, PotreePointSizeType 
 import { PointCloudAppearance } from './styling/PointCloudAppearance';
 import { RawStylableObject } from './styling/StylableObject';
 
-import { PointCloudAppearance } from './styling/PointCloudAppearance';
-import { RawStylableObject } from './styling/StylableObject';
-
-import { PointCloudAppearance } from './styling/PointCloudAppearance';
-import { RawStylableObject } from './styling/StylableObject';
-
 const PotreeDefaultPointClass = 'DEFAULT';
 
 export class PointCloudNode extends THREE.Group {

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -700,7 +700,7 @@ __metadata:
     "@cognite/reveal-parser-worker": 1.3.0
     "@cognite/sdk": 7.6.1
     "@cognite/sdk-core": 4.4.0
-    "@cognite/sdk-playground": ^5.5.0
+    "@cognite/sdk-playground": 5.4.0
     "@tweenjs/tween.js": 18.6.4
     "@types/dat.gui": 0.7.7
     "@types/draco3dgltf": 1.4.0
@@ -805,13 +805,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cognite/sdk-playground@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@cognite/sdk-playground@npm:5.5.0"
+"@cognite/sdk-playground@npm:5.4.0":
+  version: 5.4.0
+  resolution: "@cognite/sdk-playground@npm:5.4.0"
   dependencies:
-    "@cognite/sdk": ^7.7.0
-    "@cognite/sdk-core": ^4.5.0
-  checksum: bf48580ea421247f367b085346a20c9ea9b3f44af7087eeb90c4f69d8bfb74b881e0b74bf75cce9d2ff60009a1f0895b3bbb4b2b46e23242ee7ce9edf108d90f
+    "@cognite/sdk": ^7.6.1
+    "@cognite/sdk-core": ^4.4.0
+  checksum: 6bee6bf5835aa35425eb4783c07e06283a6c3a2f13415cb493a83ef9b19373cef5cc01b01fbd94eb06c2a1edb5795b4dfd515a6c8d92f2df977a2df48dde7bd3
   languageName: node
   linkType: hard
 
@@ -826,7 +826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cognite/sdk@npm:^7.7.0":
+"@cognite/sdk@npm:^7.6.1":
   version: 7.7.0
   resolution: "@cognite/sdk@npm:7.7.0"
   dependencies:


### PR DESCRIPTION
# Description

Fixed `sdk-playground` version because it was updated with breaking changes. Also, fixed accidental import problems from latest rebase from master.

# Checklist:

Quick fix for some obvious errors, tested to be working properly, not actually proud because rebase went not so good.
