### PR TITLE
improvement: hide/show HTML overlay elements

### DIFF
--- a/documentation/docs/examples/cad-2doverlay.mdx
+++ b/documentation/docs/examples/cad-2doverlay.mdx
@@ -135,6 +135,8 @@ As shown above, overlays can be removed using `remove()`. It is also possible to
 overlays by calling `clear()` or by disposing the tool using `dispose()`. The tool cannot
 be used after calling `dispose()`.
 
+Overlays can change visibility of elements with `visible(true/false)`, which will unhide/hide all the elements in the overlay.
+
 ## Clustering overlays
 
 The overlay tool also support clustering of elements. When enabled, the tool will detect

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.test.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.test.ts
@@ -113,6 +113,26 @@ describe(HtmlOverlayTool.name, () => {
     expect(behindFarPlaneElement.style.visibility).toBe('hidden');
   });
 
+  test('visible() hides or unhides elements in the overlay', () => {
+    const helper = new HtmlOverlayTool(viewer);
+    const htmlElement = document.createElement('div');
+    htmlElement.style.position = 'absolute';
+    const position = new THREE.Vector3(0, 0, 0.5);
+
+    helper.add(htmlElement, position);
+    helper.forceUpdate();
+
+    expect(htmlElement.style.visibility).toBe('visible');
+
+    helper.visible(false);
+    helper.forceUpdate();
+    expect(htmlElement.style.visibility).toBe('hidden');
+
+    helper.visible(true);
+    helper.forceUpdate();
+    expect(htmlElement.style.visibility).toBe('visible');
+  });
+
   test('Triggers position update callback', () => {
     // Arrange
     const helper = new HtmlOverlayTool(viewer);

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -135,6 +135,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   private readonly _options: HtmlOverlayToolOptions;
   private readonly _htmlOverlays: Map<HTMLElement, HtmlOverlayElement> = new Map();
   private readonly _compositeOverlays: HTMLElement[] = [];
+  private _visible: boolean;
 
   private readonly _onSceneRenderedHandler: SceneRenderedDelegate;
   private readonly _onViewerDisposedHandler: DisposedDelegate;
@@ -173,6 +174,8 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
     this._viewer.on('disposed', this._onViewerDisposedHandler);
 
     this.scheduleUpdate = debounce(() => this.forceUpdate(), 20);
+
+    this._visible = true;
 
     MetricsLogger.trackCreateTool('HtmlOverlayTool');
   }
@@ -261,6 +264,23 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   }
 
   /**
+   * Hide/unhide all HTML overlay elements.
+   * @param enable
+   */
+  visible(enable: boolean): void {
+    const visible = enable === true ? 'visible' : 'hidden';
+    this._visible = enable;
+
+    this._htmlOverlays.forEach((_element, htmlElement) => {
+      htmlElement.style.visibility = visible;
+    });
+
+    this._compositeOverlays.forEach(element => {
+      element.style.visibility = visible;
+    });
+  }
+
+  /**
    * Updates positions of all overlays. This is automatically managed and there
    * shouldn't be any reason to trigger this unless the attached elements are
    * modified externally.
@@ -268,6 +288,10 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
    * Calling this function often might cause degraded performance.
    */
   forceUpdate(): void {
+    // Do not update elements if overlay visibility is set to hidden/false.
+    if (!this._visible) {
+      return;
+    }
     this.ensureNotDisposed();
     this.cleanupClusterElements();
     if (this._htmlOverlays.size === 0) {


### PR DESCRIPTION
# Description

HTML elements in Overlay Tool can be made to hide or unhide with `visible()`. This improvement will help in MeasurementTool when user need to hide/unhide elements of the measurement labels.
[REV-400](https://cognitedata.atlassian.net/browse/REV-400)


# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
