### PR TITLE
fix: measurements are not restored when clipping plane is removed

### DIFF
--- a/viewer/packages/tools/src/Measurement/MeasurementTool.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementTool.ts
@@ -471,10 +471,8 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
 
   private onClipping() {
     const clippingPlanes = this._viewer.getGlobalClippingPlanes();
-    if (clippingPlanes.length > 0) {
-      this._measurements.forEach(measurement => {
-        measurement.updateLineClippingPlanes(clippingPlanes);
-      });
-    }
+    this._measurements.forEach(measurement => {
+      measurement.updateLineClippingPlanes(clippingPlanes);
+    });
   }
 }


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red)

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/REV-729

## Description :pencil:
This should have been taken care in [REV-579](https://cognitedata.atlassian.net/browse/REV-579)

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature. - This should have been taken care in REV-579
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.


[REV-579]: https://cognitedata.atlassian.net/browse/REV-579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ