### PR TITLE
fix: rust warnings for into_serde()

### DIFF
--- a/viewer/Cargo.lock
+++ b/viewer/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -401,6 +402,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/viewer/packages/pointclouds/wasm/Cargo.toml
+++ b/viewer/packages/pointclouds/wasm/Cargo.toml
@@ -17,6 +17,7 @@ wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 web-sys = { version = "0.3.60", features = ["console"] }
 
 serde = { version = "1.0.147", features = ["derive"] }
+serde-wasm-bindgen = "0.4.5"
 
 js-sys = "0.3.60"
 

--- a/viewer/packages/pointclouds/wasm/src/lib.rs
+++ b/viewer/packages/pointclouds/wasm/src/lib.rs
@@ -37,8 +37,8 @@ pub fn assign_points(
     init();
 
     let mut point_vec = parse_inputs::parse_points(&input_points, input_point_offset);
-    let bounding_box: BoundingBox = input_bounding_box
-        .into_serde::<InputBoundingBox>()
+    let bounding_box: BoundingBox =
+        serde_wasm_bindgen::from_value::<InputBoundingBox>(input_bounding_box.into())
         .map_err(|serde_error| {
             format!(
                 "Got error while deserializing bounding box: {}",

--- a/viewer/packages/pointclouds/wasm/src/parse_inputs.rs
+++ b/viewer/packages/pointclouds/wasm/src/parse_inputs.rs
@@ -94,10 +94,10 @@ pub fn try_parse_objects(
     input_objects: Vec<wasm_bindgen::prelude::JsValue>,
 ) -> Result<Vec<Box<dyn shapes::Shape>>, String> {
     let objects_result: Result<_, _> = input_objects
-        .iter()
+        .into_iter()
         .map(|input_object| {
-            let input_shape = input_object
-                .into_serde::<InputShape>()
+            let input_shape =
+                serde_wasm_bindgen::from_value::<InputShape>(input_object)
                 .map_err(|serde_error| {
                     format!("Got error while deserializing shape: {}", serde_error)
                 });


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:

--

## Description :pencil:

Remove warnings related to `into_serde()` being deprecated for `wasm_bindgen` in the Rust code.

## How has this been tested? :mag:

`yarn build:wasm` ** check that there are no warnings.

## Test instructions :information_source:

`yarn build:wasm` ** check that there are no warnings.


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
