### PR TITLE
Remove flat modifier, while maintaining TreeIndex precision

### DIFF
--- a/viewer/packages/rendering/src/glsl/base/determineNodeAppearance.glsl
+++ b/viewer/packages/rendering/src/glsl/base/determineNodeAppearance.glsl
@@ -2,11 +2,12 @@
 
 NodeAppearance determineNodeAppearance(sampler2D nodeAppearanceTexture, vec2 textureSize, highp float treeIndex) {
 
-  float dataTextureWidth = textureSize.x;
-  float dataTextureHeight = textureSize.y;
+  highp int dataTextureWidth = int(textureSize.x);
+  highp int dataTextureHeight = int(textureSize.y);
 
-  int xTreeIndexTextureCoord = int(mod(treeIndex, dataTextureWidth));
-  int yTreeIndexTextureCoord = int(floor(treeIndex / dataTextureWidth));
+  highp int iTreeIndex = int(treeIndex);
+  highp int xTreeIndexTextureCoord = iTreeIndex % dataTextureWidth;
+  highp int yTreeIndexTextureCoord = iTreeIndex / dataTextureWidth;
 
   vec4 texel = texelFetch(nodeAppearanceTexture, ivec2(xTreeIndexTextureCoord, yTreeIndexTextureCoord), 0);
   float alphaUnwrapped = floor((texel.a * 255.0) + 0.5);

--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
@@ -13,7 +13,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_viewPosition;
 

--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
@@ -13,11 +13,14 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_viewPosition;
 
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
@@ -13,17 +13,21 @@ in mat4 a_instanceMatrix;
 in float a_treeIndex;
 in vec3 a_color;
 
-out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_viewPosition;
 
-void main()
-{
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
+void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
+
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 
@@ -32,6 +36,5 @@ void main()
     vec3 transformed = (a_instanceMatrix * vec4(position, 1.0)).xyz;
     vec4 modelViewPosition = viewMatrix * treeIndexWorldTransform * modelMatrix * vec4(transformed, 1.0);
     v_viewPosition = modelViewPosition.xyz;
-    v_treeIndex = a_treeIndex;
     gl_Position = projectionMatrix * modelViewPosition;
 }

--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
@@ -13,17 +13,17 @@ in mat4 a_instanceMatrix;
 in float a_treeIndex;
 in vec3 a_color;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_viewPosition;
 
 void main()
 {
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/mesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.frag
@@ -13,12 +13,16 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
+
 in vec3 v_color;
 in vec3 v_viewPosition;
 
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
 void main()
 {
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
+
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/mesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.frag
@@ -13,7 +13,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_viewPosition;
 

--- a/viewer/packages/rendering/src/glsl/sector/mesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.vert
@@ -10,21 +10,23 @@ uniform sampler2D transformOverrideTexture;
 
 in vec3 position;
 in vec3 color;
-in float treeIndex; 
+in float treeIndex;
 
 out vec3 v_color;
-out float v_treeIndex;
 out vec3 v_viewPosition;
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
 
 void main() {
+    v_treeIndexHundreds = floor(treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(treeIndex, 100.0));
     v_color = color;
-    v_treeIndex = treeIndex;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/mesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.vert
@@ -10,10 +10,10 @@ uniform sampler2D transformOverrideTexture;
 
 in vec3 position;
 in vec3 color;
-in float treeIndex;
+in float treeIndex; 
 
 out vec3 v_color;
-flat out float v_treeIndex;
+out float v_treeIndex;
 out vec3 v_viewPosition;
 
 void main() {
@@ -21,10 +21,10 @@ void main() {
     v_treeIndex = treeIndex;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
@@ -12,18 +12,20 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
 in vec2 v_xy;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     float dist = dot(v_xy, v_xy);
     vec3 normal = normalize( v_normal );
     if (dist > 0.25)
       discard;
-      
+
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec2 v_xy;
 in vec3 v_color;
 in vec3 v_normal;
@@ -23,7 +23,7 @@ void main() {
     vec3 normal = normalize( v_normal );
     if (dist > 0.25)
       discard;
-
+      
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
@@ -19,18 +19,21 @@ in vec3 a_normal;
 out vec2 v_xy;
 out vec3 v_color;
 out vec3 v_normal;
-out float v_treeIndex;
 out vec3 vViewPosition;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
     v_xy = vec2(position.x, position.y);
-    v_treeIndex = a_treeIndex;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
@@ -19,7 +19,7 @@ in vec3 a_normal;
 out vec2 v_xy;
 out vec3 v_color;
 out vec3 v_normal;
-flat out float v_treeIndex;
+out float v_treeIndex;
 out vec3 vViewPosition;
 
 void main() {
@@ -27,10 +27,10 @@ void main() {
     v_treeIndex = a_treeIndex;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
@@ -24,7 +24,7 @@ in float v_angle;
 in float v_arcAngle;
 in vec4 v_centerA;
 in vec4 v_V;
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
@@ -24,11 +24,13 @@ in float v_angle;
 in float v_arcAngle;
 in vec4 v_centerA;
 in vec4 v_V;
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
   NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
   if (!determineVisibility(appearance, renderMode)) {
       discard;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
@@ -25,7 +25,6 @@ in vec3 a_localXAxis;
 in float a_angle;
 in float a_arcAngle;
 
-out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerB;
 // U, V, axis represent the 3x3 cone basis.
@@ -40,12 +39,17 @@ out float v_arcAngle;
 out vec3 v_color;
 out vec3 v_normal;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 
@@ -83,7 +87,6 @@ void main() {
     surfacePoint = mul3(modelViewMatrix, surfacePoint);
 
     // out data
-    v_treeIndex = a_treeIndex;
     v_angle = a_angle;
     v_arcAngle = a_arcAngle;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
@@ -25,7 +25,7 @@ in vec3 a_localXAxis;
 in float a_angle;
 in float a_arcAngle;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerB;
 // U, V, axis represent the 3x3 cone basis.
@@ -42,10 +42,10 @@ out vec3 v_normal;
 
 void main() {
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
@@ -23,7 +23,7 @@ in vec4 axis;
 in vec4 v_centerA;
 in vec4 v_centerB;
 in float height;
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
@@ -23,11 +23,13 @@ in vec4 axis;
 in vec4 v_centerA;
 in vec4 v_centerB;
 in float height;
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
@@ -22,7 +22,6 @@ in float a_radiusB;
 in vec3 a_normal;
 in vec3 a_color;
 
-out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerA;
 out vec4 v_centerB;
@@ -36,13 +35,18 @@ out float height;
 out vec3 v_color;
 out vec3 v_normal;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
 
   mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 
@@ -116,7 +120,6 @@ void main() {
     V.w = surfacePoint.y;
     axis.w = surfacePoint.z;
 
-    v_treeIndex = a_treeIndex;
     v_color = a_color;
     v_normal = normalMatrix * normal;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
@@ -22,7 +22,7 @@ in float a_radiusB;
 in vec3 a_normal;
 in vec3 a_color;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerA;
 out vec4 v_centerB;
@@ -39,10 +39,10 @@ out vec3 v_normal;
 void main() {
 
   mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
@@ -22,7 +22,7 @@ in float height;
 in vec4 U;
 in vec4 V;
 in vec4 sphereNormal;
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
@@ -22,11 +22,13 @@ in float height;
 in vec4 U;
 in vec4 V;
 in vec4 sphereNormal;
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
@@ -22,7 +22,7 @@ in float a_horizontalRadius;
 in float a_verticalRadius;
 in float a_height;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 // We pack vRadius as w-component of center
 out vec4 center;
 out float hRadius;
@@ -39,10 +39,10 @@ out vec3 v_normal;
 void main() {
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
@@ -22,7 +22,6 @@ in float a_horizontalRadius;
 in float a_verticalRadius;
 in float a_height;
 
-out float v_treeIndex;
 // We pack vRadius as w-component of center
 out vec4 center;
 out float hRadius;
@@ -36,13 +35,18 @@ out vec4 sphereNormal;
 out vec3 v_color;
 out vec3 v_normal;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 
@@ -90,7 +94,6 @@ void main() {
     vec3 surfacePoint = centerOfSegment + mat3(lDir, left, up) * displacement;
     vec3 transformed = surfacePoint;
 
-    v_treeIndex = a_treeIndex;
     surfacePoint = mul3(modelViewMatrix, surfacePoint);
     center.xyz = mul3(modelViewMatrix, centerWithOffset);
     center.w = a_verticalRadius; // Pack radius into w-component

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
@@ -29,7 +29,7 @@ in float v_arcAngle;
 in float v_surfacePointY;
 in vec4 v_planeA;
 in vec4 v_planeB;
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 
@@ -39,7 +39,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);
+    vec4 color = determineColor(v_color, appearance);    
     vec3 normal = normalize( v_normal );
 
     float R1 = v_centerB.w;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
@@ -29,17 +29,19 @@ in float v_arcAngle;
 in float v_surfacePointY;
 in vec4 v_planeA;
 in vec4 v_planeB;
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize( v_normal );
 
     float R1 = v_centerB.w;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
@@ -27,7 +27,7 @@ in vec3 a_localXAxis;
 in float a_angle;
 in float a_arcAngle;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerB;
 // U, V, axis represent the 3x3 cone basis.
@@ -48,13 +48,13 @@ void main() {
     mat4 modelViewMatrix = viewMatrix * modelMatrix;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
-
+    
     mat4 modelTransformOffset = inverseModelMatrix * treeIndexWorldTransform * modelMatrix;
 
     vec3 centerA = mul3(modelTransformOffset, a_centerA);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
@@ -27,7 +27,6 @@ in vec3 a_localXAxis;
 in float a_angle;
 in float a_arcAngle;
 
-out float v_treeIndex;
 // We pack the radii into w-components
 out vec4 v_centerB;
 // U, V, axis represent the 3x3 cone basis.
@@ -43,18 +42,23 @@ out float v_arcAngle;
 out vec3 v_color;
 out vec3 v_normal;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
 
     mat4 modelViewMatrix = viewMatrix * modelMatrix;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
-    
+
     mat4 modelTransformOffset = inverseModelMatrix * treeIndexWorldTransform * modelMatrix;
 
     vec3 centerA = mul3(modelTransformOffset, a_centerA);
@@ -86,7 +90,6 @@ void main() {
     surfacePoint = mul3(modelViewMatrix, surfacePoint);
 
     // varying data
-    v_treeIndex = a_treeIndex;
     v_angle = a_angle;
     v_arcAngle = a_arcAngle;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
@@ -17,12 +17,14 @@ in float v_oneMinusThicknessSqr;
 in vec2 v_xy;
 in float v_angle;
 in float v_arcAngle;
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
@@ -17,7 +17,7 @@ in float v_oneMinusThicknessSqr;
 in vec2 v_xy;
 in float v_angle;
 in float v_arcAngle;
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
@@ -19,7 +19,7 @@ in float a_arcAngle;
 in float a_thickness;
 in vec3 a_normal;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 out float v_oneMinusThicknessSqr;
 out vec2 v_xy;
 out float v_angle;
@@ -36,10 +36,10 @@ void main() {
     v_arcAngle = a_arcAngle;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
@@ -19,7 +19,6 @@ in float a_arcAngle;
 in float a_thickness;
 in vec3 a_normal;
 
-out float v_treeIndex;
 out float v_oneMinusThicknessSqr;
 out vec2 v_xy;
 out float v_angle;
@@ -28,18 +27,22 @@ out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
-    v_treeIndex = a_treeIndex;
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
     v_oneMinusThicknessSqr = (1.0 - a_thickness) * (1.0 - a_thickness);
     v_xy = vec2(position.x, position.y);
     v_angle = a_angle;
     v_arcAngle = a_arcAngle;
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
@@ -22,17 +22,19 @@ in float height;
 in vec4 U;
 in vec4 V;
 in vec4 sphereNormal;
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize(sphereNormal.xyz);
 
     float vRadius = center.w;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
@@ -22,7 +22,7 @@ in float height;
 in vec4 U;
 in vec4 V;
 in vec4 sphereNormal;
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 
@@ -32,7 +32,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);
+    vec4 color = determineColor(v_color, appearance);    
     vec3 normal = normalize(sphereNormal.xyz);
 
     float vRadius = center.w;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
@@ -17,7 +17,6 @@ in float a_horizontalRadius;
 in float a_verticalRadius;
 in float a_height;
 
-out float v_treeIndex;
 // We pack vRadius as w-component of center
 out vec4 center;
 out float hRadius;
@@ -32,8 +31,12 @@ out vec4 sphereNormal;
 out vec3 v_color;
 out vec3 v_normal;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
-    v_treeIndex = a_treeIndex;
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
     v_color = a_color;
 
     mat4 modelViewMatrix = viewMatrix * modelMatrix;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
@@ -17,7 +17,7 @@ in float a_horizontalRadius;
 in float a_verticalRadius;
 in float a_height;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 // We pack vRadius as w-component of center
 out vec4 center;
 out float hRadius;

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
@@ -26,7 +26,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);
+    vec4 color = determineColor(v_color, appearance);    
     vec3 normal = normalize(v_normal);
     updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragCoord.z, matCapTexture, GeometryType.Primitive);
 }

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
@@ -12,12 +12,14 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;
@@ -26,7 +28,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize(v_normal);
     updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragCoord.z, matCapTexture, GeometryType.Primitive);
 }

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
@@ -18,7 +18,7 @@ in float a_arcAngle;
 in float a_radius;
 in float a_tubeRadius;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
@@ -36,13 +36,13 @@ void main() {
     pos3.z = a_tubeRadius * sin(phi);
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
-
+    
     vec3 transformed = (a_instanceMatrix * vec4(pos3, 1.0)).xyz;
 
     // Calculate normal vectors if we're not picking

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
@@ -18,12 +18,16 @@ in float a_arcAngle;
 in float a_radius;
 in float a_tubeRadius;
 
-out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
     // normalized theta and phi are packed into positions
     float theta = position.x * a_arcAngle;
     float phi = position.y;
@@ -36,20 +40,19 @@ void main() {
     pos3.z = a_tubeRadius * sin(phi);
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
-    
+
     vec3 transformed = (a_instanceMatrix * vec4(pos3, 1.0)).xyz;
 
     // Calculate normal vectors if we're not picking
     vec3 center = (a_instanceMatrix * vec4(a_radius * cosTheta, a_radius * sinTheta, 0.0, 1.0)).xyz;
     vec3 objectNormal = normalize(transformed.xyz - center);
 
-    v_treeIndex = a_treeIndex;
     v_color = a_color;
     v_normal = normalMatrix * normalize(inverseModelMatrix * treeIndexWorldTransform * modelMatrix * vec4(objectNormal, 0.0)).xyz;
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
@@ -26,7 +26,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);
+    vec4 color = determineColor(v_color, appearance);    
     vec3 normal = normalize(v_normal);
     updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragCoord.z, matCapTexture, GeometryType.Primitive);
 }

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
@@ -12,12 +12,15 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
 
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;
@@ -26,7 +29,7 @@ void main() {
         discard;
     }
 
-    vec4 color = determineColor(v_color, appearance);    
+    vec4 color = determineColor(v_color, appearance);
     vec3 normal = normalize(v_normal);
     updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragCoord.z, matCapTexture, GeometryType.Primitive);
 }

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
@@ -18,7 +18,7 @@ in vec3 a_vertex2;
 in vec3 a_vertex3;
 in vec3 a_vertex4;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
@@ -33,10 +33,10 @@ void main() {
     }
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      a_treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
@@ -18,12 +18,16 @@ in vec3 a_vertex2;
 in vec3 a_vertex3;
 in vec3 a_vertex4;
 
-out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
+    v_treeIndexHundreds = floor(a_treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(a_treeIndex, 100.0));
     vec3 transformed;
     // reduce the avarage branchings
     if (position.x < 1.5) {
@@ -33,16 +37,15 @@ void main() {
     }
 
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      a_treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      a_treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 
     vec3 objectNormal = cross(a_vertex1 - a_vertex2, a_vertex1 - a_vertex3);
 
-    v_treeIndex = a_treeIndex;
     v_color = a_color;
     v_normal = normalMatrix * normalize(inverseModelMatrix * treeIndexWorldTransform * modelMatrix * vec4(objectNormal, 0.0)).xyz;
 

--- a/viewer/packages/rendering/src/glsl/sector/simple.frag
+++ b/viewer/packages/rendering/src/glsl/sector/simple.frag
@@ -12,12 +12,14 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-
-void main() {
+in highp float v_treeIndexHundreds;
+in mediump float v_treeIndexSubHundreds;
+void main()
+{
+    highp float v_treeIndex = round(v_treeIndexHundreds) * 100.0 + round(v_treeIndexSubHundreds);
     NodeAppearance appearance = determineNodeAppearance(colorDataTexture, treeIndexTextureSize, v_treeIndex);
     if (!determineVisibility(appearance, renderMode)) {
         discard;

--- a/viewer/packages/rendering/src/glsl/sector/simple.frag
+++ b/viewer/packages/rendering/src/glsl/sector/simple.frag
@@ -12,7 +12,7 @@ uniform sampler2D matCapTexture;
 uniform vec2 treeIndexTextureSize;
 uniform int renderMode;
 
-flat in float v_treeIndex;
+in float v_treeIndex;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;

--- a/viewer/packages/rendering/src/glsl/sector/simple.vert
+++ b/viewer/packages/rendering/src/glsl/sector/simple.vert
@@ -19,22 +19,25 @@ in vec4 matrix1;
 in vec4 matrix2;
 in vec4 matrix3;
 
-out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
+out highp float v_treeIndexHundreds;
+out mediump float v_treeIndexSubHundreds;
+
 void main() {
-    
+    v_treeIndexHundreds = floor(treeIndex / 100.0);
+    v_treeIndexSubHundreds = round(mod(treeIndex, 100.0));
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      treeIndex, 
-      treeIndexTextureSize, 
-      transformOverrideIndexTexture, 
-      transformOverrideTextureSize, 
+      treeIndex,
+      treeIndexTextureSize,
+      transformOverrideIndexTexture,
+      transformOverrideTextureSize,
       transformOverrideTexture
     );
 
-    v_treeIndex = treeIndex;
+    v_treeIndex = int(treeIndex);
     v_color = color;
     v_normal = normalize(normalMatrix * (inverseModelMatrix * treeIndexWorldTransform * modelMatrix * vec4(normalize(normal), 0.0)).xyz);
     mat4 instanceMatrix = mat4(matrix0, matrix1, matrix2, matrix3);

--- a/viewer/packages/rendering/src/glsl/sector/simple.vert
+++ b/viewer/packages/rendering/src/glsl/sector/simple.vert
@@ -19,18 +19,18 @@ in vec4 matrix1;
 in vec4 matrix2;
 in vec4 matrix3;
 
-flat out float v_treeIndex;
+out float v_treeIndex;
 out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
 void main() {
-
+    
     mat4 treeIndexWorldTransform = determineMatrixOverride(
-      treeIndex,
-      treeIndexTextureSize,
-      transformOverrideIndexTexture,
-      transformOverrideTextureSize,
+      treeIndex, 
+      treeIndexTextureSize, 
+      transformOverrideIndexTexture, 
+      transformOverrideTextureSize, 
       transformOverrideTexture
     );
 


### PR DESCRIPTION
# Description

This resolves an iOS Metal performance issue introduced by the fix of #2363 . The performance issue is caused by an implementation detail in the WebGL spec which is incompatible with Metal rendering, and metal emulates this detail. 

A real fix for this issue is in the works, with the EXT_PROVOKING_VERTEX extension, currently in a draft stage: https://registry.khronos.org/webgl/extensions/EXT_provoking_vertex/ . The extension is being implemented in WebKit (See https://github.com/WebKit/WebKit/pull/3701 ), but I guess we cannot expect this to be shipped soon.

As the original problem here is that "varyings" in WebGL use an algorithm that averages the three sides of the vertex, and also applies a "Perspective Correction". See "_For varyings though WebGL uses this formula_" on https://webglfundamentals.org/webgl/lessons/webgl-3d-perspective-correct-texturemapping.html 

if we do (random example proving this seems like the real issue)
```cs
float treeIndex = 3205807;
float a = treeIndex;
float b = treeIndex;
var aW = 0.9;
var bW = 0.9;
var t = 0.3;
float dividend =  (1 - t) * (float)a / aW + t * (float)b / bW;
float divisor = (1 - t) / aW + t / bW;

var result = dividend/divisor;
// Result: 3205806.5 (rounded towards nearest even: 3205806)
```

We get an offset result, but only for some values of W (and t). This varies, causing the "noise" pattern, seen in some screenshots of the "pre-fix" when tree-indices are high.

In this PR i propose a "dirty" fix, separating the TreeIndex into two different numbers in the Vertex Shader, and merging these numbers in the Fragment Shader. This removes the rounding issue given it works as the example above, as the inaccuracy does not occur for values below 2_000_000 in any of my tests. 

The current maximum supported treeIndex is 2^24 due to storing it in an RGB255 Color, so we do not yet need to handle higher values than approx 16_800_000, which the code above will handle nicely.
---- 


This PR adds another medp float to each fragment, and additional multiplications to add these together. The separation of 100ds and SubHundreds is kinda arbitrary, but medp has rounding issues when we get near 1000, so 99 as max works OK.

I might be overly defensive on rounding.

I have tested this with nodeIds up to 10_500_000, and have not spotted any issues with the approach. 

If you have any suggestion on OTHER approaches to pass these bytes through the shader I would be happy, as this feels a bit wrong... :D

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [ ] I am proud of this feature. 
  - 😅
- [ ] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
