### PR TITLE
doc: show bounds of matched nodes in example for SinglePropertyFilterNodeCollection

### DIFF
--- a/documentation/docs/examples/cad-styling-nodes.mdx
+++ b/documentation/docs/examples/cad-styling-nodes.mdx
@@ -121,10 +121,16 @@ for (let q = 200; q < 300; q++) {
     names.push(name);
   }
 }
-nodeSet.executeFilter('Item', 'Name', names);
-
 model.setDefaultNodeAppearance(DefaultNodeAppearance.Ghosted);
 model.assignStyledNodeCollection(nodeSet, { renderGhosted: false, outlineColor: NodeOutlineColor.Orange } );
+
+nodeSet.executeFilter('Item', 'Name', names).then(() => {
+  // Create boxes around the areas to make it easier for users to find areas in the 3D model to explore
+  const areas = Array.from(nodeSet.getAreas().areas());
+  for (const area of areas) {
+    viewer.addObject3D(new THREE.Box3Helper(area));
+  }
+});
 ```
 
 ## Inverting filters


### PR DESCRIPTION
# Description

Add boxes around areas matched in example to show possibilities to highlight information of interest.

![image](https://user-images.githubusercontent.com/6741854/189673768-bfe00939-309d-4dbd-87c0-cdf524427fd8.png)
![image](https://user-images.githubusercontent.com/6741854/189673817-7ebaf366-cb91-4ec2-890e-8990b2fc814d.png)


# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [x] I have asked peers to test this feature.
