### PR TITLE
fix: entered 360 image being purged from cache

### DIFF
--- a/viewer/packages/360-images/src/Image360VisualizationBox.ts
+++ b/viewer/packages/360-images/src/Image360VisualizationBox.ts
@@ -38,6 +38,10 @@ export class Image360VisualizationBox implements Image360Visualization {
     });
   }
 
+  get visible(): boolean {
+    return this._visualizationState.visible;
+  }
+
   set visible(isVisible: boolean) {
     this._visualizationState.visible = isVisible;
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-717

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an issue where currently opened / entered 360 images could be purged from cache.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

unit test :) 
But also the image you are in should not be exited when hovering on > 10 icons of other images.
