### PR TITLE
fix: create a box3 when deserializing areas in treeindex collection

### DIFF
--- a/viewer/packages/cad-styling/src/NodeCollectionDeserializer.test.ts
+++ b/viewer/packages/cad-styling/src/NodeCollectionDeserializer.test.ts
@@ -4,12 +4,15 @@
 
 import { CogniteClient } from '@cognite/sdk';
 import { IndexSet } from '@reveal/utilities';
+import { Mock } from 'moq.ts';
 
 import { createCadModel } from '../../../test-utilities/src/createCadModel';
+import { CdfModelNodeCollectionDataProvider } from './CdfModelNodeCollectionDataProvider';
 import { NodeCollectionDeserializer } from './NodeCollectionDeserializer';
+import { SerializedNodeCollection } from './SerializedNodeCollection';
 import { TreeIndexNodeCollection } from './TreeIndexNodeCollection';
 
-describe('NodeCollectionDeserializer', () => {
+describe(NodeCollectionDeserializer.name, () => {
   test('deserialize TreeIndexSet without option parameter', async () => {
     const sdk = new CogniteClient({
       appId: 'cognite.reveal.unittest',
@@ -34,5 +37,40 @@ describe('NodeCollectionDeserializer', () => {
         options: serializedCollection.options
       })
     ).toBeTruthy();
+  });
+
+  test('deserialize TreeIndexNodeCollection with areas', async () => {
+    const deserializer = NodeCollectionDeserializer.Instance;
+
+    const sdkMock = new Mock<CogniteClient>().object();
+    const nodeCollectionProviderMock = new Mock<CdfModelNodeCollectionDataProvider>().object();
+    const serializedNodeCollection: SerializedNodeCollection = {
+      token: 'TreeIndexNodeCollection',
+      state: [
+        {
+          from: 0,
+          count: 3,
+          toInclusive: 2
+        }
+      ],
+      options: {
+        areas: [
+          {
+            min: {
+              x: 0,
+              y: 0,
+              z: 0
+            },
+            max: {
+              x: 1,
+              y: 1,
+              z: 1
+            }
+          }
+        ]
+      }
+    };
+    const deserialize = deserializer.deserialize(sdkMock, nodeCollectionProviderMock, serializedNodeCollection);
+    await expect(deserialize).resolves.not.toThrow();
   });
 });

--- a/viewer/packages/cad-styling/src/NodeCollectionDeserializer.ts
+++ b/viewer/packages/cad-styling/src/NodeCollectionDeserializer.ts
@@ -2,6 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
+import * as THREE from 'three';
 import assert from 'assert';
 import { CogniteClient } from '@cognite/sdk';
 import { NumericRange, IndexSet } from '@reveal/utilities';
@@ -103,7 +104,16 @@ export class NodeCollectionDeserializer {
       descriptor.state.forEach((range: NumericRange) => indexSet.addRange(new NumericRange(range.from, range.count)));
       const nodeCollection = new TreeIndexNodeCollection(indexSet);
       if (descriptor.options?.areas !== undefined) {
-        nodeCollection.addAreas(descriptor.options.areas);
+        const areas = descriptor.options?.areas as {
+          min: { x: number; y: number; z: number };
+          max: { x: number; y: number; z: number };
+        }[];
+        const areaBoxes = areas.map(area => {
+          const min = new THREE.Vector3(area.min.x, area.min.y, area.min.z);
+          const max = new THREE.Vector3(area.max.x, area.max.y, area.max.z);
+          return new THREE.Box3(min, max);
+        });
+        nodeCollection.addAreas(areaBoxes);
       }
 
       return Promise.resolve(nodeCollection);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-550

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an issue where areas during deserialization of TreeIndexNodeCollection(s) are assumed to be box3, when they can simply be a JSON blob, causing a type missmatch.

For more context see: https://cognitedata.slack.com/archives/C01MZ6TPCH2/p1665996407443199

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
