### PR TITLE
fix: elements position in HTMLOverlay when visibility is changed from hide to show

### DIFF
--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -278,6 +278,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
     this._compositeOverlays.forEach(element => {
       element.style.visibility = visible;
     });
+    this.forceUpdate();
   }
 
   /**


### PR DESCRIPTION
The elements position in HTML Overlay are not updated when visibility of overlay is changed from hide & show.

[REV-413](https://cognitedata.atlassian.net/browse/REV-413)