### PR TITLE
fix: point cloud custom transformation

### DIFF
--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects.ts
@@ -32,7 +32,7 @@ function cdfAnnotationsToPointCloudObjects(cdfAnnotations: CdfPointCloudObjectAn
     return {
       annotationId: cdfAnnotation.annotationId,
       assetId: cdfAnnotation.assetId,
-      boundingBox: stylableObject.shape.createBoundingBox().applyMatrix4(cadFromCdfToThreeMatrix),
+      boundingBox: stylableObject.shape.createBoundingBox(),
       stylableObject
     };
   });

--- a/viewer/packages/pointclouds/src/PointCloudNode.test.ts
+++ b/viewer/packages/pointclouds/src/PointCloudNode.test.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2022 Cognite AS
+ */
+
+import { PointCloudNode } from './PointCloudNode';
+import { createPointCloudNode } from '../../../test-utilities';
+
+import * as THREE from 'three';
+
+describe(PointCloudNode.name, () => {
+  test('getModelTransformation returns transformation set by setModelTransformation', () => {
+    const node = createPointCloudNode();
+    const transform = new THREE.Matrix4()
+      .makeRotationFromEuler(new THREE.Euler(190, 35, 230))
+      .setPosition(new THREE.Vector3(12, 34, 12));
+
+    node.setModelTransformation(transform.clone());
+    const receivedTransform = node.getModelTransformation();
+
+    expect(receivedTransform).toEqual(transform);
+  });
+});

--- a/viewer/packages/pointclouds/src/PointCloudNode.ts
+++ b/viewer/packages/pointclouds/src/PointCloudNode.ts
@@ -149,17 +149,14 @@ export class PointCloudNode extends THREE.Group {
     return this._potreeNode.classNames;
   }
 
-  getBoundingBox(outBbox?: THREE.Box3): THREE.Box3 {
-    outBbox = outBbox || new THREE.Box3();
+  getBoundingBox(outBbox: THREE.Box3 = new THREE.Box3()): THREE.Box3 {
     outBbox.copy(this._potreeNode.boundingBox);
-    outBbox.applyMatrix4(this.matrixWorld);
     return outBbox;
   }
 
   setModelTransformation(matrix: THREE.Matrix4): void {
-    this._potreeNode.octree.applyMatrix4(matrix);
-    this._potreeNode.octree.updateMatrix();
-    this._potreeNode.octree.updateWorldMatrix(true, true);
+    this.matrix.copy(matrix);
+    this.updateMatrixWorld(true);
   }
 
   getModelTransformation(out = new THREE.Matrix4()): THREE.Matrix4 {

--- a/viewer/packages/pointclouds/src/PotreeNodeWrapper.ts
+++ b/viewer/packages/pointclouds/src/PotreeNodeWrapper.ts
@@ -135,9 +135,7 @@ export class PotreeNodeWrapper {
     const box: THREE.Box3 =
       this.octree.pcoGeometry.tightBoundingBox || this.octree.pcoGeometry.boundingBox || this.octree.boundingBox;
     // Apply transformation to switch axes
-    const min = new THREE.Vector3(box.min.x, box.min.z, -box.min.y);
-    const max = new THREE.Vector3(box.max.x, box.max.z, -box.max.y);
-    return new THREE.Box3().setFromPoints([min, max]);
+    return box.clone().applyMatrix4(this.octree.matrixWorld);
   }
 
   get pointColorType(): PotreePointColorType {
@@ -178,7 +176,7 @@ export class PotreeNodeWrapper {
       return {
         annotationId: a.annotationId,
         assetId: a.assetId,
-        boundingBox: a.boundingBox
+        boundingBox: a.boundingBox.clone().applyMatrix4(this.octree.matrixWorld)
       };
     });
   }

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctree.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctree.ts
@@ -77,8 +77,8 @@ export class PointCloudOctree extends PointCloudTree {
   }
 
   private updateMaterial(): void {
-    this.material.heightMin = this.pcoGeometry.tightBoundingBox.min.clone().applyMatrix4(this.matrix).y;
-    this.material.heightMax = this.pcoGeometry.tightBoundingBox.max.clone().applyMatrix4(this.matrix).y;
+    this.material.heightMin = this.pcoGeometry.tightBoundingBox.min.clone().applyMatrix4(this.matrixWorld).y;
+    this.material.heightMax = this.pcoGeometry.tightBoundingBox.max.clone().applyMatrix4(this.matrixWorld).y;
   }
 
   dispose(): void {

--- a/viewer/test-utilities/index.ts
+++ b/viewer/test-utilities/index.ts
@@ -8,7 +8,7 @@ export { createV9SceneSectorMetadata } from './src/createSceneSectorMetadata';
 
 export { createCadModelMetadata } from './src/createCadModelMetadata';
 export { createCadModel } from './src/createCadModel';
-export { createPointCloudModel } from './src/createPointCloudModel';
+export { createPointCloudModel, createPointCloudNode } from './src/createPointCloudModel';
 
 export { mockClientAuthentication } from './src/cogniteClientAuth';
 

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -20,6 +20,14 @@ import { LocalModelDataProvider } from '../../packages/data-providers';
 import { IPointCloudTreeGeometry } from '../../packages/pointclouds/src/potree-three-loader/geometry/IPointCloudTreeGeometry';
 
 export function createPointCloudModel(modelId: number, revisionId: number): CognitePointCloudModel {
+  const pointCloudNode = createPointCloudNode();
+
+  const pointCloudModel = new CognitePointCloudModel(modelId, revisionId, pointCloudNode);
+
+  return pointCloudModel;
+}
+
+export function createPointCloudNode() {
   const modelDataProvider = new LocalModelDataProvider();
   const potreeInstance = new Potree(modelDataProvider);
 
@@ -41,8 +49,5 @@ export function createPointCloudModel(modelId: number, revisionId: number): Cogn
   const nodeWrapper = new PotreeNodeWrapper(pointCloudOctree, [], Symbol('dummy'), { classificationSets: [] });
 
   const pointCloudNode = new PointCloudNode(potreeGroup, nodeWrapper);
-
-  const pointCloudModel = new CognitePointCloudModel(modelId, revisionId, pointCloudNode);
-
-  return pointCloudModel;
+  return pointCloudNode;
 }

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -27,7 +27,7 @@ export function createPointCloudModel(modelId: number, revisionId: number): Cogn
   return pointCloudModel;
 }
 
-export function createPointCloudNode() {
+export function createPointCloudNode(): PointCloudNode {
   const modelDataProvider = new LocalModelDataProvider();
   const potreeInstance = new Potree(modelDataProvider);
 

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -22,9 +22,7 @@ import { IPointCloudTreeGeometry } from '../../packages/pointclouds/src/potree-t
 export function createPointCloudModel(modelId: number, revisionId: number): CognitePointCloudModel {
   const pointCloudNode = createPointCloudNode();
 
-  const pointCloudModel = new CognitePointCloudModel(modelId, revisionId, pointCloudNode);
-
-  return pointCloudModel;
+ return new CognitePointCloudModel(modelId, revisionId, pointCloudNode);
 }
 
 export function createPointCloudNode(): PointCloudNode {

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -22,7 +22,7 @@ import { IPointCloudTreeGeometry } from '../../packages/pointclouds/src/potree-t
 export function createPointCloudModel(modelId: number, revisionId: number): CognitePointCloudModel {
   const pointCloudNode = createPointCloudNode();
 
- return new CognitePointCloudModel(modelId, revisionId, pointCloudNode);
+  return new CognitePointCloudModel(modelId, revisionId, pointCloudNode);
 }
 
 export function createPointCloudNode(): PointCloudNode {

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -46,6 +46,5 @@ export function createPointCloudNode(): PointCloudNode {
 
   const nodeWrapper = new PotreeNodeWrapper(pointCloudOctree, [], Symbol('dummy'), { classificationSets: [] });
 
-  const pointCloudNode = new PointCloudNode(potreeGroup, nodeWrapper);
-  return pointCloudNode;
+  return new PointCloudNode(potreeGroup, nodeWrapper);
 }


### PR DESCRIPTION
# Description

Point clouds were not translated properly and had their bounding boxes translated wrongly when a custom transformation was applied to them. This fixes that issue, and makes sure that stylable bounding boxes also receive the appropriate transformation when traversed by the user.

A fundamental mistake in the previous code, is that it uses `updateMatrix` on the model, which computes the local matrix from `scale`, `position` and `rotation`, overwriting the matrix we just set. (See https://threejs.org/docs/#manual/en/introduction/Matrix-transformations)

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
