### PR TITLE
docs: finalize point cloud styling docs

### DIFF
--- a/documentation/docs/examples/pointcloud-styling.mdx
+++ b/documentation/docs/examples/pointcloud-styling.mdx
@@ -6,15 +6,15 @@ description: Usage of the styling API for pointcloud models
 
 Cognite Data Fusion has a concept of "objects" in point clouds, represented by one or more bounding volumes for
 each object. The objects are backed by the [CDF Annotations API](https://docs.cognite.com/api/v1/#tag/Annotations).
-`@cognite/reveal` supports styling individual objects within a point cloud.
+Reveal supports styling individual objects within a point cloud.
 
 import { DemoWrapper } from '@site/versioned_docs/version-4.x/components/DemoWrapper';
 
 <DemoWrapper modelType="pointcloud" />
 
-In this context, a _stylable object_ represents some volume in space. Styling an object results in all points that lie within the corresponding volume to attain the assigned style.
+In this context, a _stylable object_ is represented by a volume in space. Styling an object results in all points that lie within the corresponding volume to attain the assigned style.
 
-Stylable objects must be supplied separately from the model itself. Upon adding a new point cloud model to the viewer, Reveal will automatically fetch data describing the point cloud objects from CDFs Annotations API, if any are available. To get the number of fetched stylable objects, use the property `model.stylableObjectCount`, where `model` is a `CognitePointCloudModel`.
+Stylable objects must be supplied separately from the model itself. Upon adding a new point cloud model to the viewer, Reveal will automatically fetch data describing the point cloud objects from CDF's Annotations API, if any are available. To get the number of fetched stylable objects, use the property `model.stylableObjectCount`, where `model` is a `CognitePointCloudModel`.
 
 Point cloud objects can be styled with a `PointCloudAppearance` object, containing the following attributes:
 
@@ -23,9 +23,9 @@ Point cloud objects can be styled with a `PointCloudAppearance` object, containi
 | `color`                    | `[number, number, number]?`     | Override color by setting RGB values in range [0,255]. `[0, 0, 0]` means no override. |
 | `visible`                  | `boolean?`                      | When false, stylable object will be invisible. Default value is `true`.               |
 
-To assign a style to one or more stylable objects, you must first create an instance of the abstract class `PointCloudObjectCollection`. The only implementation of this class provided by Reveal is `AnnotationIdPointCloudObjectCollection`, which is initialized with a list of annotation IDs corresponding to stylable objects. To see all available annotation IDs associated with the model, you may use the method `model.traverseStylableObjects`.
+To assign a style to one or more stylable objects, you must first create an instance of the abstract class `PointCloudObjectCollection`. Currently, the only implementation of this class provided by Reveal is `AnnotationIdPointCloudObjectCollection`, which is initialized with a list of annotation IDs corresponding to stylable objects. To see all available annotation IDs associated with the model, you may use the method `model.traverseStylableObjects`.
 
-To color all objects red:
+To color all stylable objects red:
 
 ```js runnable
 const annotationIds = [];
@@ -38,7 +38,7 @@ const appearance = { color: [255, 0, 0] };
 model.assignStyledObjectCollection(objectCollection, appearance);
 ```
 
-Use the property `model.styledCollections` to get a list of all object collections and their assigned style registered on the model.
+After assigning style to an object collection, you may use the property `model.styledCollections` to get a list of all object collections and their assigned styles registered on the model.
 
 ## Default appearance
 
@@ -61,3 +61,13 @@ Like in CAD styling, stylable objects that are part of multiple styled object co
 ## Unassigning styled object collections
 
 To reset style of an object collection, use `model.unassignStyledObjectCollection` with the previously styled `PointCloudObjectCollection` as argument. To reset all styled objects use `model.removeAllStyledCollections`
+
+## Reset all styled object collections
+
+To reset all styled object collections, use the method `model.removeAllStyledObjectCollections()`.
+
+This example removes all style on stylable object collections and makes sure the rest of the point cloud is visible.
+```js runnable
+model.removeAllStyledObjectCollections();
+model.setDefaultPointCloudAppearance({ visible: true });
+```


### PR DESCRIPTION
# Description

Finalizing the documentation for point cloud styling.
Note that it has not yet been copied into the `versioned_docs/version-4.x` yet. 4.x is not yet exposed when building documentation, so I see no rush to get it in there yet. At least it means fewer merge conflicts when we merge this into master.

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
