### PR TITLE
fix: avoid initializing multiple annotation loads

### DIFF
--- a/viewer/packages/360-images/src/entity/Image360RevisionEntity.ts
+++ b/viewer/packages/360-images/src/entity/Image360RevisionEntity.ts
@@ -29,6 +29,7 @@ export class Image360RevisionEntity implements Image360Revision {
   private _defaultAppearance: Image360AnnotationAppearance = {};
 
   private _annotations: ImageAnnotationObject[] | undefined = undefined;
+  private _annotationsPromise: Promise<ImageAnnotationObject[]> | undefined;
   private readonly _annotationFilterer: Image360AnnotationFilter;
 
   constructor(
@@ -58,7 +59,16 @@ export class Image360RevisionEntity implements Image360Revision {
       return this._annotations;
     }
 
-    return this.loadAndSetAnnotations();
+    if (this._annotationsPromise !== undefined) {
+      return this._annotationsPromise;
+    }
+
+    this._annotationsPromise = new Promise<ImageAnnotationObject[]>(async (res, _rej) => {
+      this._annotations = await this.loadAndSetAnnotations();
+      res(this._annotations);
+    });
+
+    return this._annotationsPromise;
   }
 
   public intersectAnnotations(raycaster: THREE.Raycaster): ImageAnnotationObject | undefined {
@@ -150,7 +160,6 @@ export class Image360RevisionEntity implements Image360Revision {
       .filter(isDefined);
 
     this._image360VisualizationBox.setAnnotations(annotationObjects);
-    this._annotations = annotationObjects;
     this.propagateDefaultAppearanceToAnnotations();
 
     return annotationObjects;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Earlier, if annotations were requested (through `revision.getAnnotations()`) multiple times in a short period of time, they would execute simultaneously, creating race conditions and dangling objects. This change makes sure that the download is only started once.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
