### PR TITLE
fix: threejs types version

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -58,8 +58,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-live": "3.1.1",
-    "styled-components": "5.3.6",
-    "three": "0.146.0"
+    "styled-components": "5.3.6"
   },
   "devDependencies": {
     "@types/react": "18.0.24",

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -1567,6 +1567,17 @@
     query-string "^5.1.1"
     url "^0.11.0"
 
+"@cognite/sdk-core@^4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.8.1.tgz#008c6d7e15393f3a840baf809a0037efa8266849"
+  integrity sha512-FEICothNg/aAHdAY84J/udt5NcPcoe8GlT+piFgpvV8zIFpFbUxU4oLVf20xl0AJX1xCO13iWrL/szf6BWqEcA==
+  dependencies:
+    cross-fetch "^3.0.4"
+    is-buffer "^2.0.5"
+    lodash "^4.17.11"
+    query-string "^5.1.1"
+    url "^0.11.0"
+
 "@cognite/sdk@link:../viewer/node_modules/@cognite/sdk":
   version "0.0.0"
   uid ""
@@ -2420,7 +2431,7 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/geojson@7946.0.10":
+"@types/geojson@7946.0.10", "@types/geojson@^7946.0.8":
   version "7946.0.10"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
   integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
@@ -2629,6 +2640,13 @@
   version "0.144.0"
   resolved "https://registry.yarnpkg.com/@types/three/-/three-0.144.0.tgz#a154f40122dbc3668c5424a5373f3965c6564557"
   integrity sha512-psvEs6q5rLN50jUYZ3D4pZMfxTbdt3A243blt0my7/NcL6chaCZpHe2csbCtx0SOD9fI/XnF3wnVUAYZGqCSYg==
+  dependencies:
+    "@types/webxr" "*"
+
+"@types/three@0.146.0":
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.146.0.tgz#83813ba0d2fff6bdc6d7fda3a77993a932bba45f"
+  integrity sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==
   dependencies:
     "@types/webxr" "*"
 
@@ -4816,6 +4834,11 @@ geo-three@^0.0.15:
   integrity sha512-jCzOgKvkK59ilPz3Ndn9QGhBui4X0eppn3tPw4+n8QmmyaKGDgbATr3uu5xUHR8dguoV37P0yr2Yr20UxEHogg==
   dependencies:
     "@types/offscreencanvas" "^2019.6.3"
+
+geojson@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/geojson/-/geojson-0.5.0.tgz#3cd6c96399be65b56ee55596116fe9191ce701c0"
+  integrity sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==
 
 get-caller-file@^2.0.1:
   version "2.0.5"
@@ -7944,6 +7967,13 @@ rxjs@7.5.6, rxjs@^7.5.4:
   dependencies:
     tslib "^2.1.0"
 
+rxjs@7.5.7:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  dependencies:
+    tslib "^2.1.0"
+
 rxjs@^7.1.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.3.0.tgz#39fe4f3461dc1e50be1475b2b85a0a88c1e938c6"
@@ -8651,6 +8681,23 @@ three-stdlib@2.15.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.15.0.tgz#2f5c43ea95c8f6eb1add95dd0e7c5bd6ea769838"
   integrity sha512-81jgpEajYB1HczIKAqcG8oEgRPbKJr/8KfxMY3xIHe9kDNw426PckStLt+GVmV15ezOS+QlUFVSuyjSRPpSLsg==
+  dependencies:
+    "@babel/runtime" "^7.16.7"
+    "@types/offscreencanvas" "^2019.6.4"
+    "@webgpu/glslang" "^0.0.15"
+    chevrotain "^10.1.2"
+    draco3d "^1.4.1"
+    fflate "^0.6.9"
+    ktx-parse "^0.4.5"
+    mmd-parser "^1.0.4"
+    opentype.js "^1.3.3"
+    potpack "^1.0.1"
+    zstddec "^0.0.2"
+
+three-stdlib@2.17.3:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.17.3.tgz#f92d322810d81379a51344b21e0a2e941b84cb8f"
+  integrity sha512-k2VwPXi75ySy0fxPIeUk3mLkj3/j+sCFK4g9Kp5J7w0PUh6qrCdhah7L6+On6fW5mBdVtML4Q5yEyN1R0Cfvqw==
   dependencies:
     "@babel/runtime" "^7.16.7"
     "@types/offscreencanvas" "^2019.6.4"

--- a/examples/package.json
+++ b/examples/package.json
@@ -35,7 +35,7 @@
     "@types/react-router-dom": "^5.1.6",
     "@types/stats": "^0.16.30",
     "@types/styled-components": "^5.1.4",
-    "@types/three": "0.144.0",
+    "@types/three": "0.146.0",
     "css-loader": "^6.7.1",
     "dotenv-webpack": "^7.1.0",
     "html-webpack-plugin": "^5.5.0",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -597,10 +597,10 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/three@0.144.0":
-  version "0.144.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.144.0.tgz#a154f40122dbc3668c5424a5373f3965c6564557"
-  integrity sha512-psvEs6q5rLN50jUYZ3D4pZMfxTbdt3A243blt0my7/NcL6chaCZpHe2csbCtx0SOD9fI/XnF3wnVUAYZGqCSYg==
+"@types/three@0.146.0":
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.146.0.tgz#83813ba0d2fff6bdc6d7fda3a77993a932bba45f"
+  integrity sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==
   dependencies:
     "@types/webxr" "*"
 
@@ -3838,10 +3838,10 @@ three-stdlib@2.17.3:
     potpack "^1.0.1"
     zstddec "^0.0.2"
 
-three@0.144.0:
-  version "0.144.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.144.0.tgz#2818517169f8ff94eea5f664f6ff1fcdcd436cc8"
-  integrity sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw==
+three@0.146.0:
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.146.0.tgz#fd80f0d128ab4bb821a02191ae241e4e6326f17a"
+  integrity sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A==
 
 through2@^0.6.3:
   version "0.6.5"

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@tweenjs/tween.js": "18.6.4",
     "@types/draco3dgltf": "1.4.0",
-    "@types/three": "0.144.0",
+    "@types/three": "0.146.0",
     "assert": "2.0.0",
     "async-mutex": "0.4.0",
     "comlink": "4.3.1",

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.ts
@@ -347,9 +347,6 @@ export class PointCloudOctreePickerHelper {
 
   public static getPickState(): IPickState {
     const scene = new Scene();
-    // @ts-expect-error
-    // Missing type definition for ThreeJS r144. When this fails,
-    // its most likely because the type definitions have been updated
     scene.matrixWorldAutoUpdate = false;
 
     const material = new PointCloudMaterial();

--- a/viewer/packages/rendering/src/render-pipeline-providers/DefaultRenderPipelineProvider.ts
+++ b/viewer/packages/rendering/src/render-pipeline-providers/DefaultRenderPipelineProvider.ts
@@ -200,9 +200,7 @@ export class DefaultRenderPipelineProvider implements RenderPipelineProvider {
     this._cadModels.forEach(cadModel => {
       cadModel.cadNode.matrixAutoUpdate = false;
     });
-    // @ts-expect-error
-    // Missing type definition for ThreeJS r144. When this fails,
-    // its most likely because the type definitions have been updated
+
     this._viewerScene.matrixWorldAutoUpdate = false;
 
     this._customObjects?.forEach(customObject => customObject.updateMatrixWorld(true));

--- a/viewer/packages/utilities/src/SceneHandler.ts
+++ b/viewer/packages/utilities/src/SceneHandler.ts
@@ -33,9 +33,6 @@ export class SceneHandler {
     this._customObjects = [];
     this._scene = new THREE.Scene();
 
-    // @ts-expect-error
-    // Missing type definition for ThreeJS r144. When this fails,
-    // its most likely because the type definitions have been updated
     this._scene.matrixWorldAutoUpdate = false;
   }
 

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -794,7 +794,7 @@ __metadata:
     "@types/random-seed": 0.3.3
     "@types/skmeans": 0.11.3
     "@types/stats": 0.16.30
-    "@types/three": 0.144.0
+    "@types/three": 0.146.0
     "@types/tween.js": 18.5.1
     "@typescript-eslint/eslint-plugin": 5.41.0
     "@typescript-eslint/parser": 5.41.0
@@ -2284,12 +2284,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/three@npm:0.144.0":
-  version: 0.144.0
-  resolution: "@types/three@npm:0.144.0"
+"@types/three@npm:0.146.0":
+  version: 0.146.0
+  resolution: "@types/three@npm:0.146.0"
   dependencies:
     "@types/webxr": "*"
-  checksum: 7ce69e1a48ba6d19dc9efb78c5c67a3e66c036f240386dd700eda7a5964e44550066ac45bc0997bd4fe7be446edae356313d992361c18415191468dfdbfb454d
+  checksum: f8ea5ba032f6aaa1cb5ad7dfbbd13851e8cba04365bc7fa9a5320ea7e9a2538ea5f2426391f690f0465347ade15cc145d5dc84b1730d8cceea89f746231f667c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

Renovate decided to auto-merge this. So this fixes incomplete types, docs, etc.