### PR TITLE
fix: Wrong rotation speed with keyboard navigation when camera looking down/up.

### DIFF
--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -155,7 +155,7 @@ export class ComboControls extends EventDispatcher {
     pointerRotationSpeedPolar: defaultPointerRotationSpeed,
     enableKeyboardNavigation: true,
     keyboardRotationSpeedAzimuth: defaultKeyboardRotationSpeed,
-    keyboardRotationSpeedPolar: defaultKeyboardRotationSpeed,
+    keyboardRotationSpeedPolar: defaultKeyboardRotationSpeed * 0.8,
     mouseFirstPersonRotationSpeed: defaultPointerRotationSpeed * 2,
     keyboardDollySpeed: 2,
     keyboardPanSpeed: 10,
@@ -658,7 +658,9 @@ export class ComboControls extends EventDispatcher {
       _sphericalEnd.makeSafe();
       polarAngle = _sphericalEnd.phi - oldPhi;
       _sphericalEnd.phi = oldPhi;
-      this.rotateFirstPersonMode(azimuthAngle, polarAngle);
+
+      const compensationForPolarAngleFactor = Math.sin(Math.PI / 2 - Math.abs(_sphericalEnd.phi - Math.PI / 2));
+      this.rotateFirstPersonMode(azimuthAngle * compensationForPolarAngleFactor, polarAngle);
     }
 
     const speedFactor = _keyboard.isPressed('shift') ? this._options.keyboardSpeedFactor : 1;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->


#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-202

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->
Camera was rotating too fast in keyboard navigation mode when it was "looking" too close to down/up. Now, speed is the same across any direction and keyboard navigation feels much more stable.

## How has this been tested? :mag:
In Reveal examples, navigating with the keyboard.
<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:
1. Open any model in Reveal example, try to navigate around with keyboard. 
2. When closer to any model geometry, click on it and try to navigate with the keyboard again. 
<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
