### PR TITLE
feat: include node cache in keep-alive context

### DIFF
--- a/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
+++ b/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
@@ -101,7 +101,8 @@ export function NodeCacheProvider({ children }: { children?: ReactNode }): React
   const revealKeepAliveData = useRevealKeepAlive();
 
   const fdmCache = useMemo(() => {
-    const cache = revealKeepAliveData?.fdmNodeCache.current ?? new FdmNodeCache(cdfClient, fdmClient);
+    const cache =
+      revealKeepAliveData?.fdmNodeCache.current ?? new FdmNodeCache(cdfClient, fdmClient);
     if (revealKeepAliveData !== undefined) {
       revealKeepAliveData.fdmNodeCache.current = cache;
     }

--- a/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
+++ b/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
@@ -103,11 +103,14 @@ export function NodeCacheProvider({ children }: { children?: ReactNode }): React
   const fdmCache = useMemo(() => {
     const cache =
       revealKeepAliveData?.fdmNodeCache.current ?? new FdmNodeCache(cdfClient, fdmClient);
-    if (revealKeepAliveData !== undefined) {
+
+    const isInRevealKeepAliveContext = revealKeepAliveData !== undefined;
+    if (isInRevealKeepAliveContext) {
       revealKeepAliveData.fdmNodeCache.current = cache;
     }
+
     return cache;
-  }, []);
+  }, [cdfClient, fdmClient]);
 
   return (
     <FdmNodeCacheContext.Provider value={{ cache: fdmCache }}>

--- a/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
+++ b/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
@@ -13,6 +13,7 @@ import { type DmsUniqueIdentifier } from '../../utilities/FdmSDK';
 import { type TypedReveal3DModel } from '../Reveal3DResources/types';
 import { type ThreeDModelMappings } from '../../hooks/types';
 import { DEFAULT_QUERY_STALE_TIME } from '../../utilities/constants';
+import { useRevealKeepAlive } from '../RevealKeepAlive/RevealKeepAliveContext';
 
 export type FdmNodeCacheContent = {
   cache: FdmNodeCache;
@@ -97,8 +98,15 @@ export const useFdmAssetMappings = (
 export function NodeCacheProvider({ children }: { children?: ReactNode }): ReactElement {
   const fdmClient = useFdmSdk();
   const cdfClient = useSDK();
+  const revealKeepAliveData = useRevealKeepAlive();
 
-  const fdmCache = useMemo(() => new FdmNodeCache(cdfClient, fdmClient), []);
+  const fdmCache = useMemo(() => {
+    const cache = revealKeepAliveData?.fdmNodeCache.current ?? new FdmNodeCache(cdfClient, fdmClient);
+    if (revealKeepAliveData !== undefined) {
+      revealKeepAliveData.fdmNodeCache.current = cache;
+    }
+    return cache;
+  }, []);
 
   return (
     <FdmNodeCacheContext.Provider value={{ cache: fdmCache }}>

--- a/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
+++ b/react-components/src/components/NodeCacheProvider/NodeCacheProvider.tsx
@@ -104,8 +104,8 @@ export function NodeCacheProvider({ children }: { children?: ReactNode }): React
     const cache =
       revealKeepAliveData?.fdmNodeCache.current ?? new FdmNodeCache(cdfClient, fdmClient);
 
-    const isInRevealKeepAliveContext = revealKeepAliveData !== undefined;
-    if (isInRevealKeepAliveContext) {
+    const isRevealKeepAliveContextProvided = revealKeepAliveData !== undefined;
+    if (isRevealKeepAliveContextProvided) {
       revealKeepAliveData.fdmNodeCache.current = cache;
     }
 

--- a/react-components/src/components/RevealKeepAlive/RevealKeepAlive.tsx
+++ b/react-components/src/components/RevealKeepAlive/RevealKeepAlive.tsx
@@ -5,7 +5,7 @@
 import { type Cognite3DViewer } from '@cognite/reveal';
 import { type ReactNode, type ReactElement, useRef, useEffect } from 'react';
 import { RevealKeepAliveContext } from './RevealKeepAliveContext';
-import { FdmNodeCache } from '../NodeCacheProvider/FdmNodeCache';
+import { type FdmNodeCache } from '../NodeCacheProvider/FdmNodeCache';
 
 export function RevealKeepAlive({ children }: { children?: ReactNode }): ReactElement {
   const viewerRef = useRef<Cognite3DViewer>();
@@ -19,7 +19,8 @@ export function RevealKeepAlive({ children }: { children?: ReactNode }): ReactEl
     };
   }, []);
   return (
-    <RevealKeepAliveContext.Provider value={{ viewerRef, isRevealContainerMountedRef, fdmNodeCache }}>
+    <RevealKeepAliveContext.Provider
+      value={{ viewerRef, isRevealContainerMountedRef, fdmNodeCache }}>
       {children}
     </RevealKeepAliveContext.Provider>
   );

--- a/react-components/src/components/RevealKeepAlive/RevealKeepAlive.tsx
+++ b/react-components/src/components/RevealKeepAlive/RevealKeepAlive.tsx
@@ -5,10 +5,13 @@
 import { type Cognite3DViewer } from '@cognite/reveal';
 import { type ReactNode, type ReactElement, useRef, useEffect } from 'react';
 import { RevealKeepAliveContext } from './RevealKeepAliveContext';
+import { FdmNodeCache } from '../NodeCacheProvider/FdmNodeCache';
 
 export function RevealKeepAlive({ children }: { children?: ReactNode }): ReactElement {
   const viewerRef = useRef<Cognite3DViewer>();
   const isRevealContainerMountedRef = useRef<boolean>(false);
+  const fdmNodeCache = useRef<FdmNodeCache>();
+
   useEffect(() => {
     return () => {
       viewerRef.current?.dispose();
@@ -16,7 +19,7 @@ export function RevealKeepAlive({ children }: { children?: ReactNode }): ReactEl
     };
   }, []);
   return (
-    <RevealKeepAliveContext.Provider value={{ viewerRef, isRevealContainerMountedRef }}>
+    <RevealKeepAliveContext.Provider value={{ viewerRef, isRevealContainerMountedRef, fdmNodeCache }}>
       {children}
     </RevealKeepAliveContext.Provider>
   );

--- a/react-components/src/components/RevealKeepAlive/RevealKeepAliveContext.ts
+++ b/react-components/src/components/RevealKeepAlive/RevealKeepAliveContext.ts
@@ -3,10 +3,12 @@
  */
 import { type Cognite3DViewer } from '@cognite/reveal';
 import { type MutableRefObject, createContext, useContext } from 'react';
+import { FdmNodeCache } from '../NodeCacheProvider/FdmNodeCache';
 
 export type RevealKeepAliveData = {
   viewerRef: MutableRefObject<Cognite3DViewer | undefined>;
   isRevealContainerMountedRef: MutableRefObject<boolean>;
+  fdmNodeCache: MutableRefObject<FdmNodeCache | undefined>;
 };
 
 export const RevealKeepAliveContext = createContext<RevealKeepAliveData | undefined>(undefined);

--- a/react-components/src/components/RevealKeepAlive/RevealKeepAliveContext.ts
+++ b/react-components/src/components/RevealKeepAlive/RevealKeepAliveContext.ts
@@ -3,7 +3,7 @@
  */
 import { type Cognite3DViewer } from '@cognite/reveal';
 import { type MutableRefObject, createContext, useContext } from 'react';
-import { FdmNodeCache } from '../NodeCacheProvider/FdmNodeCache';
+import { type FdmNodeCache } from '../NodeCacheProvider/FdmNodeCache';
 
 export type RevealKeepAliveData = {
   viewerRef: MutableRefObject<Cognite3DViewer | undefined>;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/UX-1456

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Make sure the `FdmNodeCache` is kept alive in the `RevealKeepAlive` context, alongside the Reveal viewer itself. This makes clicks responsive across the session, and it does not need to load the model asset mappings multiple times.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

With FDX

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Build branch and connect to FDX through e.g. `yalc`
- Start FDX
- Open 3D view of model with mapped nodes
- Keep the network tab open as you click on different mapped nodes
- Notice that the first click on a node spawns multiple requests, subsequent ones spawn none (except for the `graphql` query from the node preview card).
- Navigate away from the 3D view, e.g. by clicking `Open` on the preview card for a node
- Then navigate back again, e.g. by clicking the 3D-view icon in the top right
- Click some mapped nodes once again
- The clicks do not spawn new requests, as they would without this change

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
