### PR TITLE
fix: add minimum threshold to prevent getting stuck when two icons are overlapping

### DIFF
--- a/viewer/packages/360-images/src/Image360Facade.ts
+++ b/viewer/packages/360-images/src/Image360Facade.ts
@@ -129,22 +129,24 @@ export class Image360Facade<T> {
       return intersection !== null;
     }
 
-    function intersectionToCameraSpace([entity, intersectionPoint]: [Image360Entity, THREE.Vector3 | null]): [
+    function intersectionToCameraSpace([entity, _]: [Image360Entity, THREE.Vector3 | null]): [
       Image360Entity,
       THREE.Vector3
     ] {
-      return [entity, intersectionPoint!.sub(cameraPosition)];
+      const entityCameraPosition = new THREE.Vector3();
+      entityCameraPosition.setFromMatrixPosition(entity.transform).sub(cameraPosition);
+      return [entity, entityCameraPosition];
     }
 
     function isInFrontOfCamera([_, intersectionPoint]: [Image360Entity, THREE.Vector3]): boolean {
-      return intersectionPoint.dot(cameraDirection) > 0;
+      return intersectionPoint.dot(cameraDirection) > 0 && intersectionPoint.lengthSq() > 0.00001;
     }
 
     function byDistanceToCamera(
       [_0, a]: [Image360Entity, THREE.Vector3],
       [_1, b]: [Image360Entity, THREE.Vector3]
     ): number {
-      return a.length() - b.length();
+      return a.lengthSq() - b.lengthSq();
     }
 
     function selectEntity([entity, _]: [Image360Entity, THREE.Vector3]): Image360Entity {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-945

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an edge case where mutiple 360 images are in the same position which are not revisions.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

`site_id: Akterdekk` has some 360 images that overlap exactly and are not revisions of each other. Before this fix you get stuck / cannot click anything than the other icon which overlaps.