### PR TITLE
fix(react-components): div wrapper not expanding to fit parent

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -66,7 +66,7 @@
   },
   "packageManager": "yarn@3.6.0",
   "files": [
-    "./dist/*"
+    "dist"
   ],
   "dependencies": {
     "lodash": "^4.17.21",

--- a/react-components/src/components/RevealContainer/RevealContainer.tsx
+++ b/react-components/src/components/RevealContainer/RevealContainer.tsx
@@ -26,7 +26,11 @@ export default function RevealContainer({
     return disposeViewer;
   }, []);
 
-  return <div ref={revealDomElementRef}>{mountChildren()}</div>;
+  return (
+    <div style={{ width: '100%', height: '100%' }} ref={revealDomElementRef}>
+      {mountChildren()}
+    </div>
+  );
 
   function mountChildren(): ReactElement {
     if (viewer === undefined) return <></>;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Expands the div that Reveal mounts to such that it covers 100% of its parent.
