### PR TITLE
fix: clip measurement line & labels

### DIFF
--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -426,7 +426,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
     for (const [htmlElement, element] of this._htmlOverlays.entries()) {
       const { state } = element;
       const elementBounds = createElementBounds(element);
-      if (!state.visible || !elementBounds.intersectsBox(canvasBounds)) {
+      if (!state.visible || !elementBounds.intersectsBox(canvasBounds) || htmlElement.hidden) {
         continue;
       }
       grid.insert(elementBounds, { htmlElement, ...element });

--- a/viewer/packages/tools/src/Measurement/MeasurementLine.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementLine.ts
@@ -77,6 +77,17 @@ export class MeasurementLine {
   }
 
   /**
+   * Updates the measuring line clipping planes
+   * @param clippingPlanes current active global clipping planes.
+   */
+  updateLineClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+    const visible =
+      !this.clippingPlanesContainPoint(clippingPlanes, this._startPos) ||
+      !this.clippingPlanesContainPoint(clippingPlanes, this._endpoint);
+    this._meshes.visible = !visible;
+  }
+
+  /**
    * Get the distance between the measuring line start point & end point.
    * @returns Return distance between start & end point of the line.
    */
@@ -127,5 +138,9 @@ export class MeasurementLine {
 
     this._meshes.add(adaptiveMesh);
     this._meshes.add(fixedMesh);
+  }
+
+  private clippingPlanesContainPoint(planes: THREE.Plane[], point: THREE.Vector3) {
+    return planes.every(p => p.distanceToPoint(point) > 0);
   }
 }

--- a/viewer/packages/tools/src/Measurement/MeasurementManager.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementManager.ts
@@ -100,6 +100,17 @@ export class MeasurementManager {
   }
 
   /**
+   * Updates the measuring line clipping planes
+   * @param clippingPlanes current active global clipping planes.
+   */
+  updateLineClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+    this._line.updateLineClippingPlanes(clippingPlanes);
+    if (this._labelElement) {
+      this._labelElement.hidden = !this._line.meshes.visible;
+    }
+  }
+
+  /**
    * Update current line width.
    * @param lineWidth Width of the measuring line mesh.
    */

--- a/viewer/packages/tools/src/Measurement/MeasurementTool.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementTool.ts
@@ -69,6 +69,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
   private readonly _handlePointerClick = this.onPointerClick.bind(this);
   private readonly _handlePointerMove = this.onPointerMove.bind(this);
   private readonly _handleMeasurementCancel = this.onKeyDown.bind(this);
+  private readonly _handleClippingPlanes = this.onClipping.bind(this);
 
   private readonly _events = {
     measurementAdded: new EventTrigger<MeasurementAddedDelegate>(),
@@ -236,6 +237,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
       throw new Error('Measurement mode is active, call exitMeasurementMode()');
     }
     this._viewer.on('click', this._handlePointerClick);
+    this._viewer.on('beforeSceneRendered', this._handleClippingPlanes);
     this._events.measurementStarted.fire();
     this._measurementMode = true;
     this._showMeasurements = true;
@@ -250,6 +252,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
     }
     this.cancelActiveMeasurement();
     this._viewer.off('click', this._handlePointerClick);
+    this._viewer.off('beforeSceneRendered', this._handleClippingPlanes);
     this._events.measurementEnded.fire();
     this._measurementMode = false;
   }
@@ -463,6 +466,15 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
       this._activeMeasurement = undefined;
       this._viewer.requestRedraw();
       this._viewer.domElement.removeEventListener('pointermove', this._handlePointerMove);
+    }
+  }
+
+  private onClipping() {
+    const clippingPlanes = this._viewer.getGlobalClippingPlanes();
+    if (clippingPlanes.length > 0) {
+      this._measurements.forEach(measurement => {
+        measurement.updateLineClippingPlanes(clippingPlanes);
+      });
     }
   }
 }


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red)

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/REV-579

## Description :pencil:
Measurement line meshes and labels are clipped when slicing/clipping is used in the viewer.

## How has this been tested? :mag:
In examples


## Test instructions :information_source:
1. Load https://localhost:3000/migration?project=3d-test&env=greenfield-3d&modelId=4579637123115827&revisionId=5523802070299592
2. Add few measurements from Options-->Measurements
3. Clipping -> Global
4. Check X and Flip X
5. Slide back and forth and observe measuring line & labels appear/disappear

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
