### PR TITLE
fix: camera position, rotation reset when image 360 exit is invoked before enter image 360 is called for the first time

### DIFF
--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -61,7 +61,7 @@ export class Image360ApiHelper {
 
   private readonly _debouncePreLoad = debounce(
     entity => {
-      this._image360Facade.preload(entity, this.findRevisionIdToEnter(entity)).catch(() => { });
+      this._image360Facade.preload(entity, this.findRevisionIdToEnter(entity)).catch(() => {});
     },
     300,
     {

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -61,7 +61,7 @@ export class Image360ApiHelper {
 
   private readonly _debouncePreLoad = debounce(
     entity => {
-      this._image360Facade.preload(entity, this.findRevisionIdToEnter(entity)).catch(() => {});
+      this._image360Facade.preload(entity, this.findRevisionIdToEnter(entity)).catch(() => { });
     },
     300,
     {
@@ -398,20 +398,23 @@ export class Image360ApiHelper {
 
   public exit360Image(): void {
     this._image360Facade.allIconCullingScheme = 'clustered';
-    if (this._interactionState.currentImage360Entered !== undefined) {
-      const imageCollection = this._image360Facade.getCollectionContainingEntity(
-        this._interactionState.currentImage360Entered
-      );
-      this._interactionState.currentImage360Entered.icon.setVisible(imageCollection.isCollectionVisible);
-      imageCollection.events.image360Exited.fire();
-
-      this._interactionState.currentImage360Entered.deactivateAnnotations();
-      this._interactionState.currentImage360Entered.image360Visualization.visible = false;
-      this._interactionState.currentImage360Entered = undefined;
-      this._interactionState.revisionSelectedForEntry = undefined;
-      this._interactionState.enteredCollection = undefined;
-      MetricsLogger.trackEvent('360ImageExited', {});
+    if (this._interactionState.currentImage360Entered === undefined) {
+      return;
     }
+
+    const imageCollection = this._image360Facade.getCollectionContainingEntity(
+      this._interactionState.currentImage360Entered
+    );
+    this._interactionState.currentImage360Entered.icon.setVisible(imageCollection.isCollectionVisible);
+    imageCollection.events.image360Exited.fire();
+
+    this._interactionState.currentImage360Entered.deactivateAnnotations();
+    this._interactionState.currentImage360Entered.image360Visualization.visible = false;
+    this._interactionState.currentImage360Entered = undefined;
+    this._interactionState.revisionSelectedForEntry = undefined;
+    this._interactionState.enteredCollection = undefined;
+    MetricsLogger.trackEvent('360ImageExited', {});
+
     const { position, rotation } = this._image360Navigation.getCameraState();
     this._activeCameraManager.setActiveCameraManager(this._cachedCameraManager);
     this._activeCameraManager.setCameraState({


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-3987

## Description :pencil:

Call to `viewer.exit360Image()` even before `viewer.enter360Image()` is called for the first time resets the camera position and rotation to origin, This PR fixes the edge case

## How has this been tested? :mag:

In examples and `Search` fusion


## Test instructions :information_source:

- `cd examples && yarn && yarn start`
- Load `celanese1` 360 image data set from the `GUI`
- `Click` on any 360 image `Icon` to enter into it, immediately press `Esc` key even before camera completely enter into the 360 image


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
