### PR TITLE
feat: get asset IDs associated with image 360 

### DIFF
--- a/viewer/packages/360-images/src/collection/DefaultImage360Collection.ts
+++ b/viewer/packages/360-images/src/collection/DefaultImage360Collection.ts
@@ -254,6 +254,18 @@ export class DefaultImage360Collection implements Image360Collection {
       });
     }
   }
+
+  getAssetIds(): Promise<IdEither[]> {
+    const fileDescriptors = this.image360Entities
+      .map(entity =>
+        entity
+          .getRevisions()
+          .map(revision => revision.getDescriptors().faceDescriptors)
+          .flat()
+      )
+      .flat();
+    return this._image360DataProvider.get360ImageAssets(fileDescriptors);
+  }
 }
 
 function matchesAssetRef(assetLink: AnnotationsCogniteAnnotationTypesImagesAssetLink, matchRef: IdEither): boolean {

--- a/viewer/packages/360-images/src/collection/Image360Collection.ts
+++ b/viewer/packages/360-images/src/collection/Image360Collection.ts
@@ -107,4 +107,9 @@ export interface Image360Collection {
    * Find 360 images associated with a asset with the given assetRef
    */
   findImageAnnotation(filter: Image360AnnotationAssetFilter): Promise<Image360AnnotationAssetQueryResult[]>;
+
+  /**
+   * Get IDs of all CDF assets associated with this 360 image collection through CDF annotations
+   */
+  getAssetIds(): Promise<IdEither[]>;
 }

--- a/viewer/packages/data-providers/src/Image360Provider.ts
+++ b/viewer/packages/data-providers/src/Image360Provider.ts
@@ -2,7 +2,12 @@
  * Copyright 2022 Cognite AS
  */
 
-import { Image360DescriptorProvider, Image360FileProvider, Image360AnnotationProvider } from './types';
+import {
+  Image360DescriptorProvider,
+  Image360FileProvider,
+  Image360AnnotationProvider,
+  Image360AssetProvider
+} from './types';
 
 export interface Image360Provider<T> extends Image360DescriptorProvider<T>, Image360DataProvider {}
-export interface Image360DataProvider extends Image360FileProvider, Image360AnnotationProvider {}
+export interface Image360DataProvider extends Image360FileProvider, Image360AnnotationProvider, Image360AssetProvider {}

--- a/viewer/packages/data-providers/src/image-360-data-providers/Cdf360ImageEventProvider.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/Cdf360ImageEventProvider.ts
@@ -356,7 +356,7 @@ export class Cdf360ImageEventProvider implements Image360Provider<Metadata> {
       return assetIds;
     });
 
-    const assetIds = (await Promise.all(assetListPromises)).flat() as IdEither[];
+    const assetIds = (await Promise.all(assetListPromises)).flat().filter(isIdEither);
 
     return assetIds;
   }
@@ -367,4 +367,8 @@ function isAssetLinkAnnotationData(
 ): annotationData is AnnotationsCogniteAnnotationTypesImagesAssetLink {
   const data = annotationData as AnnotationsCogniteAnnotationTypesImagesAssetLink;
   return data.text !== undefined && data.textRegion !== undefined && data.assetRef !== undefined;
+}
+
+function isIdEither(assetRef: { id?: number; externalId?: string }): assetRef is IdEither {
+  return assetRef.id !== undefined && assetRef.externalId !== undefined;
 }

--- a/viewer/packages/data-providers/src/image-360-data-providers/Cdf360ImageEventProvider.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/Cdf360ImageEventProvider.ts
@@ -21,11 +21,13 @@ import {
   IdEither,
   Metadata,
   CogniteInternalId,
-  AnnotationsCogniteAnnotationTypesImagesAssetLink
+  AnnotationsCogniteAnnotationTypesImagesAssetLink,
+  AnnotationData
 } from '@cognite/sdk';
 import { Historical360ImageSet, Image360EventDescriptor, Image360Face, Image360FileDescriptor } from '../types';
 import { Image360Provider } from '../Image360Provider';
 import { Log } from '@reveal/logger';
+import assert from 'assert';
 
 type Event360Metadata = Event360Filter & Event360TransformationData;
 
@@ -346,9 +348,10 @@ export class Cdf360ImageEventProvider implements Image360Provider<Metadata> {
           }
         })
         .autoPagingToArray();
-      const assetIds = annotationArray.map(
-        annotation => (annotation.data as AnnotationsCogniteAnnotationTypesImagesAssetLink).assetRef
-      );
+      const assetIds = annotationArray.map(annotation => {
+        assert(isAssetLinkAnnotationData(annotation.data), 'Received annotation that was not an assetLink');
+        return annotation.data.assetRef;
+      });
 
       return assetIds;
     });
@@ -357,4 +360,11 @@ export class Cdf360ImageEventProvider implements Image360Provider<Metadata> {
 
     return assetIds;
   }
+}
+
+function isAssetLinkAnnotationData(
+  annotationData: AnnotationData
+): annotationData is AnnotationsCogniteAnnotationTypesImagesAssetLink {
+  const data = annotationData as AnnotationsCogniteAnnotationTypesImagesAssetLink;
+  return data.text !== undefined && data.textRegion !== undefined && data.assetRef !== undefined;
 }

--- a/viewer/packages/data-providers/src/image-360-data-providers/Local360ImageProvider.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/Local360ImageProvider.ts
@@ -104,4 +104,8 @@ export class Local360ImageProvider implements Image360Provider<unknown> {
   getFilesByAssetRef(_assetId: IdEither): Promise<CogniteInternalId[]> {
     return Promise.resolve([]);
   }
+
+  get360ImageAssets(_image360FileDescriptors: Image360FileDescriptor[]): Promise<IdEither[]> {
+    return Promise.resolve([]);
+  }
 }

--- a/viewer/packages/data-providers/src/types.ts
+++ b/viewer/packages/data-providers/src/types.ts
@@ -33,6 +33,10 @@ export interface Image360FileProvider {
   ): Promise<Image360Face[]>;
 }
 
+export interface Image360AssetProvider {
+  get360ImageAssets(image360FileDescriptors: Image360FileDescriptor[]): Promise<IdEither[]>;
+}
+
 export type Historical360ImageSet = Image360EventDescriptor & {
   imageRevisions: Image360Descriptor[];
 };

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -841,6 +841,7 @@ export type Image360AnnotationIntersection = {
 // @public
 export interface Image360Collection {
     findImageAnnotation(filter: Image360AnnotationAssetFilter): Promise<Image360AnnotationAssetQueryResult[]>;
+    getAssetIds(): Promise<IdEither[]>;
     getDefaultAnnotationStyle(): Image360AnnotationAppearance;
     readonly id: string;
     readonly image360Entities: Image360[];


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Add method for getting all assets associated with a 360 image collection. Needed for the next release of Data Explorer

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

- Open image set XOM-HCU1_north_v02
- Run this function in e.g. `Image360UI`
- Observe that it has two matches

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
