### PR TITLE
(fix): Image collection does not need number modelid

### DIFF
--- a/react-components/src/hooks/useSceneConfig.ts
+++ b/react-components/src/hooks/useSceneConfig.ts
@@ -151,19 +151,17 @@ function getSceneModels(sceneResponse: SceneResponse): CadOrPointCloudModel[] {
 
 function getImageCollections(sceneResponse: SceneResponse): Image360Collection[] {
   const imageCollections: Image360Collection[] = [];
-  if (sceneResponse.items.sceneModels.length > 0) {
+  if (sceneResponse.items.image360CollectionsEdges.length > 0) {
     const sceneModels = sceneResponse.items.image360CollectionsEdges;
     sceneModels.forEach((sceneModel) => {
       const imageCollectionProperties = extractProperties(
         sceneModel.properties
       ) as Scene360ImageCollectionsProperties;
-      if (!isNaN(Number(sceneModel.endNode.externalId))) {
-        const collection: Image360Collection = {
-          ...imageCollectionProperties
-        };
+      const collection: Image360Collection = {
+        ...imageCollectionProperties
+      };
 
-        imageCollections.push(collection);
-      }
+      imageCollections.push(collection);
     });
   }
   return imageCollections;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
An image collection does not need a Cdf3dModel with `externalId` of type number to work, this is only necessary for CAD and Point Cloud models

## How has this been tested? :mag:
Have tested in storybook

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
