### PR TITLE
fix: Entering a clicked 360 Image is slow after hovering many icons

### DIFF
--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -60,7 +60,7 @@ export class Image360ApiHelper {
     this._cachedCameraManager = activeCameraManager.innerCameraManager;
     this._requestRedraw = requestRedraw;
     this._preLoadObservable = new Subject();
-    this._preLoadObservable.pipe(debounceTime(250)).subscribe(entity => this._image360Facade.preload(entity));
+    this._preLoadObservable.pipe(debounceTime(150)).subscribe(entity => this._image360Facade.preload(entity));
 
     const setHoverIconEventHandler = (event: MouseEvent) => this.setHoverIconOnIntersect(event);
     domElement.addEventListener('mousemove', setHoverIconEventHandler);

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -16,6 +16,7 @@ import { Cdf360ImageEventProvider } from '@reveal/data-providers';
 import { InputHandler, pixelToNormalizedDeviceCoordinates, PointerEventData, SceneHandler } from '@reveal/utilities';
 import { CameraManager, ProxyCameraManager, StationaryCameraManager } from '@reveal/camera-manager';
 import { MetricsLogger } from '@reveal/metrics';
+import { debounceTime, Subject } from 'rxjs';
 
 export class Image360ApiHelper {
   private readonly _image360Facade: Image360Facade<Metadata>;
@@ -37,6 +38,7 @@ export class Image360ApiHelper {
   private readonly _activeCameraManager: ProxyCameraManager;
   private readonly _image360Navigation: StationaryCameraManager;
   private _cachedCameraManager: CameraManager;
+  private readonly _preLoadObservable: Subject<Image360Entity>;
 
   constructor(
     cogniteClient: CogniteClient,
@@ -57,6 +59,8 @@ export class Image360ApiHelper {
     this._activeCameraManager = activeCameraManager;
     this._cachedCameraManager = activeCameraManager.innerCameraManager;
     this._requestRedraw = requestRedraw;
+    this._preLoadObservable = new Subject();
+    this._preLoadObservable.pipe(debounceTime(250)).subscribe(entity => this._image360Facade.preload(entity));
 
     const setHoverIconEventHandler = (event: MouseEvent) => this.setHoverIconOnIntersect(event);
     domElement.addEventListener('mousemove', setHoverIconEventHandler);
@@ -274,6 +278,7 @@ export class Image360ApiHelper {
     this._domElement.removeEventListener('mousemove', this._domEventHandlers.setHoverIconEventHandler);
     this._domElement.addEventListener('pointerup', this._domEventHandlers.enter360Image);
     this._domElement.addEventListener('keydown', this._domEventHandlers.exit360ImageOnEscapeKey);
+    this._preLoadObservable.unsubscribe();
 
     if (this._activeCameraManager.innerCameraManager === this._image360Navigation) {
       this._activeCameraManager.setActiveCameraManager(this._cachedCameraManager);
@@ -328,7 +333,7 @@ export class Image360ApiHelper {
 
     if (entity !== undefined) {
       entity.icon.hoverSpriteVisible = true;
-      this._image360Facade.preload(entity);
+      this._preLoadObservable.next(entity);
     }
 
     this._requestRedraw();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/REV-794

## Description :pencil:
I now throttle the amount of calls to `preload` when hovering using `debounceTime`. I am using debounce with both leading and trailing, so the first icon to be hovered will send a request right away. This makes the delay value less critical as it will not affect the download of the first image set.

## How has this been tested? :mag:

I added a console.log that was printed on hover and one on preload. I then loaded Hibernia_RS2 and looked at how the functions were called. See task for movie.

## Test instructions :information_source:

Do what I did. Or just play around in Hibernia_RS2 and look for anything suspicious. 

## Checklist :ballot_box_with_check:

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
