### PR TITLE
fix: Make keyboard navigation independent of FPS

### DIFF
--- a/viewer/packages/camera-manager/app/index.ts
+++ b/viewer/packages/camera-manager/app/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2021 Cognite AS
+ * Copyright 2021-2023 Cognite AS
  */
 import * as THREE from 'three';
 import { ComboControls } from '../src/ComboControls';
@@ -61,7 +61,7 @@ function init() {
   document.body.appendChild(renderer.domElement);
 }
 
-function render(time: number) {
+function render(deltaTimeS: number) {
   currentControlsState = controls.getState();
 
   if (keyboard.isPressed('KeyC')) {
@@ -74,7 +74,7 @@ function render(time: number) {
     controls.setState(currentControlsState.position, currentControlsState.target.copy(new THREE.Vector3(3, 2, 0)));
   }
 
-  controls.update(time);
+  controls.update(deltaTimeS);
   sphere.position.copy(controls.getState().target);
   renderer.render(scene, camera);
 }

--- a/viewer/packages/camera-manager/app/index.ts
+++ b/viewer/packages/camera-manager/app/index.ts
@@ -64,13 +64,13 @@ function init() {
 function render(time: number) {
   currentControlsState = controls.getState();
 
-  if (keyboard.isPressed('c')) {
+  if (keyboard.isPressed('KeyC')) {
     controls.setState(currentControlsState.position, currentControlsState.target.add(new THREE.Vector3(-0.1, 0, 0)));
   }
-  if (keyboard.isPressed('b')) {
+  if (keyboard.isPressed('KeyB')) {
     controls.setState(currentControlsState.position, currentControlsState.target.add(new THREE.Vector3(0.1, 0, 0)));
   }
-  if (keyboard.isPressed('f')) {
+  if (keyboard.isPressed('KeyF')) {
     controls.setState(currentControlsState.position, currentControlsState.target.copy(new THREE.Vector3(3, 2, 0)));
   }
 

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -18,7 +18,7 @@ import {
   Vector2,
   Vector3
 } from 'three';
-import Keyboard, { EventCode } from './Keyboard';
+import Keyboard from './Keyboard';
 
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') !== -1;
 
@@ -653,28 +653,11 @@ export class ComboControls extends EventDispatcher {
     document.addEventListener('pointerup', onTouchEnd);
   };
 
-  private isKeyPressed(key: EventCode): boolean {
-    return this._keyboard.isPressed(key);
-  }
-
-  /**
-   * Calculates the movement direction based on keyboard input.
-   *
-   * Given two keys representing positive and negative directions (e.g., left and right, or up and down),
-   * this method returns 1 for the positive key, -1 for the negative key, or 0 if neither or both is pressed.
-   *
-   * @param positiveKey - Key representing the positive movement direction.
-   * @param negativeKey - Key representing the negative movement direction.
-   * @returns A value indicating the direction of movement: 1 (positive), -1 (negative), or 0 (none).
-   */
-  private getKeyboardMovementValue(positiveKey: EventCode, negativeKey: EventCode): number {
-    return (this.isKeyPressed(positiveKey) ? 1 : 0) - (this.isKeyPressed(negativeKey) ? 1 : 0);
-  }
-
   private handleRotation(): void {
     const azimuthAngle =
-      this._options.keyboardRotationSpeedAzimuth * this.getKeyboardMovementValue('ArrowLeft', 'ArrowRight');
-    let polarAngle = this._options.keyboardRotationSpeedPolar * this.getKeyboardMovementValue('ArrowUp', 'ArrowDown');
+      this._options.keyboardRotationSpeedAzimuth * this._keyboard.getKeyboardMovementValue('ArrowLeft', 'ArrowRight');
+    let polarAngle =
+      this._options.keyboardRotationSpeedPolar * this._keyboard.getKeyboardMovementValue('ArrowUp', 'ArrowDown');
 
     if (azimuthAngle === 0 && polarAngle === 0) {
       return;
@@ -694,7 +677,7 @@ export class ComboControls extends EventDispatcher {
 
   private handleDolly(): void {
     const speedFactor = this._keyboard.isShiftPressed() ? this._options.keyboardSpeedFactor : 1;
-    const moveDirection = this.getKeyboardMovementValue('KeyW', 'KeyS');
+    const moveDirection = this._keyboard.getKeyboardMovementValue('KeyW', 'KeyS');
     if (moveDirection === 0) {
       return;
     }
@@ -710,8 +693,8 @@ export class ComboControls extends EventDispatcher {
   }
 
   private handlePan(): void {
-    const horizontalMovement = this.getKeyboardMovementValue('KeyA', 'KeyD');
-    const verticalMovement = this.getKeyboardMovementValue('KeyE', 'KeyQ');
+    const horizontalMovement = this._keyboard.getKeyboardMovementValue('KeyA', 'KeyD');
+    const verticalMovement = this._keyboard.getKeyboardMovementValue('KeyE', 'KeyQ');
 
     if (horizontalMovement === 0 && verticalMovement === 0) {
       return;

--- a/viewer/packages/camera-manager/src/ComboControls.ts
+++ b/viewer/packages/camera-manager/src/ComboControls.ts
@@ -683,12 +683,11 @@ export class ComboControls extends EventDispatcher {
     }
 
     const booleanMoveDirection = moveDirection === 1;
-    this.dolly(
-      0,
-      0,
-      this.getDollyDeltaDistance(booleanMoveDirection, speedFactor * this._options.keyboardDollySpeed),
-      true
+    const dollyDeltaDistance = this.getDollyDeltaDistance(
+      booleanMoveDirection,
+      speedFactor * this._options.keyboardDollySpeed
     );
+    this.dolly(0, 0, dollyDeltaDistance, true);
     this._firstPersonMode = true;
   }
 

--- a/viewer/packages/camera-manager/src/Keyboard.ts
+++ b/viewer/packages/camera-manager/src/Keyboard.ts
@@ -1,30 +1,39 @@
 /*!
- * Copyright 2021 Cognite AS
+ * Copyright 2021-2023 Cognite AS
  */
 
-const keyMap: { [s: string]: string } = {
-  16: 'shift',
-  17: 'ctrl',
-  18: 'alt',
-  27: 'escape',
-  32: 'space',
-  37: 'left',
-  38: 'up',
-  39: 'right',
-  40: 'down',
-  65: 'a',
-  66: 'b',
-  67: 'c',
-  68: 'd',
-  69: 'e',
-  70: 'f',
-  81: 'q',
-  83: 's',
-  87: 'w'
-};
+// https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code
+// The following list is not complete, add more if needed on the caller side.
+const EVENT_CODES = [
+  'MetaLeft',
+  'MetaRight',
+  'ShiftLeft',
+  'ShiftRight',
+  'ControlLeft',
+  'ControlRight',
+  'AltLeft',
+  'AltRight',
+  'Escape',
+  'Space',
+  'ArrowLeft',
+  'ArrowUp',
+  'ArrowRight',
+  'ArrowDown',
+  'KeyA',
+  'KeyB',
+  'KeyC',
+  'KeyD',
+  'KeyE',
+  'KeyF',
+  'KeyQ',
+  'KeyS',
+  'KeyW'
+] as const;
+
+export type EventCode = (typeof EVENT_CODES)[number];
 
 export default class Keyboard {
-  private keys: { [s: string]: number } = {};
+  private readonly _keys = new Set<string>();
   private _disabled = false;
   private readonly _domElement: HTMLElement;
 
@@ -46,8 +55,24 @@ export default class Keyboard {
     this.addEventListeners();
   }
 
-  public isPressed(key: string): boolean {
-    return this.keys[key] >= 1;
+  public isPressed(key: EventCode): boolean {
+    return this._keys.has(key);
+  }
+
+  public isShiftPressed(): boolean {
+    return this.isPressed('ShiftLeft') || this.isPressed('ShiftRight');
+  }
+
+  public isCtrlPressed(): boolean {
+    return this.isPressed('ControlLeft') || this.isPressed('ControlRight');
+  }
+
+  public isAltPressed(): boolean {
+    return this.isPressed('AltLeft') || this.isPressed('AltRight');
+  }
+
+  public isMetaPressed(): boolean {
+    return this.isPressed('MetaLeft') || this.isPressed('MetaRight');
   }
 
   public dispose(): void {
@@ -57,40 +82,26 @@ export default class Keyboard {
 
   private readonly addEventListeners = () => {
     this.clearPressedKeys();
-
-    this._domElement.addEventListener('keydown', this.onKeydown);
-    this._domElement.addEventListener('keyup', this.onKeyup);
+    this._domElement.addEventListener('keydown', this.onKeyDown);
+    this._domElement.addEventListener('keyup', this.onKeyUp);
     this._domElement.addEventListener('blur', this.clearPressedKeys);
   };
 
   private readonly removeEventListeners = () => {
-    this._domElement.removeEventListener('keydown', this.onKeydown);
-    this._domElement.removeEventListener('keyup', this.onKeyup);
+    this._domElement.removeEventListener('keydown', this.onKeyDown);
+    this._domElement.removeEventListener('keyup', this.onKeyUp);
     this._domElement.removeEventListener('blur', this.clearPressedKeys);
   };
 
-  private readonly onKeydown = (event: KeyboardEvent) => {
-    if (event.metaKey || event.altKey || event.ctrlKey) {
-      return;
-    }
-
-    if (event.keyCode in keyMap) {
-      if (this.keys[keyMap[event.keyCode]] === 0) {
-        this.keys[keyMap[event.keyCode]] = 2;
-      }
-      event.preventDefault();
-    }
+  private readonly onKeyDown = (event: KeyboardEvent) => {
+    this._keys.add(event.code);
   };
 
-  private readonly onKeyup = (event: KeyboardEvent) => {
-    if (event.keyCode in keyMap) {
-      this.keys[keyMap[event.keyCode]] = 0;
-    }
+  private readonly onKeyUp = (event: KeyboardEvent) => {
+    this._keys.delete(event.code);
   };
 
   private readonly clearPressedKeys = () => {
-    Object.keys(keyMap).forEach((key: string) => {
-      this.keys[keyMap[key]] = 0;
-    });
+    this._keys.clear();
   };
 }

--- a/viewer/packages/camera-manager/src/Keyboard.ts
+++ b/viewer/packages/camera-manager/src/Keyboard.ts
@@ -30,7 +30,7 @@ const EVENT_CODES = [
   'KeyW'
 ] as const;
 
-export type EventCode = (typeof EVENT_CODES)[number];
+type EventCode = (typeof EVENT_CODES)[number];
 
 export default class Keyboard {
   private readonly _keys = new Set<string>();
@@ -78,6 +78,20 @@ export default class Keyboard {
   public dispose(): void {
     this.clearPressedKeys();
     this.removeEventListeners();
+  }
+
+  /**
+   * Calculates the movement direction based on keyboard input.
+   *
+   * Given two keys representing positive and negative directions (e.g., left and right, or up and down),
+   * this method returns 1 for the positive key, -1 for the negative key, or 0 if neither or both is pressed.
+   *
+   * @param positiveKey - Key representing the positive movement direction.
+   * @param negativeKey - Key representing the negative movement direction.
+   * @returns A value indicating the direction of movement: 1 (positive), -1 (negative), or 0 (none).
+   */
+  public getKeyboardMovementValue(positiveKey: EventCode, negativeKey: EventCode): number {
+    return (this.isPressed(positiveKey) ? 1 : 0) - (this.isPressed(negativeKey) ? 1 : 0);
   }
 
   private readonly addEventListeners = () => {


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
No JIRA ticket. This PR build upon #3620, and that PR should be reviewed and merged first.

## Description :pencil:
Previously the keyboard panning, rotation, and dolly calculation were not dependent on the frame rate. That meant that on my MacBook Pro with a 120Hz screen, all the interactions were way too quick — just about 4 as quick as intended I believe after reading the code.

I have made the aforementioned function dependent on the frame rate so that we get the intended navigation speed regardless of the frame rate. This PR also fixes a bug I noticed when using large 3D models. Before, the navigation speed would be much slower than expected when you were in a dense place in the 3D model. That was before Reveal was not able to render the models there with full FPS.

The previous keyboard navigation speed:
TODO: Upload screen recording.

The current navigation speed:
TODO: Upload screen recording.

## How has this been tested? :mag:

I've used the example viewer and tested panning with WASDQE and rotation with the arrows. Now the navigation is much slower (approximately 4x slower), and the panning and rotation speed is the same regardless of the FPS.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
