### PR TITLE
feat: new annotation shape convention

### DIFF
--- a/viewer/api-entry-points/core.ts
+++ b/viewer/api-entry-points/core.ts
@@ -58,7 +58,8 @@ export {
   SceneRenderedDelegate,
   PointerEventDelegate,
   PointerEventData,
-  DisposedDelegate
+  DisposedDelegate,
+  CDF_TO_VIEWER_TRANSFORMATION
 } from '../packages/utilities';
 
 export { PointCloudObjectMetadata } from '../packages/data-providers';

--- a/viewer/packages/api/index.ts
+++ b/viewer/packages/api/index.ts
@@ -7,7 +7,6 @@ export { CogniteCadModel } from '@reveal/cad-model';
 export { ViewerState, ModelState, ClippingPlanesState } from './src/utilities/ViewStateHelper';
 
 export * from './src/public/types';
-export { CDF_TO_VIEWER_TRANSFORMATION } from './src/public/constants';
 
 const REVEAL_VERSION = process.env.VERSION;
 export { REVEAL_VERSION };

--- a/viewer/packages/data-providers/index.ts
+++ b/viewer/packages/data-providers/index.ts
@@ -20,8 +20,6 @@ export { StylableObject, SerializableStylableObject } from './src/pointcloud-sty
 export { CdfPointCloudStylableObjectProvider } from './src/pointcloud-stylable-object-providers/CdfPointCloudStylableObjectProvider';
 export { DummyPointCloudStylableObjectProvider } from './src/pointcloud-stylable-object-providers/DummyPointCloudStylableObjectProvider';
 
-export { cadFromCdfToThreeMatrix } from './src/utilities/applyDefaultModelTransformation';
-
 export { Image360Provider } from './src/Image360Provider';
 export {
   BinaryFileProvider,

--- a/viewer/packages/data-providers/src/utilities/applyDefaultModelTransformation.ts
+++ b/viewer/packages/data-providers/src/utilities/applyDefaultModelTransformation.ts
@@ -5,15 +5,13 @@
 import * as THREE from 'three';
 
 import { File3dFormat } from '../types';
-
-// The below is equal to new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(-Math.PI / 2, 0, 0));
-export const cadFromCdfToThreeMatrix = new THREE.Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
+import { CDF_TO_VIEWER_TRANSFORMATION } from '@reveal/utilities';
 
 export function applyDefaultModelTransformation(matrix: THREE.Matrix4, format: File3dFormat | string): void {
   switch (format) {
     case File3dFormat.GltfCadModel:
     case File3dFormat.EptPointCloud:
-      matrix.premultiply(cadFromCdfToThreeMatrix);
+      matrix.premultiply(CDF_TO_VIEWER_TRANSFORMATION);
       break;
 
     default:

--- a/viewer/packages/pointclouds/wasm/src/linalg.rs
+++ b/viewer/packages/pointclouds/wasm/src/linalg.rs
@@ -31,29 +31,28 @@ impl BoundingBox {
         min2(&self.min, &point) == self.min && max2(&self.max, &point) == self.max
     }
 
-    pub fn get_centered_unit_cube_corner(corner_index: u32) -> DVec4 {
+    pub fn get_base_cube_corner(corner_index: u32) -> DVec4 {
         vec4(
-            if (corner_index & 1) == 0 { -0.5 } else { 0.5 },
-            if (corner_index & 2) == 0 { -0.5 } else { 0.5 },
-            if (corner_index & 4) == 0 { -0.5 } else { 0.5 },
+            if (corner_index & 1) == 0 { -1.0 } else { 1.0 },
+            if (corner_index & 2) == 0 { -1.0 } else { 1.0 },
+            if (corner_index & 4) == 0 { -1.0 } else { 1.0 },
             1.0,
         )
     }
 
-    pub fn get_transformed_unit_cube(matrix: &DMat4) -> Self {
+    pub fn get_transformed_base_cube(matrix: &DMat4) -> Self {
         let bounding_box = (0..8)
             .map(|i: u32| {
-                let unit_corner = BoundingBox::get_centered_unit_cube_corner(i);
+                let unit_corner = BoundingBox::get_base_cube_corner(i);
                 let transformed_corner = matrix * unit_corner;
                 vec4_to_vec3(&transformed_corner)
             })
             .collect();
-
         bounding_box
     }
 
-    pub fn get_unit_bounding_box() -> Self {
-        let points = (0..8).map(|i| vec4_to_vec3(&BoundingBox::get_centered_unit_cube_corner(i)));
+    pub fn get_base_cube_bounding_box() -> Self {
+        let points = (0..8).map(|i| vec4_to_vec3(&BoundingBox::get_base_cube_corner(i)));
         let min_point: DVec3 = points.clone().reduce(|v0, v1| min2(&v0, &v1)).unwrap();
         let max_point: DVec3 = points.reduce(|v0, v1| max2(&v0, &v1)).unwrap();
         BoundingBox {

--- a/viewer/packages/pointclouds/wasm/src/parse_inputs.rs
+++ b/viewer/packages/pointclouds/wasm/src/parse_inputs.rs
@@ -64,11 +64,15 @@ pub fn parse_points(
     point_vec
 }
 
+const RADIUS_SCALE_FACTOR: f64 = 1.15;
+const MAX_RADIUS_INCREASE_METER: f64 = 0.06;
+
 fn create_cylinder(input: InputCylinder, id: u16) -> Box<shapes::Cylinder> {
+    let radius = (input.radius * RADIUS_SCALE_FACTOR).max(input.radius + MAX_RADIUS_INCREASE_METER);
     Box::new(shapes::Cylinder::new(
         vec3(input.center_a[0], input.center_a[1], input.center_a[2]),
         vec3(input.center_b[0], input.center_b[1], input.center_b[2]),
-        input.radius,
+        radius,
         id,
     ))
 }

--- a/viewer/packages/pointclouds/wasm/src/parse_inputs.rs
+++ b/viewer/packages/pointclouds/wasm/src/parse_inputs.rs
@@ -68,7 +68,7 @@ const RADIUS_SCALE_FACTOR: f64 = 1.15;
 const MAX_RADIUS_INCREASE_METER: f64 = 0.06;
 
 fn create_cylinder(input: InputCylinder, id: u16) -> Box<shapes::Cylinder> {
-    let radius = (input.radius * RADIUS_SCALE_FACTOR).max(input.radius + MAX_RADIUS_INCREASE_METER);
+    let radius = (input.radius * RADIUS_SCALE_FACTOR).min(input.radius + MAX_RADIUS_INCREASE_METER);
     Box::new(shapes::Cylinder::new(
         vec3(input.center_a[0], input.center_a[1], input.center_a[2]),
         vec3(input.center_b[0], input.center_b[1], input.center_b[2]),

--- a/viewer/packages/pointclouds/wasm/src/point_octree/point_octree.rs
+++ b/viewer/packages/pointclouds/wasm/src/point_octree/point_octree.rs
@@ -42,19 +42,19 @@ mod tests {
 
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    fn create_random_points_in_unit_box(num_points: u32) -> Vec<Vec3WithIndex> {
+    fn create_random_points_in_base_box(num_points: u32) -> Vec<Vec3WithIndex> {
         let mut rng = ChaCha8Rng::seed_from_u64(0xbaadf00d);
 
         let mut points = Vec::<Vec3WithIndex>::with_capacity(num_points as usize);
 
-        let unit_box = BoundingBox::get_unit_bounding_box();
+        let base_box = BoundingBox::get_base_cube_bounding_box();
 
         for i in 0..num_points {
             points.push(Vec3WithIndex {
                 vec: vec3(
-                    rng.gen_range(unit_box.min.x..unit_box.max.x),
-                    rng.gen_range(unit_box.min.y..unit_box.max.y),
-                    rng.gen_range(unit_box.min.z..unit_box.max.z),
+                    rng.gen_range(base_box.min.x..base_box.max.x),
+                    rng.gen_range(base_box.min.y..base_box.max.y),
+                    rng.gen_range(base_box.min.z..base_box.max.z),
                 ),
                 index: i as usize,
             });
@@ -68,11 +68,11 @@ mod tests {
         const NUM_POINTS: u32 = 1_000;
         const OBJECT_ID: u16 = 42;
 
-        let mut points = create_random_points_in_unit_box(NUM_POINTS);
+        let mut points = create_random_points_in_base_box(NUM_POINTS);
 
         let shape: Box<dyn Shape> =
             Box::<OrientedBox>::new(OrientedBox::new(DMat4::identity(), OBJECT_ID));
-        let bounding_box = BoundingBox::get_transformed_unit_cube(&DMat4::identity());
+        let bounding_box = BoundingBox::get_transformed_base_cube(&DMat4::identity());
         let array = Uint16Array::new_with_length(NUM_POINTS);
 
         let octree = PointOctree::new(bounding_box.clone(), &mut points);
@@ -89,10 +89,10 @@ mod tests {
         const NUM_POINTS: u32 = 1_000;
         const OBJECT_ID: u16 = 42;
 
-        let mut points = create_random_points_in_unit_box(NUM_POINTS);
+        let mut points = create_random_points_in_base_box(NUM_POINTS);
 
-        let box_matrix = translate(&DMat4::identity(), &vec3(1.0, 0.0, 0.0));
-        let bounding_box = BoundingBox::get_transformed_unit_cube(&box_matrix);
+        let box_matrix = translate(&DMat4::identity(), &vec3(2.0, 0.0, 0.0));
+        let bounding_box = BoundingBox::get_transformed_base_cube(&box_matrix);
         let shape: Box<dyn Shape> =
             Box::<OrientedBox>::new(OrientedBox::new(box_matrix, OBJECT_ID));
         let array = Uint16Array::new_with_length(NUM_POINTS);

--- a/viewer/packages/pointclouds/wasm/src/shapes/cylinder.rs
+++ b/viewer/packages/pointclouds/wasm/src/shapes/cylinder.rs
@@ -25,21 +25,21 @@ impl Cylinder {
     }
 
     fn get_scaled_orthogonal_basis(&self) -> DMat3 {
-        let axis_vec = self.center_a - self.center_b;
+        let half_axis_vec = (self.center_a - self.center_b) / 2.0;
         let axis_option_0 = vec3(1.0, 0.0, 0.0);
         let axis_option_1 = vec3(0.0, 1.0, 0.0);
 
         let chosen_axis =
-            if dot(&axis_option_0, &axis_vec).abs() < dot(&axis_option_1, &axis_vec).abs() {
+            if dot(&axis_option_0, &half_axis_vec).abs() < dot(&axis_option_1, &half_axis_vec).abs() {
                 axis_option_0
             } else {
                 axis_option_1
             };
 
-        let perp_vector_0: DVec3 = chosen_axis.cross(&axis_vec).normalize() * 2.0 * self.radius;
-        let perp_vector_1: DVec3 = perp_vector_0.cross(&axis_vec).normalize() * 2.0 * self.radius;
+        let perp_vector_0: DVec3 = chosen_axis.cross(&half_axis_vec).normalize() * self.radius;
+        let perp_vector_1: DVec3 = perp_vector_0.cross(&half_axis_vec).normalize() * self.radius;
 
-        DMat3::from_columns(&[axis_vec, perp_vector_0, perp_vector_1])
+        DMat3::from_columns(&[half_axis_vec, perp_vector_0, perp_vector_1])
     }
 }
 
@@ -73,7 +73,7 @@ impl Shape for Cylinder {
         let scaled_basis = self.get_scaled_orthogonal_basis();
         let matrix = create_transform_from_axes(&scaled_basis, &center);
 
-        BoundingBox::get_transformed_unit_cube(&matrix)
+        BoundingBox::get_transformed_base_cube(&matrix)
     }
 
     fn get_object_id(&self) -> u16 {

--- a/viewer/packages/pointclouds/wasm/src/shapes/oriented_box.rs
+++ b/viewer/packages/pointclouds/wasm/src/shapes/oriented_box.rs
@@ -55,29 +55,29 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn identity_oriented_box_does_not_contain_cardinal_unit_vectors() {
+    fn identity_oriented_box_does_not_contain_doubled_cardinal_unit_vectors() {
         let ob = OrientedBox::new(DMat4::identity(), 0);
-        assert!(!ob.contains_point(&vec3(1.0, 0.0, 0.0)));
-        assert!(!ob.contains_point(&vec3(0.0, 1.0, 0.0)));
-        assert!(!ob.contains_point(&vec3(0.0, 0.0, 1.0)));
+        assert!(!ob.contains_point(&vec3(2.0, 0.0, 0.0)));
+        assert!(!ob.contains_point(&vec3(0.0, 2.0, 0.0)));
+        assert!(!ob.contains_point(&vec3(0.0, 0.0, 2.0)));
     }
 
     #[wasm_bindgen_test]
     fn translated_oriented_box_contains_only_translated_origin() {
         let ob = OrientedBox::new(
-            nalgebra_glm::inverse(&translate(&DMat4::identity(), &vec3(1.0, 1.0, 1.0))),
+            nalgebra_glm::inverse(&translate(&DMat4::identity(), &vec3(2.0, 2.0, 2.0))),
             0,
         );
         assert!(!ob.contains_point(&vec3(0.0, 0.0, 0.0)));
-        assert!(ob.contains_point(&vec3(1.0, 1.0, 1.0)));
+        assert!(ob.contains_point(&vec3(2.0, 2.0, 2.0)));
     }
 
     #[wasm_bindgen_test]
     fn scaled_oriented_box_contains_only_points_in_scaled_direction() {
         let ob = OrientedBox::new(inverse(&scale(&DMat4::identity(), &vec3(3.0, 1.0, 1.0))), 0);
-        assert!(ob.contains_point(&vec3(1.0, 0.0, 0.0)));
-        assert!(!ob.contains_point(&vec3(0.0, 1.0, 0.0)));
-        assert!(!ob.contains_point(&vec3(0.0, 0.0, 1.0)));
+        assert!(ob.contains_point(&vec3(2.0, 0.0, 0.0)));
+        assert!(!ob.contains_point(&vec3(0.0, 2.0, 0.0)));
+        assert!(!ob.contains_point(&vec3(0.0, 0.0, 2.0)));
     }
 
     #[wasm_bindgen_test]
@@ -88,9 +88,9 @@ mod tests {
         ));
 
         let ob = OrientedBox::new(matrix, 0);
-        assert!(!ob.contains_point(&vec3(1.0, 0.0, 0.0)));
-        assert!(!ob.contains_point(&vec3(0.0, 1.0, 0.0)));
-        assert!(ob.contains_point(&vec3(0.0, 0.0, 1.0)));
+        assert!(!ob.contains_point(&vec3(2.0, 0.0, 0.0)));
+        assert!(!ob.contains_point(&vec3(0.0, 2.0, 0.0)));
+        assert!(ob.contains_point(&vec3(0.0, 0.0, 2.0)));
     }
 
     #[wasm_bindgen_test]
@@ -98,8 +98,8 @@ mod tests {
         let original_box = OrientedBox::new(DMat4::identity(), 0);
         let bounding_box = original_box.create_bounding_box();
 
-        assert!(comp_max(&abs(&(bounding_box.min - vec3(-0.5, -0.5, -0.5)))) < 1e-2);
-        assert!(comp_max(&abs(&(bounding_box.max - vec3(0.5, 0.5, 0.5)))) < 1e-2);
+        assert!(comp_max(&abs(&(bounding_box.min - vec3(-1.0, -1.0, -1.0)))) < 1e-2);
+        assert!(comp_max(&abs(&(bounding_box.max - vec3(1.0, 1.0, 1.0)))) < 1e-2);
     }
 
     #[wasm_bindgen_test]

--- a/viewer/packages/pointclouds/wasm/src/shapes/oriented_box.rs
+++ b/viewer/packages/pointclouds/wasm/src/shapes/oriented_box.rs
@@ -22,13 +22,13 @@ impl shape::Shape for OrientedBox {
     fn contains_point(&self, point: &DVec3) -> bool {
         let transformed_point =
             vec4_to_vec3(&(self.inv_instance_matrix * vec4(point.x, point.y, point.z, 1.0)));
-        BoundingBox::get_unit_bounding_box().contains_point(&transformed_point)
+        BoundingBox::get_base_cube_bounding_box().contains_point(&transformed_point)
     }
 
     fn create_bounding_box(&self) -> BoundingBox {
         let instance_matrix = inverse(&self.inv_instance_matrix);
 
-        BoundingBox::get_transformed_unit_cube(&instance_matrix)
+        BoundingBox::get_transformed_base_cube(&instance_matrix)
     }
 
     fn get_object_id(&self) -> u16 {

--- a/viewer/packages/utilities/index.ts
+++ b/viewer/packages/utilities/index.ts
@@ -55,6 +55,8 @@ export { DeferredPromise } from './src/DeferredPromise';
 
 export { SceneHandler } from './src/SceneHandler';
 
+export { CDF_TO_VIEWER_TRANSFORMATION } from './src/constants';
+
 export * from './src/workers/workerize-transferable';
 
 export * from './src/shapes';

--- a/viewer/packages/utilities/src/constants.ts
+++ b/viewer/packages/utilities/src/constants.ts
@@ -4,7 +4,8 @@
 
 import { Matrix4 } from 'three';
 
-import { cadFromCdfToThreeMatrix } from '@reveal/data-providers';
+// The below is equal to new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(-Math.PI / 2, 0, 0));
+export const cadFromCdfToThreeMatrix = new Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
 
 /**
  * The transformation matrix from CDF coordinates to ThreeJS/Reveal.

--- a/viewer/packages/utilities/src/shapes/Box.test.ts
+++ b/viewer/packages/utilities/src/shapes/Box.test.ts
@@ -13,7 +13,7 @@ describe(Box.name, () => {
     const box = new Box(new Matrix4().identity());
     const boundingBox = box.createBoundingBox();
 
-    expect(boundingBox.min.distanceTo(new Vector3(-0.5, -0.5, -0.5))).toBeLessThan(EPSILON);
-    expect(boundingBox.max.distanceTo(new Vector3(0.5, 0.5, 0.5))).toBeLessThan(EPSILON);
+    expect(boundingBox.min.distanceTo(new Vector3(-1.0, -1.0, -1.0))).toBeLessThan(EPSILON);
+    expect(boundingBox.max.distanceTo(new Vector3(1.0, 1.0, 1.0))).toBeLessThan(EPSILON);
   });
 });

--- a/viewer/packages/utilities/src/shapes/Box.ts
+++ b/viewer/packages/utilities/src/shapes/Box.ts
@@ -23,7 +23,7 @@ export class Box implements IShape {
   }
 
   createBoundingBox(): Box3 {
-    const baseBox = new Box3(new Vector3(-0.5, -0.5, -0.5), new Vector3(0.5, 0.5, 0.5));
+    const baseBox = new Box3(new Vector3(-1.0, -1.0, -1.0), new Vector3(1.0, 1.0, 1.0));
     const instanceMatrix = this._invInstanceMatrix.clone().invert();
 
     return baseBox.applyMatrix4(instanceMatrix);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-675

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

As described in the JIRA issue, the convention for cylinder radius and box instance matrix stored in annotations has changed. This update ensures we conform to the new convention.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Using model https://localhost:3000/?env=greenfield-3d&project=3d-test&modelId=483291133841466&revisionId=8824423208021992&edlRadius=0.9&edl=true&camPos=-913.2022704556516%2C14.697374931762509%2C-2175.049044169158&camTarget=-910.7439520833598%2C10.997326784528468%2C-2178.830714380757 (with provided viewpoint), the difference is pretty clear. Many of the segments around the bend are cubes, which do not show up at all using the old convention.

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
