### PR TITLE
fix(react-components): mimic react.memo type signature with withSuppressRevealEvents HOC

### DIFF
--- a/react-components/src/higher-order-components/withSuppressRevealEvents.tsx
+++ b/react-components/src/higher-order-components/withSuppressRevealEvents.tsx
@@ -2,10 +2,16 @@
  * Copyright 2023 Cognite AS
  */
 
-import { useRef, type ComponentType, type JSX, useEffect, type ReactElement } from 'react';
+import {
+  useRef,
+  type ComponentType,
+  useEffect,
+  type ReactElement,
+  type FunctionComponent
+} from 'react';
 
-export function withSuppressRevealEvents<T extends JSX.IntrinsicAttributes>(
-  Component: ComponentType<T>
+export function withSuppressRevealEvents<T extends object>(
+  Component: FunctionComponent<T>
 ): ComponentType<T> {
   return function SuppressRevealEvents(props: T): ReactElement {
     const divRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Change type signature of withSuppressRevealEvents to allow wrapping components without intrisic attributes.