### PR TITLE
improvement: point cloud style blending

### DIFF
--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
@@ -360,9 +360,12 @@ void main() {
 								vec3 styleColorHSV = rgb2hsv(styleColor);
 
 								vColorHSV.xy = styleColorHSV.xy;
+								// Add 20% brightness from original point & 80% from styled.
 								vColorHSV.z = (vColorHSV.z * (styleColorHSV.z * 0.8 + 0.2));
 
-								vColor = hsv2rgb(vColorHSV);
+								vec3 vColorRGB = hsv2rgb(vColorHSV);
+								// Mix 30% color from original point & 70% from styled.
+								vColor = (vColor * 0.3) + (vColorRGB * 0.7);
         }
 #endif
 }

--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
@@ -356,16 +356,8 @@ void main() {
         }
 #if !defined(color_type_point_index)
         if (any(greaterThan(styleColor, vec3(0.0)))) {
-                vec3 vColorHSV = rgb2hsv(vColor);
-								vec3 styleColorHSV = rgb2hsv(styleColor);
-
-								vColorHSV.xy = styleColorHSV.xy;
-								// Add 20% brightness from original point & 80% from styled.
-								vColorHSV.z = (vColorHSV.z * (styleColorHSV.z * 0.8 + 0.2));
-
-								vec3 vColorRGB = hsv2rgb(vColorHSV);
-								// Mix 30% color from original point & 70% from styled.
-								vColor = (vColor * 0.3) + (vColorRGB * 0.7);
+					// Mix 20% color from original color & 80% from style color.
+					vColor = (styleColor * 0.8 + vColor * 0.2);
         }
 #endif
 }

--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
@@ -2,6 +2,8 @@ precision highp float;
 precision highp int;
 
 #pragma glslify: import('../base/pointSizeRelativeToScreen.glsl');
+#pragma glslify: import('../color/rgb2hsv.glsl');
+#pragma glslify: import('../color/hsv2rgb.glsl');
 
 #define max_clip_boxes 30
 
@@ -354,7 +356,13 @@ void main() {
         }
 #if !defined(color_type_point_index)
         if (any(greaterThan(styleColor, vec3(0.0)))) {
-                vColor = 0.5 * (styleColor + vColor);
+                vec3 vColorHSV = rgb2hsv(vColor);
+								vec3 styleColorHSV = rgb2hsv(styleColor);
+
+								vColorHSV.xy = styleColorHSV.xy;
+								vColorHSV.z = (vColorHSV.z * (styleColorHSV.z * 0.8 + 0.2));
+
+								vColor = hsv2rgb(vColorHSV);
         }
 #endif
 }

--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
@@ -2,8 +2,6 @@ precision highp float;
 precision highp int;
 
 #pragma glslify: import('../base/pointSizeRelativeToScreen.glsl');
-#pragma glslify: import('../color/rgb2hsv.glsl');
-#pragma glslify: import('../color/hsv2rgb.glsl');
 
 #define max_clip_boxes 30
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-847

## Description :pencil:
Improved the styling in point cloud by blending with more styled color saturation & reducing original color for final output color

## How has this been tested? :mag:

In examples

## Test instructions :information_source:

`cd examples && yarn && yarn start`
In example, `GUI---->Point cloud details #1----->Default styling---->change Color && Apply`

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
