### PR TITLE
chore: disable automerging of threejs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,6 +40,14 @@
     },
     {
       "matchPackagePrefixes": [
+        "three",
+        "@types/three"
+      ],
+      "matchPaths": ["viewer/package.json", "examples/package.json"],
+      "automerge": false
+    },
+    {
+      "matchPackagePrefixes": [
         ""
       ],
       "addLabels": [


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

As of recent changes, we now automerge patch and minor versions of dependencies. This makes sure that threejs doesn't automerge as well... it sometimes brakes API even in minor versions...
