### PR TITLE
chore: bump reveal version to 3.2.1 in documentation

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -41,7 +41,7 @@
     "@azure/msal-browser": "2.30.0",
     "@cognite/reveal": "link:../viewer/dist",
     "@cognite/reveal-2.x": "npm:@cognite/reveal@2.3",
-    "@cognite/reveal-3.x": "npm:@cognite/reveal@3.x.x",
+    "@cognite/reveal-3.x": "npm:@cognite/reveal@3.2.1",
     "@cognite/reveal-4.x": "link:../viewer/dist",
     "@cognite/sdk": "link:../viewer/node_modules/@cognite/sdk",
     "@cognite/sdk-2.x": "npm:@cognite/sdk@^5.1.3",

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -1482,10 +1482,10 @@
     skmeans "^0.11.3"
     three "0.133.0"
 
-"@cognite/reveal-3.x@npm:@cognite/reveal@3.x.x":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@cognite/reveal/-/reveal-3.2.0.tgz#b1ec6f28643f55f346d595b88ad2010a7ad768c0"
-  integrity sha512-Vl3Hq0DpG7yN2lJAVc+W+IktLkraVzBlgFWLoWUJQ94dyzPFxbgFxn5b1exhl0Om5KZ1+gLSdW2NtUS+ynpdmA==
+"@cognite/reveal-3.x@npm:@cognite/reveal@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@cognite/reveal/-/reveal-3.2.1.tgz#7053f9988e279b24758125f51e96a6d6fed59be0"
+  integrity sha512-DaGXM3L0FcCYgSHsnYb2rvM+8ASdTupMS0XeuI8lw6pZtvNKFyi+a7zOdd5p6Hp7uLpvKOmI68W1nUP9pHDakg==
   dependencies:
     "@cognite/reveal-parser-worker" "1.3.0"
     "@tweenjs/tween.js" "18.6.4"
@@ -1510,6 +1510,7 @@
 
 "@cognite/reveal-4.x@link:../viewer/dist":
   version "0.0.0"
+  uid ""
 
 "@cognite/reveal-parser-worker@1.3.0":
   version "1.3.0"
@@ -1520,6 +1521,7 @@
 
 "@cognite/reveal@link:../viewer/dist":
   version "0.0.0"
+  uid ""
 
 "@cognite/sdk-2.x@npm:@cognite/sdk@^5.1.3":
   version "5.1.3"
@@ -1581,8 +1583,20 @@
     query-string "^5.1.1"
     url "^0.11.0"
 
+"@cognite/sdk-core@^4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.8.1.tgz#008c6d7e15393f3a840baf809a0037efa8266849"
+  integrity sha512-FEICothNg/aAHdAY84J/udt5NcPcoe8GlT+piFgpvV8zIFpFbUxU4oLVf20xl0AJX1xCO13iWrL/szf6BWqEcA==
+  dependencies:
+    cross-fetch "^3.0.4"
+    is-buffer "^2.0.5"
+    lodash "^4.17.11"
+    query-string "^5.1.1"
+    url "^0.11.0"
+
 "@cognite/sdk@link:../viewer/node_modules/@cognite/sdk":
   version "0.0.0"
+  uid ""
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -2440,7 +2454,7 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/geojson@7946.0.10":
+"@types/geojson@7946.0.10", "@types/geojson@^7946.0.8":
   version "7946.0.10"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
   integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
@@ -2647,6 +2661,13 @@
   version "0.141.0"
   resolved "https://registry.yarnpkg.com/@types/three/-/three-0.141.0.tgz#d9d81a54b28ebc2a56931dfd4d9c54d25c20d6c8"
   integrity sha512-OJdKDgTPVBUgc+s74DYoy4aLznbFFC38Xm4ElmU1YwGNgR7GGFVvFCX7lpVgOsT6S1zSJtGdajTsOYE8/xY9nA==
+  dependencies:
+    "@types/webxr" "*"
+
+"@types/three@0.144.0":
+  version "0.144.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.144.0.tgz#a154f40122dbc3668c5424a5373f3965c6564557"
+  integrity sha512-psvEs6q5rLN50jUYZ3D4pZMfxTbdt3A243blt0my7/NcL6chaCZpHe2csbCtx0SOD9fI/XnF3wnVUAYZGqCSYg==
   dependencies:
     "@types/webxr" "*"
 
@@ -7951,6 +7972,13 @@ rxjs@7.5.6, rxjs@^7.5.4:
   dependencies:
     tslib "^2.1.0"
 
+rxjs@7.5.7:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  dependencies:
+    tslib "^2.1.0"
+
 rxjs@^7.1.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.3.0.tgz#39fe4f3461dc1e50be1475b2b85a0a88c1e938c6"
@@ -8645,6 +8673,23 @@ three-stdlib@2.15.0:
     potpack "^1.0.1"
     zstddec "^0.0.2"
 
+three-stdlib@2.17.3:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.17.3.tgz#f92d322810d81379a51344b21e0a2e941b84cb8f"
+  integrity sha512-k2VwPXi75ySy0fxPIeUk3mLkj3/j+sCFK4g9Kp5J7w0PUh6qrCdhah7L6+On6fW5mBdVtML4Q5yEyN1R0Cfvqw==
+  dependencies:
+    "@babel/runtime" "^7.16.7"
+    "@types/offscreencanvas" "^2019.6.4"
+    "@webgpu/glslang" "^0.0.15"
+    chevrotain "^10.1.2"
+    draco3d "^1.4.1"
+    fflate "^0.6.9"
+    ktx-parse "^0.4.5"
+    mmd-parser "^1.0.4"
+    opentype.js "^1.3.3"
+    potpack "^1.0.1"
+    zstddec "^0.0.2"
+
 three@0.125.2:
   version "0.125.2"
   resolved "https://registry.yarnpkg.com/three/-/three-0.125.2.tgz#dcba12749a2eb41522e15212b919cd3fbf729b12"
@@ -8659,6 +8704,11 @@ three@0.141.0:
   version "0.141.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.141.0.tgz#16677a12b9dd0c3e1568ebad0fd09de15d5a8216"
   integrity sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA==
+
+three@0.144.0:
+  version "0.144.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.144.0.tgz#2818517169f8ff94eea5f664f6ff1fcdcd436cc8"
+  integrity sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw==
 
 through2@^0.6.3:
   version "0.6.5"


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Bumps reveal 3.x in documentation.

## How has this been tested? :mag:
<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Open 3.x documentation and check reveal version (by mouse hover on cognite logo) in live example.
