### PR TITLE
improvement: reduce bundle size by avoiding webworker and JS files

### DIFF
--- a/viewer/README.md
+++ b/viewer/README.md
@@ -153,6 +153,12 @@ Add the following script to your package's `package.json`:
 Running the command `yarn start` will host a localhost site with a template HTML that includes the `/app/index.ts` script that has been transpiled to javascript.
 To see an example of this check out the `packages/camera-manager` package.
 
+## Debugging
+
+### Worker source maps
+
+When bundling source maps with inlined web workers, the bundle size grows huge. Therefore source maps for workers are disabled by default. In order to add source maps to workers, pass `--env workerSourceMaps=true` to the `yarn build` script.
+
 ## Creating and running visual tests
 
 Visual test files must be on the format `visual-tests/SomeTest.VisualTest.ts`. See one of the existing tests

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -94,12 +94,19 @@ module.exports = env => {
         type: 'umd'
       }
     },
-    devtool: development ? 'eval-source-map' : 'source-map',
+    devtool: false, // development ? 'eval-source-map' : 'source-map',
     watchOptions: {
       aggregateTimeout: 1500,
       ignored: /node_modules/
     },
     plugins: [
+      development ? new webpack.EvalSourceMapDevToolPlugin({
+        test: /\.ts$/
+      }) :
+        new webpack.SourceMapDevToolPlugin({
+          test: /\.ts$/,
+          filename: '[file].map'
+        }),
       new copyPkgJsonPlugin({
         remove: development
           ? ['devDependencies', 'scripts', 'workspaces', 'husky']

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -100,13 +100,14 @@ module.exports = env => {
       ignored: /node_modules/
     },
     plugins: [
-      development ? new webpack.EvalSourceMapDevToolPlugin({
-        test: /\.ts$/
-      }) :
-        new webpack.SourceMapDevToolPlugin({
-          test: /\.ts$/,
-          filename: '[file].map'
-        }),
+      development
+        ? new webpack.EvalSourceMapDevToolPlugin({
+            test: /\.ts$/
+          })
+        : new webpack.SourceMapDevToolPlugin({
+            test: /\.ts$/,
+            filename: '[file].map'
+          }),
       new copyPkgJsonPlugin({
         remove: development
           ? ['devDependencies', 'scripts', 'workspaces', 'husky']

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -14,6 +14,7 @@ const MIXPANEL_TOKEN_PROD = '8c900bdfe458e32b768450c20750853d';
 
 module.exports = env => {
   const development = env?.development ?? false;
+  const useWorkerSourceMaps = env?.workerSourceMaps === 'true';
 
   return {
     mode: development ? 'development' : 'production',
@@ -102,7 +103,8 @@ module.exports = env => {
     plugins: [
       development
         ? new webpack.EvalSourceMapDevToolPlugin({
-            test: /\.ts$/
+            test: /\.ts$/,
+            exclude: useWorkerSourceMaps ? /^$/ : /\.worker\.ts$/
           })
         : new webpack.SourceMapDevToolPlugin({
             test: /\.ts$/,

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -107,7 +107,6 @@ module.exports = env => {
             exclude: useWorkerSourceMaps ? /^$/ : /\.worker\.ts$/
           })
         : new webpack.SourceMapDevToolPlugin({
-            test: /\.ts$/,
             filename: '[file].map'
           }),
       new copyPkgJsonPlugin({

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -94,7 +94,7 @@ module.exports = env => {
         type: 'umd'
       }
     },
-    devtool: false, // development ? 'eval-source-map' : 'source-map',
+    devtool: false,
     watchOptions: {
       aggregateTimeout: 1500,
       ignored: /node_modules/

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -127,7 +127,7 @@ module.exports = env => {
             {
               folder: 'dist',
               method: absoluteItemPath => {
-                return new RegExp(/\.worker.js$/, 'm').test(absoluteItemPath);
+                return new RegExp(/\.worker\.js(\.map)?$/, 'm').test(absoluteItemPath);
               }
             }
           ]


### PR DESCRIPTION
#### Type of change

![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->
https://cognitedata.atlassian.net/browse/REV-561

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

## How has this been tested? :mag:

`yarn build` then `du -sh dist/index.js`

## Test instructions :information_source:

`yarn build && du -sh dist/index.js` on unix-based systems.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
