### PR TITLE
fix: wrong resolve of viewer symlink

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = {
   ],
   resolve: {
     extensions: ['.tsx', '.ts', '.js', '.css'],
+    symlinks: false
   },
   devtool: 'inline-source-map',
   output: {


### PR DESCRIPTION
# Description

The way examples symlinks reveal is currently wrong and causes it to wrongfully resolve dependencies in the /viewers node_modules. This can cause dependencies to be resolved even though they should not.

Before this change:
![image](https://user-images.githubusercontent.com/6595726/188175398-9fb2c21f-ad23-484d-8804-6a5fc169021c.png)

After this change:
![image](https://user-images.githubusercontent.com/6595726/188175465-dc996cd5-37fe-404e-af6f-48507a88efb0.png)
