### PR TITLE
chore: allow passing arguments to jest when running visual tests

### DIFF
--- a/viewer/README.md
+++ b/viewer/README.md
@@ -137,7 +137,7 @@ Visual test files must be on the format `visual-tests/SomeTest.VisualTest.ts`. S
 for example on how to create a test.
 
 Visual tests can be run from `viewer/` using `yarn test:visual`. This will run all visual tests. You can also
-run a single test by using `yarn test:visual -- -t"SomeTest"` (will run all tests with "SomeTest" in the name).
+run a single test by using `yarn test:visual -- -t="SomeTest"` (will run all tests with "SomeTest" in the name).
 
 ### Recommended package folder structure
     ├── app                   # Runnable app

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -139,6 +139,8 @@ for example on how to create a test.
 Visual tests can be run from `viewer/` using `yarn test:visual`. This will run all visual tests. You can also
 run a single test by using `yarn test:visual -- -t="SomeTest"` (will run all tests with "SomeTest" in the name).
 
+For more information about visual tests, see [visual-tests/README.md](visual-tests/README.md).
+
 ### Recommended package folder structure
     ├── app                   # Runnable app
       └──index.ts             # Entry point for runnable app

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -137,7 +137,7 @@ Visual test files must be on the format `visual-tests/SomeTest.VisualTest.ts`. S
 for example on how to create a test.
 
 Visual tests can be run from `viewer/` using `yarn test:visual`. This will run all visual tests. You can also
-run a single test by using `yarn test:visual -- -t="SomeTest"` (will run all tests with "SomeTest" in the name).
+run a single test by using `yarn test:visual -- -t="SomeTest"` (will run all tests with "SomeTest" in the name). Note that arguments only will be passed to the client, to pass arguments to the server you will need to manually start the server and client separately.
 
 For more information about visual tests, see [visual-tests/README.md](visual-tests/README.md).
 

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -131,6 +131,14 @@ Add the following script to your package's `package.json`:
 Running the command `yarn start` will host a localhost site with a template HTML that includes the `/app/index.ts` script that has been transpiled to javascript.
 To see an example of this check out the `packages/camera-manager` package.
 
+## Creating and running visual tests
+
+Visual test files must be on the format `visual-tests/SomeTest.VisualTest.ts`. See one of the existing tests
+for example on how to create a test.
+
+Visual tests can be run from `viewer/` using `yarn test:visual`. This will run all visual tests. You can also
+run a single test by using `yarn test:visual -- -t"SomeTest"` (will run all tests with "SomeTest" in the name).
+
 ### Recommended package folder structure
     ├── app                   # Runnable app
       └──index.ts             # Entry point for runnable app

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -32,7 +32,7 @@
     "test": "jest --maxWorkers=4",
     "test:visual:client": "cross-env JEST_PUPPETEER_CONFIG=visual-tests/jest-puppeteer.config.js jest --config=visual-tests/jest.config.js --verbose",
     "test:visual:server": "webpack-dev-server --config packages/webpack.config.js",
-    "test:visual": "concurrently -k -s \"first\" \"yarn run test:visual:client\" \"yarn run test:visual:server\"",
+    "test:visual": "concurrently --passthrough-arguments -k -s \"first\" \"yarn run test:visual:client {@}\" \"yarn run test:visual:server\"",
     "coverage": "jest --coverage",
     "lint": "eslint . --ext .ts,.js --max-warnings 0 --cache",
     "prebump": "yarn version --no-git-tag-version && yarn && cd ../documentation && yarn replace-latest-by-next",


### PR DESCRIPTION
# Description

Allow passing arguments to jest when running `yarn test:visual`. This allows to e.g. run a single visual test:

`yarn test:visual -- -t="Rendering.VisualTest.ts"`

or any other option supported by the Jest API.


# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
Not done, but reviewer should test this.