### PR TITLE
chore: delete preview docs when PR is closed

### DIFF
--- a/.github/workflows/cleanup-on-close.yml
+++ b/.github/workflows/cleanup-on-close.yml
@@ -1,0 +1,30 @@
+name: Cleanup on PR close
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-preview-docs:
+    name: Delete preview docs
+    if: "contains(github.event.pull_request.labels.*.name, 'preview-docs')"
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Initialize variables
+        run: |
+          echo "PR_NUMBER=$(jq --raw-output .pull_request.number $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
+
+      - name: Create empty directory
+        run: |
+          mkdir empty_dir
+        
+      - name: Clean preview docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.REVEAL_DOCS_PREVIEW_DEPLOY_KEY }}
+          external_repository: cognitedata/reveal-docs-preview
+          publish_branch: master
+          publish_dir: empty_dir/
+          destination_dir: ${{ env.PR_NUMBER }}
+          keep_files: false 

--- a/.github/workflows/cleanup-on-close.yml
+++ b/.github/workflows/cleanup-on-close.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   delete-preview-docs:
     name: Delete preview docs
-    if: "contains(github.event.pull_request.labels.*.name, 'preview-docs')"
     runs-on: ubuntu-latest
     steps: 
       - name: Initialize variables
@@ -19,7 +18,7 @@ jobs:
         run: |
           mkdir empty_dir
         
-      - name: Clean preview docs
+      - name: Delete preview docs
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.REVEAL_DOCS_PREVIEW_DEPLOY_KEY }}


### PR DESCRIPTION
# Description

Delete preview docs when PR is closed to reduce time it takes to deploy preview docs.

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
Nope, test is in CI