### PR TITLE
fix: renders are now triggered when zooming into 360 image

### DIFF
--- a/viewer/packages/camera-manager/src/StationaryCameraManager.ts
+++ b/viewer/packages/camera-manager/src/StationaryCameraManager.ts
@@ -186,5 +186,6 @@ export class StationaryCameraManager implements CameraManager {
     const sensitivityScaler = 0.05;
     this._camera.fov = Math.min(Math.max(this._camera.fov + event.deltaY * sensitivityScaler, 10), this._defaultFOV);
     this._camera.updateProjectionMatrix();
+    this._cameraChangedListeners.forEach(cb => cb(this._camera.position, this._camera.position));
   };
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) 


Renders are now triggered when zooming into 360 image