### PR TITLE
(refactor) Add customObject to the CustomObjectIntersection and export some function

### DIFF
--- a/viewer/api-entry-points/core.ts
+++ b/viewer/api-entry-points/core.ts
@@ -69,6 +69,8 @@ export {
   CustomObject,
   CustomObjectIntersection,
   CustomObjectIntersectInput,
+  getNormalizedPixelCoordinatesBySize,
+  getNormalizedPixelCoordinates,
   CDF_TO_VIEWER_TRANSFORMATION
 } from '../packages/utilities';
 

--- a/viewer/packages/utilities/src/customObject/CustomObject.ts
+++ b/viewer/packages/utilities/src/customObject/CustomObject.ts
@@ -97,7 +97,7 @@ export class CustomObject {
       customObject: this,
       point,
       distanceToCamera: distance,
-      boundingBox: undefined
+      userData: intersection[0]
     };
     if (this.shouldPickBoundingBox) {
       const boundingBox = new Box3().setFromObject(this.object);

--- a/viewer/packages/utilities/src/customObject/CustomObjectIntersection.ts
+++ b/viewer/packages/utilities/src/customObject/CustomObjectIntersection.ts
@@ -13,7 +13,7 @@ export type CustomObjectIntersection = {
   /**
    * The intersection type.
    */
-  type: 'customObject';
+  type: string;
   /**
    * Coordinate of the intersection.
    */
@@ -23,6 +23,18 @@ export type CustomObjectIntersection = {
    */
   distanceToCamera: number;
 
+  /**
+   * The CustomObject that was intersected.
+   */
   customObject: CustomObject;
+
+  /**
+   * The bounding box of the part of the CustomObject that was intersected.
+   */
   boundingBox?: Box3;
+
+  /**
+   * Additional info, for instance which part of the CustomObject was intersected.
+   */
+  userData?: any;
 };


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
In order to get proper info of the intersection, a userData field is added. Also updated the type to be a string. I misunderstood the syntax.

I discovered this needs when updating the contextualize editor. Click on AnnotationsViedw, I need to know which annotation is clicked on. All are in the same object3D.

