### PR TITLE
feat: blend texture and styling color

### DIFF
--- a/viewer/packages/rendering/src/glsl/sector/mesh.frag
+++ b/viewer/packages/rendering/src/glsl/sector/mesh.frag
@@ -36,11 +36,14 @@ void main()
     }
 
 #if defined(IS_TEXTURED)
-    vec3 baseColor = texture(tDiffuse, v_uv).rgb;
+    vec3 diffuseColor = texture(tDiffuse, v_uv).rgb;
+    vec4 color = determineColor(diffuseColor, appearance);
+
+    color = vec4(mix(diffuseColor, vec3(color), 0.6), color.a);
 #else
-    vec3 baseColor = v_color;
+    vec4 color = determineColor(v_color, appearance);
 #endif
-    vec4 color = determineColor(baseColor, appearance);
+
     vec3 normal = derivateNormal(v_viewPosition);
     updateFragmentColor(renderMode, color, v_treeIndex, normal, gl_FragCoord.z, matCapTexture, GeometryType.TriangleMesh);
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-773

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Let textures shine through style override colors, instead of becoming invisible.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Open https://localhost:3000/?modelUrl=textured and apply e.g. highlighted node styling to all nodes. Observe that the texture is still visible.

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
