### PR TITLE
fix: throw error if same image 360 collection is added twice

### DIFF
--- a/viewer/packages/360-images/src/collection/DefaultImage360Collection.ts
+++ b/viewer/packages/360-images/src/collection/DefaultImage360Collection.ts
@@ -33,6 +33,11 @@ export class DefaultImage360Collection implements Image360Collection {
   };
   private readonly _icons: IconCollection;
   private _isCollectionVisible: boolean;
+  private readonly _collectionId: string;
+
+  get id(): string {
+    return this._collectionId;
+  }
 
   get targetRevisionDate(): Date | undefined {
     return this._targetRevisionDate;
@@ -56,7 +61,8 @@ export class DefaultImage360Collection implements Image360Collection {
     return this._isCollectionVisible;
   }
 
-  constructor(entities: Image360Entity[], icons: IconCollection) {
+  constructor(collectionId: string, entities: Image360Entity[], icons: IconCollection) {
+    this._collectionId = collectionId;
     this.image360Entities = entities;
     this._icons = icons;
     this._isCollectionVisible = true;

--- a/viewer/packages/360-images/src/collection/Image360CollectionFactory.ts
+++ b/viewer/packages/360-images/src/collection/Image360CollectionFactory.ts
@@ -11,6 +11,8 @@ import { Image360Icon } from '../icons/Image360Icon';
 import { IconCollection } from '../icons/IconCollection';
 import { Vector3 } from 'three';
 import { Historical360ImageSet } from '@reveal/data-providers/src/types';
+import uniq from 'lodash/uniq';
+import assert from 'assert';
 
 export class Image360CollectionFactory<T> {
   private readonly _image360DataProvider: Image360Provider<T>;
@@ -53,7 +55,11 @@ export class Image360CollectionFactory<T> {
         );
       });
 
-    return new DefaultImage360Collection(entities, collectionIcons);
+    const collectionIds = uniq(historicalDescriptors.map(desc => desc.collectionId));
+
+    assert(collectionIds.length === 1);
+
+    return new DefaultImage360Collection(collectionIds[0], entities, collectionIcons);
 
     function isDefined(
       pair: [Historical360ImageSet | undefined, Image360Icon | undefined]

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -113,10 +113,17 @@ export class Image360ApiHelper {
   }
 
   public async add360ImageSet(
-    eventFilter: { [key: string]: string },
+    eventFilter: Metadata,
     collectionTransform: THREE.Matrix4,
     preMultipliedRotation: boolean
   ): Promise<Image360Collection> {
+    const id: string | undefined = eventFilter.site_id;
+    if (id === undefined) {
+      throw new Error('Image set filter must contain site_id');
+    }
+    if (this._image360Facade.collections.map(collection => collection.id).includes(id)) {
+      throw new Error(`Image set with id=${id} has already been added`);
+    }
     const imageCollection = await this._image360Facade.create(eventFilter, collectionTransform, preMultipliedRotation);
     this._requestRedraw();
     return imageCollection;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-852

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Now throws if user attempts to add the same 360 image collection more than once.

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

In examples, attempt to add the same image360set twice, notice an error being thrown.
