### PR TITLE
fix: mobile default settings should not include ssao, add iPad fix

### DIFF
--- a/viewer/packages/api/src/public/migration/renderOptionsHelpers.test.ts
+++ b/viewer/packages/api/src/public/migration/renderOptionsHelpers.test.ts
@@ -2,12 +2,25 @@
  * Copyright 2022 Cognite AS
  */
 import { Cognite3DViewerOptions } from './types';
-import { determineAntiAliasingMode } from './renderOptionsHelpers';
+import { determineAntiAliasingMode, determineSsaoRenderParameters } from './renderOptionsHelpers';
 import { PropType } from '../../utilities/reflection';
 import { DeviceDescriptor } from '@reveal/utilities';
 import { AntiAliasingMode } from '@reveal/rendering';
+import log from '@reveal/logger';
+import { LogLevelNumbers } from 'loglevel';
 
 describe(determineAntiAliasingMode.name, () => {
+  let currentLogLevel: LogLevelNumbers;
+
+  beforeAll(() => {
+    currentLogLevel = log.getLevel();
+    log.setLevel('ERROR');
+  });
+
+  afterAll(() => {
+    log.setLevel(currentLogLevel);
+  });
+
   const mobileDevice: DeviceDescriptor = { deviceType: 'mobile' };
   const tabletDevice: DeviceDescriptor = { deviceType: 'tablet' };
   const desktopDevice: DeviceDescriptor = { deviceType: 'desktop' };
@@ -17,6 +30,8 @@ describe(determineAntiAliasingMode.name, () => {
     DeviceDescriptor,
     ReturnType<typeof determineAntiAliasingMode>
   ][] = [
+    [undefined, mobileDevice, { antiAliasing: AntiAliasingMode.FXAA, multiSampleCount: 0 }],
+    [undefined, tabletDevice, { antiAliasing: AntiAliasingMode.FXAA, multiSampleCount: 0 }],
     ['disabled', mobileDevice, { antiAliasing: AntiAliasingMode.NoAA, multiSampleCount: 0 }],
     ['msaa8', mobileDevice, { antiAliasing: AntiAliasingMode.NoAA, multiSampleCount: 0 }],
     ['msaa16+fxaa', mobileDevice, { antiAliasing: AntiAliasingMode.FXAA, multiSampleCount: 0 }],
@@ -28,6 +43,27 @@ describe(determineAntiAliasingMode.name, () => {
   ];
   test.each(testCases)('mode %p on device %p, returns %p', (modeHint, device, expectedResult) => {
     const result = determineAntiAliasingMode(modeHint, device);
+    expect(result).toEqual(expectedResult);
+  });
+});
+
+describe(determineSsaoRenderParameters.name, () => {
+  const mobileDevice: DeviceDescriptor = { deviceType: 'mobile' };
+  const tabletDevice: DeviceDescriptor = { deviceType: 'tablet' };
+  const desktopDevice: DeviceDescriptor = { deviceType: 'desktop' };
+
+  const testCases: [
+    PropType<Cognite3DViewerOptions, 'ssaoQualityHint'>,
+    DeviceDescriptor,
+    ReturnType<typeof determineSsaoRenderParameters>
+  ][] = [
+    [undefined, mobileDevice, { sampleSize: 0, depthCheckBias: 0.0125, sampleRadius: 1.0 }],
+    [undefined, tabletDevice, { sampleSize: 0, depthCheckBias: 0.0125, sampleRadius: 1.0 }],
+    [undefined, desktopDevice, { sampleSize: 32, depthCheckBias: 0.0125, sampleRadius: 1.0 }]
+  ];
+
+  test.each(testCases)('ssao params %p on device %p, returns %p', (modeHint, device, expectedResult) => {
+    const result = determineSsaoRenderParameters(modeHint, device);
     expect(result).toEqual(expectedResult);
   });
 });

--- a/viewer/packages/api/src/public/migration/renderOptionsHelpers.ts
+++ b/viewer/packages/api/src/public/migration/renderOptionsHelpers.ts
@@ -139,7 +139,7 @@ function restrictSsaoOptionBasedOnDevice(
 
     case 'disabled':
     case undefined:
-      return ssaoQualityHint;
+      return 'disabled';
 
     default:
       assertNever(ssaoQualityHint);

--- a/viewer/packages/utilities/src/isMobileOrTablet.ts
+++ b/viewer/packages/utilities/src/isMobileOrTablet.ts
@@ -32,5 +32,13 @@ export function isMobileOrTablet(): boolean {
       check = true;
     }
   })(navigator.userAgent || navigator.vendor || (window as any).opera);
-  return check;
+  return check || isIPad();
+}
+
+function isIPad(): boolean {
+  return (
+    ['iPad Simulator', 'iPod Simulator', 'iPad', 'iPod'].includes(navigator.platform) ||
+    // iPad on iOS 13+ detection ('Request Desktop Website' workaround)
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  ); // Super hacky and will fail when Macs get touch...
 }


### PR DESCRIPTION
# Description

3.1.0 introduces a regression such that mobile / tablet gets ssao shading when no options are supplied. This fixes that, as well as adds an additional check for matching iPads.

For more context see #2236 
