### PR TITLE
chore: lock Renovate's node version to v16

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,5 +71,10 @@
       // https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days
       "internalChecksFilter": "strict"
     }
-  ]
+  ],
+  "force": {
+    "constraints": {
+      "node": "< 17.0.0"
+    }
+  }
 }


### PR DESCRIPTION
#### Type of change
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:

All NPM-related Renovate PRs have crashed and been unable to update their lockfile lately.
This tries to fix that by restricting Renovate's node version to stop at v16, as we observed similar issues locally when using NodeJS v18

## How has this been tested? :mag:

It hasn't

## Test instructions :information_source:

Screw around, find out.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
