### PR TITLE
fix: redraw point cloud on classification change

### DIFF
--- a/viewer/packages/pointclouds/src/PotreeNodeWrapper.ts
+++ b/viewer/packages/pointclouds/src/PotreeNodeWrapper.ts
@@ -95,6 +95,7 @@ export class PotreeNodeWrapper {
 
     this._classification[key].w = visible ? 1.0 : 0.0;
     this.octree.material.classification = this._classification;
+    this._needsRedraw = true;
   }
 
   resetRedraw(): void {


### PR DESCRIPTION
# Description

This ensures that pointclouds are redrawn after a point class has changed visibility. Without this change, the user must e.g. move the camera to re-trigger a redraw and see the class change.

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
