### PR TITLE
fix: sector repository not gracefully handling sector loader errors

### DIFF
--- a/viewer/packages/sector-loader/package.json
+++ b/viewer/packages/sector-loader/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@reveal/cad-parsers": "workspace:*",
+    "@reveal/logger": "workspace:*",
     "@reveal/metrics": "workspace:*",
     "@reveal/modeldata-api": "workspace:*",
     "@reveal/rendering": "workspace:*",

--- a/viewer/packages/sector-loader/src/GltfSectorRepository.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorRepository.ts
@@ -55,7 +55,15 @@ export class GltfSectorRepository implements SectorRepository {
     if (this._gltfCache.has(cacheKey)) {
       return this._gltfCache.get(cacheKey);
     }
-    const consumedSector = await this._gltfSectorLoader.loadSector(sector);
+
+    const consumedSector = await this._gltfSectorLoader.loadSector(sector).catch(() => {
+      return undefined;
+    });
+
+    if (!consumedSector) {
+      return this.getEmptyDiscardedSector(sector.modelIdentifier, metadata);
+    }
+
     consumedSector.group?.reference();
     this._gltfCache.forceInsert(cacheKey, consumedSector);
 

--- a/viewer/packages/sector-loader/tests/GltfSectorRepository.test.ts
+++ b/viewer/packages/sector-loader/tests/GltfSectorRepository.test.ts
@@ -5,11 +5,12 @@
 import { GltfSectorRepository } from '../src/GltfSectorRepository';
 import { createBinaryFileProviderMock, createWantedSectorMock } from './mockSectorUtils';
 
-import { IMock } from 'moq.ts';
+import { IMock, Mock } from 'moq.ts';
 
 import { BinaryFileProvider } from '@reveal/modeldata-api';
 import { CadMaterialManager } from '@reveal/rendering';
 import { WantedSector } from '@reveal/cad-parsers';
+import Log from '@reveal/logger';
 
 describe(GltfSectorRepository.name, () => {
   let binaryFileProvider: IMock<BinaryFileProvider>;
@@ -42,5 +43,20 @@ describe(GltfSectorRepository.name, () => {
     await sectorRepository.loadSector(wantedSectorMock.object());
 
     expect(loaderObserver.mock.calls).toHaveLength(1);
+  });
+
+  test('loadSector should gracefully handle errors from sectorLoader', async () => {
+    const currentLogLevel = Log.getLevel();
+    Log.setLevel('silent');
+
+    const binaryFileProvider = createBinaryFileProviderMock();
+    const materialManager = new Mock<CadMaterialManager>();
+
+    const sectorRepository = new GltfSectorRepository(binaryFileProvider.object(), materialManager.object());
+
+    //Sector loader will throw since there is no valid materials for given object
+    await expect(sectorRepository.loadSector(wantedSectorMock.object())).resolves.not.toThrow();
+
+    Log.setLevel(currentLogLevel);
   });
 });

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -1385,6 +1385,7 @@ __metadata:
   resolution: "@reveal/sector-loader@workspace:packages/sector-loader"
   dependencies:
     "@reveal/cad-parsers": "workspace:*"
+    "@reveal/logger": "workspace:*"
     "@reveal/metrics": "workspace:*"
     "@reveal/modeldata-api": "workspace:*"
     "@reveal/rendering": "workspace:*"


### PR DESCRIPTION
# Description
If you f.ex. delete a model while sectors are still downloading, it will throw an error when the are consumed. This error was not catched and will spam the console. We still log an error, but now the user can opt out by silencing the logger.

The actual proper fix is to cancel in flight sectors, but requires a larger effort (tracking task: https://cognitedata.atlassian.net/browse/REV-414)

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [x] I have asked peers to test this feature.
