### PR TITLE
fix(react-components): useModelName hook cache

### DIFF
--- a/react-components/src/components/RevealToolbar/LayersButton.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton.tsx
@@ -61,7 +61,7 @@ export const LayersButton = (): ReactElement => {
         setPointCloudModelIds(pointCloudIds);
       }
     }
-  }, [viewer.models, cadModelIds, pointCloudModelIds]);
+  }, [viewer.models]);
 
   const updated3DResourcesLayerData: Reveal3DResourcesLayerStates = useMemo(() => {
     if (cadModelName.data === null && pointCloudModelName.data === null) {

--- a/react-components/src/hooks/use3DModelName.tsx
+++ b/react-components/src/hooks/use3DModelName.tsx
@@ -28,7 +28,9 @@ export const use3DModelName = (ids: number[]): UseQueryResult<string[] | undefin
     return modelResolvedNames;
   };
 
-  const queryResult = useQuery<string[] | undefined>(['cdf', '3d', 'model', ids], queryFunction);
+  const queryResult = useQuery<string[] | undefined>(['cdf', '3d', 'model', ids], queryFunction, {
+    staleTime: Infinity
+  });
 
   return queryResult;
 };


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:

`use3DModelName` hook was triggering API was not caching the result of the query and even though query key remain same. This was a result of `staleTime` was set to default `0` causing it not to cache the result. This PR fixes the issue

## How has this been tested? :mag:

In storybook

## Test instructions :information_source:

- `cd react-components && yarn && yarn build && yarn storybook`
- After the models are loaded, in `Network Tab` check for any API result calls when click on the `Reveal viewer`

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
