### PR TITLE
fix(react-components): make sure far plane encapsulates sky box

### DIFF
--- a/react-components/src/hooks/useSkyboxFromScene.tsx
+++ b/react-components/src/hooks/useSkyboxFromScene.tsx
@@ -51,7 +51,8 @@ function initializeSkybox(
   texture: THREE.Texture,
   viewer: Cognite3DViewer
 ): [THREE.Object3D, () => void] {
-  const skyboxGeometry = new THREE.SphereGeometry(1000, 20, 20);
+  const skyBoxRadius = 10;
+  const skyboxGeometry = new THREE.SphereGeometry(skyboxRadius, 20, 20);
   const skyboxMaterial = new THREE.MeshBasicMaterial({
     side: THREE.BackSide,
     map: texture
@@ -75,7 +76,9 @@ function initializeSkybox(
   ): void => {
     // Force low near-projection-plane to ensure the sphere geometry is in bounds
     (camera as any).lastNear = camera.near;
+    (camera as any).lastFar = camera.far;
     camera.near = 0.1;
+    camera.far = skyBoxRadius + 0.1;
     camera.updateProjectionMatrix();
   };
 
@@ -85,6 +88,7 @@ function initializeSkybox(
     camera: THREE.PerspectiveCamera
   ): void => {
     camera.near = (camera as any).lastNear;
+    camera.far = (camera as any).lastFar;
     camera.updateProjectionMatrix();
   };
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Ensure that the far plane in sky box rendering is guaranteed to be on the far side of the skybox, so that it doesn't clip it in the middle of the screen.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
