### PR TITLE
bug: Screenshot resizing viewer canvas on macOS & iOS

### DIFF
--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1131,7 +1131,7 @@ export class Cognite3DViewer {
     const originalDomeStyle = {
       position: this.domElement.style.position,
       width: this.domElement.style.width,
-      height: this.domElement.style.position,
+      height: this.domElement.style.height,
       flexGrow: this.domElement.style.flexGrow,
       margin: this.domElement.style.margin,
       padding: this.domElement.style.padding,

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1128,7 +1128,16 @@ export class Cognite3DViewer {
     }
 
     const { width: originalWidth, height: originalHeight } = this.renderer.getSize(new THREE.Vector2());
-    const originalDomeStyle = { ...this.domElement.style };
+    const originalDomeStyle = {
+      position: this.domElement.style.position,
+      width: this.domElement.style.width,
+      height: this.domElement.style.position,
+      flexGrow: this.domElement.style.flexGrow,
+      margin: this.domElement.style.margin,
+      padding: this.domElement.style.padding,
+      left: this.domElement.style.left,
+      top: this.domElement.style.top
+    };
 
     try {
       // Position and scale domElement to match requested resolution.


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-624

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

I was able to reproduce something similar in Firefox. I found that `originalDomeStyle` is not properly copied from `domElement.style`, so when the state of the domElement is reset all properties are still undefined and the dom is left as it was while the screenshot was rendered. 

Code:
```
const originalDomeStyle = { ...this.domElement.style };
console.log(this.domElement.style.position);
console.log(originalDomeStyle.position);
```

Result Chrome:
```
relative
relative
```

Result Firefox:
```
relative
undefined
```

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Tested on Chrome and FireFox. Since I do not own any macOS/iOS devices I only have the assumption that this will also be a fix for those. I will ask a macOS/iOS friend to test :)

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

Go to 'Creating screenshots ' under 'Loading CAD models' documentation and compare 4x to Next.


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [x] I have asked peers to test this feature.
