### PR TITLE
fix: Not working check for duplicate comment in documentation preview PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,9 @@ jobs:
             :orange_book: Documentation preview is available from
             https://cognitedata.github.io/reveal-docs-preview/${{ env.PR_NUMBER }}/docs/next/.
           check_for_duplicate_msg: true
+          duplicate_msg_pattern: |
+            :orange_book: Documentation preview is available from
+            https://cognitedata.github.io/reveal-docs-preview/${{ env.PR_NUMBER }}/docs/next/.
 
 
   cleanup:

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -90,7 +90,7 @@ export function Migration() {
       } else if (!(project && environmentParam)) {
         throw new Error('Must either provide URL parameters "env", "project", ' +
                         '"modelId" and "revisionId" to load model from CDF ' +
-                        '"or "modelUrl" to load model from URL.s');
+                        '"or "modelUrl" to load model from URL.');
       }
 
       // Prepare viewer

--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -90,7 +90,7 @@ export function Migration() {
       } else if (!(project && environmentParam)) {
         throw new Error('Must either provide URL parameters "env", "project", ' +
                         '"modelId" and "revisionId" to load model from CDF ' +
-                        '"or "modelUrl" to load model from URL.');
+                        '"or "modelUrl" to load model from URL.s');
       }
 
       // Prepare viewer


### PR DESCRIPTION
# Description

Attempt to fix check for duplicate messages on PRs with documentation preview enabled.

# Checklist:

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.

PR includes only a change in CI script, so most points don't apply.
