### PR TITLE
fix(react-components): export SetFlexibleControlsType and SetOrbitOrFirstPersonControlsType properly, and bump to 0.38.0

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/RevealToolbar/RevealToolbar.tsx
+++ b/react-components/src/components/RevealToolbar/RevealToolbar.tsx
@@ -17,6 +17,10 @@ import { type QualitySettings } from './SettingsContainer/types';
 import styled from 'styled-components';
 import { SelectSceneButton } from './SelectSceneButton';
 import { RuleBasedOutputsButton } from './RuleBasedOutputsButton';
+import {
+  SetFlexibleControlsType,
+  SetOrbitOrFirstPersonControlsType
+} from './SetFlexibleControlsType';
 
 const StyledToolBar = styled(ToolBar)`
   position: absolute;
@@ -107,6 +111,8 @@ export const RevealToolbar = withSuppressRevealEvents(
   ResetCameraButton: typeof ResetCameraButton;
   SelectSceneButton: typeof SelectSceneButton;
   RuleBasedOutputsButton: typeof RuleBasedOutputsButton;
+  SetOrbitOrFirstPersonControlsType: typeof SetOrbitOrFirstPersonControlsType;
+  SetFlexibleControlsType: typeof SetFlexibleControlsType;
 };
 
 RevealToolbar.FitModelsButton = FitModelsButton;
@@ -119,3 +125,5 @@ RevealToolbar.HelpButton = HelpButton;
 RevealToolbar.ResetCameraButton = ResetCameraButton;
 RevealToolbar.SelectSceneButton = SelectSceneButton;
 RevealToolbar.RuleBasedOutputsButton = RuleBasedOutputsButton;
+RevealToolbar.SetOrbitOrFirstPersonControlsType = SetOrbitOrFirstPersonControlsType;
+RevealToolbar.SetFlexibleControlsType = SetFlexibleControlsType;

--- a/react-components/src/components/RevealToolbar/RevealToolbar.tsx
+++ b/react-components/src/components/RevealToolbar/RevealToolbar.tsx
@@ -21,6 +21,7 @@ import {
   SetFlexibleControlsType,
   SetOrbitOrFirstPersonControlsType
 } from './SetFlexibleControlsType';
+import { SceneSelectionDropdown } from '../RevealTopbar/SceneSelectionDropdown';
 
 const StyledToolBar = styled(ToolBar)`
   position: absolute;
@@ -113,6 +114,7 @@ export const RevealToolbar = withSuppressRevealEvents(
   RuleBasedOutputsButton: typeof RuleBasedOutputsButton;
   SetOrbitOrFirstPersonControlsType: typeof SetOrbitOrFirstPersonControlsType;
   SetFlexibleControlsType: typeof SetFlexibleControlsType;
+  SceneSelectionDropdown: typeof SceneSelectionDropdown;
 };
 
 RevealToolbar.FitModelsButton = FitModelsButton;
@@ -127,3 +129,4 @@ RevealToolbar.SelectSceneButton = SelectSceneButton;
 RevealToolbar.RuleBasedOutputsButton = RuleBasedOutputsButton;
 RevealToolbar.SetOrbitOrFirstPersonControlsType = SetOrbitOrFirstPersonControlsType;
 RevealToolbar.SetFlexibleControlsType = SetFlexibleControlsType;
+RevealToolbar.SceneSelectionDropdown = SceneSelectionDropdown;

--- a/react-components/src/components/RevealTopbar/RevealTopbar.tsx
+++ b/react-components/src/components/RevealTopbar/RevealTopbar.tsx
@@ -10,11 +10,7 @@ import { type CustomToolbarContent } from '../RevealToolbar/RevealToolbar';
 import { SettingsButton } from '../RevealToolbar/SettingsButton';
 import { HelpButton } from '../RevealToolbar/HelpButton';
 import { Divider } from '@cognite/cogs.js';
-import {
-  SetFlexibleControlsType,
-  SetOrbitOrFirstPersonControlsType
-} from '../RevealToolbar/SetFlexibleControlsType';
-import { SceneSelectionDropdown } from './SceneSelectionDropdown';
+import { SetOrbitOrFirstPersonControlsType } from '../RevealToolbar/SetFlexibleControlsType';
 import { RuleBasedOutputsButton } from '../RevealToolbar/RuleBasedOutputsButton';
 
 export type CustomTopbarContent = CustomToolbarContent & { topbarContent?: ReactNode };
@@ -38,7 +34,7 @@ const DefaultContentWrapper = (props: CustomTopbarContent): ReactElement => {
   );
 };
 
-const RevealTopbarContainer = ({
+export const RevealTopbar = ({
   customSettingsContent,
   lowFidelitySettings,
   highFidelitySettings,
@@ -60,18 +56,6 @@ const RevealTopbarContainer = ({
     </StyledTopBar>
   );
 };
-
-export const RevealTopbar = RevealTopbarContainer as typeof RevealTopbarContainer & {
-  SetFlexibleControlsType: typeof SetFlexibleControlsType;
-  SetOrbitOrFirstPersonControlsType: typeof SetOrbitOrFirstPersonControlsType;
-  SceneSelectionDropdown: typeof SceneSelectionDropdown;
-  RuleBasedOutputsButton: typeof RuleBasedOutputsButton;
-};
-
-RevealTopbar.SetFlexibleControlsType = SetFlexibleControlsType;
-RevealTopbar.SetOrbitOrFirstPersonControlsType = SetOrbitOrFirstPersonControlsType;
-RevealTopbar.SceneSelectionDropdown = SceneSelectionDropdown;
-RevealTopbar.RuleBasedOutputsButton = RuleBasedOutputsButton;
 
 const StyledTopBar = styled.div`
   width: 100%;

--- a/react-components/src/components/RevealTopbar/RevealTopbar.tsx
+++ b/react-components/src/components/RevealTopbar/RevealTopbar.tsx
@@ -63,13 +63,13 @@ const RevealTopbarContainer = ({
 
 export const RevealTopbar = RevealTopbarContainer as typeof RevealTopbarContainer & {
   SetFlexibleControlsType: typeof SetFlexibleControlsType;
-  SetOrbitOrFistPersonControlsType: typeof SetOrbitOrFirstPersonControlsType;
+  SetOrbitOrFirstPersonControlsType: typeof SetOrbitOrFirstPersonControlsType;
   SceneSelectionDropdown: typeof SceneSelectionDropdown;
   RuleBasedOutputsButton: typeof RuleBasedOutputsButton;
 };
 
 RevealTopbar.SetFlexibleControlsType = SetFlexibleControlsType;
-RevealTopbar.SetOrbitOrFistPersonControlsType = SetOrbitOrFirstPersonControlsType;
+RevealTopbar.SetOrbitOrFirstPersonControlsType = SetOrbitOrFirstPersonControlsType;
 RevealTopbar.SceneSelectionDropdown = SceneSelectionDropdown;
 RevealTopbar.RuleBasedOutputsButton = RuleBasedOutputsButton;
 

--- a/react-components/stories/Topbar.stories.tsx
+++ b/react-components/stories/Topbar.stories.tsx
@@ -52,7 +52,7 @@ const TopbarContent = (): ReactElement => {
   return (
     <>
       <SceneSelectionDropdown selectedScene={scene} setSelectedScene={setScene} />
-      <RevealTopbar.SetOrbitOrFistPersonControlsType orientation="horizontal" />
+      <RevealTopbar.SetOrbitOrFirstPersonControlsType orientation="horizontal" />
       <RevealToolbar.LayersButton storeStateInUrl={true} />
       <RuleBasedOutputsButton />
       <RevealToolbar.HelpButton />

--- a/react-components/stories/Topbar.stories.tsx
+++ b/react-components/stories/Topbar.stories.tsx
@@ -52,7 +52,7 @@ const TopbarContent = (): ReactElement => {
   return (
     <>
       <SceneSelectionDropdown selectedScene={scene} setSelectedScene={setScene} />
-      <RevealTopbar.SetOrbitOrFirstPersonControlsType orientation="horizontal" />
+      <RevealToolbar.SetOrbitOrFirstPersonControlsType orientation="horizontal" />
       <RevealToolbar.LayersButton storeStateInUrl={true} />
       <RuleBasedOutputsButton />
       <RevealToolbar.HelpButton />


### PR DESCRIPTION
I don't know why, but I can not import these buttons in fusion. So I hope this will help