### PR TITLE
fix: properly dispose old classifiction texture when creating a new one

### DIFF
--- a/viewer/packages/pointclouds/src/potree-three-loader/rendering/PointCloudMaterial.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/rendering/PointCloudMaterial.ts
@@ -522,6 +522,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
   }
 
   private recomputeClassification(): void {
+    this.classificationTexture?.dispose();
     this.classificationTexture = generateClassificationTexture(this._classification);
     this.setUniform('classificationLUT', this.classificationTexture);
   }


### PR DESCRIPTION
# Description
Fixes a memory leak where texture is not properly disposed.