### PR TITLE
fix: Missing redraw on Image Icon Visibility change

### DIFF
--- a/viewer/packages/360-images/src/collection/DefaultImage360Collection.ts
+++ b/viewer/packages/360-images/src/collection/DefaultImage360Collection.ts
@@ -150,6 +150,7 @@ export class DefaultImage360Collection implements Image360Collection {
   public setIconsVisibility(visible: boolean): void {
     this._isCollectionVisible = visible;
     this.image360Entities.forEach(entity => entity.icon.setVisible(visible));
+    this._needsRedraw = true;
   }
 
   /**


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
N/A

## Description :pencil:

When toggling image visibility there is no redraw after the fix in #3463. This adds a forced redraw after the image visibility is changed.

There may still be more issues with _needsRedraw, but most of the interactions with 360 images from the 360ImageApi manages this correctly. Will add more PRs as I find stuff :)

## How has this been tested? :mag:

N/A

## Test instructions :information_source:

Toggle a image collection visibility without any movement. Images should dissappear and reappear.


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
