### PR TITLE
chore: security upgrades for viewer/

### DIFF
--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -1524,6 +1524,7 @@
 
 "@cognite/reveal-4.x@link:../viewer/dist":
   version "0.0.0"
+  uid ""
 
 "@cognite/reveal-parser-worker@1.1.1":
   version "1.1.1"
@@ -1541,6 +1542,7 @@
 
 "@cognite/reveal@link:../viewer/dist":
   version "0.0.0"
+  uid ""
 
 "@cognite/sdk-1.x@npm:@cognite/sdk@^3.4.0":
   version "3.5.2"
@@ -1622,8 +1624,20 @@
     query-string "^5.1.1"
     url "^0.11.0"
 
+"@cognite/sdk-core@^4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.8.1.tgz#008c6d7e15393f3a840baf809a0037efa8266849"
+  integrity sha512-FEICothNg/aAHdAY84J/udt5NcPcoe8GlT+piFgpvV8zIFpFbUxU4oLVf20xl0AJX1xCO13iWrL/szf6BWqEcA==
+  dependencies:
+    cross-fetch "^3.0.4"
+    is-buffer "^2.0.5"
+    lodash "^4.17.11"
+    query-string "^5.1.1"
+    url "^0.11.0"
+
 "@cognite/sdk@link:../viewer/node_modules/@cognite/sdk":
   version "0.0.0"
+  uid ""
 
 "@cognite/three-combo-controls@^1.4.3":
   version "1.4.3"
@@ -6839,7 +6853,7 @@ pascal-case@^3.1.2:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-path-browserify@1.0.1:
+path-browserify@1.0.1, path-browserify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
   integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
@@ -7258,7 +7272,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-proj4@2.8.0:
+proj4@2.8.0, proj4@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.8.0.tgz#b2cb8f3ccd56d4dcc7c3e46155cd02caa804b170"
   integrity sha512-baC+YcD4xsSqJ+CpCZljj2gcQDhlKb+J+Zjv/2KSBwWNjk4M0pafgQsE+mWurd84tflMIsP+7j7mtIpFDHzQfQ==

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -9176,9 +9176,9 @@ __metadata:
   linkType: hard
 
 "minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+  version: 1.2.6
+  resolution: "minimist@npm:1.2.6"
+  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
   languageName: node
   linkType: hard
 

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -11942,8 +11942,8 @@ resolve@^1.9.0:
   linkType: hard
 
 "terser@npm:^5.10.0, terser@npm:^5.7.2":
-  version: 5.14.1
-  resolution: "terser@npm:5.14.1"
+  version: 5.15.0
+  resolution: "terser@npm:5.15.0"
   dependencies:
     "@jridgewell/source-map": ^0.3.2
     acorn: ^8.5.0
@@ -11951,7 +11951,7 @@ resolve@^1.9.0:
     source-map-support: ~0.5.20
   bin:
     terser: bin/terser
-  checksum: 7b0e51f3d193a11cad82f07e3b0c1d62122eec786f809bdf2a54b865aaa1450872c3a7b6c33b5a40e264834060ffc1d4e197f971a76da5b0137997d756eb7548
+  checksum: b2358c989fcb76b4a1c265f60e175c950d3f776e5f619a9f58f54e8d2d792cd6b4cca86071834075f3b9943556d695357bafdd4ee2390de2fc9fd96ba3efa8c8
   languageName: node
   linkType: hard
 

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -6199,23 +6199,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.14.1
-  resolution: "follow-redirects@npm:1.14.1"
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.7":
+  version: 1.15.2
+  resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 7381a55bdc6951c5c1ab73a8da99d9fa4c0496ce72dba92cd2ac2babe0e3ebde9b81c5bca889498ad95984bc773d713284ca2bb17f1b1e1416e5f6531e39a488
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.14.7":
-  version: 1.15.1
-  resolution: "follow-redirects@npm:1.15.1"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 6aa4e3e3cdfa3b9314801a1cd192ba756a53479d9d8cca65bf4db3a3e8834e62139245cd2f9566147c8dfe2efff1700d3e6aefd103de4004a7b99985e71dd533
+  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
   languageName: node
   linkType: hard
 

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -9623,11 +9623,11 @@ __metadata:
   linkType: hard
 
 "nth-check@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "nth-check@npm:2.0.0"
+  version: 2.1.1
+  resolution: "nth-check@npm:2.1.1"
   dependencies:
     boolbase: ^1.0.0
-  checksum: a22eb19616719d46a5b517f76c32e67e4a2b6a229d67ba2f3efb296e24d79687d52b904c2298cd16510215d5d2a419f8ba671f5957a3b4b73905f62ba7aafa3b
+  checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
   languageName: node
   linkType: hard
 
@@ -11864,21 +11864,7 @@ resolve@^1.9.0:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.2, tar@npm:^6.1.0":
-  version: 6.1.6
-  resolution: "tar@npm:6.1.6"
-  dependencies:
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    minipass: ^3.0.0
-    minizlib: ^2.1.1
-    mkdirp: ^1.0.3
-    yallist: ^4.0.0
-  checksum: 583f1165281746b4c48adee4ff7bab4895e73999eeda3c8d59779e47c29dc1dc714d832608a491fead4fd794bf9e0bd51b3d4a4fbad87f487a8b360321d70e8c
-  languageName: node
-  linkType: hard
-
-"tar@npm:^6.1.11, tar@npm:^6.1.2":
+"tar@npm:^6.0.2, tar@npm:^6.1.0, tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
   dependencies:

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -4831,21 +4831,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:3.1.5":
+"cross-fetch@npm:3.1.5, cross-fetch@npm:^3.0.4":
   version: 3.1.5
   resolution: "cross-fetch@npm:3.1.5"
   dependencies:
     node-fetch: 2.6.7
   checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
-  languageName: node
-  linkType: hard
-
-"cross-fetch@npm:^3.0.4":
-  version: 3.1.4
-  resolution: "cross-fetch@npm:3.1.4"
-  dependencies:
-    node-fetch: 2.6.1
-  checksum: 2107e5e633aa327bdacab036b1907c7ddd28651ede0c1d4fd14db04510944d56849a8255e2f5b8f9a1da0e061b6cee943f6819fe29ed9a130195e7fadd82a4ff
   languageName: node
   linkType: hard
 
@@ -9470,13 +9461,6 @@ __metadata:
   dependencies:
     semver: ^7.3.5
   checksum: 3644dd51f4f189358ef56055407501aa698632d67448585b38c46c81a482a0c3bfb06da513ac4060a12ce5f607f208ba9d9c8280f1c38329670b709bd735fcae
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:2.6.1":
-  version: 2.6.1
-  resolution: "node-fetch@npm:2.6.1"
-  checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
   languageName: node
   linkType: hard
 

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -2854,20 +2854,13 @@ __metadata:
   linkType: hard
 
 "ansi-regex@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "ansi-regex@npm:3.0.0"
-  checksum: 2ad11c416f81c39f5c65eafc88cf1d71aa91d76a2f766e75e457c2a3c43e8a003aadbf2966b61c497aa6a6940a36412486c975b3270cdfc3f413b69826189ec3
+  version: 3.0.1
+  resolution: "ansi-regex@npm:3.0.1"
+  checksum: 09daf180c5f59af9850c7ac1bd7fda85ba596cc8cbeb210826e90755f06c818af86d9fa1e6e8322fab2c3b9e9b03f56c537b42241139f824dd75066a1e7257cc
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "ansi-regex@npm:5.0.0"
-  checksum: b1bb4e992a5d96327bb4f72eaba9f8047f1d808d273ad19d399e266bfcc7fb19a4d1a127a32f7bc61fe46f1a94a4d04ec4c424e3fbe184929aa866323d8ed4ce
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^5.0.1":
+"ansi-regex@npm:^5.0.0, ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b


### PR DESCRIPTION
# Description

Upgraded using `yarn up -R <dependency>` which only works with Yarn 3.

[Prototype Pollution in minimist ](https://github.com/cognitedata/reveal/security/dependabot/145)[Critical](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Acritical)
#145 opened 6 months ago • Detected in minimist (npm) • viewer/yarn.lock

[Terser insecure use of regular expressions before v4.8.1 and v5.14.2 leads to ReDoS ](https://github.com/cognitedata/reveal/security/dependabot/192)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#192 opened 2 months ago • Detected in terser (npm) • viewer/yarn.lock

[Inefficient Regular Expression Complexity in chalk/ansi-regex ](https://github.com/cognitedata/reveal/security/dependabot/143)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#143 opened 6 months ago • Detected in ansi-regex (npm) • viewer/yarn.lock

[Inefficient Regular Expression Complexity in chalk/ansi-regex ](https://github.com/cognitedata/reveal/security/dependabot/137)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#137 opened 6 months ago • Detected in ansi-regex (npm) • viewer/yarn.lock

[node-fetch is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor ](https://github.com/cognitedata/reveal/security/dependabot/84)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#84 opened 8 months ago • Detected in node-fetch (npm) • viewer/yarn.lock

[Exposure of sensitive information in follow-redirects ](https://github.com/cognitedata/reveal/security/dependabot/79)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#79 opened 8 months ago • Detected in follow-redirects (npm) • viewer/yarn.lock

[Inefficient Regular Expression Complexity in nth-check ](https://github.com/cognitedata/reveal/security/dependabot/74)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#74 opened 8 months ago • Detected in nth-check (npm) • viewer/yarn.lock

[Arbitrary File Creation/Overwrite on Windows via insufficient relative path sanitization ](https://github.com/cognitedata/reveal/security/dependabot/71)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#71 opened 8 months ago • Detected in tar (npm) • viewer/yarn.lock

[Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links ](https://github.com/cognitedata/reveal/security/dependabot/70)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#70 opened 8 months ago • Detected in tar (npm) • viewer/yarn.lock

[Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links ](https://github.com/cognitedata/reveal/security/dependabot/69)[High](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Ahigh)
#69 opened 8 months ago • Detected in tar (npm) • viewer/yarn.lock

[Incorrect Authorization in cross-fetch ](https://github.com/cognitedata/reveal/security/dependabot/167)[Moderate](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Amoderate)
#167 opened 5 months ago • Detected in cross-fetch (npm) • viewer/yarn.lock

[Exposure of Sensitive Information to an Unauthorized Actor in follow-redirects ](https://github.com/cognitedata/reveal/security/dependabot/101)[Moderate](https://github.com/cognitedata/reveal/security/dependabot?q=is%3Aopen+severity%3Amoderate)
#101 opened 8 months ago • Detected in follow-redirects (npm) • viewer/yarn.lock

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
