### PR TITLE
fix: 360 images are invisible/clipped when loaded without CAD/Point cloud model

### DIFF
--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -136,7 +136,6 @@ export class Cognite3DViewer {
   private readonly _mouseHandler: InputHandler;
 
   private readonly _models: CogniteModel[] = [];
-  private readonly _extraObjects: THREE.Object3D[] = [];
 
   private isDisposed = false;
 
@@ -873,7 +872,6 @@ export class Cognite3DViewer {
       return;
     }
     object.updateMatrixWorld(true);
-    this._extraObjects.push(object);
     this._sceneHandler.addCustomObject(object);
     this.revealManager.requestRedraw();
     this.recalculateBoundingBox();
@@ -894,10 +892,6 @@ export class Cognite3DViewer {
       return;
     }
     this._sceneHandler.removeCustomObject(object);
-    const index = this._extraObjects.indexOf(object);
-    if (index >= 0) {
-      this._extraObjects.splice(index, 1);
-    }
     this.revealManager.requestRedraw();
     this.recalculateBoundingBox();
   }
@@ -1434,7 +1428,7 @@ export class Cognite3DViewer {
       }
     });
 
-    this._extraObjects.forEach(obj => {
+    this._sceneHandler.customObjects.forEach(obj => {
       bbox.setFromObject(obj);
       if (!bbox.isEmpty()) {
         combinedBbox.union(bbox);


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/REV-680

## Description :pencil:
When 360 images are loaded into viewer without CAD or point cloud models, the 360 images are not visible.

## How has this been tested? :mag:
Tested in `examples`


## Test instructions :information_source:

- Run `examples` and load https://localhost:3000/migration?project=3d-test&env=greenfield-3d&modelId=4923307033982497&revisionId=3100284276970593
- Add 360 images in the example options with below values
        - site_id is helideck-site-2
        - translation offset is  (11, 49, 32)
        - rotation is axis: (0, 1, 0)
        - radians is 3.08923
- In Developer tool->Console run viewer.removeModel(viewer.models[0])- 
- Now click on the 360 sprite icon to enter 360 image view


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
