### PR TITLE
fix(react-components): Point cloud layer visibility issue

### DIFF
--- a/react-components/src/components/PointCloudContainer/PointCloudContainer.tsx
+++ b/react-components/src/components/PointCloudContainer/PointCloudContainer.tsx
@@ -137,6 +137,10 @@ export function PointCloudContainer({
 }
 
 function applyStyling(model: CognitePointCloudModel, styling: PointCloudModelStyling): void {
+  const currentStyling = model.getDefaultPointCloudAppearance();
+  if (currentStyling.visible === false) {
+    return;
+  }
   if (styling.defaultStyle !== undefined) {
     model.setDefaultPointCloudAppearance(styling.defaultStyle);
   }

--- a/react-components/stories/Reveal3DResources.stories.tsx
+++ b/react-components/stories/Reveal3DResources.stories.tsx
@@ -2,10 +2,12 @@
  * Copyright 2023 Cognite AS
  */
 import type { Meta, StoryObj } from '@storybook/react';
-import { Reveal3DResources, RevealContainer } from '../src';
+import { Reveal3DResources, RevealContainer, RevealToolbar } from '../src';
 import { Color, Matrix4 } from 'three';
 import { createSdkByUrlToken } from './utilities/createSdkByUrlToken';
 import { RevealResourcesFitCameraOnLoad } from './utilities/with3dResoursesFitCameraOnLoad';
+import { DefaultPointCloudAppearance } from '@cognite/reveal';
+import styled from 'styled-components';
 
 const meta = {
   title: 'Example/Reveal3DResources',
@@ -17,6 +19,18 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const sdk = createSdkByUrlToken();
+
+const StyledRevealToolBar = styled(RevealToolbar)`
+  position: absolute;
+  left: 20px;
+  top: 80px;
+`;
+
+export const defaultResourceStyling = {
+  pointcloud: {
+    default: DefaultPointCloudAppearance
+  }
+} as const;
 
 export const Main: Story = {
   args: {
@@ -53,12 +67,14 @@ export const Main: Story = {
         }}>
         <RevealResourcesFitCameraOnLoad
           resources={resources}
+          defaultResourceStyling={defaultResourceStyling}
           onResourceLoadError={(resource, error) => {
             console.log(
               `Failed to load resource ${JSON.stringify(resource)}: ${JSON.stringify(error)}`
             );
           }}
         />
+        <StyledRevealToolBar />
       </RevealContainer>
     );
   }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-2315

## Description :pencil:
When point cloud `styling` value is passed through `RevealContainer` and if the point cloud model is un-selected in the `Layer` button than when page is refreshed, the un-selected point model is visible as the styling value from the `RevealContianer` overrides the visibility applied when model is loaded.

This PR fixes the problem.

## How has this been tested? :mag:

In Storybook and FDX through yalc

## Test instructions :information_source:

- `cd react-components && yarn && yarn build && yarn storybook`
- Select `Reveal3DResources` example
- Open the canvas of the story in a new window
- Change the 3D resources data by unselecting point-cloud model in `Layer Button` and confirm that the state changes in Url
- Can copy the Url and load it in new tab.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
