### PR TITLE
fix(react-components): translation config updated to enable FDX to append translation from react-component

### DIFF
--- a/react-components/src/common/i18n/index.tsx
+++ b/react-components/src/common/i18n/index.tsx
@@ -12,4 +12,4 @@ export const translations = {
 export type TranslationKeys = keyof typeof en;
 
 export const useTranslation = (): ReturnType<typeof useTypedTranslation<TranslationKeys>> =>
-  useTypedTranslation<TranslationKeys>();
+  useTypedTranslation<TranslationKeys>('reveal-react-components');

--- a/react-components/src/components/RevealToolbar/RevealToolbar.tsx
+++ b/react-components/src/components/RevealToolbar/RevealToolbar.tsx
@@ -59,7 +59,7 @@ const RevealToolbarContainer = (
     props = { ...props, ...defaultStyle };
   }
   return (
-    <I18nWrapper translations={translations} defaultNamespace="reveal-react-components">
+    <I18nWrapper translations={translations} addNamespace="reveal-react-components">
       <ToolBar {...props}>{props.toolBarContent ?? <DefaultContentWrapper {...props} />}</ToolBar>
     </I18nWrapper>
   );


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:

`I18nWrapper` translation gets override by `defaultNamespace` property from `reveal-react-components` in `FDX`, to overcome this issue `addNamespace` property should be used to append `reveal-react-components` translation into `FDX`

## How has this been tested? :mag:

In `FDX` and storybook

## Test instructions :information_source:

- `cd react-components && yarn && yarn build`
- `yalc` link `reveal-react-components` to `fusion` and run `flexible-data-explorer`


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
