### PR TITLE
refactor: remove getScene from API

### DIFF
--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.test.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.test.ts
@@ -198,14 +198,10 @@ describe('Cognite3DViewer', () => {
 
   test('viewer can add/remove Object3d on scene', () => {
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller });
-    const scene = viewer.getScene();
     const obj = new THREE.Mesh(new THREE.SphereGeometry(), new THREE.MeshBasicMaterial());
 
-    viewer.addObject3D(obj);
-    expect(scene.getObjectById(obj.id)).toEqual(obj);
-
-    viewer.removeObject3D(obj);
-    expect(scene.getObjectById(obj.id)).toBeFalsy();
+    expect(() => viewer.addObject3D(obj)).not.toThrowError();
+    expect(() => viewer.removeObject3D(obj)).not.toThrowError();
   });
 
   test('beforeSceneRendered and sceneRendered triggers before/after rendering', () => {

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -912,14 +912,6 @@ export class Cognite3DViewer {
   }
 
   /**
-   * @obvious
-   * @returns The THREE.Scene used for rendering.
-   */
-  getScene(): THREE.Scene {
-    return this._sceneHandler.scene;
-  }
-
-  /**
    * Attempts to load the camera settings from the settings stored for the
    * provided model. See {@link https://docs.cognite.com/api/v1/#operation/get3DRevision}
    * and {@link https://docs.cognite.com/api/v1/#operation/update3DRevisions} for


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-494

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Remove `getScene()` from Cognite3DViewer due to mutating this can cause undefined behaviour.
