### PR TITLE
feat: add Image360Collection return type for easier extendability in the future

### DIFF
--- a/documentation/docs/examples/image360.mdx
+++ b/documentation/docs/examples/image360.mdx
@@ -17,7 +17,7 @@ add360ImageSet(
   datasource: 'events', 
   eventFilter: { [key: string]: string }, 
   add360ImageOptions?: AddImage360Options
-): Promise<Image360[]>;
+): Promise<Image360Collection>;
 
 remove360Images(...image360Entities: Image360[]): Promise<void>:
 
@@ -34,6 +34,8 @@ Once the data is ingested, a set of 360 images can be added to the viewer with `
 At this time, the only valid `datasource` is `'events'`, but you can expect more to be added in the future.
 The `eventFilter` property describes the filter that is used when fetching data from the data source.
 This is a generic key-value pair and can point to any metdata that was set during ingestion.
+`viewer.add360ImageSet(...)` will return a `Image360Collection` which contains each of the `image360` entities for this given set.
+The definition of `Image360Collection` can be found [here.](../api/interfaces/cognite_reveal.Image360Collection)
 
 The `AddImage360Options` is used for correcting / adding transformations to the set of 360 images. The declaration can be found [here.](../api/modules/cognite_reveal#addimage360options)
 

--- a/examples/src/utils/Image360UI.ts
+++ b/examples/src/utils/Image360UI.ts
@@ -7,7 +7,7 @@ import { Cognite3DViewer, Image360 } from "@cognite/reveal";
 import * as dat from 'dat.gui';
 
 export class Image360UI {
-  constructor(private viewer: Cognite3DViewer, private gui: dat.GUI){
+  constructor(viewer: Cognite3DViewer, gui: dat.GUI){
     let entities: Image360[] = [];
 
     const optionsFolder = gui.addFolder('Add Options');

--- a/examples/src/utils/Image360UI.ts
+++ b/examples/src/utils/Image360UI.ts
@@ -62,7 +62,7 @@ export class Image360UI {
       const translationMatrix = new THREE.Matrix4().makeTranslation(translation.x, translation.y, translation.z);
       const collectionTransform = translationMatrix.multiply(rotationMatrix);
       const set = await viewer.add360ImageSet('events', {site_id: params.siteId}, {collectionTransform, preMultipliedRotation: params.premultipliedRotation});
-      entities = entities.concat(set);
+      entities = entities.concat(set.image360Entities);
       viewer.requestRedraw();
     }
   }

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -184,28 +184,23 @@
     commander "^2.15.1"
 
 "@cognite/reveal@link:../viewer":
-  version "4.0.0-alpha.0"
+  version "0.0.0"
+  uid ""
+
+"@cognite/sdk-core@^4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk-core/-/sdk-core-4.8.2.tgz#00f69eaf93d433223f650891d098e1ffb0738631"
+  integrity sha512-nV17d8Z+NMErVyO2hv6yafpl32TmRwMc1pPYnMp+J4FcE0bCUqvL6AduXAPQZ443NZx86+Obz5SWzUg3PXzfkA==
   dependencies:
-    "@tweenjs/tween.js" "18.6.4"
-    "@types/draco3dgltf" "1.4.0"
-    "@types/three" "0.146.0"
-    assert "2.0.0"
-    async-mutex "0.4.0"
-    comlink "4.3.1"
-    glslify "7.1.1"
-    glslify-import "3.1.0"
-    html2canvas "^1.4.1"
-    lodash "4.17.21"
-    loglevel "1.8.1"
-    mixpanel-browser "2.45.0"
-    path-browserify "1.0.1"
-    proj4 "2.8.0"
-    rxjs "7.5.7"
-    skmeans "0.11.3"
-    three-stdlib "2.19.0"
+    cross-fetch "^3.0.4"
+    is-buffer "^2.0.5"
+    lodash "^4.17.11"
+    query-string "^5.1.1"
+    url "^0.11.0"
 
 "@cognite/sdk@link:../viewer/node_modules/@cognite/sdk":
   version "0.0.0"
+  uid ""
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
@@ -409,6 +404,11 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/geojson@^7946.0.8":
+  version "7946.0.10"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
+  integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
 
 "@types/history@*":
   version "4.7.9"
@@ -1262,6 +1262,13 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cross-fetch@^3.0.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1866,6 +1873,11 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+geojson@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/geojson/-/geojson-0.5.0.tgz#3cd6c96399be65b56ee55596116fe9191ce701c0"
+  integrity sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==
+
 get-intrinsic@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -2362,6 +2374,11 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.6.tgz#fd6170b0b8c7e2cc73de342ef8284a2202023c44"
@@ -2818,6 +2835,13 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -2847,7 +2871,7 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-object-assign@^4.1.1:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -3167,6 +3191,11 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -3178,6 +3207,20 @@ qs@6.10.3:
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
   dependencies:
     side-channel "^1.0.4"
+
+query-string@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -3674,6 +3717,11 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
+
 string.prototype.codepointat@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz#004ad44c8afc727527b108cd462b4d971cd469bc"
@@ -3885,6 +3933,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-loader@^9.3.1:
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.3.1.tgz#fe25cca56e3e71c1087fe48dc67f4df8c59b22d4"
@@ -3946,6 +3999,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -4010,6 +4071,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webpack-cli@^4.10.0:
   version "4.10.0"
@@ -4140,6 +4206,14 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"

--- a/viewer/api-entry-points/core.ts
+++ b/viewer/api-entry-points/core.ts
@@ -76,4 +76,4 @@ export {
   StyledPointCloudObjectCollection
 } from '../packages/pointcloud-styling';
 
-export { Image360, Image360Visualization } from '../packages/360-images';
+export { Image360, Image360Visualization, Image360Collection } from '../packages/360-images';

--- a/viewer/packages/360-images/index.ts
+++ b/viewer/packages/360-images/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { Image360 } from './src/Image360';
+export { Image360Collection } from './src/Image360Collection';
 export { Image360Facade } from './src/Image360Facade';
 export { Image360EntityFactory } from './src/Image360EntityFactory';
 export { Image360Entity } from './src/Image360Entity';

--- a/viewer/packages/360-images/src/Image360Collection.ts
+++ b/viewer/packages/360-images/src/Image360Collection.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright 2022 Cognite AS
+ */
+
+import { Image360 } from './Image360';
+
+/**
+ * A wrapper that represents a set of 360 images.
+ */
+export interface Image360Collection {
+  /**
+   * A list containing all the 360 images in this set.
+   */
+  readonly image360Entities: Image360[];
+}

--- a/viewer/packages/360-images/src/Image360Icon.ts
+++ b/viewer/packages/360-images/src/Image360Icon.ts
@@ -7,7 +7,7 @@ import * as THREE from 'three';
 
 export class Image360Icon extends THREE.Group {
   private readonly MIN_PIXEL_SIZE = 32;
-  private readonly MAX_PIXEL_SIZE = 256;
+  private readonly MAX_PIXEL_SIZE = 128;
   private readonly _hoverSprite: THREE.Sprite;
   private readonly _outerSprite: THREE.Sprite;
   private readonly _sceneHandler: SceneHandler;
@@ -127,7 +127,7 @@ export class Image360Icon extends THREE.Group {
       context.beginPath();
       context.lineWidth = textureSize / 16;
       context.strokeStyle = '#FFFFFF';
-      context.arc(textureSize / 2, textureSize / 2, textureSize / 2 - context.lineWidth / 2, 0, 2 * Math.PI);
+      context.arc(textureSize / 2, textureSize / 2, textureSize / 2 - context.lineWidth / 2 - 2, 0, 2 * Math.PI);
       context.stroke();
     }
 

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -63,7 +63,7 @@ import {
   determineResolutionCap,
   determineSsaoRenderParameters
 } from './renderOptionsHelpers';
-import { Image360Entity } from '@reveal/360-images';
+import { Image360Collection, Image360Entity } from '@reveal/360-images';
 import { Image360ApiHelper } from '../../api-helpers/Image360ApiHelper';
 import html2canvas from 'html2canvas';
 import { Image360 } from '@reveal/360-images/src/Image360';
@@ -694,11 +694,11 @@ export class Cognite3DViewer {
    * await viewer.add360ImageSet('events', eventFilter);
    * ```
    */
-  add360ImageSet(
+  async add360ImageSet(
     datasource: 'events',
     eventFilter: { [key: string]: string },
     add360ImageOptions?: AddImage360Options
-  ): Promise<Image360[]> {
+  ): Promise<Image360Collection> {
     if (datasource !== 'events') {
       throw new Error(`${datasource} is an unknown datasource from 360 images`);
     }
@@ -710,7 +710,13 @@ export class Cognite3DViewer {
     const collectionTransform = add360ImageOptions?.collectionTransform ?? new THREE.Matrix4();
     const preMultipliedRotation = add360ImageOptions?.preMultipliedRotation ?? true;
 
-    return this._image360ApiHelper.add360ImageSet(eventFilter, collectionTransform, preMultipliedRotation);
+    const image360Entities = await this._image360ApiHelper.add360ImageSet(
+      eventFilter,
+      collectionTransform,
+      preMultipliedRotation
+    );
+
+    return { image360Entities };
   }
 
   /**

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -766,6 +766,11 @@ export interface Image360 {
 }
 
 // @public
+export interface Image360Collection {
+    readonly image360Entities: Image360[];
+}
+
+// @public
 export interface Image360Visualization {
     opacity: number;
 }

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -327,7 +327,7 @@ export class Cognite3DViewer {
     constructor(options: Cognite3DViewerOptions);
     add360ImageSet(datasource: 'events', eventFilter: {
         [key: string]: string;
-    }, add360ImageOptions?: AddImage360Options): Promise<Image360[]>;
+    }, add360ImageOptions?: AddImage360Options): Promise<Image360Collection>;
     addCadModel(options: AddModelOptions): Promise<CogniteCadModel>;
     addModel(options: AddModelOptions): Promise<CogniteModel>;
     addObject3D(object: THREE_2.Object3D): void;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-605
https://cognitedata.atlassian.net/browse/REV-621
https://cognitedata.atlassian.net/browse/REV-622

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Adds a Image360Collection type that wraps a list of 360 images such that we can add additional per-collection funcionality in the future without breaking the API.

Also fix small nits such as off the outer rim of the 360 image icon being a little bit off, as well as reducing the max size of the icon.