### PR TITLE
fix: Fix more point cloud leaks

### DIFF
--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -800,6 +800,7 @@ export class Cognite3DViewer {
         const pcModel = model as CognitePointCloudModel;
         this._sceneHandler.removePointCloudModel(pcModel.pointCloudNode);
         this.revealManager.removeModel(model.type, pcModel.pointCloudNode);
+        this._pointCloudPickingHandler.reset();
         break;
 
       default:

--- a/viewer/packages/pointclouds/src/PointCloudFactory.ts
+++ b/viewer/packages/pointclouds/src/PointCloudFactory.ts
@@ -10,8 +10,6 @@ import { DEFAULT_POINT_CLOUD_METADATA_FILE } from './constants';
 import { PointCloudStylableObjectProvider } from '@reveal/data-providers';
 import { IPointClassificationsProvider } from './classificationsProviders/IPointClassificationsProvider';
 
-import { ModelDataProvider } from '@reveal/data-providers';
-
 import { PointCloudMaterialManager } from '@reveal/rendering';
 import { createObjectIdMaps } from './potree-three-loader/utils/createObjectIdMaps';
 
@@ -22,12 +20,12 @@ export class PointCloudFactory {
   private readonly _pointCloudMaterialManager: PointCloudMaterialManager;
 
   constructor(
-    modelLoader: ModelDataProvider,
+    potreeInstance: Potree,
     pointCloudObjectProvider: PointCloudStylableObjectProvider,
     classificationsProvider: IPointClassificationsProvider,
     pointCloudMaterialManager: PointCloudMaterialManager
   ) {
-    this._potreeInstance = new Potree(modelLoader, pointCloudMaterialManager);
+    this._potreeInstance = potreeInstance;
     this._pointCloudObjectProvider = pointCloudObjectProvider;
     this._classificationsProvider = classificationsProvider;
     this._pointCloudMaterialManager = pointCloudMaterialManager;

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
@@ -53,6 +53,10 @@ export class PointCloudPickingHandler {
     this._picker = new PointCloudOctreePicker(renderer);
   }
 
+  reset(): void {
+    this._picker.dispose();
+  }
+
   intersectPointClouds(nodes: PointCloudNode[], input: IntersectInput): IntersectPointCloudNodeResult[] {
     const { normalizedCoords, camera } = input;
     this._normalized.set(normalizedCoords.x, normalizedCoords.y);

--- a/viewer/packages/pointclouds/src/createPointCloudManager.ts
+++ b/viewer/packages/pointclouds/src/createPointCloudManager.ts
@@ -27,7 +27,7 @@ export function createPointCloudManager(
 
   const potreeInstance = new Potree(modelDataProvider, pointCloudMaterialManager);
   const pointCloudFactory = new PointCloudFactory(
-    modelDataProvider,
+    potreeInstance,
     pointCloudStylableObjectProvider,
     classificationsProvider,
     pointCloudMaterialManager

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePicker.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePicker.ts
@@ -22,6 +22,8 @@ export class PointCloudOctreePicker {
       this.pickState.material.dispose();
       this.pickState.renderTarget.dispose();
     }
+
+    this.pickState = undefined;
   }
 
   pick(camera: Camera, ray: Ray, octrees: PointCloudOctree[], params: Partial<PickParams> = {}): PickPoint | null {

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.ts
@@ -143,6 +143,8 @@ export class PointCloudOctreePickerHelper {
 
       renderer.render(pickState.scene, camera);
 
+      // Reset children, avoid keeping references to point cloud nodes
+      pickState.scene.children = [];
       nodes.forEach(node => renderedNodes.push({ node, octree }));
     }
     return renderedNodes;


### PR DESCRIPTION
- fix: create only one Potree instance
- fix: stop point cloud picker helper from keeping references to nodes
- fix: unref pick state on dispose
- fix: reset picking handler on point cloud removal

#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-428

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Found a few more point cloud memory leak sources, here some of them are fixed.

Note that there are still more weird things going on with point cloud geometry buffers. E.g. the workers and the buffers they processed seem to be retained in memory, at least in Firefox.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
