### PR TITLE
fix: paraboloid shape in point cloud rendering

### DIFF
--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.frag
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.frag
@@ -77,7 +77,6 @@ void main() {
 	#endif
 
 	#if defined(use_edl)
-		// We decided to use same depth value for all point shape.
 		// Note: potree library use different depth value for Paraboloid shape namely log2(linearDepth).
 		outputColor.a = vLogDepth;
 	#endif

--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.frag
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.frag
@@ -23,7 +23,7 @@ in vec3 vColor;
 	in float vLinearDepth;
 #endif
 
-#if !defined(paraboloid_point_shape) && defined(use_edl)
+#if defined(use_edl)
 	in float vLogDepth;
 #endif
 
@@ -74,15 +74,12 @@ void main() {
 			outputColor.r = linearDepth;
 			outputColor.g = expDepth;
 		#endif
+	#endif
 
-		#if defined(use_edl)
-			outputColor.a = log2(linearDepth);
-		#endif
-
-	#else
-		#if defined(use_edl)
-			outputColor.a = vLogDepth;
-		#endif
+	#if defined(use_edl)
+		// We decided to use same depth value for all point shape.
+		// Note: potree library use different depth value for Paraboloid shape namely log2(linearDepth).
+		outputColor.a = vLogDepth;
 	#endif
 
 	#if defined weighted_splats

--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
@@ -76,7 +76,7 @@ out vec3 vColor;
 	out float vLinearDepth;
 #endif
 
-#if !defined(paraboloid_point_shape) && defined(use_edl)
+#if defined(use_edl)
 	out float vLogDepth;
 #endif
 
@@ -242,7 +242,7 @@ void main() {
 		vLinearDepth = gl_Position.w;
 	#endif
 
-	#if !defined(paraboloid_point_shape) && defined(use_edl)
+	#if defined(use_edl)
 		// Division by 10 is added to make depth values more "flat" so that EDL effect is visible at distance.
 		vLogDepth = log2(-mvPosition.z)/10.0;
 	#endif

--- a/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
+++ b/viewer/packages/rendering/src/glsl/pointcloud/pointcloud.vert
@@ -82,6 +82,7 @@ out vec3 vColor;
 
 #if defined(weighted_splats) || defined(paraboloid_point_shape) || defined(hq_depth_pass)
 	out float vRadius;
+	out vec3 vViewPosition;
 #endif
 
 #if defined(adaptive_point_size) || defined(color_type_lod)
@@ -228,6 +229,9 @@ vec4 getClassification() {
 
 void main() {
     vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+		#if defined paraboloid_point_shape
+			vViewPosition = mvPosition.xyz;
+		#endif
 
     vec4 classification = getClassification();
     float outColorAlpha = classification.a;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->
https://cognitedata.atlassian.net/browse/REV-881
https://cognitedata.atlassian.net/browse/REV-883

## Description :pencil:
Fixes Paraboloid shape type for point cloud rendering which was broken and when EDL is enable for paraboloid shape, the depth value is more prominent than other point shapes, so fixed the same as other point shape depth.

## How has this been tested? :mag:
In Reveal examples


## Test instructions :information_source:
1. Load [Reveal examples](https://localhost:3000/migration?project=3d-test&env=greenfield-3d&modelId=4579637123115827&revisionId=5523802070299592&edl=true&camPos=-151.0207655458611%2C77.05650411313886%2C54.59477449304217&camTarget=-151.43219465886696%2C76.9145944469877%2C54.12480300534449)
2. GUI ---> Options---> `pointShape` ----> `Paraboloid`


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
