### PR TITLE
Use vec2 instead of struct for packing TreeIndexes

### DIFF
--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.frag
@@ -16,7 +16,7 @@ uniform int renderMode;
 
 in vec3 v_color;
 in vec3 v_viewPosition;
-in TreeIndexPacked v_treeIndexPacked;
+in highp vec2 v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/instancedMesh.vert
@@ -17,7 +17,7 @@ in vec3 a_color;
 out vec3 v_color;
 out vec3 v_viewPosition;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/mesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.frag
@@ -18,7 +18,7 @@ uniform int renderMode;
 in vec3 v_color;
 in vec3 v_viewPosition;
 
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/mesh.vert
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.vert
@@ -15,8 +15,7 @@ in float treeIndex;
 
 out vec3 v_color;
 out vec3 v_viewPosition;
-out TreeIndexPacked v_treeIndexPacked;
-out mediump float v_treeIndexSubHundreds;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.frag
@@ -17,7 +17,7 @@ in vec2 v_xy;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/circle.vert
@@ -22,7 +22,7 @@ out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
@@ -27,7 +27,7 @@ in vec4 v_centerA;
 in vec4 v_V;
 in vec3 v_color;
 in vec3 v_normal;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.vert
@@ -40,7 +40,7 @@ out float v_arcAngle;
 out vec3 v_color;
 out vec3 v_normal;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.frag
@@ -26,7 +26,7 @@ in vec4 v_centerB;
 in float height;
 in vec3 v_color;
 in vec3 v_normal;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/eccentricCone.vert
@@ -36,7 +36,7 @@ out float height;
 out vec3 v_color;
 out vec3 v_normal;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.frag
@@ -25,7 +25,7 @@ in vec4 V;
 in vec4 sphereNormal;
 in vec3 v_color;
 in vec3 v_normal;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/ellipsoidSegment.vert
@@ -36,7 +36,7 @@ out vec4 sphereNormal;
 out vec3 v_color;
 out vec3 v_normal;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.frag
@@ -22,7 +22,7 @@ uniform int renderMode;
 // Note! Must be placed after all uniforms in order for this to work on iOS (REV-287)
 #pragma glslify: import('../../base/updateFragmentDepth.glsl')
 
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 in vec3 v_color;
 
 in vec3 v_viewPos;
@@ -47,7 +47,7 @@ void main()
     }
 
     vec4 color = determineColor(v_color, appearance);
-    
+
     vec3 rayTarget = v_viewPos;
     vec3 rayDirection = normalize(rayTarget); // rayOrigin is (0,0,0) in camera space
 
@@ -103,7 +103,7 @@ void main()
         }
     }
 
-    //TODO - christjt 2022/10/10: This seems wrong when hitting inner surface 
+    //TODO - christjt 2022/10/10: This seems wrong when hitting inner surface
     vec3 p_local = p - v_centerB;
     vec3 normal = normalize(p_local - v_modelBasis[2] * dot(p_local, v_modelBasis[2]));
 

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalCylinder.vert
@@ -36,7 +36,7 @@ out vec2 v_angles;
 out vec3 v_color;
 out float v_radius;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.frag
@@ -21,7 +21,7 @@ in float v_arcAngle;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/generalring.vert
@@ -28,7 +28,7 @@ out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.frag
@@ -25,7 +25,7 @@ in vec4 V;
 in vec4 sphereNormal;
 in vec3 v_color;
 in vec3 v_normal;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/sphericalSegment.vert
@@ -32,7 +32,7 @@ out vec4 sphereNormal;
 out vec3 v_color;
 out vec3 v_normal;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.frag
@@ -16,7 +16,7 @@ uniform int renderMode;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/torusSegment.vert
@@ -23,7 +23,7 @@ out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.frag
@@ -17,7 +17,7 @@ in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
 
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/trapezium.vert
@@ -23,7 +23,7 @@ out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexPacked = packTreeIndex(a_treeIndex);

--- a/viewer/packages/rendering/src/glsl/sector/simple.frag
+++ b/viewer/packages/rendering/src/glsl/sector/simple.frag
@@ -15,7 +15,7 @@ uniform int renderMode;
 in vec3 v_color;
 in vec3 v_normal;
 in vec3 vViewPosition;
-in TreeIndexPacked  v_treeIndexPacked;
+in highp vec2  v_treeIndexPacked;
 
 void main()
 {

--- a/viewer/packages/rendering/src/glsl/sector/simple.vert
+++ b/viewer/packages/rendering/src/glsl/sector/simple.vert
@@ -23,7 +23,7 @@ out vec3 v_color;
 out vec3 v_normal;
 out vec3 vViewPosition;
 
-out TreeIndexPacked v_treeIndexPacked;
+out highp vec2 v_treeIndexPacked;
 
 void main() {
     v_treeIndexHundreds = floor(treeIndex / 100.0);

--- a/viewer/packages/rendering/src/glsl/treeIndex/treeIndexPacking.glsl
+++ b/viewer/packages/rendering/src/glsl/treeIndex/treeIndexPacking.glsl
@@ -1,11 +1,13 @@
-struct TreeIndexPacked
+// We cannot use a struct because of issue: https://github.com/KhronosGroup/WebGL/issues/3351
+// Some (most?) android devices do not allow highp in fragment structs. Which seem like an driver bug.
+struct UnusedTreeIndexPacked
 {
   highp float thousands;
   highp float subThousands;
 };
 
 /**
- * Packs a treeIndex integer (passed in as a float) into two floats.
+ * Packs a treeIndex integer (passed in as a float) into two floats in a vec2.
  * This avoids a precision issue causing wrong TreeIndexes to arrive to the fragment shader.
  *
  * Note: Instead of this we SHOULD use the "flat" modifier, but the "flat" modifier is
@@ -13,20 +15,20 @@ struct TreeIndexPacked
  * EXT_provoking_vertex is implemented in WebKit.
  * https://registry.khronos.org/webgl/extensions/EXT_provoking_vertex/
  */
-TreeIndexPacked packTreeIndex(float treeIndex) {
+highp vec2 packTreeIndex(float treeIndex) {
     highp float roundedTreeIndex = round(treeIndex);
     // We pack the potentially big input into two lower numbers representing the amount of 1000s and the "remaining up to 999 ones"
     // This avoids high numbers, and keeps precision while being "ok" enough for our usecase.
     highp float treeIndexThousands = floor(roundedTreeIndex / 1000.0);
     highp float treeIndexSubThousands = mod(roundedTreeIndex, 1000.0);
 
-    return TreeIndexPacked(treeIndexThousands, treeIndexSubThousands);
+    return vec2(treeIndexThousands, treeIndexSubThousands);
 }
 
 /**
  * Unpacks the packed treeIndex to an int representing the original input TreeIndex
  */
-float unpackTreeIndex(TreeIndexPacked treeIndexPacked) {
-    highp float treeIndex = round(treeIndexPacked.thousands) * 1000.0 + round(treeIndexPacked.subThousands);
+highp float unpackTreeIndex(highp vec2 treeIndexPacked) {
+    highp float treeIndex = round(treeIndexPacked.x) * 1000.0 + round(treeIndexPacked.y);
     return treeIndex;
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:

N/A

## Description :pencil:

This works around another issue with tree index precision, this time on adreno gpus when passing values in structs: https://github.com/KhronosGroup/WebGL/issues/3351


## How has this been tested? :mag:

Tested working on Adreno 660, Chrome Windows, and will verify on iPad when its been charged.

I do not think any automated tests will catch these issues if they are not ran on device.

## Test instructions :information_source:

The code is deployed here, with large (>5 000 000) tree indexes. Clicking a part should hide it. Not its neighbors, and not display noise. Also coloring by tree index should work as expected, this did not work at all on Adreno with the previous struct based code.

https://proud-pond-057d1ea03-nihreveal.westeurope.1.azurestaticapps.net/?modelUrl=primitives_hda


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
