### PR TITLE
fix: axis cross manipulates stationary camera position

### DIFF
--- a/viewer/packages/camera-manager/src/StationaryCameraManager.ts
+++ b/viewer/packages/camera-manager/src/StationaryCameraManager.ts
@@ -31,11 +31,9 @@ export class StationaryCameraManager implements CameraManager {
     return this._camera;
   }
 
+  // Stationary camera only reacts to rotation being set
   setCameraState(state: CameraState): void {
-    const position = state.position ?? this._camera.position;
     const rotation = state.rotation ?? this._camera.quaternion;
-
-    this._camera.position.copy(position);
     this._camera.quaternion.copy(rotation);
   }
 
@@ -53,7 +51,8 @@ export class StationaryCameraManager implements CameraManager {
     this._isEnabled = true;
 
     const { position, rotation } = cameraManager.getCameraState();
-    this.setCameraState({ position, rotation });
+    this.setCameraState({ rotation });
+    this._camera.position.copy(position);
 
     this._defaultFOV = cameraManager.getCamera().fov;
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-604

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes clicking axis cross tool would moving you out of the 360 image.

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

Using the Viewer.tsx example, load (in 3d-test):

modelId: `4923307033982497`
revisionId: `3100284276970593`

Using the dropdown dat.gui load 360 images with the follow parameters:

- site_id is `helideck-site-2`
- translation offset is  `(11, 49, 32)`
- rotation (defined with axis rotation and  radians) is axis: `(0, 1, 0)` and radians `3.08923`

Then click the axis view tool.

