### PR TITLE
fix: remove syntax error in jsdoc

### DIFF
--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -419,10 +419,10 @@ export class Cognite3DViewer {
   /**
    * Dispose of WebGL resources. Can be used to free up memory when the viewer is no longer in use.
    * @see {@link https://threejs.org/docs/#manual/en/introduction/How-to-dispose-of-objects}
-   * ```ts
+   * ```js
    * // Viewer is no longer in use, free up memory
    * viewer.dispose();
-   * ```.
+   * ```
    */
   dispose(): void {
     if (this.isDisposed) {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes a small syntax error in `dispose` which broke some parts of the typedoc generation.