### PR TITLE
fix: only add exit 360 image key listener when entering 360 image

### DIFF
--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -59,7 +59,6 @@ export class Image360ApiHelper {
     inputHandler.on('click', enter360Image);
 
     const exit360ImageOnEscapeKey = (event: KeyboardEvent) => this.exit360ImageOnEscape(event);
-    domElement.addEventListener('keydown', exit360ImageOnEscapeKey);
 
     this._domEventHandlers = {
       setHoverIconEventHandler,
@@ -112,6 +111,8 @@ export class Image360ApiHelper {
     }
     this._transitionInProgress = false;
     this._interactionState.lastImage360Entered = image360Entity;
+    this._domElement.addEventListener('keydown', this._domEventHandlers.exit360ImageOnEscapeKey);
+
     this._requestRedraw();
   }
 
@@ -206,6 +207,7 @@ export class Image360ApiHelper {
       position,
       target: new THREE.Vector3(0, 0, -1).applyQuaternion(rotation).add(position)
     });
+    this._domElement.removeEventListener('keydown', this._domEventHandlers.exit360ImageOnEscapeKey);
   }
 
   public dispose(): void {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-642

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes issue when resetting camera position to (0, 0, 0) when clicking escape key when not in 360 image.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Clicking escape button in examples should not have any effect.
