### PR TITLE
fix: expose and fix bug causing getBoundingBoxByNodeId/TreeIndex not to modify out parameter

### DIFF
--- a/viewer/packages/cad-model/src/wrappers/Cognite3DModel.ts
+++ b/viewer/packages/cad-model/src/wrappers/Cognite3DModel.ts
@@ -421,10 +421,11 @@ export class Cognite3DModel extends THREE.Object3D implements CogniteModelBase, 
    */
   async getBoundingBoxByNodeId(nodeId: number, box?: THREE.Box3): Promise<THREE.Box3> {
     try {
+      box = box ?? new THREE.Box3();
       const boxesResponse = await this.nodesApiClient.getBoundingBoxesByNodeIds(this.modelId, this.revisionId, [
         nodeId
       ]);
-      box = boxesResponse[0];
+      box.copy(boxesResponse[0]);
       box.applyMatrix4(this.cadModel.modelMatrix);
       return box;
     } catch (error) {

--- a/viewer/test-utilities/src/createCadModel.ts
+++ b/viewer/test-utilities/src/createCadModel.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 import { CadNode, Cognite3DModel } from '../../packages/cad-model';
-import { NodesLocalClient } from '../../packages/nodes-api';
+import { NodesApiClient, NodesLocalClient } from '../../packages/nodes-api';
 import { CadMaterialManager } from '../../packages/rendering';
 
 import { createCadModelMetadata } from './createCadModelMetadata';
@@ -15,7 +15,8 @@ export function createCadModel(
   modelId: number,
   revisionId: number,
   depth: number = 3,
-  children: number = 3
+  children: number = 3,
+  nodesApiClient?: NodesApiClient
 ): Cognite3DModel {
   const materialManager = new CadMaterialManager();
   const cadRoot = generateV9SectorTree(depth, children);
@@ -25,8 +26,8 @@ export function createCadModel(
   const mockV8SectorRepository = new Mock<SectorRepository>();
 
   const cadNode = new CadNode(cadMetadata, materialManager, mockV8SectorRepository.object());
-  const apiClient = new NodesLocalClient();
-  const model = new Cognite3DModel(modelId, revisionId, cadNode, apiClient);
+  nodesApiClient = nodesApiClient ?? new NodesLocalClient();
+  const model = new Cognite3DModel(modelId, revisionId, cadNode, nodesApiClient);
 
   return model;
 }


### PR DESCRIPTION
# Description

getBoundingBoxByNodeId()/TreeIndex() didn't modify out parameter, so only return value works. Exposed in unit test and fixed.


# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
Exposed and fixed in test, should be enough.