### PR TITLE
fix: trigger update event when ComboControls receives new target

### DIFF
--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -349,6 +349,7 @@ export class ComboControls extends EventDispatcher {
 
   public setViewTarget = (target: Vector3) => {
     this._viewTarget.copy(target);
+    this.triggerCameraChangeEvent();
   };
 
   public setScrollTarget = (target: Vector3) => {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Ensure `setViewTarget` calls on `CompoControls` triggers a `cameraChange` event. This ensures the scene is redrawn continuously while the camera interpolates between two view targets.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Manually, by clicking around in models and seeing smooth camera movement

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
