### PR TITLE
fix: issue causing low rendering performance for Chrome >= 93 on Intel Mac with old 3D models (REV-451)

### DIFF
--- a/viewer/packages/api/src/public/createRevealManager.ts
+++ b/viewer/packages/api/src/public/createRevealManager.ts
@@ -126,17 +126,10 @@ export function createRevealManager(
     renderer
   );
   sceneHandler.customObjects.push(pointCloudManager.pointCloudGroupWrapper);
-  const cadManager = createCadManager(
-    modelMetadataProvider,
-    modelDataProvider,
-    renderer,
-    materialManager,
-    depthRenderPipeline,
-    {
-      ...revealOptions.internal?.cad,
-      continuousModelStreaming: revealOptions.continuousModelStreaming
-    }
-  );
+  const cadManager = createCadManager(modelMetadataProvider, modelDataProvider, materialManager, depthRenderPipeline, {
+    ...revealOptions.internal?.cad,
+    continuousModelStreaming: revealOptions.continuousModelStreaming
+  });
   return new RevealManager(cadManager, pointCloudManager, pipelineExecutor, defaultRenderPipeline, materialManager);
 }
 

--- a/viewer/packages/cad-geometry-loaders/src/createCadManager.ts
+++ b/viewer/packages/cad-geometry-loaders/src/createCadManager.ts
@@ -13,16 +13,13 @@ import { CadModelFactory } from '@reveal/cad-model';
 export function createCadManager(
   modelMetadataProvider: ModelMetadataProvider,
   modelDataProvider: ModelDataProvider,
-  renderer: THREE.WebGLRenderer,
   materialManager: CadMaterialManager,
   depthOnlyRenderPipeline: CadGeometryRenderModePipelineProvider,
   cadOptions: InternalRevealCadOptions & { continuousModelStreaming?: boolean }
 ): CadManager {
   const cadModelFactory = new CadModelFactory(materialManager, modelMetadataProvider, modelDataProvider);
   const sectorCuller =
-    cadOptions && cadOptions.sectorCuller
-      ? cadOptions.sectorCuller
-      : createV8SectorCuller(renderer, depthOnlyRenderPipeline);
+    cadOptions && cadOptions.sectorCuller ? cadOptions.sectorCuller : createV8SectorCuller(depthOnlyRenderPipeline);
   const cadModelUpdateHandler = new CadModelUpdateHandler(sectorCuller, cadOptions.continuousModelStreaming);
   return new CadManager(materialManager, cadModelFactory, cadModelUpdateHandler);
 }

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/createV8SectorCuller.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/createV8SectorCuller.ts
@@ -9,10 +9,8 @@ import { SectorCuller } from './SectorCuller';
 import { ByVisibilityGpuSectorCuller } from './ByVisibilityGpuSectorCuller';
 import { GpuOrderSectorsByVisibilityCoverage } from './OrderSectorsByVisibilityCoverage';
 
-export function createV8SectorCuller(
-  renderer: THREE.WebGLRenderer,
-  depthOnlyRenderPipeline: CadGeometryRenderModePipelineProvider
-): SectorCuller {
-  const coverageUtil = new GpuOrderSectorsByVisibilityCoverage({ renderer, depthOnlyRenderPipeline });
-  return new ByVisibilityGpuSectorCuller({ renderer, coverageUtil });
+export function createV8SectorCuller(depthOnlyRenderPipeline: CadGeometryRenderModePipelineProvider): SectorCuller {
+  const renderer = new THREE.WebGLRenderer();
+  const coverageUtil = new GpuOrderSectorsByVisibilityCoverage({ renderer: renderer, depthOnlyRenderPipeline });
+  return new ByVisibilityGpuSectorCuller({ renderer: renderer, coverageUtil });
 }


### PR DESCRIPTION
# Description

In Chrome v >= 93, reusing the same WebGL context for on-screen rendering and GPU sector culling seems to downgrade performance for certain configurations (at least Intel Macs). This only happens for "old" (v8) 3D models, because GPU sector culling is only used for v8 models.

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
