### PR TITLE
fix: remove enabled field from camera manager interface

### DIFF
--- a/viewer/packages/camera-manager/src/CameraManager.ts
+++ b/viewer/packages/camera-manager/src/CameraManager.ts
@@ -105,8 +105,4 @@ export interface CameraManager {
    * @obvious
    */
   dispose(): void;
-  /**
-   * Enabled is true if this camera manager is active. When disabled, the camera manager shouldn't consume or react to any DOM events.
-   */
-  enabled: boolean;
 }

--- a/viewer/packages/camera-manager/src/DefaultCameraManager.ts
+++ b/viewer/packages/camera-manager/src/DefaultCameraManager.ts
@@ -163,21 +163,6 @@ export class DefaultCameraManager implements CameraManager {
   }
 
   /**
-   * Sets whether camera controls through mouse, touch and keyboard are enabled.
-   */
-  private set enabled(enabled: boolean) {
-    this._controls.enabled = enabled;
-    this.isEnabled = enabled;
-  }
-
-  /**
-   * Gets whether camera controls through mouse, touch and keyboard are enabled.
-   */
-  get enabled(): boolean {
-    return this.isEnabled;
-  }
-
-  /**
    * Gets current Combo Controls options.
    */
   getComboControlsOptions(): Readonly<ComboControlsOptions> {
@@ -245,9 +230,9 @@ export class DefaultCameraManager implements CameraManager {
   }
 
   activate(cameraManager?: CameraManager): void {
-    if (this.enabled) return;
+    if (this.isEnabled) return;
 
-    this.enabled = true;
+    this.isEnabled = true;
     this.setupControls();
 
     if (cameraManager) {
@@ -258,9 +243,9 @@ export class DefaultCameraManager implements CameraManager {
   }
 
   deactivate(): void {
-    if (!this.enabled) return;
+    if (!this.isEnabled) return;
 
-    this.enabled = false;
+    this.isEnabled = false;
     this.teardownControls(true);
   }
 
@@ -278,7 +263,7 @@ export class DefaultCameraManager implements CameraManager {
   setCameraControlsOptions(controlsOptions: CameraControlsOptions): void {
     this._cameraControlsOptions = { ...DefaultCameraManager.DefaultCameraControlsOptions, ...controlsOptions };
 
-    if (this.enabled) {
+    if (this.isEnabled) {
       // New EventListeners are added in 'setupControls', so to avoid “doubling” of some behaviours we need to tear down controls first.
       this.teardownControls(false);
       this.setupControls();

--- a/viewer/packages/camera-manager/src/ProxyCameraManager.ts
+++ b/viewer/packages/camera-manager/src/ProxyCameraManager.ts
@@ -19,10 +19,6 @@ export class ProxyCameraManager implements CameraManager {
 
   private _activeCameraManager: CameraManager;
 
-  get enabled(): boolean {
-    return this._activeCameraManager.enabled;
-  }
-
   get innerCameraManager(): CameraManager {
     return this._activeCameraManager;
   }

--- a/viewer/packages/camera-manager/src/StationaryCameraManager.ts
+++ b/viewer/packages/camera-manager/src/StationaryCameraManager.ts
@@ -25,7 +25,6 @@ export class StationaryCameraManager implements CameraManager {
   private readonly _domElement: HTMLElement;
   private _defaultFOV: number;
   private readonly _stopEventTrigger: DebouncedCameraStopEventTrigger;
-  private _isEnabled = false;
   private _isDragging = false;
 
   constructor(domElement: HTMLElement, camera: THREE.PerspectiveCamera) {
@@ -33,10 +32,6 @@ export class StationaryCameraManager implements CameraManager {
     this._camera = camera;
     this._defaultFOV = camera.fov;
     this._stopEventTrigger = new DebouncedCameraStopEventTrigger(this);
-  }
-
-  get enabled(): boolean {
-    return this._isEnabled;
   }
 
   getCamera(): THREE.PerspectiveCamera {
@@ -61,8 +56,6 @@ export class StationaryCameraManager implements CameraManager {
   }
 
   activate(cameraManager: CameraManager): void {
-    this._isEnabled = true;
-
     const { position, rotation } = cameraManager.getCameraState();
     this.setCameraState({ rotation });
     this._camera.position.copy(position);
@@ -81,8 +74,6 @@ export class StationaryCameraManager implements CameraManager {
   }
 
   deactivate(): void {
-    this._isEnabled = false;
-
     this._domElement.removeEventListener('pointermove', this.rotateCamera);
     this._domElement.removeEventListener('pointerdown', this.enableDragging);
     this._domElement.removeEventListener('pointerup', this.disableDragging);
@@ -166,7 +157,7 @@ export class StationaryCameraManager implements CameraManager {
   };
 
   private readonly rotateCamera = (event: PointerEvent) => {
-    if (!this._isDragging || !this._isEnabled) {
+    if (!this._isDragging) {
       return;
     }
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Removing `enabled` field from the `CameraManager` in favor of using activate / deactivate. Enabled had no direct usages in Reveal, so makes sense to remove it. 