### PR TITLE
bug: Update Moving Resolution Factor behavior

### DIFF
--- a/viewer/packages/rendering/src/ResizeHandler.ts
+++ b/viewer/packages/rendering/src/ResizeHandler.ts
@@ -36,10 +36,8 @@ export class ResizeHandler {
     this._cameraManager = cameraManager;
 
     this._onCameraChangeCallback = () => {
-      this._currentResolutionThreshold = Math.min(
-        this._movingResolutionFactor * getPhysicalSize(renderer),
-        this._movingResolutionFactor * this._stoppedCameraResolutionThreshold
-      );
+      this._currentResolutionThreshold =
+        this._movingResolutionFactor * Math.min(getPhysicalSize(renderer), this._stoppedCameraResolutionThreshold);
       this._shouldResize = true;
     };
     this._onCameraStopCallback = () => {

--- a/viewer/packages/rendering/src/ResizeHandler.ts
+++ b/viewer/packages/rendering/src/ResizeHandler.ts
@@ -38,7 +38,7 @@ export class ResizeHandler {
     this._onCameraChangeCallback = () => {
       this._currentResolutionThreshold = Math.min(
         this._movingResolutionFactor * getPhysicalSize(renderer),
-        this._stoppedCameraResolutionThreshold
+        this._movingResolutionFactor * this._stoppedCameraResolutionThreshold
       );
       this._shouldResize = true;
     };


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:

Now takes the max resolution into account.
The MCRF would often use the max resolution when it was running on a large screen. This adjusts it to use the min of: the percentage of the max resolution and the percentage of the current estimated resolution.

## How has this been tested? :mag:

Tested in client. No integration tests or unit tests.

## Test instructions :information_source:

Previous behavior:
Set the renderResolutionThreshold to a relatively low number (For instance 1360 * 720). And try to use moving camera resolution factor. On a low res screen it will work, but on a high res screen the resolution will not change.

New behavior: 
If the resolution is lower than the max, we use half that. If the current resolution is higher than max, we adjust the therenderResolutionThreshold isntead.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [x] I have asked peers to test this feature.
