### PR TITLE
fix: SSAO noise on large-scale models

### DIFF
--- a/viewer/packages/rendering/src/glsl/post-processing/pure-depth-ssao.frag
+++ b/viewer/packages/rendering/src/glsl/post-processing/pure-depth-ssao.frag
@@ -68,11 +68,18 @@ void main(){
 
   vec3 viewNormal = computeWorldNormalFromDepth(tDepth, vec2(float(textureSize.x), float(textureSize.y)), vUv, d);
 
+  float cosAngle = abs(dot(viewNormal, vec3(0.0, 0.0, 1.0)));
+  float sinAngle = length(cross(viewNormal, vec3(0.0, 0.0, 1.0)));
+  // float tanAngle = sinAngle / cosAngle;
+  float secAngle = clamp(cosAngle / sinAngle, 1e-2, 1.0);
+
   vec3 viewPosition = viewPosFromDepth(d, vUv);
+  float distanceFactor = length(viewPosition) / 50.0;
 
-  vec3 randomVec = normalize(vec3(rand2d(vUv), rand2d(vUv * 3.0), rand2d(vUv * 5.0)));
+  // vec3 covector = abs(dot(vec3(1.0, 0.0, 0.0), viewNormal)) < abs(dot(vec3(0.0, 1.0, 0.0), viewNormal)) ? vec3(1.0, 0.0, 0.0) : vec3(0.0, 1.0, 0.0);
+  vec3 covector = normalize(vec3(rand2d(vUv), rand2d(vUv * 3.0), rand2d(vUv * 5.0)));
 
-  vec3 tangent = normalize(randomVec - viewNormal * dot(randomVec, viewNormal));
+  vec3 tangent = normalize(covector - viewNormal * dot(covector, viewNormal));
 
   vec3 bitangent = cross(viewNormal, tangent);
 
@@ -80,12 +87,15 @@ void main(){
 
   float occlusion = 0.0;
 
-  for (int i = 0; i < MAX_KERNEL_SIZE; i++){
-    
-    vec3 sampleVector = TBN * kernel[i];
-    sampleVector = viewPosition + sampleVector * sampleRadius;
+  float minNormDot = 0.0;
 
-    vec4 offset = projMatrix * vec4(sampleVector, 1.0);
+  for (int i = 0; i < MAX_KERNEL_SIZE; i++) {
+    vec3 kvec = kernel[i];
+    // kvec.z = abs(kvec.z);
+    vec3 sampleVector = TBN * kvec;
+    vec3 samplePosition = viewPosition + sampleVector * sampleRadius * distanceFactor;
+
+    vec4 offset = projMatrix * vec4(samplePosition, 1.0);
     offset.xyz /= offset.w;
     offset.xyz = offset.xyz * 0.5 + 0.5;
 
@@ -94,10 +104,14 @@ void main(){
 
     float rangeCheck = smoothstep(0.0, 1.0, sampleRadius / length(viewPosition - realPos));
 
-    occlusion += (realPos.z >= sampleVector.z + bias ? 1.0 : 0.0) * rangeCheck;
+    occlusion += ((realPos.z >= samplePosition.z + bias * (1.0 / secAngle) * distanceFactor) ? 1.0 : 0.0) * rangeCheck;
+    // occlusion += ((realPos.z >= sampleVector.z + bias) ? 1.0 : 0.0) * rangeCheck;
+    minNormDot += dot(sampleVector, viewNormal) / float(MAX_KERNEL_SIZE);
   }
 
   float occlusionFactor = 1.0 - clamp(occlusion / float(MAX_KERNEL_SIZE), 0.0, 1.0);
 
   outputColor = vec4(occlusionFactor);
+  // outputColor = vec4(viewNormal.xy, minNormDot, 1.0);
+  // outputColor = vec4(TBN * kernel[MAX_KERNEL_SIZE - 1], 1.0);
 }

--- a/viewer/packages/rendering/src/glsl/post-processing/pure-depth-ssao.frag
+++ b/viewer/packages/rendering/src/glsl/post-processing/pure-depth-ssao.frag
@@ -81,8 +81,6 @@ void main(){
 
   float occlusion = 0.0;
 
-  float minNormDot = 0.0;
-
   for (int i = 0; i < MAX_KERNEL_SIZE; i++) {
     vec3 sampleVector = TBN * kernel[i];
     vec3 samplePosition = viewPosition + sampleVector * sampleRadius * distanceFactor;
@@ -96,8 +94,7 @@ void main(){
 
     float rangeCheck = smoothstep(0.0, 1.0, sampleRadius / length(viewPosition - realPos));
 
-    occlusion += ((realPos.z >= samplePosition.z + bias) ? 1.0 : 0.0) * rangeCheck;
-    minNormDot += dot(sampleVector, viewNormal) / float(MAX_KERNEL_SIZE);
+    occlusion += (realPos.z >= samplePosition.z + bias ? 1.0 : 0.0) * rangeCheck;
   }
 
   float occlusionFactor = 1.0 - clamp(occlusion / float(MAX_KERNEL_SIZE), 0.0, 1.0);

--- a/viewer/packages/rendering/src/glsl/post-processing/pure-depth-ssao.frag
+++ b/viewer/packages/rendering/src/glsl/post-processing/pure-depth-ssao.frag
@@ -54,12 +54,14 @@ vec3 computeWorldNormalFromDepth(sampler2D depthTexture, vec2 resolution, vec2 u
   vec2 verticalSampleUv = verticalSampleCondition ? uv2 : uv4;
 
   vec3 viewPos = viewPosFromDepth(sampleDepth, vUv);
-  
+
   vec3 viewPos1 = (horizontalSampleCondition == verticalSampleCondition) ? viewPosFromDepth(horizontalSampleDepth, horizontalSampleUv) : viewPosFromDepth(verticalSampleDepth, verticalSampleUv);
   vec3 viewPos2 = (horizontalSampleCondition == verticalSampleCondition) ? viewPosFromDepth(verticalSampleDepth, verticalSampleUv) : viewPosFromDepth(horizontalSampleDepth, horizontalSampleUv);
 
   return normalize(cross(viewPos1 - viewPos, viewPos2 - viewPos));
 }
+
+float LARGE_DISTANCE_SAMPLE_FACTOR = 0.05;
 
 void main(){
   float d = texture(tDepth, vUv).r;
@@ -69,7 +71,8 @@ void main(){
   vec3 viewNormal = computeWorldNormalFromDepth(tDepth, vec2(float(textureSize.x), float(textureSize.y)), vUv, d);
 
   vec3 viewPosition = viewPosFromDepth(d, vUv);
-  float distanceFactor = max(length(viewPosition) / 20.0, 1.0);
+
+  float distanceFactor = max(length(viewPosition) * LARGE_DISTANCE_SAMPLE_FACTOR, 1.0);
 
   vec3 covector = normalize(vec3(rand2d(vUv), rand2d(vUv * 3.0), rand2d(vUv * 5.0)));
 

--- a/viewer/packages/rendering/src/render-passes/SSAOPass.ts
+++ b/viewer/packages/rendering/src/render-passes/SSAOPass.ts
@@ -65,8 +65,8 @@ export class SSAOPass implements RenderPass {
   private createKernel(kernelSize: number): THREE.Vector3[] {
     const result: THREE.Vector3[] = [];
     for (let i = 0; i < kernelSize; i++) {
-      const sample = new THREE.Vector3();
-      while (sample.length() < 1.0) {
+      const sample = new THREE.Vector3(1, 1, 1);
+      while (sample.length() > 1.0) {
         // Ensure some distance in samples
         sample.x = Math.random() * 2 - 1;
         sample.y = Math.random() * 2 - 1;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-318

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes the visual noise on large-scale models.

This does not make SSAO independent of depth range, as the Jira issue states, but makes the bias stronger on high ranges, to avoid the noise issue, which seems to stem from resolution limitations in the depth buffer.

SSAO is still tuned to "normal"-scale models, as can be seen in the oversized model below.

Also fixes an error in the generation of random unit hemisphere vectors.

## Results

These images are taken with interior (https://localhost:3000/?env=greenfield-3d&project=3d-test&modelId=8257821301169759&revisionId=7934734851519456&camPos=107.44678591593261%2C30.27114915044054%2C-290.1136229159823&camTarget=104.25858462418007%2C30.263734642188922%2C-289.98314277533814) and an oversized component (https://localhost:3000/?env=greenfield-3d&project=3d-test&modelId=8689700051040317&revisionId=4408958562516833&camPos=880.4091796875%2C923.9152221679685%2C1388.767822265625&camTarget=50.36891174316406%2C647.2351684570312%2C5.367408752441406)

### New algorithm

#### Interior 
![new-interior](https://user-images.githubusercontent.com/70905152/215088753-10c3fec8-785c-475f-81d0-db53dc9ffa47.png)

#### Oversized component
![new-large](https://user-images.githubusercontent.com/70905152/215088761-271d907d-f497-4e35-b15a-c11acb147ff1.png)

### Old algorithm
![old-interior](https://user-images.githubusercontent.com/70905152/215088766-592ff3c8-6f32-4320-8b2f-ef37153e8a1f.png)
![old-large](https://user-images.githubusercontent.com/70905152/215088768-cc14a655-f5a7-4c90-b997-b9842da2d682.png)

Note that the SSAO is invisible for the large component. It will only be visible when getting closer to the model. I personally don't think this is a problem, as there are other effects (e.g. the matcap and viewpoint-dependent lighting).

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
