### PR TITLE
fix: issue causing AssetNodeCollection.getAreas() to return coordinates in "CDF space" and not "ThreeJS space"

### DIFF
--- a/examples/src/pages/Migration.tsx
+++ b/examples/src/pages/Migration.tsx
@@ -202,7 +202,7 @@ export function Migration() {
 
         viewer.loadCameraFromModel(model);
         if (model instanceof Cognite3DModel) {
-          new NodeStylingUI(gui.addFolder(`Node styling #${modelUi.cadModels.length}`), client, model);
+          new NodeStylingUI(gui.addFolder(`Node styling #${modelUi.cadModels.length}`), client, viewer, model);
           new BulkHtmlOverlayUI(gui.addFolder(`Node tagging #${modelUi.cadModels.length}`), viewer, model, client);
         } else if (model instanceof CognitePointCloudModel) {
           new PointCloudClassificationFilterUI(gui.addFolder(`Class filter #${modelUi.pointCloudModels.length}`), model);

--- a/viewer/packages/cad-styling/src/AssetNodeCollection.ts
+++ b/viewer/packages/cad-styling/src/AssetNodeCollection.ts
@@ -65,7 +65,7 @@ export class AssetNodeCollection extends NodeCollection {
     );
     this._fetchResultHelper = fetchResultHelper;
 
-    function mapBoundingBox(box?: THREE.Box3) {
+    function mapBoundingBoxToCdf(box?: THREE.Box3) {
       if (box === undefined) {
         return undefined;
       }
@@ -77,7 +77,7 @@ export class AssetNodeCollection extends NodeCollection {
 
     const filterQuery = {
       assetId: filter.assetId,
-      intersectsBoundingBox: mapBoundingBox(filter.boundingBox),
+      intersectsBoundingBox: mapBoundingBoxToCdf(filter.boundingBox),
       limit: 1000
     };
 
@@ -109,7 +109,9 @@ export class AssetNodeCollection extends NodeCollection {
       .map(node => {
         const bmin = node.boundingBox!.min;
         const bmax = node.boundingBox!.max;
-        return new THREE.Box3().setFromArray([bmin[0], bmin[1], bmin[2], bmax[0], bmax[1], bmax[2]]);
+        const bounds = new THREE.Box3().setFromArray([bmin[0], bmin[1], bmin[2], bmax[0], bmax[1], bmax[2]]);
+        this._modelMetadataProvider.mapBoxFromCdfToModelCoordinates(bounds, bounds);
+        return bounds;
       });
 
     return boundingBoxes;

--- a/viewer/packages/cad-styling/src/NodeCollection.ts
+++ b/viewer/packages/cad-styling/src/NodeCollection.ts
@@ -36,6 +36,11 @@ export abstract class NodeCollection {
 
   abstract get isLoading(): boolean;
   abstract getIndexSet(): IndexSet;
+  /**
+   * Returns areas surrounding the nodes in the collection. The areas
+   * are boxes in "ThreeJS coordinates". Note that not all
+   * implementations supports this.
+   */
   abstract getAreas(): AreaCollection;
   abstract clear(): void;
   abstract serialize(): SerializedNodeCollection;


### PR DESCRIPTION
# Description

Fix issue in AssetNodeCollection causing getAreas() to return bounds in CDF space, not ThreeJS. This causes features such as prioritizedForLoadingHint not to work correctly.

Also added debug tool to show bounds of nodes filtering to example UI.

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
Framework for unit tests not in place here - will add test in #2389.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
