### PR TITLE
fix: node appearance provider still issuing events after cad node disposal

### DIFF
--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
@@ -233,7 +233,7 @@ function createDetermineSectorsInput([settings, _, camera, clipping, models]: [
   ClippingInput,
   CadNode[]
 ]): DetermineSectorsPayload {
-  const prioritizedAreas = models.flatMap(model => model.prioritizedAreas);
+  const prioritizedAreas = models.filter(model => !model.isDisposed).flatMap(model => model.prioritizedAreas);
   return {
     ...camera,
     ...settings,

--- a/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.ts
@@ -62,7 +62,7 @@ export class SectorLoader {
     }
 
     const cadModels = input.models;
-    const visibleCadModels = cadModels.filter(x => x.visible);
+    const visibleCadModels = cadModels.filter(x => x.visible && !x.isDisposed);
 
     const sectorCullerInput: DetermineSectorsInput = {
       ...input,

--- a/viewer/packages/cad-model/src/wrappers/CadNode.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadNode.ts
@@ -37,6 +37,8 @@ export class CadNode extends Object3D {
   private readonly _batchedGeometryMeshGroup: Group;
   private readonly _styledTreeIndexSets: StyledTreeIndexSets;
 
+  private _isDisposed: boolean = false;
+
   private _needsRedraw: boolean = false;
 
   public readonly treeIndexToSectorsMap = new TreeIndexToSectorsMap();
@@ -153,6 +155,10 @@ export class CadNode extends Object3D {
     return this._materialManager.getRenderMode();
   }
 
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
   public loadSector(sector: WantedSector, abortSignal?: AbortSignal): Promise<ConsumedSector> {
     return this._sectorRepository.loadSector(sector, abortSignal);
   }
@@ -203,6 +209,7 @@ export class CadNode extends Object3D {
   }
 
   public dispose(): void {
+    this.nodeAppearanceProvider.dispose();
     this.nodeAppearanceProvider.off('changed', this._setModelRenderLayers);
     this._sectorRepository.clearCache();
     this._materialManager.removeModelMaterials(this._cadModelMetadata.modelIdentifier);
@@ -210,6 +217,7 @@ export class CadNode extends Object3D {
     this._rootSector?.dereferenceAllNodes();
     this._rootSector?.clear();
     this.clear();
+    this._isDisposed = true;
 
     delete this._geometryBatchingManager;
     // @ts-ignore

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
@@ -156,6 +156,13 @@ export class NodeAppearanceProvider {
     return this._styledCollections.some(x => x.nodeCollection.isLoading);
   }
 
+  dispose(): void {
+    this.scheduleNotifyChanged.cancel();
+    this._events.changed.unsubscribeAll();
+    this._events.loadingStateChanged.unsubscribeAll();
+    this._events.prioritizedAreasChanged.unsubscribeAll();
+  }
+
   private notifyChanged() {
     this._cachedPrioritizedAreas = undefined;
     this._events.changed.fire();

--- a/viewer/packages/cad-styling/visual-tests/Highlighted.VisualTest.ts
+++ b/viewer/packages/cad-styling/visual-tests/Highlighted.VisualTest.ts
@@ -22,7 +22,7 @@ export default class HighlightedVisualTest extends StreamingVisualTestFixture {
       .getModelNodeAppearanceProvider(modelIdentifier)
       .assignStyledNodeCollection(nodes, DefaultNodeAppearance.Highlighted);
 
-    // Styles are not applied immidiatly, so wait a little for styling to take effect
+    // Styles are not applied immediately, so wait a little for styling to take effect
     await new Promise(resolve => setTimeout(resolve, 100));
 
     model.geometryNode.position.set(25, 0, -15);

--- a/viewer/packages/rendering/src/CadMaterialManager.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.ts
@@ -267,6 +267,7 @@ export class CadMaterialManager {
     for (const [_, wrapper] of this.materialsMap) {
       wrapper.nodeAppearanceTextureBuilder.dispose();
       wrapper.nodeTransformTextureBuilder.dispose();
+      wrapper.nodeAppearanceProvider.dispose();
     }
   }
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->


## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

If you add / remove a styled node collection and immidiatly remove the model, reveal will throw an error. Maintain is experiencing this issue and has been pushing to get it resolved.

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

Assign a styled node collection and remove the model. Before this fix, this would error.

I am not able to create a unit test for this, as the event is debounced such that there is no place for me to catch the error.

- [ ] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
