### PR TITLE
fix: disallow opening multiple 360 images

### DIFF
--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -96,6 +96,7 @@ export class Image360ApiHelper {
 
   public async enter360Image(image360Entity: Image360Entity): Promise<void> {
     const lastEntered360ImageEntity = this._interactionState.currentImage360Entered;
+    this._interactionState.currentImage360Entered = image360Entity;
 
     if (lastEntered360ImageEntity === image360Entity) {
       this._requestRedraw();
@@ -103,6 +104,10 @@ export class Image360ApiHelper {
     }
 
     await this._image360Facade.preload(image360Entity);
+
+    if (this._interactionState.currentImage360Entered !== image360Entity) {
+      return;
+    }
 
     this.set360CameraManager();
 
@@ -124,7 +129,6 @@ export class Image360ApiHelper {
       ]);
     }
     this._transitionInProgress = false;
-    this._interactionState.currentImage360Entered = image360Entity;
     this._domElement.addEventListener('keydown', this._domEventHandlers.exit360ImageOnEscapeKey);
 
     this._requestRedraw();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-767

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an issue where multiple 360 images can be entered / opened if you click another 360 images before the first one completes loading.

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

Open any 360 image set, throttle your network speed in your browser and click two 360 images. Previously this would open both (once the finish downloading). Current behaviour should be to transition into the last clicked.
