### PR TITLE
fix: Camera moving resolution from scaled output size

### DIFF
--- a/viewer/packages/rendering/src/ResizeHandler.ts
+++ b/viewer/packages/rendering/src/ResizeHandler.ts
@@ -26,6 +26,7 @@ export class ResizeHandler {
   private readonly _resizeObserver: ResizeObserver | undefined;
 
   private _shouldResize: boolean = false;
+  private _cameraMoving: boolean = false;
 
   constructor(renderer: WebGLRenderer, cameraManager: CameraManager, resizeOptions?: ResizeHandlerOptions) {
     this._stoppedCameraResolutionThreshold =
@@ -36,14 +37,11 @@ export class ResizeHandler {
     this._cameraManager = cameraManager;
 
     this._onCameraChangeCallback = () => {
-      this._currentResolutionThreshold = Math.min(
-        this._movingResolutionFactor * getPhysicalSize(renderer),
-        this._stoppedCameraResolutionThreshold
-      );
+      this._cameraMoving = true;
       this._shouldResize = true;
     };
     this._onCameraStopCallback = () => {
-      this._currentResolutionThreshold = this._stoppedCameraResolutionThreshold;
+      this._cameraMoving = false;
       this._shouldResize = true;
     };
 
@@ -126,8 +124,9 @@ export class ResizeHandler {
 
     const [virtualWidth, virtualHeight] = getVirtualDomElementWidthAndHeight(canvas);
 
-    const newVirtualWidth = Math.round(virtualWidth * downScale);
-    const newVirtualHeight = Math.round(virtualHeight * downScale);
+    const movingFactor = this._cameraMoving ? this._movingResolutionFactor : 1;
+    const newVirtualWidth = Math.round(virtualWidth * downScale * movingFactor);
+    const newVirtualHeight = Math.round(virtualHeight * downScale * movingFactor);
     const newAspectRatio = newVirtualWidth / newVirtualHeight;
 
     if (camera.aspect !== newAspectRatio) {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
This is a fix for how the current scaling factor works whilst the camera is moving. At the moment it either takes the minimum of either the capped stopped resolution, or the uncapped target resolution of the canvas multiplied by the `movingResolutionFactor`, which causes issues when the `_stoppedCameraResolutionThreshold` is a lower value (the movingResolutionFactor stops having an effect, and has a decreasing effect the closer these two values become).

This change adjusts the behaviour so that the calculated buffer size is always multiplied by the `movingResolutionFactor` when the camera is moving, which I believe is the intended behaviour and how I assumed it worked from the docs.

## How has this been tested? :mag:
I've tested this out locally by printing out the buffer sizes when the camera is moving and paused. Beforehand, the buffer size would not change when the camera was moving if the `_stoppedCameraResolutionThreshold` was set low.

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
