### PR TITLE
improvement: scale-down-resolution now relative to physical canvas size

### DIFF
--- a/documentation/docs/examples/rendering-resolution.mdx
+++ b/documentation/docs/examples/rendering-resolution.mdx
@@ -35,6 +35,6 @@ In order to improve the user experience for low-end devices, Reveal can be confi
 viewer.setResolutionOptions({ movingCameraResolutionFactor: 0.5 });
 ```
 
-The factor must be between 0 and 1 and is multiplied into the maximum render resolution when the camera is moving. Supplying e.g. a factor of 0.25 will divide the total number of pixels rendered by approximately four while moving.
+The factor must be between 0 and 1 and is multiplied into the render resolution of the canvas when the camera is moving. Supplying e.g. a factor of 0.25 will divide the total number of pixels rendered by approximately four while moving.
 
 If using a custom camera manager, be aware that this feature uses the current `CameraManager`'s `'cameraStop'` and `'cameraChange'` events to decide whether the camera is moving or not.

--- a/viewer/packages/api/src/public/migration/types.ts
+++ b/viewer/packages/api/src/public/migration/types.ts
@@ -242,7 +242,8 @@ export type ResolutionOptions = {
    * A factor that will scale down the resolution when moving the camera. This can
    * be used to achieve a better user experience on devices with limited hardware.
    * Values must be greater than 0 and at most 1.
-   * A value of e.g. 0.25 will approximately divide the number of pixels on the screen by four.
+   * This factor is applied to the number of physical pixels of the canvas.
+   * A value of e.g. 0.25 will approximately divide the number of pixels rendered on the screen by four.
    */
   movingCameraResolutionFactor?: number;
 };

--- a/viewer/packages/rendering/src/ResizeHandler.test.ts
+++ b/viewer/packages/rendering/src/ResizeHandler.test.ts
@@ -160,7 +160,7 @@ describe(ResizeHandler.name, () => {
 });
 
 function getRendererResolution(renderer: WebGLRenderer): number {
-    const originalSize = new Vector2();
-    renderer.getSize(originalSize);
-    return originalSize.x * originalSize.y;
+  const originalSize = new Vector2();
+  renderer.getSize(originalSize);
+  return originalSize.x * originalSize.y;
 }

--- a/viewer/packages/rendering/src/ResizeHandler.test.ts
+++ b/viewer/packages/rendering/src/ResizeHandler.test.ts
@@ -148,6 +148,7 @@ describe(ResizeHandler.name, () => {
 
     const originalRenderResolution = getRendererResolution(renderer);
 
+    resizeHandler.setResolutionThreshold(0.5 * originalRenderResolution);
     resizeHandler.setMovingCameraResolutionFactor(0.25);
     cameraChangeEventHandler!(new Vector3(), new Vector3());
     resizeHandler.handleResize(cameraManager.getCamera());

--- a/viewer/packages/rendering/src/ResizeHandler.ts
+++ b/viewer/packages/rendering/src/ResizeHandler.ts
@@ -36,8 +36,10 @@ export class ResizeHandler {
     this._cameraManager = cameraManager;
 
     this._onCameraChangeCallback = () => {
-      this._currentResolutionThreshold = Math.min(this._movingResolutionFactor * getPhysicalSize(renderer),
-                                                  this._stoppedCameraResolutionThreshold);
+      this._currentResolutionThreshold = Math.min(
+        this._movingResolutionFactor * getPhysicalSize(renderer),
+        this._stoppedCameraResolutionThreshold
+      );
       this._shouldResize = true;
     };
     this._onCameraStopCallback = () => {

--- a/viewer/packages/rendering/src/ResizeHandler.ts
+++ b/viewer/packages/rendering/src/ResizeHandler.ts
@@ -36,7 +36,8 @@ export class ResizeHandler {
     this._cameraManager = cameraManager;
 
     this._onCameraChangeCallback = () => {
-      this._currentResolutionThreshold = this._movingResolutionFactor * getPhysicalSize(renderer);
+      this._currentResolutionThreshold = Math.min(this._movingResolutionFactor * getPhysicalSize(renderer),
+                                                  this._stoppedCameraResolutionThreshold);
       this._shouldResize = true;
     };
     this._onCameraStopCallback = () => {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-662

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Earlier, the camera-move downscale factor was based on the render resolution threshold, which may have been the default value or some value set by the user. 

With this, the factor will be directly applied to the number of physical pixels in the render area, making 1 use the full resolution, and e.g. 0.25 approximately halve the resolution in each dimension.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- open examples
- resize the window to be small
- adjust the slider in Camera -> Camera move resolution factor to some low number
- observe that the resolution is visibly lower, even if the resolution cap is presumably much larger than the number of physical pixels covering the canvas.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.


[REV-662]: https://cognitedata.atlassian.net/browse/REV-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ