### PR TITLE
Allow setting batchSize for SinglePropertyFilterNodeCollection execut…

### DIFF
--- a/viewer/packages/cad-styling/src/SinglePropertyFilterNodeCollection.ts
+++ b/viewer/packages/cad-styling/src/SinglePropertyFilterNodeCollection.ts
@@ -59,7 +59,7 @@ export class SinglePropertyFilterNodeCollection extends CdfNodeCollectionBase {
    * @param propertyKey Node property key, e.g. `':FU'`.
    * @param propertyValues Lookup values, e.g. `["AR100APG539","AP500INF534","AP400INF553", ...]`
    */
-  executeFilter(propertyCategory: string, propertyKey: string, propertyValues: string[], batchSize: number): Promise<void> {
+  executeFilter(propertyCategory: string, propertyKey: string, propertyValues: string[], batchSize: number = 1000): Promise<void> {
     const { requestPartitions } = this._options;
 
     const outputsUrl = this.buildUrl();

--- a/viewer/packages/cad-styling/src/SinglePropertyFilterNodeCollection.ts
+++ b/viewer/packages/cad-styling/src/SinglePropertyFilterNodeCollection.ts
@@ -59,7 +59,7 @@ export class SinglePropertyFilterNodeCollection extends CdfNodeCollectionBase {
    * @param propertyKey Node property key, e.g. `':FU'`.
    * @param propertyValues Lookup values, e.g. `["AR100APG539","AP500INF534","AP400INF553", ...]`
    */
-  executeFilter(propertyCategory: string, propertyKey: string, propertyValues: string[]): Promise<void> {
+  executeFilter(propertyCategory: string, propertyKey: string, propertyValues: string[], batchSize: number): Promise<void> {
     const { requestPartitions } = this._options;
 
     const outputsUrl = this.buildUrl();
@@ -77,7 +77,7 @@ export class SinglePropertyFilterNodeCollection extends CdfNodeCollectionBase {
         const response = postAsListResponse<Node3D[]>(this._client, outputsUrl, {
           data: {
             filter,
-            limit: 1000,
+            limit: min(1000, batchSize),
             partition: `${p}/${requestPartitions}`
           }
         });
@@ -103,8 +103,8 @@ export class SinglePropertyFilterNodeCollection extends CdfNodeCollectionBase {
   }
 }
 
-function splitQueryToBatches(propertyValues: string[]): string[][] {
-  return chunk(propertyValues, 1000);
+function splitQueryToBatches(propertyValues: string[], batchSize: number = 1000): string[][] {
+  return chunk(propertyValues, min(1000, batchSize));
 }
 
 type RawListResponse<T> = {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/BND3D-1608

https://cognitedata.atlassian.net/browse/

## Description :pencil:
A 1000 variables is too heavy for the database, resulting in partial table scans with **o**^**n** searches of values, resulting in time out for big models. A simple fix for this is to reduce the batch size down to 10, and at the same time set the limit.

## How has this been tested? :mag:
It hasn't been tested in code, but the requests have been run with similar chunking logic in the reveal docs


## Test instructions :information_source:
You can test in docs with 1000 values for filtering doing them with batchSize 1000, and batchSize 10.


## Checklist :ballot_box_with_check:
- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
  Nope, I am not sure how I do this.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
  Nope...
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
