### PR TITLE
fix(react-components): don't limit search result that will be filtered

### DIFF
--- a/react-components/src/hooks/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/hooks/useSearchMappedEquipmentAssetMappings.tsx
@@ -33,9 +33,10 @@ export const useSearchMappedEquipmentAssetMappings = (
   userSdk?: CogniteClient
 ): UseQueryResult<Asset[]> => {
   const sdk = useSDK(userSdk);
+  const modelsKey = models.map((model) => [model.modelId, model.revisionId]);
 
   return useQuery(
-    ['reveal', 'react-components', 'search-mapped-asset-mappings', query, models],
+    ['reveal', 'react-components', 'search-mapped-asset-mappings', query, modelsKey],
     async () => {
       if (query === '') {
         const assetMappings = await getAssetMappingsByModels(sdk, models, limit);
@@ -45,7 +46,7 @@ export const useSearchMappedEquipmentAssetMappings = (
         return modelsAssets.map(({ assets }) => assets).flat();
       }
 
-      const searchedAssets = await sdk.assets.search({ search: { query }, limit });
+      const searchedAssets = await sdk.assets.search({ search: { query }, limit: 1000 });
       const assetMappings = await getAssetMappingsByModels(
         sdk,
         models,


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->
## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->


There's a bug in the asset-search code related to limits.
The code works in two steps - it first fetches assets that satisfy the search query. It then filters these assets based on the mappings available in the 3D model(s). 
Previously, we used the same limit in both these queries, which in many cases causes the result from the first step to be trimmed down to a lower number, like 0. This tries to mitigate it somewhat by always returning the max number of results, 1000, from the first search.


## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Linked into fusion-shell and this PR: https://github.com/cognitedata/fusion/pull/4867

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
