### PR TITLE
fix: sort styled node collections by importance

### DIFF
--- a/viewer/packages/cad-model/src/wrappers/CogniteCadModel.test.ts
+++ b/viewer/packages/cad-model/src/wrappers/CogniteCadModel.test.ts
@@ -100,9 +100,9 @@ describe(CogniteCadModel.name, () => {
 
     expect(model.styledNodeCollections).toEqual([
       { nodeCollection: collection1, importance: 0, appearance: DefaultNodeAppearance.InFront },
-      { nodeCollection: collection2, importance: 0, appearance: DefaultNodeAppearance.Hidden },
-      { nodeCollection: collection3, importance: 0, appearance: DefaultNodeAppearance.Default },
-      { nodeCollection: collection4, importance: 3, appearance: DefaultNodeAppearance.Ghosted }
+      { nodeCollection: collection3, importance: 0, appearance: DefaultNodeAppearance.Hidden },
+      { nodeCollection: collection4, importance: 0, appearance: DefaultNodeAppearance.Default },
+      { nodeCollection: collection2, importance: 3, appearance: DefaultNodeAppearance.Ghosted }
     ]);
   });
 

--- a/viewer/packages/cad-model/src/wrappers/CogniteCadModel.test.ts
+++ b/viewer/packages/cad-model/src/wrappers/CogniteCadModel.test.ts
@@ -87,6 +87,25 @@ describe(CogniteCadModel.name, () => {
     expect(model.styledNodeCollections).toBeEmpty();
   });
 
+  test('styled node collections are kept in order of importance', () => {
+    const collection1 = new TreeIndexNodeCollection();
+    const collection2 = new TreeIndexNodeCollection();
+    const collection3 = new TreeIndexNodeCollection();
+    const collection4 = new TreeIndexNodeCollection();
+
+    model.assignStyledNodeCollection(collection1, DefaultNodeAppearance.InFront, 0);
+    model.assignStyledNodeCollection(collection2, DefaultNodeAppearance.Ghosted, 3);
+    model.assignStyledNodeCollection(collection3, DefaultNodeAppearance.Hidden);
+    model.assignStyledNodeCollection(collection4, DefaultNodeAppearance.Default, 0);
+
+    expect(model.styledNodeCollections).toEqual([
+      { nodeCollection: collection1, importance: 0, appearance: DefaultNodeAppearance.InFront },
+      { nodeCollection: collection2, importance: 0, appearance: DefaultNodeAppearance.Hidden },
+      { nodeCollection: collection3, importance: 0, appearance: DefaultNodeAppearance.Default },
+      { nodeCollection: collection4, importance: 3, appearance: DefaultNodeAppearance.Ghosted }
+    ]);
+  });
+
   test('getBoundingBoxByTreeIndex() modifies out-parameter', async () => {
     const bbox = new THREE.Box3();
     const result = await model.getBoundingBoxByTreeIndex(1, bbox);

--- a/viewer/packages/cad-model/src/wrappers/CogniteCadModel.ts
+++ b/viewer/packages/cad-model/src/wrappers/CogniteCadModel.ts
@@ -85,7 +85,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
   private readonly cadModel: CadModelMetadata;
   private readonly nodesApiClient: NodesApiClient;
   private readonly nodeIdAndTreeIndexMaps: NodeIdAndTreeIndexMaps;
-  private readonly _styledNodeCollections: {
+  private _styledNodeCollections: {
     nodeCollection: NodeCollection;
     appearance: NodeAppearance;
     importance: number;
@@ -182,7 +182,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
     } else {
       this._styledNodeCollections.push({ nodeCollection: nodeCollection, appearance, importance });
     }
-    sortBy(this._styledNodeCollections, sc => sc.importance); // Using lodash sortBy as array.sort is not stable
+    this._styledNodeCollections = sortBy(this._styledNodeCollections, sc => sc.importance); // Using lodash sortBy as array.sort is not stable
     this.cadNode.nodeAppearanceProvider.assignStyledNodeCollection(nodeCollection, appearance, importance);
   }
 

--- a/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceProvider.ts
@@ -26,7 +26,7 @@ type StyledNodeCollection = {
 };
 
 export class NodeAppearanceProvider {
-  private readonly _styledCollections = new Array<StyledNodeCollection>();
+  private _styledCollections = new Array<StyledNodeCollection>();
   private _lastFiredLoadingState?: boolean;
   private _cachedPrioritizedAreas?: PrioritizedArea[] = undefined;
 
@@ -104,7 +104,7 @@ export class NodeAppearanceProvider {
     }
 
     // Sort ascending, to set the most important styles last so they override the unimportant
-    sortBy(this._styledCollections, sc => sc.importance); // Using lodash sortBy as array.sort is not stable
+    this._styledCollections = sortBy(this._styledCollections, sc => sc.importance); // Using lodash sortBy as array.sort is not stable
 
     if (appearance.prioritizedForLoadingHint) {
       this.notifyPrioritizedAreasChanged();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fix a bug where it is incorrectly assumed that `lodash.sortBy` sorts in-place. It instead creates a new array.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Add a few collections with importance 0 with the examples UI
- Add a big collection overlapping (some of) the others, but with negative importance
- It should not override the styling set by previous collections

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
