### PR TITLE
docs: include nodeId in example intersection result properly

### DIFF
--- a/documentation/docs/examples/click-reactions-cad.mdx
+++ b/documentation/docs/examples/click-reactions-cad.mdx
@@ -25,7 +25,8 @@ viewer.on('click', async event => {
     event.offsetX, event.offsetY
   );
   if (intersection) {
-    const toPresent = { treeIndex: intersection.treeIndex, nodeId: intersection.nodeID, point: intersection.point };
+    const nodeId = await model.mapTreeIndexToNodeId(intersection.treeIndex);
+    const toPresent = { treeIndex: intersection.treeIndex, nodeId, point: intersection.point };
     alert(`Clicked object!: ${JSON.stringify(toPresent)}`);
   };
 });

--- a/documentation/versioned_docs/version-3.x/examples/click-reactions-cad.mdx
+++ b/documentation/versioned_docs/version-3.x/examples/click-reactions-cad.mdx
@@ -25,7 +25,8 @@ viewer.on('click', async event => {
     event.offsetX, event.offsetY
   );
   if (intersection) {
-    const toPresent = { treeIndex: intersection.treeIndex, nodeId: intersection.nodeID, point: intersection.point };
+    const nodeId = await model.mapTreeIndexToNodeId(intersection.treeIndex);
+    const toPresent = { treeIndex: intersection.treeIndex, nodeId, point: intersection.point };
     alert(`Clicked object!: ${JSON.stringify(toPresent)}`);
   };
 });

--- a/documentation/versioned_docs/version-4.x/examples/click-reactions-cad.mdx
+++ b/documentation/versioned_docs/version-4.x/examples/click-reactions-cad.mdx
@@ -25,7 +25,8 @@ viewer.on('click', async event => {
     event.offsetX, event.offsetY
   );
   if (intersection) {
-    const toPresent = { treeIndex: intersection.treeIndex, nodeId: intersection.nodeID, point: intersection.point };
+    const nodeId = await model.mapTreeIndexToNodeId(intersection.treeIndex);
+    const toPresent = { treeIndex: intersection.treeIndex, nodeId, point: intersection.point };
     alert(`Clicked object!: ${JSON.stringify(toPresent)}`);
   };
 });


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Docs](https://img.shields.io/badge/Type-Docs-blue) <!--changes to the documentation -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-574

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

The doc example tried to access nodeID in the intersection result, which is not a valid field. Changing it to retrieve the node ID another way.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In the documentation, CAD clicking site, check that node ID shows up when running the first example snippet.


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
