### PR TITLE
bug: Fail to transition to 360 image boxes due to textures not being set on revision

### DIFF
--- a/viewer/packages/360-images/src/entity/Image360RevisionEntity.ts
+++ b/viewer/packages/360-images/src/entity/Image360RevisionEntity.ts
@@ -74,7 +74,7 @@ export class Image360RevisionEntity implements Image360Revision {
     return { firstCompleted, fullResolutionCompleted: awaitFullResolution() };
 
     async function awaitFullResolution(): Promise<void> {
-      await fullResolutionFaces;
+      await Promise.all([firstCompleted, fullResolutionFaces]);
     }
   }
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/REV-878

## Description :pencil:
After some investigation we found that the `fullResolutionCompleted` promise sometimes can be resolved before `firstCompleted`, resulting in the revision being added to the cache before `this._textures` has been set. This fixes this problem, but we suspect that the code here can be improved for both readability and stability: https://cognitedata.atlassian.net/browse/REV-880

## How has this been tested? :mag:
Using the Hibernia_RS2 image set. 


## Test instructions :information_source:
The best way to reproduce this is to spam-click icons.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
