### PR TITLE
fix: block events to viewer when measurement tool is active

### DIFF
--- a/viewer/packages/tools/src/Measurement/MeasurementTool.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementTool.ts
@@ -236,7 +236,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
     if (this._measurementMode) {
       throw new Error('Measurement mode is active, call exitMeasurementMode()');
     }
-    this._viewer.on('click', this._handlePointerClick);
+    this._viewer.domElement.addEventListener('pointerdown', this._handlePointerClick, { capture: true });
     this._viewer.on('beforeSceneRendered', this._handleClippingPlanes);
     this._events.measurementStarted.fire();
     this._measurementMode = true;
@@ -251,7 +251,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
       throw new Error('Measurement mode is not active, call enterMeasurementMode()');
     }
     this.cancelActiveMeasurement();
-    this._viewer.off('click', this._handlePointerClick);
+    this._viewer.domElement.removeEventListener('pointerdown', this._handlePointerClick, { capture: true });
     this._viewer.off('beforeSceneRendered', this._handleClippingPlanes);
     this._events.measurementEnded.fire();
     this._measurementMode = false;
@@ -377,7 +377,12 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
     super.dispose();
   }
 
-  private async onPointerClick(event: { offsetX: number; offsetY: number }): Promise<void> {
+  private async onPointerClick(event: MouseEvent): Promise<void> {
+
+    if (event.target === this._viewer.canvas) {
+      event.stopPropagation();
+    }
+
     const { offsetX, offsetY } = event;
 
     const intersection = await this._viewer.getIntersectionFromPixel(offsetX, offsetY);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Measurement tool now blocks `pointerdown` events targeted at the viewer canvas to prevent click events in viewer when measuring.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
