### PR TITLE
feat: custom classification

### DIFF
--- a/viewer/packages/pointclouds/src/CognitePointCloudModel.ts
+++ b/viewer/packages/pointclouds/src/CognitePointCloudModel.ts
@@ -112,7 +112,7 @@ export class CognitePointCloudModel extends THREE.Object3D implements CogniteMod
    * @param visible Boolean flag that determines if the point class type should be visible or not.
    * @throws Error if the model doesn't have the class given.
    */
-  setClassVisible(pointClass: number | WellKnownAsprsPointClassCodes, visible: boolean): void {
+  setClassVisible(pointClass: number | WellKnownAsprsPointClassCodes | string, visible: boolean): void {
     this.pointCloudNode.setClassVisible(pointClass, visible);
   }
 
@@ -123,7 +123,7 @@ export class CognitePointCloudModel extends THREE.Object3D implements CogniteMod
    * @returns True if points from the given class will be visible.
    * @throws Error if the model doesn't have the class given.
    */
-  isClassVisible(pointClass: number | WellKnownAsprsPointClassCodes): boolean {
+  isClassVisible(pointClass: number | WellKnownAsprsPointClassCodes | string): boolean {
     return this.pointCloudNode.isClassVisible(pointClass);
   }
 
@@ -133,7 +133,7 @@ export class CognitePointCloudModel extends THREE.Object3D implements CogniteMod
    * classes from {@link WellKnownAsprsPointClassCodes} or a number for user defined classes.
    * @returns True if model has values in the class given.
    */
-  hasClass(pointClass: number | WellKnownAsprsPointClassCodes): boolean {
+  hasClass(pointClass: number | WellKnownAsprsPointClassCodes | string): boolean {
     return this.pointCloudNode.hasClass(pointClass);
   }
 
@@ -141,7 +141,7 @@ export class CognitePointCloudModel extends THREE.Object3D implements CogniteMod
    * Returns a list of sorted classification codes present in the model.
    * @returns A sorted list of classification codes from the model.
    */
-  getClasses(): Array<number | WellKnownAsprsPointClassCodes> {
+  getClasses(): Array<number | WellKnownAsprsPointClassCodes | string> {
     return this.pointCloudNode.getClasses();
   }
 

--- a/viewer/packages/pointclouds/src/PointCloudNode.ts
+++ b/viewer/packages/pointclouds/src/PointCloudNode.ts
@@ -114,7 +114,7 @@ export class PointCloudNode extends THREE.Group {
    * @param visible Boolean flag that determines if the point class type should be visible or not.
    * @throws Error if the model doesn't have the class given.
    */
-  setClassVisible(pointClass: number | WellKnownAsprsPointClassCodes, visible: boolean): void {
+  setClassVisible(pointClass: number | WellKnownAsprsPointClassCodes | string, visible: boolean): void {
     this._potreeNode.setClassificationAndRecompute(pointClass, visible);
   }
 
@@ -125,7 +125,7 @@ export class PointCloudNode extends THREE.Group {
    * @returns true if points from the given class will be visible.
    * @throws Error if the model doesn't have the class given.
    */
-  isClassVisible(pointClass: number | WellKnownAsprsPointClassCodes): boolean {
+  isClassVisible(pointClass: number | WellKnownAsprsPointClassCodes | string): boolean {
     if (!this.hasClass(pointClass)) {
       throw new Error(`Point cloud model doesn't have class ${pointClass}`);
     }
@@ -139,7 +139,7 @@ export class PointCloudNode extends THREE.Group {
    * classes from {@link WellKnownAsprsPointClassCodes} or a number for user defined classes.
    * @returns true if model has values in the class given.
    */
-  hasClass(pointClass: number | WellKnownAsprsPointClassCodes): boolean {
+  hasClass(pointClass: number | WellKnownAsprsPointClassCodes | string): boolean {
     const key = createPointClassKey(pointClass);
     return this._potreeNode.classification[key] !== undefined;
   }
@@ -148,7 +148,7 @@ export class PointCloudNode extends THREE.Group {
    * Returns a list of sorted classification codes present in the model.
    * @returns A sorted list of classification codes from the model.
    */
-  getClasses(): Array<number | WellKnownAsprsPointClassCodes> {
+  getClasses(): Array<number | WellKnownAsprsPointClassCodes | string> {
     return Object.keys(this._potreeNode.classification)
       .map(x => {
         return x === PotreeDefaultPointClass ? -1 : parseInt(x, 10);

--- a/viewer/packages/pointclouds/src/constants.ts
+++ b/viewer/packages/pointclouds/src/constants.ts
@@ -3,3 +3,4 @@
  */
 
 export const DEFAULT_POINT_CLOUD_METADATA_FILE = 'ept.json';
+export const DEFAULT_POINT_CLOUD_CLASS_DEFINITION_FILE = 'classes.json';

--- a/viewer/packages/pointclouds/src/createPointClassKey.ts
+++ b/viewer/packages/pointclouds/src/createPointClassKey.ts
@@ -6,7 +6,7 @@ import { WellKnownAsprsPointClassCodes } from './types';
 
 const PotreeDefaultPointClass = 'DEFAULT';
 
-export function createPointClassKey(pointClass: number | WellKnownAsprsPointClassCodes): number {
+export function createPointClassKey(pointClass: number | WellKnownAsprsPointClassCodes | string): number {
   if (pointClass === WellKnownAsprsPointClassCodes.Default) {
     // Potree has a special class 'DEFAULT'. Our map has number keys, but this one is specially
     // handled in Potree so we ignore type.

--- a/viewer/packages/pointclouds/src/factory/CdfPointCloudFactory.test.ts
+++ b/viewer/packages/pointclouds/src/factory/CdfPointCloudFactory.test.ts
@@ -46,10 +46,10 @@ const potreeMock = new Mock<Potree>()
   .setup(p => p.loadPointCloud)
   .returns(() =>
     Promise.resolve(
-      new Mock<PointCloudOctree>()
+      [new Mock<PointCloudOctree>()
         .setup(p => p.material)
         .returns(new Mock<PointCloudMaterial>().object())
-        .object()
+        .object(), undefined]
     )
   );
 

--- a/viewer/packages/pointclouds/src/factory/CdfPointCloudFactory.ts
+++ b/viewer/packages/pointclouds/src/factory/CdfPointCloudFactory.ts
@@ -79,13 +79,13 @@ export class CdfPointCloudFactory implements PointCloudFactory {
     const annotations = await this.getAnnotations(modelIdentifier as CdfModelIdentifier);
     const annotationInfo = annotationsToObjectInfo(annotations);
 
-    const pointCloudOctree = await this._potreeInstance.loadPointCloud(
+    const [pointCloudOctree, classMap] = await this._potreeInstance.loadPointCloud(
       modelBaseUrl,
       DEFAULT_POINT_CLOUD_METADATA_FILE,
       annotationInfo
     );
 
     pointCloudOctree.name = `PointCloudOctree: ${modelBaseUrl}`;
-    return new PotreeNodeWrapper(pointCloudOctree, annotationInfo.annotations);
+    return new PotreeNodeWrapper(pointCloudOctree, annotationInfo.annotations, classMap);
   }
 }

--- a/viewer/packages/pointclouds/src/potree-three-loader/Potree.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/Potree.ts
@@ -34,6 +34,7 @@ import { Box3Helper } from './utils/box3-helper';
 import { LRU } from './utils/lru';
 import { ModelDataProvider } from '@reveal/modeldata-api';
 import { PointCloudObjectProvider } from '../styling/PointCloudObjectProvider';
+import { ClassDefinition } from './loading/ClassDefinition';
 
 export class QueueItem {
   constructor(
@@ -80,11 +81,10 @@ export class Potree implements IPotree {
     baseUrl: string,
     fileName: string,
     annotationObjectInfo: PointCloudObjectProvider
-  ): Promise<PointCloudOctree> {
+  ): Promise<[PointCloudOctree, ClassDefinition | undefined]> {
     const rawObjects = annotationObjectInfo.createRawObjectArray();
-
-    const geometry = await EptLoader.load(baseUrl, fileName, this._modelDataProvider, rawObjects);
-    return new PointCloudOctree(this, geometry, annotationObjectInfo);
+    const [geometry, classMap] = await EptLoader.load(baseUrl, fileName, this._modelDataProvider, rawObjects);
+    return [new PointCloudOctree(this, geometry, annotationObjectInfo), classMap];
   }
 
   updatePointClouds(pointClouds: PointCloudOctree[], camera: Camera, renderer: WebGLRenderer): IVisibilityUpdateResult {

--- a/viewer/packages/pointclouds/src/potree-three-loader/loading/ClassDefinition.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/loading/ClassDefinition.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright 2022 Cognite AS
+ */
+
+export type ClassDefinition = {
+  [key: string]: number
+};

--- a/viewer/packages/pointclouds/src/potree-three-loader/loading/EptLoader.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/loading/EptLoader.ts
@@ -1,7 +1,9 @@
 import { ModelDataProvider } from '@reveal/modeldata-api';
 import { RawStylableObject } from '../../styling/StylableObject';
+import { DEFAULT_POINT_CLOUD_CLASS_DEFINITION_FILE } from '../../constants';
 import { PointCloudEptGeometry } from '../geometry/PointCloudEptGeometry';
 import { PointCloudEptGeometryNode } from '../geometry/PointCloudEptGeometryNode';
+import { ClassDefinition } from './ClassDefinition';
 import { EptJson } from './EptJson';
 
 export class EptLoader {
@@ -10,15 +12,26 @@ export class EptLoader {
     fileName: string,
     modelDataProvider: ModelDataProvider,
     stylableObjects: RawStylableObject[]
-  ): Promise<PointCloudEptGeometry> {
-    return modelDataProvider.getJsonFile(baseUrl, fileName).then(async (json: EptJson) => {
+  ): Promise<[PointCloudEptGeometry, ClassDefinition | undefined]> {
+    const eptJsonPromise = modelDataProvider.getJsonFile(baseUrl, fileName);
+
+    const classesJsonPromise: Promise<ClassDefinition | undefined> = modelDataProvider.getJsonFile(baseUrl, DEFAULT_POINT_CLOUD_CLASS_DEFINITION_FILE)
+      .then(json => json as ClassDefinition)
+      .catch(_ => {
+        // Classes file not found, ignoring
+        return undefined;
+      });
+
+    return eptJsonPromise.then(async (json: EptJson) => {
       const url = baseUrl + '/';
       const geometry = new PointCloudEptGeometry(url, json, modelDataProvider, stylableObjects);
       const root = new PointCloudEptGeometryNode(geometry, modelDataProvider);
 
+
+
       geometry.root = root;
       await geometry.root.load();
-      return geometry;
+      return [geometry, await classesJsonPromise];
     });
   }
 }

--- a/viewer/packages/pointclouds/src/potree-three-loader/types/IPotree.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/types/IPotree.ts
@@ -3,6 +3,7 @@ import { LRU } from '../utils/lru';
 import { PointCloudOctree } from '../tree/PointCloudOctree';
 import { IVisibilityUpdateResult } from './IVisibilityUpdateResult';
 import { PointCloudObjectProvider } from '../../styling/PointCloudObjectProvider';
+import { ClassDefinition } from '../loading/ClassDefinition';
 
 export interface IPotree {
   pointBudget: number;
@@ -13,7 +14,7 @@ export interface IPotree {
     baseUrl: string,
     fileName: string,
     stylableObjectInfo: PointCloudObjectProvider
-  ): Promise<PointCloudOctree>;
+  ): Promise<[PointCloudOctree, ClassDefinition | undefined]>;
 
   updatePointClouds(pointClouds: PointCloudOctree[], camera: Camera, renderer: WebGLRenderer): IVisibilityUpdateResult;
 }


### PR DESCRIPTION
# Description

There has been an internal request for having custom classes for a point cloud instead of the default-provided LAS classes. Furthermore, there is a request for having these classes automatically determined per point cloud.

The design in this PR involves assuming there exists a `classes.json` file in the same folder as `ept.json` in CDF. If there is no such file, the behavior is as before.

https://cognitedata.atlassian.net/browse/REV-442

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
