### PR TITLE
fix(react-components): "mapped"-styling not always set on right model

### DIFF
--- a/react-components/src/hooks/useCalculateModelsStyling.tsx
+++ b/react-components/src/hooks/useCalculateModelsStyling.tsx
@@ -18,7 +18,6 @@ import { useMemo } from 'react';
 import {
   type NodeId,
   type FdmEdgeWithNode,
-  type ModelRevisionKey,
   type AssetId,
   type ModelRevisionAssetNodesResult
 } from '../components/NodeCacheProvider/types';

--- a/react-components/src/hooks/useCalculateModelsStyling.tsx
+++ b/react-components/src/hooks/useCalculateModelsStyling.tsx
@@ -243,19 +243,15 @@ function useJoinStylingGroups(
 }
 
 function groupStyleGroupByModel(styleGroup: ModelStyleGroup[]): ModelStyleGroup[] {
-  const auxillaryMap = new Map<ModelRevisionKey, ModelStyleGroup>();
-
-  styleGroup.forEach(({ model, styleGroup }) => {
-    const key = `${model.modelId}/${model.revisionId}` as const;
-    const storedGroup = auxillaryMap.get(key);
-    if (storedGroup !== undefined) {
-      storedGroup.styleGroup.push(...styleGroup);
+  return styleGroup.reduce((accumulatedGroups, currentGroup) => {
+    const existingGroupWithModel = accumulatedGroups.find(group => group.model === currentGroup.model);
+    if (existingGroupWithModel !== undefined) {
+      existingGroupWithModel.styleGroup.push(...currentGroup.styleGroup);
     } else {
-      auxillaryMap.set(key, { model, styleGroup });
+      accumulatedGroups.push({ ...currentGroup });
     }
-  });
-
-  return [...auxillaryMap.values()];
+    return accumulatedGroups;
+  }, [] as ModelStyleGroup[]);
 }
 
 function extractDefaultStyles(typedModels: CadModelOptions[]): StyledModel[] {

--- a/react-components/src/hooks/useCalculateModelsStyling.tsx
+++ b/react-components/src/hooks/useCalculateModelsStyling.tsx
@@ -242,15 +242,17 @@ function useJoinStylingGroups(
 }
 
 function groupStyleGroupByModel(styleGroup: ModelStyleGroup[]): ModelStyleGroup[] {
-  return styleGroup.reduce((accumulatedGroups, currentGroup) => {
-    const existingGroupWithModel = accumulatedGroups.find(group => group.model === currentGroup.model);
+  return styleGroup.reduce<ModelStyleGroup[]>((accumulatedGroups, currentGroup) => {
+    const existingGroupWithModel = accumulatedGroups.find(
+      (group) => group.model === currentGroup.model
+    );
     if (existingGroupWithModel !== undefined) {
       existingGroupWithModel.styleGroup.push(...currentGroup.styleGroup);
     } else {
       accumulatedGroups.push({ ...currentGroup });
     }
     return accumulatedGroups;
-  }, [] as ModelStyleGroup[]);
+  }, []);
 }
 
 function extractDefaultStyles(typedModels: CadModelOptions[]): StyledModel[] {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Sometimes, when loading the scene in FDX, the styling that indicates what 3D nodes are asset-mapped on CAD models is not applied.  The reason for this seems to be related to a peculiar behavior FDX displays when mounted in the Fusion shell. In short, model components are mounted twice.

To my understanding, as an effect of that, asset-mapped styling is applied to both models, but when grouping computed styling, we risk that the all styles that apply to both models, are grouped together and applied to only one of them. This is fixed in this PR by not simply categorizing on grounds of a "modelId/revisionId" key, but using strict equality checks on the `AddModel` objects. 

This also ensures that different instances of the same model have their styling computed individually, as they should.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Linked into FDX locally, reloaded repeatedly to see that "mapped"-styling is applied correctly and consequently. 


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
