### PR TITLE
feat: overwrite nodes/treeIndices if styling is equal

### DIFF
--- a/react-components/stories/HighlightNode.stories.tsx
+++ b/react-components/stories/HighlightNode.stories.tsx
@@ -70,11 +70,13 @@ const StoryContent = ({ resources }: { resources: AddResourceOptions[] }): React
 
     setStylingGroups([
       {
-        fdmAssetExternalIds: [{ externalId: nodeData.fdmNode.externalId, space: 'pdms-mapping' }],
+        fdmAssetExternalIds: [
+          { externalId: nodeData.fdmNode.externalId, space: nodeData.fdmNode.space }
+        ],
         style: { cad: DefaultNodeAppearance.Highlighted }
       }
     ]);
-    void cameraNavigation.fitCameraToInstance(nodeData.fdmNode.externalId, 'pdms-mapping');
+    void cameraNavigation.fitCameraToInstance(nodeData.fdmNode.externalId, nodeData.fdmNode.space);
   }, [nodeData?.fdmNode]);
 
   return (


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Style cache optimization when styles are equal but tree indices / node ids differ. When this happens we can simply overwrite the node collection instead of reapplying the style.