### PR TITLE
fix(react-components): missing some point cloud annotation boundingbox when asset selected

### DIFF
--- a/react-components/src/components/NodeCacheProvider/PointCloudAnnotationCache.ts
+++ b/react-components/src/components/NodeCacheProvider/PointCloudAnnotationCache.ts
@@ -129,7 +129,7 @@ export class PointCloudAnnotationCache {
 
     const annotationIdToAssetMap = new Map<number, Asset>();
     assets.forEach((asset) => {
-      uniqueAnnotationMapping.forEach((mapping) => {
+      filteredAnnotationMapping.forEach((mapping) => {
         if (mapping.assetId === asset.id) {
           annotationIdToAssetMap.set(mapping.annotationId, asset);
         }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
In Search (FDX), when an point cloud mapped asset which is has multiple annotation in it is selected, some of the annotation were not used to calculate the union of boundingbox which caused the camera to show incorrect view, this PR fixes the issue.

## How has this been tested? :mag:

In Search


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
