### PR TITLE
feat: Make it possible to change the position of a datamodels backed 360 collection

### DIFF
--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -844,7 +844,8 @@ export class Cognite3DViewer {
    */
   async add360ImageSet(
     datasource: 'datamodels',
-    dataModelIdentifier: Image360DataModelIdentifier
+    dataModelIdentifier: Image360DataModelIdentifier,
+    add360ImageOptions?: AddImage360Options
   ): Promise<Image360Collection>;
   /**
    * Adds a set of 360 images to the scene from the /events API in Cognite Data Fusion.

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -339,7 +339,7 @@ export class ClusteredAreaCollection implements AreaCollection {
 // @public (undocumented)
 export class Cognite3DViewer {
     constructor(options: Cognite3DViewerOptions);
-    add360ImageSet(datasource: 'datamodels', dataModelIdentifier: Image360DataModelIdentifier): Promise<Image360Collection>;
+    add360ImageSet(datasource: 'datamodels', dataModelIdentifier: Image360DataModelIdentifier, add360ImageOptions?: AddImage360Options): Promise<Image360Collection>;
     add360ImageSet(datasource: 'events', eventFilter: {
         [key: string]: string;
     }, add360ImageOptions?: AddImage360Options): Promise<Image360Collection>;


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:
Make it possible to change the position of a datamodels backed 360 collection. This is useful for e.g. aligning 360 collections in a Scene.

## How has this been tested? :mag:
Have created a custom Reveal build and tested different 360 collection transformations in the SceneContainer storybook.

## Checklist :ballot_box_with_check:

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
