### PR TITLE
fix: point cloud points are rendered smaller during picking along with CAD models

### DIFF
--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.frag
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.frag
@@ -1,31 +1,17 @@
 precision highp float;
 precision highp int;
 
-uniform mat4 viewMatrix;
-uniform vec3 cameraPosition;
 
 uniform mat4 projectionMatrix;
-uniform float opacity;
 
-uniform float spacing;
 uniform float pcIndex;
-uniform float screenWidth;
-uniform float screenHeight;
 
 out vec4 outputColor;
-
-#ifdef highlight_point
-	uniform vec4 highlightedPointColor;
-#endif
 
 in vec3 vColor;
 
 #if !defined(color_type_point_index)
 	in float vOpacity;
-#endif
-
-#if defined(weighted_splats)
-	in float vLinearDepth;
 #endif
 
 #if !defined(paraboloid_point_shape) && defined(use_edl)
@@ -39,8 +25,6 @@ in vec3 vColor;
 #if defined(weighted_splats) || defined(paraboloid_point_shape)
 	in float vRadius;
 #endif
-
-float specularStrength = 1.0;
 
 void main() {
 	vec3 color = vColor;

--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
@@ -13,9 +13,7 @@ in vec4 indices;
 uniform mat4 modelMatrix;
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
-uniform mat4 viewMatrix;
 
-uniform float screenWidth;
 uniform float screenHeight;
 uniform float fov;
 uniform float spacing;
@@ -29,15 +27,11 @@ uniform float octreeSize;
 uniform float opacity;
 uniform float level;
 uniform float vnStart;
-uniform bool isLeafNode;
 
 uniform vec2 intensityRange;
 uniform float intensityGamma;
 uniform float intensityContrast;
 uniform float intensityBrightness;
-uniform float rgbGamma;
-uniform float rgbContrast;
-uniform float rgbBrightness;
 
 uniform sampler2D visibleNodes;
 uniform sampler2D gradient;
@@ -154,7 +148,7 @@ float getLOD() {
 	float depth = level;
 
 	for (float i = 0.0; i <= 30.0; i++) {
-		float nodeSizeAtLevel = octreeSize  / pow(2.0, i + level + 0.0);
+		float nodeSizeAtLevel = octreeSize  / pow(2.0, i + level);
 
 		vec3 index3d = (position-offset) / nodeSizeAtLevel;
 		index3d = floor(index3d + 0.5);

--- a/viewer/packages/rendering/src/pointcloud-rendering/PointCloudMaterial.ts
+++ b/viewer/packages/rendering/src/pointcloud-rendering/PointCloudMaterial.ts
@@ -352,14 +352,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
     } else {
       this.fov = Math.PI / 2; // will result in slope = 1 in the shader
     }
-    const renderTarget = renderer.getRenderTarget();
-    if (renderTarget !== null) {
-      this.screenWidth = renderTarget.width;
-      this.screenHeight = renderTarget.height;
-    } else {
-      this.screenWidth = renderer.domElement.clientWidth * pixelRatio;
-      this.screenHeight = renderer.domElement.clientHeight * pixelRatio;
-    }
+    this.screenWidth = renderer.domElement.clientWidth * pixelRatio;
+    this.screenHeight = renderer.domElement.clientHeight * pixelRatio;
 
     if (this.useDrawingBufferSize) {
       renderer.getDrawingBufferSize(PointCloudMaterial.helperVec2);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/REV-635

## Description :pencil:
Picking in point cloud along with CAD models would resize the point size to smaller value/tiny size. This was due to the `PointCloudMaterial` would use `renderTarget` size values for `screenWidth` & `screenHeight` uniforms. As `renderTarget` size is set to 1 during CAD model intersection causing the wrong value been set to `screenHeight`

## How has this been tested? :mag:

In `examples`, load CAD model & add any point could model.
`Click` on point cloud model

## Test instructions :information_source:

Run `examples`, load any CAD model. Add point cloud model (eg. modelId: 585243814592633, revisionId: 3257698523483861).
`Click` on point cloud

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
