### PR TITLE
fix: remove build viewer dependency and download viewer step for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,8 @@ jobs:
   run-coverage-tests:
     name: Run unit tests
     runs-on: ubuntu-latest 
-    needs: build-viewer
     steps:
     - uses: actions/checkout@v2
-
-    - name: Download viewer build artifact 
-      uses: actions/download-artifact@v3
-      with:
-        name: viewer
-        path: viewer/dist/
 
     - uses: actions/cache@v2
       id: npm_cache


### PR DESCRIPTION
# Description

Unit tests do not depend on viewer being built, as it will built it itself using ts-jest. So removing this dependency to increase paralellism during CI.