### PR TITLE
fix(react-components): border imprint of split window widget and enabled dragging when minimized

### DIFF
--- a/react-components/src/components/Widgets/WindowWidget.tsx
+++ b/react-components/src/components/Widgets/WindowWidget.tsx
@@ -54,6 +54,9 @@ export const WindowWidget = ({
   }
 
   const handleExpand = (): void => {
+    if (!isMinimized) {
+      setPosition({ x: 0, y: 0 });
+    }
     setIsMinimized((prev) => !prev);
   };
 
@@ -102,17 +105,13 @@ export const WindowWidget = ({
             }
           : {}
       }>
-      <Draggable
-        onDrag={handleDrag}
-        position={isMinimized ? { x: 0, y: 0 } : position}
-        handle=".widget-header"
-        disabled={isMinimized}>
+      <Draggable onDrag={handleDrag} position={position} handle=".widget-header">
         <ResizableBox
           width={size.width}
           height={size.height}
           minConstraints={[WIDGET_WINDOW_MIN_WIDTH, WIDGET_INSIDE_WINDOW_MIN_HEIGHT]}
           maxConstraints={[parentContainerElement.clientWidth, parentContainerElement.clientHeight]}
-          resizeHandles={isMinimized ? [] : ['se']}
+          resizeHandles={isMinimized ? [] : ['se', 'ne', 'e', 's']}
           onResize={handleResize}>
           <Widget>
             <Widget.Header title={title} type={type} header={header} subtitle={subtitle}>

--- a/react-components/src/components/Widgets/elements.ts
+++ b/react-components/src/components/Widgets/elements.ts
@@ -25,7 +25,4 @@ export const StyledComponent = styled.div<{ isMinimized: boolean }>`
   min-width: 20%;
   min-height: 10%;
   max-width: ${({ isMinimized }) => (isMinimized ? '300px' : '100%')};
-  box-shadow:
-    0px 1px 1px 1px rgba(79, 82, 104, 0.06),
-    0px 1px 2px 1px rgba(79, 82, 104, 0.04);
 `;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-3778

## Description :pencil:
Removed border imprint of split window widget, enabled dragging of split window in minimized state and add resizing in height (Y-axis) & width (X-axis)

## How has this been tested? :mag:

In Storybook


## Test instructions :information_source:

- `yarn && yarn build && yarn storybook`
- Select `SplitWindow` example
- When window is minimized, the window should be able to drag and in expanded state, the window is allowed to resize in X, Y & XY axis


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
