### PR TITLE
fix: wrong separator when parsing 360 image events

### DIFF
--- a/viewer/packages/data-providers/src/image-360-data-providers/Cdf360ImageEventProvider.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/Cdf360ImageEventProvider.ts
@@ -190,14 +190,14 @@ export class Cdf360ImageEventProvider implements Image360Provider<Metadata> {
     };
 
     function parseTransform(transformationData: Event360TransformationData): THREE.Matrix4 {
-      const translationComponents = transformationData.translation.split(' ').map(parseFloat);
+      const translationComponents = transformationData.translation.split(',').map(parseFloat);
       const milimetersInMeters = 1000;
       const translation = new THREE.Vector3(
         translationComponents[0],
         translationComponents[2],
         -translationComponents[1]
       ).divideScalar(milimetersInMeters);
-      const rotationAxisComponents = transformationData.rotation_axis.split(' ').map(parseFloat);
+      const rotationAxisComponents = transformationData.rotation_axis.split(',').map(parseFloat);
       const rotationAxis = new THREE.Vector3(
         rotationAxisComponents[0],
         rotationAxisComponents[2],


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

woops...