### PR TITLE
feat: allow vieweranchor to have stickiness

### DIFF
--- a/react-components/src/components/ViewerAnchor/ViewerAnchor.tsx
+++ b/react-components/src/components/ViewerAnchor/ViewerAnchor.tsx
@@ -91,7 +91,7 @@ function computeCssOffsetWithStickiness(
   [domWidth, domHeight]: [number, number],
   sticky?: boolean,
   stickyMargin?: number
-) {
+): string {
   if (sticky !== true) {
     return `translateX(${unboundedPosition.x}px) translateY(${unboundedPosition.y}px)`;
   }

--- a/react-components/src/components/ViewerAnchor/ViewerAnchor.tsx
+++ b/react-components/src/components/ViewerAnchor/ViewerAnchor.tsx
@@ -14,10 +14,17 @@ export type ViewerAnchorElementMapping = {
 
 export type ViewerAnchorProps = {
   position: Vector3;
+  sticky?: boolean;
+  stickyMargin?: number;
   children: ReactElement;
 };
 
-export const ViewerAnchor = ({ position, children }: ViewerAnchorProps): ReactElement => {
+export const ViewerAnchor = ({
+  position,
+  children,
+  sticky,
+  stickyMargin
+}: ViewerAnchorProps): ReactElement => {
   const viewer = useReveal();
   const [divTranslation, setDivTranslation] = useState(new Vector2());
   const [visible, setVisible] = useState(false);
@@ -52,6 +59,17 @@ export const ViewerAnchor = ({ position, children }: ViewerAnchorProps): ReactEl
 
   const htmlRef = useRef<HTMLDivElement>(null);
 
+  const domDimensions = [viewer.domElement.clientWidth, viewer.domElement.clientHeight] as [
+    number,
+    number
+  ];
+  const cssTranslation = computeCssOffsetWithStickiness(
+    divTranslation,
+    domDimensions,
+    sticky,
+    stickyMargin
+  );
+
   return visible ? (
     <div
       ref={htmlRef}
@@ -59,7 +77,7 @@ export const ViewerAnchor = ({ position, children }: ViewerAnchorProps): ReactEl
         position: 'absolute',
         left: '0px',
         top: '0px',
-        transform: `translateX(${divTranslation.x}px) translateY(${divTranslation.y}px)`
+        transform: cssTranslation
       }}>
       {children}
     </div>
@@ -67,3 +85,25 @@ export const ViewerAnchor = ({ position, children }: ViewerAnchorProps): ReactEl
     <></>
   );
 };
+
+function computeCssOffsetWithStickiness(
+  unboundedPosition: Vector2,
+  [domWidth, domHeight]: [number, number],
+  sticky?: boolean,
+  stickyMargin?: number
+) {
+  if (sticky !== true) {
+    return `translateX(${unboundedPosition.x}px) translateY(${unboundedPosition.y}px)`;
+  }
+
+  const margin = stickyMargin ?? 0;
+
+  const maxXPos = `${domWidth}px - 100% - ${margin}px`;
+  const maxYPos = `${domHeight}px - 100% - ${margin}px`;
+
+  const minXPos = `${margin}px`;
+  const minYPos = `${margin}px`;
+
+  return `translateX(max(${minXPos}, min(${maxXPos}, ${unboundedPosition.x}px)))
+translateY(max(${minYPos}, min(${maxYPos}, ${unboundedPosition.y}px)))`;
+}

--- a/react-components/stories/ViewerAnchor.stories.tsx
+++ b/react-components/stories/ViewerAnchor.stories.tsx
@@ -60,7 +60,7 @@ export const Main: Story = {
             </SuppressedDiv>
           </div>
         </ViewerAnchor>
-        <ViewerAnchor position={position2}>
+        <ViewerAnchor position={position2} sticky stickyMargin={20}>
           <p
             style={{
               backgroundColor: 'red',


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/UX-1376

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Add stickiness-property to viewer-anchor, to allow for it to clamp to the edge of the viewer instead of flying away.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Using the `ViewerAnchor` story.

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

Use the `ViewerAnchor` story.


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
