### PR TITLE
fix: sector parser test now properly computes color data override texture

### DIFF
--- a/viewer/packages/sector-parser/app/SectorParser.VisualTest.ts
+++ b/viewer/packages/sector-parser/app/SectorParser.VisualTest.ts
@@ -16,8 +16,6 @@ export default class SectorParserVisualTestFixture extends SimpleVisualTestFixtu
 
     const group = this.initializeGroup(scene);
 
-    const materialMap = this.setMaterialMap();
-
     const loader = new GltfSectorParser();
 
     const gltfOutput = (await modelMetadataProvider.getModelOutputs(modelIdentifier)).find(
@@ -25,6 +23,8 @@ export default class SectorParserVisualTestFixture extends SimpleVisualTestFixtu
     )!;
     const modelUri = await modelMetadataProvider.getModelUri(modelIdentifier, gltfOutput);
     const sceneJson = await modelDataProvider.getJsonFile(modelUri, 'scene.json');
+
+    const materialMap = TestMaterials.getMaterialsMap((sceneJson.maxTreeIndex as number) + 1);
 
     const sectors = sceneJson.sectors as [
       {
@@ -73,24 +73,6 @@ export default class SectorParserVisualTestFixture extends SimpleVisualTestFixtu
         });
       })
     );
-  }
-
-  private setMaterialMap(): Map<RevealGeometryCollectionType, THREE.RawShaderMaterial> {
-    return new Map([
-      [RevealGeometryCollectionType.BoxCollection, TestMaterials.createBoxMaterial()],
-      [RevealGeometryCollectionType.CircleCollection, TestMaterials.createCircleMaterial()],
-      [RevealGeometryCollectionType.ConeCollection, TestMaterials.createConeMaterial()],
-      [RevealGeometryCollectionType.EccentricConeCollection, TestMaterials.createEccentricConeMaterial()],
-      [RevealGeometryCollectionType.EllipsoidSegmentCollection, TestMaterials.createEllipsoidSegmentMaterial()],
-      [RevealGeometryCollectionType.GeneralCylinderCollection, TestMaterials.createGeneralCylinderMaterial()],
-      [RevealGeometryCollectionType.GeneralRingCollection, TestMaterials.createGeneralRingMaterial()],
-      [RevealGeometryCollectionType.QuadCollection, TestMaterials.createQuadMaterial()],
-      [RevealGeometryCollectionType.TorusSegmentCollection, TestMaterials.createTorusSegmentMaterial()],
-      [RevealGeometryCollectionType.TrapeziumCollection, TestMaterials.createTrapeziumMaterial()],
-      [RevealGeometryCollectionType.NutCollection, TestMaterials.createNutMaterial()],
-      [RevealGeometryCollectionType.TriangleMesh, TestMaterials.createTriangleMeshMaterial()],
-      [RevealGeometryCollectionType.InstanceMesh, TestMaterials.createInstancedMeshMaterial()]
-    ]);
   }
 
   private initializeGroup(scene: THREE.Scene) {

--- a/viewer/packages/sector-parser/app/testMaterials.ts
+++ b/viewer/packages/sector-parser/app/testMaterials.ts
@@ -6,347 +6,192 @@ import * as THREE from 'three';
 // TODO: Fix dependencies such that test app doesn't depend on core internals
 import matCapTextureImage from '../../../packages/rendering/src/rendering/matCapTextureData';
 import { sectorShaders } from '../../../packages/rendering/src/rendering/shaders';
+import { RevealGeometryCollectionType } from '../src/types';
 
 const matCapTexture = new THREE.Texture(matCapTextureImage);
 matCapTexture.needsUpdate = true;
 
-const blendingOptions = {
-  blending: THREE.CustomBlending,
-  blendDst: THREE.ZeroFactor,
-  blendDstAlpha: THREE.OneFactor,
-  blendSrc: THREE.OneFactor,
-  blendSrcAlpha: THREE.ZeroFactor
-};
+function getColorDataTexture(treeIndexCount: number) {
+  const { width, height } = determinePowerOfTwoDimensions(treeIndexCount);
+  const textureElementCount = width * height;
 
-export function createInstancedMeshMaterial(): THREE.RawShaderMaterial {
+  const buffer = new Uint8ClampedArray(4 * textureElementCount);
+  for (let i = 0; i < textureElementCount; i++) {
+    buffer[i * 4 + 3] = 1;
+  }
+  // Color and style override texture
+  const overrideColorPerTreeIndexTexture = new THREE.DataTexture(buffer, width, height);
+
+  return { colorDataTexture: overrideColorPerTreeIndexTexture, width, height };
+
+  function determinePowerOfTwoDimensions(elementCount: number): { width: number; height: number } {
+    const width = Math.max(1, ceilToPowerOfTwo(Math.sqrt(elementCount)));
+    const height = Math.max(1, ceilToPowerOfTwo(elementCount / width));
+    return { width, height };
+  }
+
+  function ceilToPowerOfTwo(v: number): number {
+    return Math.pow(2, Math.ceil(Math.log(v) / Math.log(2)));
+  }
+}
+
+export function getMaterialsMap(treeIndexCount: number): Map<RevealGeometryCollectionType, THREE.RawShaderMaterial> {
+  const { colorDataTexture, width, height } = getColorDataTexture(treeIndexCount);
+  colorDataTexture.needsUpdate = true;
+
+  const sharedParams = {
+    clipping: false,
+    uniforms: {
+      renderMode: { value: 1 },
+      inverseModelMatrix: {
+        value: new THREE.Matrix4()
+      },
+      matCapTexture: { value: matCapTexture },
+      treeIndexTextureSize: { value: new THREE.Vector2(width, height) },
+      colorDataTexture: { value: colorDataTexture }
+    },
+    extensions: {
+      derivatives: true
+    },
+    side: THREE.DoubleSide,
+    glslVersion: THREE.GLSL3,
+    blending: THREE.CustomBlending,
+    blendDst: THREE.ZeroFactor,
+    blendDstAlpha: THREE.OneFactor,
+    blendSrc: THREE.OneFactor,
+    blendSrcAlpha: THREE.ZeroFactor
+  };
+  return new Map([
+    [
+      RevealGeometryCollectionType.BoxCollection,
+      createMaterial(
+        'Primitives (Box)',
+        sectorShaders.boxPrimitive.vertex,
+        sectorShaders.boxPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.CircleCollection,
+      createMaterial(
+        'Primitives (Circle)',
+        sectorShaders.circlePrimitive.vertex,
+        sectorShaders.circlePrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.ConeCollection,
+      createMaterial(
+        'Primitives (Cone)',
+        sectorShaders.conePrimitive.vertex,
+        sectorShaders.conePrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.EccentricConeCollection,
+      createMaterial(
+        'Primitives (EccentricCone)',
+        sectorShaders.eccentricConePrimitive.vertex,
+        sectorShaders.eccentricConePrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.EllipsoidSegmentCollection,
+      createMaterial(
+        'Primitives (EllipsoidSegment)',
+        sectorShaders.ellipsoidSegmentPrimitive.vertex,
+        sectorShaders.ellipsoidSegmentPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.GeneralCylinderCollection,
+      createMaterial(
+        'Primitives (GeneralCylinder)',
+        sectorShaders.generalCylinderPrimitive.vertex,
+        sectorShaders.generalCylinderPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.GeneralRingCollection,
+      createMaterial(
+        'Primitives (GeneralRing)',
+        sectorShaders.generalRingPrimitive.vertex,
+        sectorShaders.generalRingPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.QuadCollection,
+      createMaterial(
+        'Primitives (Quad)',
+        sectorShaders.quadPrimitive.vertex,
+        sectorShaders.quadPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.TorusSegmentCollection,
+      createMaterial(
+        'Primitives (TorusSegment)',
+        sectorShaders.torusSegmentPrimitive.vertex,
+        sectorShaders.torusSegmentPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.TrapeziumCollection,
+      createMaterial(
+        'Primitives (Trapezium)',
+        sectorShaders.trapeziumPrimitive.vertex,
+        sectorShaders.trapeziumPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.NutCollection,
+      createMaterial(
+        'Primitives (Nut)',
+        sectorShaders.nutPrimitive.vertex,
+        sectorShaders.nutPrimitive.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.TriangleMesh,
+      createMaterial(
+        'Primitives (TriangleMesh)',
+        sectorShaders.detailedMesh.vertex,
+        sectorShaders.detailedMesh.fragment,
+        sharedParams
+      )
+    ],
+    [
+      RevealGeometryCollectionType.InstanceMesh,
+      createMaterial(
+        'Primitives (InstancedMesh)',
+        sectorShaders.instancedMesh.vertex,
+        sectorShaders.instancedMesh.fragment,
+        sharedParams
+      )
+    ]
+  ]);
+}
+
+function createMaterial(
+  name: string,
+  vertexShader: string,
+  fragmentShader: string,
+  sharedParams: THREE.ShaderMaterialParameters
+): THREE.RawShaderMaterial {
   return new THREE.RawShaderMaterial({
-    name: 'Instanced meshes',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    extensions: {
-      derivatives: true
-    },
-    side: THREE.DoubleSide,
-    fragmentShader: sectorShaders.instancedMesh.fragment,
-    vertexShader: sectorShaders.instancedMesh.vertex,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
+    ...sharedParams,
+    name,
+    vertexShader,
+    fragmentShader
   });
-}
-
-export function createGeneralCylinderMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (General cylinder)',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      cameraPosition: {
-        value: new THREE.Vector3()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    vertexShader: sectorShaders.generalCylinderPrimitive.vertex,
-    fragmentShader: sectorShaders.generalCylinderPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createTriangleMeshMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Triangle meshes',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    extensions: {
-      derivatives: true
-    },
-    side: THREE.DoubleSide,
-    fragmentShader: sectorShaders.detailedMesh.fragment,
-    vertexShader: sectorShaders.detailedMesh.vertex,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createBoxMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Box)',
-    clipping: false,
-    vertexShader: sectorShaders.boxPrimitive.vertex,
-    fragmentShader: sectorShaders.boxPrimitive.fragment,
-    side: THREE.DoubleSide,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createCircleMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Circle)',
-    clipping: false,
-    vertexShader: sectorShaders.circlePrimitive.vertex,
-    fragmentShader: sectorShaders.circlePrimitive.fragment,
-    side: THREE.DoubleSide,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createConeMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Cone)',
-    clipping: false,
-    vertexShader: sectorShaders.conePrimitive.vertex,
-    fragmentShader: sectorShaders.conePrimitive.fragment,
-    side: THREE.DoubleSide,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createEccentricConeMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Eccentric cone)',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    vertexShader: sectorShaders.eccentricConePrimitive.vertex,
-    fragmentShader: sectorShaders.eccentricConePrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createGeneralRingMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (General rings)',
-    clipping: false,
-    uniforms: {
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      renderMode: { value: 1 },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    vertexShader: sectorShaders.generalRingPrimitive.vertex,
-    fragmentShader: sectorShaders.generalRingPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createEllipsoidSegmentMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Ellipsoid segments)',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    vertexShader: sectorShaders.ellipsoidSegmentPrimitive.vertex,
-    fragmentShader: sectorShaders.ellipsoidSegmentPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createNutMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Nuts)',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    vertexShader: sectorShaders.nutPrimitive.vertex,
-    fragmentShader: sectorShaders.nutPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createQuadMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Quads)',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    vertexShader: sectorShaders.quadPrimitive.vertex,
-    fragmentShader: sectorShaders.quadPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createTrapeziumMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Trapezium)',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    vertexShader: sectorShaders.trapeziumPrimitive.vertex,
-    fragmentShader: sectorShaders.trapeziumPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
-}
-
-export function createTorusSegmentMaterial(): THREE.RawShaderMaterial {
-  const material = new THREE.RawShaderMaterial({
-    name: 'Primitives (Torus segment)',
-    clipping: false,
-    uniforms: {
-      renderMode: { value: 1 },
-      inverseModelMatrix: {
-        value: new THREE.Matrix4()
-      },
-      matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(1, 1) },
-      colorDataTexture: { value: new THREE.DataTexture(new Uint8ClampedArray([0, 0, 0, 1]), 1, 1) }
-    },
-    extensions: {
-      derivatives: true
-    },
-    vertexShader: sectorShaders.torusSegmentPrimitive.vertex,
-    fragmentShader: sectorShaders.torusSegmentPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    ...blendingOptions
-  });
-
-  material.uniforms.colorDataTexture.value.needsUpdate = true;
-
-  return material;
 }


### PR DESCRIPTION
# Description
Small refactor to properly handle color override data texture. This is needed for textureFetch logic in the shader which #2364  introduces.
