### PR TITLE
fix: add sparse-octree as dependency to preserve types

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "WebGL based 3D viewer for CAD and point clouds processed in Cognite Data Fusion.",
   "homepage": "https://github.com/cognitedata/reveal/tree/master/viewer",
   "repository": {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -74,7 +74,8 @@
     "path-browserify": "1.0.1",
     "random-seed": "0.3.0",
     "rxjs": "7.8.1",
-    "skmeans": "0.11.3"
+    "skmeans": "0.11.3",
+    "sparse-octree": "7.1.8"
   },
   "devDependencies": {
     "@azure/msal-browser": "2.38.2",
@@ -129,7 +130,6 @@
     "remove-files-webpack-plugin": "1.5.0",
     "resize-observer-polyfill": "1.5.1",
     "shx": "0.3.4",
-    "sparse-octree": "7.1.8",
     "stats.js": "0.17.0",
     "three": "0.155.0",
     "ts-jest": "29.1.1",


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->

![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Needs to be a normal dependency such that users get the correct types.