### PR TITLE
fix: adaptive point sizing giving too large points in picking

### DIFF
--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePicker.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePicker.ts
@@ -62,7 +62,6 @@ export class PointCloudOctreePicker {
       return PointCloudOctreePickerHelper.getPickPoint(hit, renderedNodes);
     } finally {
       // Cleanup
-      pickMaterial.clearVisibleNodeTextureOffsets();
       this._pickerHelper.resetState();
     }
   }

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.ts
@@ -213,6 +213,8 @@ export class PointCloudOctreePickerHelper {
     pickMaterial.clipping = nodeMaterial.clipping;
     pickMaterial.clipIntersection = nodeMaterial.clipIntersection;
     pickMaterial.defines = nodeMaterial.defines;
+
+    pickMaterial.visibleNodeTextureOffsets = nodeMaterial.visibleNodeTextureOffsets;
   }
 
   public static updatePickRenderTarget(pickState: IPickState, width: number, height: number): void {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-857

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

When clicking while using adaptive point sizing, the click would often snap to a point that is relatively far from the clicked position on the screen. 

This was due to adaptive point size LoD computations failing, yielding very large points. Then the closest point within a large radius of the click position would take priority.

This PR fixes the LoD computation by ensuring the pick material uses the same visibility data texture as the actual pick material. 

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

By clicking

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
