### PR TITLE
fix: apply clipping planes on newly loaded point clouds

### DIFF
--- a/viewer/packages/pointclouds/src/PointCloudManager.ts
+++ b/viewer/packages/pointclouds/src/PointCloudManager.ts
@@ -29,6 +29,7 @@ export class PointCloudManager {
   private readonly _loadingStateHandler: PointCloudLoadingStateHandler;
   private readonly _potreeInstance: Potree;
   private readonly _pointCloudNodes: PointCloudNode[] = [];
+  private _globalClippingPlanes: THREE.Plane[] = [];
 
   private readonly _cameraSubject: Subject<THREE.PerspectiveCamera> = new Subject();
   private readonly _modelSubject: Subject<{ modelIdentifier: ModelIdentifier; operation: 'add' | 'remove' }> =
@@ -94,6 +95,7 @@ export class PointCloudManager {
   }
 
   set clippingPlanes(planes: THREE.Plane[]) {
+    this._globalClippingPlanes = planes;
     this._pointCloudNodes.forEach(node => node.octree.setGlobalClippingPlane(planes));
     this.requestRedraw();
   }
@@ -131,7 +133,10 @@ export class PointCloudManager {
     this._loadingStateHandler.onModelAdded();
 
     this._modelSubject.next({ modelIdentifier, operation: 'add' });
-    this._materialManager.initializeClippingPlanesForPointCloud(modelIdentifier.revealInternalId);
+    this._materialManager.initializeClippingPlanesForPointCloud(
+      modelIdentifier.revealInternalId,
+      this._globalClippingPlanes
+    );
 
     return pointCloudNode;
   }

--- a/viewer/packages/rendering/src/PointCloudMaterialManager.ts
+++ b/viewer/packages/rendering/src/PointCloudMaterialManager.ts
@@ -5,6 +5,7 @@
 import { PointCloudObjectIdMaps } from './pointcloud-rendering/PointCloudObjectIdMaps';
 import { PointCloudMaterial } from './pointcloud-rendering';
 import { PointCloudMaterialParameters } from './render-passes/types';
+import { Plane } from 'three';
 
 export class PointCloudMaterialManager {
   private readonly _modelsMaterialsMap: Map<symbol, PointCloudMaterial> = new Map();
@@ -38,16 +39,16 @@ export class PointCloudMaterialManager {
     return material;
   }
 
-  initializeClippingPlanesForPointCloud(modelIdentifier: symbol): void {
+  initializeClippingPlanesForPointCloud(modelIdentifier: symbol, clippingPlanes: Plane[]): void {
     const material = this.getModelMaterial(modelIdentifier);
 
     material.clipping = true;
     material.clipIntersection = false;
-    material.clippingPlanes = [];
+    material.clippingPlanes = [...clippingPlanes];
 
     material.defines = {
       ...material.defines,
-      NUM_CLIPPING_PLANES: 0,
+      NUM_CLIPPING_PLANES: clippingPlanes.length,
       UNION_CLIPPING_PLANES: 0
     };
   }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/REV-969

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Make sure global clipping planes are applied to point cloud models upon load. Before, it would be necessary to e.g. adjust the clipping planes again after load, as to make it effective on the point cloud.

CAD models don't have this issue.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Load CAD in examples: https://localhost:3000/?project=3d-test&env=greenfield-3d&modelId=8411313177673164&revisionId=3695367058006389
- Adjust Y clipping plane to cut about half the model
- Add point cloud model, model id: 5263029421485530, revision id: 7116592220967518
- Rotate around to see the newly added point cloud (it is some distance away from the CAD model)
- Observe that it is not sliced. To confirm, touch the slicer slightly, and see that half the point cloud model vanishes instantly

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
