### PR TITLE
fix: backport three due to commonjs import error

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -62,7 +62,7 @@
     "ws:lint": "cd $INIT_CWD && eslint . --ext .ts,.js --max-warnings 0 --cache"
   },
   "dependencies": {
-    "@tweenjs/tween.js": "21.0.0",
+    "@tweenjs/tween.js": "19.0.0",
     "assert": "2.0.0",
     "async-mutex": "0.4.0",
     "glslify": "7.1.1",

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -742,7 +742,7 @@ __metadata:
     "@azure/msal-browser": 2.37.1
     "@cognite/sdk": 8.2.0
     "@microsoft/api-extractor": ^7.33.6
-    "@tweenjs/tween.js": 21.0.0
+    "@tweenjs/tween.js": 19.0.0
     "@types/dat.gui": 0.7.10
     "@types/gl": ^6.0.2
     "@types/glob": 8.1.0
@@ -1951,10 +1951,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tweenjs/tween.js@npm:21.0.0":
-  version: 21.0.0
-  resolution: "@tweenjs/tween.js@npm:21.0.0"
-  checksum: 3c2498e9916a599a54d9f8e2bd2dfe0ceb249e3453d29c7b4287310f0fbe12f37d82e986263b411a672d50544dafdda7827b1707a7250023a6440351a741dddc
+"@tweenjs/tween.js@npm:19.0.0":
+  version: 19.0.0
+  resolution: "@tweenjs/tween.js@npm:19.0.0"
+  checksum: 8bb50058e6d20e74c7cd0d2d5675ce7aeb1505e4d92b667e35157b787ed885208eba3c85cae86c7dfed3016897ead2e667b251228f15130bb6fa61030a734b69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes error importing threejs.

Once these two make it in, we should be able to bump again:
https://github.com/tweenjs/tween.js/pull/661
https://github.com/tweenjs/tween.js/pull/659