### PR TITLE
improvement: Add approximate bounding sphere

### DIFF
--- a/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.ts
+++ b/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.ts
@@ -3,7 +3,7 @@
  */
 import assert from 'assert';
 import minBy from 'lodash/minBy';
-import { BufferGeometry, Group, InstancedMesh, InterleavedBufferAttribute, RawShaderMaterial } from 'three';
+import { BufferGeometry, Group, InstancedMesh, InterleavedBufferAttribute, RawShaderMaterial, Sphere } from 'three';
 import { Materials, setModelRenderLayers, StyledTreeIndexSets } from '@reveal/rendering';
 import { ParsedGeometry, RevealGeometryCollectionType } from '@reveal/sector-parser';
 import {

--- a/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.ts
+++ b/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.ts
@@ -323,7 +323,7 @@ export class MultiBufferBatchingManager implements DrawCallBatchingManager {
     const instancedMesh = new InstancedMesh(instanceBufferGeometry, material, 0);
     instancedMesh.visible = false;
     instancedMesh.frustumCulled = false;
-    instancedMesh.boundingSphere = new Sphere(); // Creates a dummy bounding sphere to avoid a calculated sphere on first render. The THREEjs calculated sphere is never updated after the first calculate, so the calculated sphere is misleading after we add data to the batch)
+    instancedMesh.boundingSphere = new Sphere(); // Unused, to avoid a calculated sphere on first render
 
     instancedMesh.onBeforeRender = (_0, _1, camera: THREE.Camera) => {
       (material.uniforms.inverseModelMatrix?.value as THREE.Matrix4)?.copy(instancedMesh.matrixWorld).invert();

--- a/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.ts
+++ b/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.ts
@@ -323,6 +323,7 @@ export class MultiBufferBatchingManager implements DrawCallBatchingManager {
     const instancedMesh = new InstancedMesh(instanceBufferGeometry, material, 0);
     instancedMesh.visible = false;
     instancedMesh.frustumCulled = false;
+    instancedMesh.boundingSphere = new Sphere(); // Creates a dummy bounding sphere to avoid a calculated sphere on first render. The THREEjs calculated sphere is never updated after the first calculate, so the calculated sphere is misleading after we add data to the batch)
 
     instancedMesh.onBeforeRender = (_0, _1, camera: THREE.Camera) => {
       (material.uniforms.inverseModelMatrix?.value as THREE.Matrix4)?.copy(instancedMesh.matrixWorld).invert();

--- a/viewer/packages/sector-loader/src/GltfSectorLoader.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorLoader.ts
@@ -35,8 +35,7 @@ export class GltfSectorLoader {
 
       const group = new AutoDisposeGroup();
 
-      // Note: This bounding box includes instanced meshes etc and may not be an accurate representation of the TriangleMesh bounding box.
-      const geometryBoundingBox = sector.metadata.geometryBoundingBox;
+      const wholeSectorBoundingBox = sector.metadata.geometryBoundingBox;
 
       const parsedSectorGeometry = await this._gltfSectorParser.parseSector(sectorByteBuffer);
 
@@ -81,7 +80,7 @@ export class GltfSectorLoader {
             });
             break;
           case RevealGeometryCollectionType.TriangleMesh:
-            this.createMesh(group, parsedGeometry.geometryBuffer, materials.triangleMesh, geometryBoundingBox);
+            this.createMesh(group, parsedGeometry.geometryBuffer, materials.triangleMesh, wholeSectorBoundingBox);
             break;
           case RevealGeometryCollectionType.TexturedTriangleMesh:
             const material = this._materialManager.addTexturedMeshMaterial(
@@ -89,7 +88,7 @@ export class GltfSectorLoader {
               sector.metadata.id,
               parsedGeometry.texture!
             );
-            this.createMesh(group, parsedGeometry.geometryBuffer, material, geometryBoundingBox);
+            this.createMesh(group, parsedGeometry.geometryBuffer, material, wholeSectorBoundingBox);
             break;
           default:
             assertNever(type);

--- a/viewer/packages/sector-loader/src/GltfSectorLoader.ts
+++ b/viewer/packages/sector-loader/src/GltfSectorLoader.ts
@@ -35,6 +35,9 @@ export class GltfSectorLoader {
 
       const group = new AutoDisposeGroup();
 
+      // Note: This bounding box includes instanced meshes etc and may not be an accurate representation of the TriangleMesh bounding box.
+      const geometryBoundingBox = sector.metadata.geometryBoundingBox;
+
       const parsedSectorGeometry = await this._gltfSectorParser.parseSector(sectorByteBuffer);
 
       const materials = this._materialManager.getModelMaterials(sector.modelIdentifier);
@@ -78,7 +81,7 @@ export class GltfSectorLoader {
             });
             break;
           case RevealGeometryCollectionType.TriangleMesh:
-            this.createMesh(group, parsedGeometry.geometryBuffer, materials.triangleMesh);
+            this.createMesh(group, parsedGeometry.geometryBuffer, materials.triangleMesh, geometryBoundingBox);
             break;
           case RevealGeometryCollectionType.TexturedTriangleMesh:
             const material = this._materialManager.addTexturedMeshMaterial(
@@ -86,7 +89,7 @@ export class GltfSectorLoader {
               sector.metadata.id,
               parsedGeometry.texture!
             );
-            this.createMesh(group, parsedGeometry.geometryBuffer, material);
+            this.createMesh(group, parsedGeometry.geometryBuffer, material, geometryBoundingBox);
             break;
           default:
             assertNever(type);
@@ -127,10 +130,18 @@ export class GltfSectorLoader {
     return treeIndexSet;
   }
 
-  private createMesh(group: AutoDisposeGroup, geometry: THREE.BufferGeometry, material: THREE.RawShaderMaterial) {
+  private createMesh(
+    group: AutoDisposeGroup,
+    geometry: THREE.BufferGeometry,
+    material: THREE.RawShaderMaterial,
+    geometryBoundingBox: THREE.Box3
+  ) {
+    // Assigns an approximate bounding-sphere to the geometry to avoid recalculating this on first render
+    geometry.boundingSphere = geometryBoundingBox.getBoundingSphere(new THREE.Sphere());
+
     const mesh = new THREE.Mesh(geometry, material);
     group.add(mesh);
-    mesh.frustumCulled = false;
+    mesh.frustumCulled = false; // Note: Frustum culling does not play well with node-transforms
 
     mesh.userData.treeIndices = this.createTreeIndexSet(geometry);
 


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->
N/A

## Description :pencil:

Avoids calculating the bounding sphere on first render for every sector

The sphere is not really used due to frustumCulled = false. But using the apporixmate _may_ be better for performance than just adding a `new Sphere()` in origio.

BUT:

* This changes the geometry property, and does not do it in the GLTF parsing. This feels a bit wrong 🤔 . 
* We could also replace boundingBox, but its not used anywhere. 

## How has this been tested? :mag:

Tested by observing the absense of computeBoundingSphere in the profiler. No visual changes observed. Also tested with `new Sphere()` instead of the approximate sphere, with no visual changes. (Probably due to the frustum culling is disabled)

## Test instructions :information_source:

With a larger model, check the rendering pass for similar images to this in the main branch, and then test the same model with this branch and you should NOT see any computeBoundingBox in the timeline:
![image](https://github.com/cognitedata/reveal/assets/3185998/ba9b6d60-36b7-4261-a9d3-874f016382bf)


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [x] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [x] I have added TSDoc to any public facing changes.
- [x] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
