### PR TITLE
fix(react-components): used named imports for lodash

### DIFF
--- a/react-components/src/components/Image360HistoricalDetails/Image360HistoricalDetails.tsx
+++ b/react-components/src/components/Image360HistoricalDetails/Image360HistoricalDetails.tsx
@@ -8,7 +8,7 @@ import { Image360HistoricalPanel } from './Panel/Image360HistoricalPanel';
 import { Image360HistoricalSummary } from './Toolbar/Image360HistoricalSummary';
 import { formatDate } from './utils/FormatDate';
 import styled from 'styled-components';
-import uniqueId from 'lodash/uniqueId';
+import { uniqueId } from 'lodash';
 
 export type Image360HistoricalDetailsProps = {
   viewer: Cognite3DViewer;

--- a/react-components/src/components/RevealToolbar/LayersButton.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton.tsx
@@ -14,7 +14,7 @@ import {
 } from '@cognite/reveal';
 import { useReveal } from '../RevealContainer/RevealContext';
 import { use3DModelName } from '../../hooks/use3DModelName';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 
 export const LayersButton = (): ReactElement => {
   const viewer = useReveal();

--- a/react-components/src/components/RevealToolbar/LayersContainer/CadModelLayersContainer.tsx
+++ b/react-components/src/components/RevealToolbar/LayersContainer/CadModelLayersContainer.tsx
@@ -7,7 +7,7 @@ import { useReveal } from '../../RevealContainer/RevealContext';
 import { type CogniteCadModel } from '@cognite/reveal';
 import { Checkbox, Flex, Menu } from '@cognite/cogs.js';
 import { StyledChipCount, StyledLabel, StyledSubMenu } from './elements';
-import uniqueId from 'lodash/uniqueId';
+import { uniqueId } from 'lodash';
 import { type Reveal3DResourcesLayersProps } from './types';
 
 export const CadModelLayersContainer = ({

--- a/react-components/src/components/RevealToolbar/LayersContainer/Image360LayersContainer.tsx
+++ b/react-components/src/components/RevealToolbar/LayersContainer/Image360LayersContainer.tsx
@@ -7,7 +7,7 @@ import { useReveal } from '../../RevealContainer/RevealContext';
 import { Checkbox, Flex, Menu } from '@cognite/cogs.js';
 import { StyledChipCount, StyledLabel, StyledSubMenu } from './elements';
 import { type Image360Collection } from '@cognite/reveal';
-import uniqueId from 'lodash/uniqueId';
+import { uniqueId } from 'lodash';
 import { type Reveal3DResourcesLayersProps } from './types';
 
 export const Image360CollectionLayerContainer = ({

--- a/react-components/src/components/RevealToolbar/LayersContainer/PointCloudLayersContainer.tsx
+++ b/react-components/src/components/RevealToolbar/LayersContainer/PointCloudLayersContainer.tsx
@@ -8,7 +8,7 @@ import { useReveal } from '../../RevealContainer/RevealContext';
 import { Checkbox, Flex, Menu } from '@cognite/cogs.js';
 import { StyledChipCount, StyledLabel, StyledSubMenu } from './elements';
 import { type CognitePointCloudModel } from '@cognite/reveal';
-import uniqueId from 'lodash/uniqueId';
+import { uniqueId } from 'lodash';
 import { type Reveal3DResourcesLayersProps } from './types';
 
 export const PointCloudLayersContainer = ({


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

FDX errors when trying to import the default export from lodash. Might be able to configure the tsconfig for FDX to make it work, but it is just easier to use named imports. 
