### PR TITLE
fix: export point cloud object metadata

### DIFF
--- a/documentation/docs/examples/pointcloud-styling.mdx
+++ b/documentation/docs/examples/pointcloud-styling.mdx
@@ -22,7 +22,7 @@ After the model and associated stylable objects are loaded, you may list the obj
 |----------------------------|---------------------------------|---------------------------------------------------------------------------------------|
 | `annotationId`             | `number`                        | The ID of the CDF annotation that this stylable object corresponds to.                |
 | `assetId`                  | `number?`                       | The ID of the CDF asset associated with the annotation, if any.                       |
-| `boundingBox`              | `THREE.Box3`                    | The bounding box of the bounding box in Reveal space.                                 |
+| `boundingBox`              | `THREE.Box3`                    | The bounding box of the stylable object in Reveal space.                              |
 
 To visualize all bounding boxes associated with the stylable objects:
 

--- a/examples/src/utils/PointCloudObjectStylingUI.ts
+++ b/examples/src/utils/PointCloudObjectStylingUI.ts
@@ -8,6 +8,7 @@ import {
   AnnotationIdPointCloudObjectCollection,
   PointCloudAppearance,
   DefaultPointCloudAppearance,
+  PointCloudObjectMetadata,
   THREE
 } from '@cognite/reveal';
 
@@ -36,7 +37,7 @@ export class PointCloudObjectStylingUI {
         this._model.removeAllStyledObjectCollections();
       },
       randomColors: () => {
-        model.traverseStylableObjects((object) => {
+        model.traverseStylableObjects((object: PointCloudObjectMetadata) => {
           const objectStyle: [number, number, number] = [
             Math.floor(Math.random() * 255),
             Math.floor(Math.random() * 255),

--- a/viewer/index.ts
+++ b/viewer/index.ts
@@ -53,9 +53,7 @@ export {
   DisposedDelegate
 } from './packages/utilities';
 
-export {
-  PointCloudObjectMetadata
-} from './packages/data-providers';
+export { PointCloudObjectMetadata } from './packages/data-providers';
 
 export { Cognite3DModel, BoundingBoxClipper, GeometryFilter, WellKnownUnit } from './packages/cad-model';
 

--- a/viewer/index.ts
+++ b/viewer/index.ts
@@ -53,6 +53,10 @@ export {
   DisposedDelegate
 } from './packages/utilities';
 
+export {
+  PointCloudObjectMetadata
+} from './packages/data-providers';
+
 export { Cognite3DModel, BoundingBoxClipper, GeometryFilter, WellKnownUnit } from './packages/cad-model';
 
 export { CognitePointCloudModel } from './packages/pointclouds';


### PR DESCRIPTION
# Description

Exports a previously hidden type, which is used in the `traverseStylableObjects` call in `CognitePointCloudModel`.

# Checklist:

Here is a checklist that should completed before merging this given feature. 
Any shortcomings from the items below should be explained and detailed within the contents of this PR.

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation. (Already done)
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
