### PR TITLE
bug: Navigation: Unwanted behavior when dragging mouse outside the browser window and letting go

### DIFF
--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -72,6 +72,9 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
   private readonly _reusableVector3s = new ReusableVector3s();
   private readonly _rotationHelper = new FlexibleControlsRotationHelper();
 
+  // Used in mouse move, if not dragging it is undefined
+  private _mouseDragInfo: MouseDragInfo | undefined = undefined;
+
   //        FlexibleControlsType.OrbitInCenter
   //          , - ~ ~ ~ - ,
   //      , '               ' ,
@@ -389,85 +392,88 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
   //================================================
 
   private readonly onPointerDown = async (event: PointerEvent) => {
-    if (!this.isEnabled) return;
-    switch (event.pointerType) {
-      case 'mouse':
-        await this.onMouseDown(event);
-        break;
-      case 'touch':
-        this._pointEventCache.push(event);
-        this.onTouchStart(event);
-        break;
-      default:
-        break;
+    if (!this.isEnabled) {
+      return;
+    }
+    if (isMouse(event)) {
+      await this.onMouseDown(event);
+    } else if (isTouch(event)) {
+      this.onTouchStart(event);
     }
   };
+
   private readonly onMouseDown = async (event: PointerEvent) => {
-    if (!this.isEnabled) return;
+    if (!this.isEnabled) {
+      return;
+    }
     this._cameraVector.synchronizeEnd();
     switch (event.button) {
-      case MOUSE.LEFT: {
-        await this.startMouse(event, false);
+      case MOUSE.LEFT:
+      case MOUSE.RIGHT:
         break;
-      }
-      case MOUSE.RIGHT: {
-        event.preventDefault();
-        await this.startMouse(event, true);
-        break;
-      }
+
       default:
-        break;
+        return;
     }
+    event.preventDefault();
+    const mouseDragInfo = new MouseDragInfo(
+      getMousePosition(this._domElement, event.clientX, event.clientY),
+      event.button === MOUSE.RIGHT
+    );
+    this._mouseDragInfo = mouseDragInfo;
   };
 
-  private async startMouse(initialEvent: PointerEvent, isRight: boolean): Promise<void> {
-    let prevPosition = getMousePosition(this._domElement, initialEvent.clientX, initialEvent.clientY);
-    let translator: FlexibleControlsTranslator | undefined;
+  private readonly onPointerMove = async (event: PointerEvent) => {
+    if (!this._mouseDragInfo || !this.isEnabled || !isMouse(event)) {
+      return;
+    }
+    if (!isPressed(event)) {
+      if (this._mouseDragInfo) {
+        // No buttons is pressed, and still in mouse dragging, issue a onPointerUp()
+        // This can happend when you move the mouse outside the window and release the mouse button
+        // It shouldn't, but it is dependent of the context where the viewer is used.
+        this.onPointerUp(event);
+      }
+      return;
+    }
+    if (event.button === MOUSE.LEFT || event.button === MOUSE.RIGHT) {
+      this.onPointerMove(event);
+    }
+    const position = this.getMousePosition(event);
+    const deltaPosition = position.clone().sub(this._mouseDragInfo.prevPosition);
+    if (deltaPosition.x == 0 && deltaPosition.y == 0) {
+      return;
+    }
+    const { isRight } = this._mouseDragInfo;
+    let { translator } = this._mouseDragInfo;
 
-    const onMouseMove = async (event: PointerEvent) => {
-      const position = this.getMousePosition(event);
-      const deltaPosition = position.clone().sub(prevPosition);
-      if (deltaPosition.x == 0 && deltaPosition.y == 0) {
-        return;
+    if (this._keyboard.isShiftPressedOnly()) {
+      translator = undefined;
+      // Zooming forward and backward
+      deltaPosition.multiplyScalar(this._options.mouseDollySpeed);
+      this.pan(0, 0, deltaPosition.y);
+    } else if (isRight || this._keyboard.isCtrlPressedOnly()) {
+      // Pan left, right, up or down
+      if (!translator) {
+        translator = new FlexibleControlsTranslator(this);
+        await translator.initialize(event);
       }
-      if (this._keyboard.isShiftPressedOnly()) {
-        translator = undefined;
-        // Zooming forward and backward
-        deltaPosition.multiplyScalar(this._options.mouseDollySpeed);
-        this.pan(0, 0, deltaPosition.y);
-      } else if (isRight || this._keyboard.isCtrlPressedOnly()) {
-        // Pan left, right, up or down
-        if (translator == null) {
-          translator = new FlexibleControlsTranslator(this);
-          await translator.initialize(event);
-        }
-        if (!translator.translate(event)) {
-          // If not, translate in a simpler way
-          deltaPosition.multiplyScalar(this._options.mousePanSpeed);
-          this.pan(deltaPosition.x, deltaPosition.y, 0);
-        }
-      } else if (!isRight) {
-        translator = undefined;
-        this.rotate(deltaPosition);
+      if (!translator.translate(event)) {
+        // If not, translate in a simpler way
+        deltaPosition.multiplyScalar(this._options.mousePanSpeed);
+        this.pan(deltaPosition.x, deltaPosition.y, 0);
       }
-      prevPosition = position;
-    };
-    const onMouseUp = () => {
-      window.removeEventListener('pointermove', onMouseMove);
-      window.removeEventListener('pointerup', onMouseUp);
-    };
-    window.addEventListener('pointermove', onMouseMove, { passive: false });
-    window.addEventListener('pointerup', onMouseUp, { passive: false });
-  }
+    } else if (!isRight) {
+      translator = undefined;
+      this.rotate(deltaPosition);
+    }
+    this._mouseDragInfo.update(position, translator);
+  };
 
   private readonly onPointerUp = (event: PointerEvent) => {
-    if (!this.isEnabled) return;
-    switch (event.pointerType) {
-      case 'touch':
-        remove(this._pointEventCache, ev => ev.pointerId === event.pointerId);
-        break;
-      default:
-        break;
+    this._mouseDragInfo = undefined;
+    if (isTouch(event)) {
+      remove(this._pointEventCache, ev => ev.pointerId === event.pointerId);
     }
   };
 
@@ -532,6 +538,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     this._domElement.addEventListener('focus', this.onFocusChanged);
     this._domElement.addEventListener('blur', this.onFocusChanged);
 
+    window.addEventListener('pointermove', this.onPointerMove);
     window.addEventListener('pointerup', this.onPointerUp);
     window.addEventListener('pointerdown', this.onFocusChanged);
   }
@@ -543,6 +550,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     this._domElement.removeEventListener('focus', this.onFocusChanged);
     this._domElement.removeEventListener('blur', this.onFocusChanged);
 
+    window.removeEventListener('pointermove', this.onPointerMove);
     window.removeEventListener('pointerup', this.onPointerUp);
     window.removeEventListener('pointerdown', this.onFocusChanged);
   }
@@ -940,4 +948,32 @@ function getWheelDelta(event: WheelEvent): number {
  */
 function getTimeScale(deltaTimeS: number): number {
   return deltaTimeS * TARGET_FPS;
+}
+
+export function isMouse(event: PointerEvent): boolean {
+  return event.pointerType === 'mouse';
+}
+
+export function isTouch(event: PointerEvent): boolean {
+  return event.pointerType === 'touch';
+}
+
+export function isPressed(event: PointerEvent): boolean {
+  return event.buttons !== 0;
+}
+
+// helper class from mouseDown, mouseMove and mouseUp
+// It keeps track of the previous position and how it is translated
+class MouseDragInfo {
+  public constructor(prevPosition: Vector2, isRight: boolean) {
+    this.prevPosition = prevPosition;
+    this.isRight = isRight;
+  }
+  public update(prevPosition: Vector2, translator: FlexibleControlsTranslator | undefined): void {
+    this.prevPosition.copy(prevPosition);
+    this.translator = translator;
+  }
+  public readonly prevPosition: Vector2;
+  public readonly isRight: boolean = false;
+  public translator: FlexibleControlsTranslator | undefined = undefined;
 }

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -430,12 +430,12 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
       if (deltaPosition.x == 0 && deltaPosition.y == 0) {
         return;
       }
-      if (this._keyboard.isShiftPressed()) {
+      if (this._keyboard.isShiftPressedOnly()) {
         translator = undefined;
         // Zooming forward and backward
         deltaPosition.multiplyScalar(this._options.mouseDollySpeed);
         this.pan(0, 0, deltaPosition.y);
-      } else if (isRight || this._keyboard.isCtrlPressed()) {
+      } else if (isRight || this._keyboard.isCtrlPressedOnly()) {
         // Pan left, right, up or down
         if (translator == null) {
           translator = new FlexibleControlsTranslator(this);

--- a/viewer/packages/camera-manager/src/Keyboard.ts
+++ b/viewer/packages/camera-manager/src/Keyboard.ts
@@ -68,8 +68,16 @@ export default class Keyboard {
     return this.isPressed('ShiftLeft') || this.isPressed('ShiftRight');
   }
 
+  public isShiftPressedOnly(): boolean {
+    return this._keys.size === 1 && this.isShiftPressed();
+  }
+
   public isCtrlPressed(): boolean {
     return this.isPressed('ControlLeft') || this.isPressed('ControlRight');
+  }
+
+  public isCtrlPressedOnly(): boolean {
+    return this._keys.size === 1 && this.isCtrlPressed();
   }
 
   public isAltPressed(): boolean {
@@ -112,13 +120,11 @@ export default class Keyboard {
 
   private readonly onKeyDown = (event: KeyboardEvent) => {
     if (!isEventCode(event.code)) return;
-
     this._keys.add(event.code);
   };
 
   private readonly onKeyUp = (event: KeyboardEvent) => {
     if (!isEventCode(event.code)) return;
-
     this._keys.delete(event.code);
   };
 


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->
#### Jira ticket :blue_book:

https://cognitedata.atlassian.net/browse/BND3D-3895

## Description :pencil:


## How has this been tested? :mag:

In search, rotate the mouse outside the viewer and release the mouse button. Continue navigation inside. Check that it rotates normally

## Checklist :ballot_box_with_check:

The old functions captured some temporary values. Now this is collected in the class `MouseDragInfo `as a field in `FlexibleControls`. The problem was the `onPointerUp()` was not called sometimes when the mouse was outside the browser. Now this function is forced to called when no mouse buttons are pressed in `onMouseMove()`

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [x] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [x] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
