### PR TITLE
fix: remove TreeIndex interpolation in fragment shaders

### DIFF
--- a/viewer/packages/rendering/src/glsl/base/determineNodeAppearance.glsl
+++ b/viewer/packages/rendering/src/glsl/base/determineNodeAppearance.glsl
@@ -1,17 +1,14 @@
 #pragma glslify: import('../math/floatBitsSubset.glsl')
 
-NodeAppearance determineNodeAppearance(sampler2D nodeAppearanceTexture, vec2 textureSize, float treeIndex) {
-  treeIndex = floor(treeIndex + 0.5);
+NodeAppearance determineNodeAppearance(sampler2D nodeAppearanceTexture, vec2 textureSize, highp float treeIndex) {
+
   float dataTextureWidth = textureSize.x;
   float dataTextureHeight = textureSize.y;
 
-  float u = mod(treeIndex, dataTextureWidth);
-  float v = floor(treeIndex / dataTextureWidth);
-  float uCoord = (u + 0.5) / dataTextureWidth;
-  float vCoord = (v + 0.5) / dataTextureHeight;
-  vec2 treeIndexUv = vec2(uCoord, vCoord);
-  
-  vec4 texel = texture(nodeAppearanceTexture, treeIndexUv);
+  int xTreeIndexTextureCoord = int(mod(treeIndex, dataTextureWidth));
+  int yTreeIndexTextureCoord = int(floor(treeIndex / dataTextureWidth));
+
+  vec4 texel = texelFetch(nodeAppearanceTexture, ivec2(xTreeIndexTextureCoord, yTreeIndexTextureCoord), 0);
   float alphaUnwrapped = floor((texel.a * 255.0) + 0.5);
 
   bool isVisible = floatBitsSubset(alphaUnwrapped, 0, 1) == 1.0;

--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
@@ -13,7 +13,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_viewPosition;
 

--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
@@ -13,17 +13,17 @@ in mat4 a_instanceMatrix;
 in float a_treeIndex;
 in vec3 a_color;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_viewPosition;
 
 void main()
 {
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/mesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.frag
@@ -13,7 +13,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_viewPosition;
 

--- a/viewer/packages/rendering/src/glsl/sector/mesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.vert
@@ -10,10 +10,10 @@ uniform sampler2D transformOverrideTexture;
 
 in vec3 position;
 in vec3 color;
-in float treeIndex; 
+in float treeIndex;
 
 out vec3 v_color;
-out float v_treeIndex;
+flat out float v_treeIndex;
 out vec3 v_viewPosition;
 
 void main() {
@@ -21,10 +21,10 @@ void main() {
     v_treeIndex = treeIndex;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec2 v_xy;
 in vec3 v_color;
 in vec3 v_normal;
@@ -23,7 +23,7 @@ void main() {
     vec3 normal = normalize( v_normal );
     if (dist > 0.25)
       discard;
-      
+
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
@@ -19,7 +19,7 @@ in vec3 a_normal;
 out vec2 v_xy;
 out vec3 v_color;
 out vec3 v_normal;
-out float v_treeIndex;
+flat out float v_treeIndex;
 out vec3 vViewPosition;
 
 void main() {
@@ -27,10 +27,10 @@ void main() {
     v_treeIndex = a_treeIndex;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
@@ -24,7 +24,7 @@ in float v_angle;
 in float v_arcAngle;
 in vec4 v_centerA;
 in vec4 v_V;
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
@@ -25,7 +25,7 @@ in vec3 a_localXAxis;
 in float a_angle;
 in float a_arcAngle;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerB;
 // U, V, axis represent the 3x3 cone basis.
@@ -42,10 +42,10 @@ out vec3 v_normal;
 
 void main() {
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
@@ -23,7 +23,7 @@ in vec4 axis;
 in vec4 v_centerA;
 in vec4 v_centerB;
 in float height;
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
@@ -22,7 +22,7 @@ in float a_radiusB;
 in vec3 a_normal;
 in vec3 a_color;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerA;
 out vec4 v_centerB;
@@ -39,10 +39,10 @@ out vec3 v_normal;
 void main() {
 
   mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
@@ -22,7 +22,7 @@ in float height;
 in vec4 U;
 in vec4 V;
 in vec4 sphereNormal;
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
@@ -22,7 +22,7 @@ in float a_horizontalRadius;
 in float a_verticalRadius;
 in float a_height;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 // We pack vRadius as w-component of center
 out vec4 center;
 out float hRadius;
@@ -39,10 +39,10 @@ out vec3 v_normal;
 void main() {
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
@@ -29,7 +29,7 @@ in float v_arcAngle;
 in float v_surfacePointY;
 in vec4 v_planeA;
 in vec4 v_planeB;
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 
@@ -39,7 +39,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize( v_normal );
 
     float R1 = v_centerB.w;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
@@ -27,7 +27,7 @@ in vec3 a_localXAxis;
 in float a_angle;
 in float a_arcAngle;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerB;
 // U, V, axis represent the 3x3 cone basis.
@@ -48,13 +48,13 @@ void main() {
     mat4 modelViewMatrix = viewMatrix * modelMatrix;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
-    
+
     mat4 modelTransformOffset = inverseModelMatrix * treeIndexWorldTransform * modelMatrix;
 
     vec3 centerA = mul3(modelTransformOffset, a_centerA);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
@@ -17,7 +17,7 @@ in float v_oneMinusThicknessSqr;
 in vec2 v_xy;
 in float v_angle;
 in float v_arcAngle;
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
@@ -19,7 +19,7 @@ in float a_arcAngle;
 in float a_thickness;
 in vec3 a_normal;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 out float v_oneMinusThicknessSqr;
 out vec2 v_xy;
 out float v_angle;
@@ -36,10 +36,10 @@ void main() {
     v_arcAngle = a_arcAngle;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
@@ -22,7 +22,7 @@ in float height;
 in vec4 U;
 in vec4 V;
 in vec4 sphereNormal;
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 
@@ -32,7 +32,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize(sphereNormal.xyz);
 
     float vRadius = center.w;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
@@ -17,7 +17,7 @@ in float a_horizontalRadius;
 in float a_verticalRadius;
 in float a_height;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 // We pack vRadius as w-component of center
 out vec4 center;
 out float hRadius;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
@@ -26,7 +26,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize(v_normal);
     updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragCoord.z, matCapTexture, GeometryType.Primitive);
 }

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
@@ -18,7 +18,7 @@ in float a_arcAngle;
 in float a_radius;
 in float a_tubeRadius;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
@@ -36,13 +36,13 @@ void main() {
     pos3.z = a_tubeRadius * sin(phi);
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
-    
+
     vec3 transformed = (a_instanceMatrix * vec4(pos3, 1.0)).xyz;
 
     // Calculate normal vectors if we're not picking

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
@@ -26,7 +26,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize(v_normal);
     updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragCoord.z, matCapTexture, GeometryType.Primitive);
 }

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
@@ -18,7 +18,7 @@ in vec3 a_vertex2;
 in vec3 a_vertex3;
 in vec3 a_vertex4;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
@@ -33,10 +33,10 @@ void main() {
     }
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/simple.frag
+++ b/viewer/packages/rendering/src/glsl/sector/simple.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
+flat in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;

--- a/viewer/packages/rendering/src/glsl/sector/simple.vert
+++ b/viewer/packages/rendering/src/glsl/sector/simple.vert
@@ -19,18 +19,18 @@ in vec4 matrix1;
 in vec4 matrix2;
 in vec4 matrix3;
 
-out float v_treeIndex;
+flat out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
 void main() {
-    
+
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 


### PR DESCRIPTION
# Description

Related to #2363 , read that for more information about the issue.

This may be tested by adding a model where tree-indexes are surpassing 3 million, and doing some selection or similar. 

We tested this by just doing

```cs
while(treeindex < 3_000_000) treeIndex++;
```

before running any 3d model through the pipeline. And then applying a highlight, or hide NodeAppearance on click, to apply it to a specific node.

Co-authored-by: @vero-so 

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
