### PR TITLE
refactor: Use the flexible camera manager in 360 images

### DIFF
--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -111,11 +111,10 @@ export class Image360ApiHelper {
 
     this._activeCameraManager = activeCameraManager;
     this._onBeforeSceneRenderedEvent = onBeforeSceneRendered;
-    if (true || !FlexibleCameraManager.as(activeCameraManager.innerCameraManager)) {
+    if (!FlexibleCameraManager.as(activeCameraManager.innerCameraManager)) {
       this._stationaryCameraManager = new StationaryCameraManager(domElement, activeCameraManager.getCamera().clone());
       this._cachedCameraManager = activeCameraManager.innerCameraManager;
     }
-
     const setHoverIconEventHandler = (event: MouseEvent) => this.setHoverIconOnIntersect(event.offsetX, event.offsetY);
     domElement.addEventListener('mousemove', setHoverIconEventHandler);
 

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -111,15 +111,13 @@ export class Image360ApiHelper {
 
     this._activeCameraManager = activeCameraManager;
     this._onBeforeSceneRenderedEvent = onBeforeSceneRendered;
-    if (!FlexibleCameraManager.as(activeCameraManager.innerCameraManager)) {
+    if (true || !FlexibleCameraManager.as(activeCameraManager.innerCameraManager)) {
       this._stationaryCameraManager = new StationaryCameraManager(domElement, activeCameraManager.getCamera().clone());
       this._cachedCameraManager = activeCameraManager.innerCameraManager;
     }
 
     const setHoverIconEventHandler = (event: MouseEvent) => this.setHoverIconOnIntersect(event.offsetX, event.offsetY);
     domElement.addEventListener('mousemove', setHoverIconEventHandler);
-    const dblclickEventHandler = (event: MouseEvent) => event.stopPropagation();
-    domElement.addEventListener('dblclick', dblclickEventHandler);
 
     const enter360Image = (event: PointerEventData) => this.enter360ImageOnIntersect(event);
     inputHandler.on('click', enter360Image);
@@ -226,7 +224,6 @@ export class Image360ApiHelper {
   public async enter360Image(image360Entity: Image360Entity, revision?: Image360RevisionEntity): Promise<void> {
     const revisionToEnter = revision ?? this.findRevisionIdToEnter(image360Entity);
     if (revisionToEnter === this._interactionState.revisionSelectedForEntry) {
-      console.log('enter360Image A');
       return;
     }
     this._interactionState.revisionSelectedForEntry = revisionToEnter;
@@ -236,11 +233,9 @@ export class Image360ApiHelper {
       if (this._interactionState.revisionSelectedForEntry === revisionToEnter) {
         this._interactionState.revisionSelectedForEntry = undefined;
       }
-      console.log('enter360Image B');
       return;
     }
     if (this._interactionState.revisionSelectedForEntry !== revisionToEnter) {
-      console.log('enter360Image C');
       return;
     }
     const lastEntered360ImageEntity = this._interactionState.currentImage360Entered;

--- a/viewer/packages/camera-manager/index.ts
+++ b/viewer/packages/camera-manager/index.ts
@@ -17,5 +17,6 @@ export { FlexibleControlsOptions } from './src/Flexible/FlexibleControlsOptions'
 export { FlexibleWheelZoomType } from './src/Flexible/FlexibleWheelZoomType';
 export { FlexibleControlsType } from './src/Flexible/FlexibleControlsType';
 export { FlexibleMouseActionType } from './src/Flexible/FlexibleMouseActionType';
+export { asFlexibleCameraManager } from './src/Flexible/IFlexibleCameraManager';
 
 export * from './src/types';

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleCameraManager.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleCameraManager.ts
@@ -420,7 +420,6 @@ export class FlexibleCameraManager implements IFlexibleCameraManager {
     if (!this.isEnabled || !this.isEnableClickAndDoubleClick || this.controls.isStationary) {
       return;
     }
-    console.log('onClick');
     if (this.options.mouseClickType !== FlexibleMouseActionType.None) {
       await this.mouseAction(event, this.options.mouseClickType);
     }
@@ -430,7 +429,6 @@ export class FlexibleCameraManager implements IFlexibleCameraManager {
     if (!this.isEnabled || !this.isEnableClickAndDoubleClick || this.controls.isStationary) {
       return;
     }
-    console.log('onDoubleClick');
     if (this.options.mouseDoubleClickType !== FlexibleMouseActionType.None) {
       await this.mouseAction(event, this.options.mouseDoubleClickType);
     }

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleCameraMarkers.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleCameraMarkers.ts
@@ -23,7 +23,9 @@ export class FlexibleCameraMarkers {
   //================================================
 
   public update(manager: FlexibleCameraManager): void {
-    if (manager.options.showTarget && manager.options.controlsType !== FlexibleControlsType.FirstPerson) {
+    const isFirstPerson =
+      manager.controls.isStationary || manager.options.controlsType === FlexibleControlsType.FirstPerson;
+    if (manager.options.showTarget && !isFirstPerson) {
       if (!this._targetMarker) {
         this._targetMarker = createSprite(manager.options.outerMarkerColor, manager.options.innerMarkerColor);
         this._scene.add(this._targetMarker);

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -278,7 +278,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     if (!(this._camera instanceof PerspectiveCamera)) {
       return false;
     }
-    const fov = MathUtils.clamp(value, this.options.minimumFov, this.options.defaultFov);
+    const fov = this.options.getLegalFov(value);
     if (this.fov === fov) {
       return false;
     }

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -198,7 +198,6 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     if (this._isStationary) {
       this.setFov(this.options.defaultFov);
     }
-    console.log('isStationary', value);
     this._isStationary = value;
   }
 

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -43,6 +43,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
 
   private _isEnabled: boolean = true;
   private _isInitialized: boolean = false;
+  private _isStationary = false; // If true the options.controlsType should not be used. Camera cannot change position and zooms by fov
   public temporarlyDisableKeyboard: boolean = false;
 
   private readonly _options: FlexibleControlsOptions;
@@ -118,13 +119,15 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
   // CONSTRUCTOR
   //================================================
 
-  constructor(
-    camera: PerspectiveCamera | OrthographicCamera,
-    domElement: HTMLElement,
-    options: FlexibleControlsOptions
-  ) {
+  constructor(camera: PerspectiveCamera | undefined, domElement: HTMLElement, options: FlexibleControlsOptions) {
     super();
-    this._camera = camera;
+
+    if (camera) {
+      this._camera = camera;
+      options.defaultFov = this.fov;
+    } else {
+      this._camera = new PerspectiveCamera(options.defaultFov, undefined, 0.1, 10000);
+    }
     this._domElement = domElement;
     this._options = options;
     this._keyboard = new Keyboard(this._domElement);
@@ -146,6 +149,10 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
 
   get camera(): PerspectiveCamera | OrthographicCamera {
     return this._camera;
+  }
+
+  get domElement(): HTMLElement {
+    return this._domElement;
   }
 
   get target(): DampedVector3 {
@@ -178,6 +185,28 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
 
   public get controlsType(): FlexibleControlsType {
     return this.options.controlsType;
+  }
+
+  public get isStationary(): boolean {
+    return this._isStationary;
+  }
+
+  public set isStationary(value: boolean) {
+    if (this._isStationary == value) {
+      return;
+    }
+    if (this._isStationary) {
+      this.setFov(this.options.defaultFov);
+    }
+    console.log('isStationary', value);
+    this._isStationary = value;
+  }
+
+  public get fov(): number {
+    if (!(this._camera instanceof PerspectiveCamera)) {
+      return 0;
+    }
+    return this._camera.fov;
   }
 
   set getPickedPointByPixelCoordinates(getPickedPointByPixelCoordinates: GetPickedPointByPixelCoordinates | undefined) {
@@ -246,6 +275,22 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     }
   }
 
+  setFov(value: number, triggerCameraChangeEvent: boolean = true): boolean {
+    if (!(this._camera instanceof PerspectiveCamera)) {
+      return false;
+    }
+    const fov = MathUtils.clamp(value, this.options.minimumFov, this.options.defaultFov);
+    if (this.fov === fov) {
+      return false;
+    }
+    this._camera.fov = fov;
+    this._camera.updateProjectionMatrix();
+    if (triggerCameraChangeEvent) {
+      this.triggerCameraChangeEvent();
+    }
+    return true;
+  }
+
   public setPositionAndTarget(position: Vector3, target: Vector3): void {
     this.isInitialized = true;
     this._cameraPosition.copy(position);
@@ -256,7 +301,12 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     vector.normalize();
     this._cameraVector.copy(vector);
     this._rawCameraRotation = undefined;
+    this.updateCameraAndTriggerCameraChangeEvent();
+  }
 
+  public setPosition(position: Vector3): void {
+    this._cameraPosition.copy(position);
+    this._rawCameraRotation = undefined;
     this.updateCameraAndTriggerCameraChangeEvent();
   }
 
@@ -323,7 +373,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     // So we get y = x * tan (a), where y is parallel to the screen
     // half of the fov is center to top of screen
     if (this._camera instanceof PerspectiveCamera) {
-      const fovFactor = Math.tan(MathUtils.degToRad(this._camera.fov / 2));
+      const fovFactor = Math.tan(MathUtils.degToRad(this.fov / 2));
       speed *= fovFactor; // Typical value is 0.57
     }
     const factor = 2 / this._domElement.clientHeight;
@@ -402,7 +452,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     }
   };
 
-  private readonly onMouseDown = async (event: PointerEvent) => {
+  private async onMouseDown(event: PointerEvent) {
     if (!this.isEnabled) {
       return;
     }
@@ -423,7 +473,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
       event.button === MOUSE.RIGHT
     );
     this._mouseDragInfo = mouseDragInfo;
-  };
+  }
 
   private readonly onPointerMove = async (event: PointerEvent) => {
     if (!this._mouseDragInfo || !this.isEnabled || !isMouse(event)) {
@@ -449,12 +499,12 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     const { isRight } = this._mouseDragInfo;
     let { translator } = this._mouseDragInfo;
 
-    if (this._keyboard.isShiftPressedOnly()) {
+    if (!this.isStationary && this._keyboard.isShiftPressedOnly()) {
       translator = undefined;
       // Zooming forward and backward
       deltaPosition.multiplyScalar(this._options.mouseDollySpeed);
       this.pan(0, 0, deltaPosition.y);
-    } else if (isRight || this._keyboard.isCtrlPressedOnly()) {
+    } else if (!this.isStationary && (isRight || this._keyboard.isCtrlPressedOnly())) {
       // Pan left, right, up or down
       if (!translator) {
         translator = new FlexibleControlsTranslator(this);
@@ -480,22 +530,57 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
   };
 
   private readonly onMouseWheel = (event: WheelEvent) => {
-    if (!this.isEnabled) return;
+    if (!this.isEnabled) {
+      return;
+    }
     event.preventDefault();
 
     const delta = getWheelDelta(event);
     if (this._camera instanceof PerspectiveCamera) {
-      const deltaDistance = delta * this.getWheelSpeed();
       const pixelCoords = getClickOrTouchEventPoint(event, this._domElement);
       const normalizedCoords = getNormalizedPixelCoordinates(this._domElement, pixelCoords.x, pixelCoords.y);
-      this.dollyWithWheelScroll(normalizedCoords, -deltaDistance);
+      if (this.isStationary) {
+        const deltaDistance = delta * this.options.wheelDollySpeed;
+        this.zoomCameraByFov(normalizedCoords, deltaDistance);
+      } else {
+        const deltaDistance = delta * this.getWheelSpeed();
+        this.dollyWithWheelScroll(normalizedCoords, -deltaDistance);
+      }
     } else if (this._camera instanceof OrthographicCamera) {
       const deltaDistance = Math.sign(delta) * this._options.orthographicCameraDollyFactor;
       this.dollyOrthographicCamera(deltaDistance);
     }
   };
 
-  private readonly onTouchStart = (event: PointerEvent) => {
+  private zoomCameraByFov(normalizedCoords: Vector2, delta: number) {
+    // Added to prevent browser scrolling when zooming
+    if (!(this._camera instanceof PerspectiveCamera)) {
+      return;
+    }
+    const getCursorRay = (normalizedCoords: Vector2) => {
+      const ray = new Vector3(normalizedCoords.x, normalizedCoords.y, 1)
+        .unproject(this._camera)
+        .sub(this._camera.position)
+        .normalize();
+      return ray;
+    };
+
+    const preCursorRay = getCursorRay(normalizedCoords);
+
+    if (!this.setFov(this.fov + delta, false)) {
+      return;
+    }
+    // When zooming the camera is rotated towards the cursor position
+    const postCursorRay = getCursorRay(normalizedCoords);
+    const arcBetweenRays = new Quaternion().setFromUnitVectors(postCursorRay, preCursorRay);
+    const forwardVector = this.cameraVector.getEndVector();
+
+    forwardVector.applyQuaternion(arcBetweenRays);
+    this._cameraVector.copy(forwardVector);
+    this.triggerCameraChangeEvent();
+  }
+
+  private onTouchStart(event: PointerEvent) {
     if (!this.isEnabled) return;
     this._touchEvents.push(event);
     event.preventDefault();
@@ -507,13 +592,15 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
         break;
 
       case 2:
-        this.startTouchPinch(event);
+        if (!this.isStationary) {
+          this.startTouchPinch(event);
+        }
         break;
 
       default:
         break;
     }
-  };
+  }
 
   private readonly onFocusChanged = (event: MouseEvent | TouchEvent | FocusEvent) => {
     if (!this.isEnabled) return;
@@ -657,7 +744,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     let deltaAzimuthAngle = this._options.mouseRotationSpeedAzimuth * delta.x;
     let deltaPolarAngle = this._options.mouseRotationSpeedPolar * delta.y;
     // It is more natural that the first persion rotate slower then the other modes
-    if (this.controlsType == FlexibleControlsType.FirstPerson) {
+    if (this.isStationary || this.controlsType == FlexibleControlsType.FirstPerson) {
       deltaAzimuthAngle *= 0.5;
       deltaPolarAngle *= 0.5;
     }
@@ -858,8 +945,12 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     }
     let handled = false;
     const timeScale = getTimeScale(deltaTimeS);
-    if (this.handleRotationFromKeyboard(timeScale)) handled = true;
-    if (this.handleMoveFromKeyboard(timeScale)) handled = true;
+    if (this.handleRotationFromKeyboard(timeScale)) {
+      handled = true;
+    }
+    if (!this.isStationary && this.handleMoveFromKeyboard(timeScale)) {
+      handled = true;
+    }
     return handled;
   }
 
@@ -877,7 +968,9 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     if (deltaAzimuthAngle === 0 && deltaPolarAngle === 0) {
       return false;
     }
-    this.setControlsType(FlexibleControlsType.FirstPerson);
+    if (!this.isStationary) {
+      this.setControlsType(FlexibleControlsType.FirstPerson);
+    }
     this.rotateByAngles(-deltaAzimuthAngle, -deltaPolarAngle);
     return true;
   }
@@ -890,7 +983,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     if (deltaX === 0 && deltaY === 0 && deltaZ === 0) {
       return false;
     }
-    if (this.controlsType === FlexibleControlsType.Orbit) {
+    if (!this.isStationary) {
       this.setControlsType(FlexibleControlsType.FirstPerson);
     }
     const speedFactor = this._keyboard.isShiftPressed() ? this._options.keyboardFastMoveFactor : 1;

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
@@ -83,6 +83,7 @@ export class FlexibleControlsOptions {
 
   // For when it is isStationary
   public minimumFov: number = 5;
+  public maximumFov: number = 100;
   public defaultFov: number = 60;
 
   // Shaw target as a Marker settings
@@ -118,6 +119,10 @@ export class FlexibleControlsOptions {
   //================================================
   // INSTANCE METHODS: Getters
   //================================================
+
+  public getLegalFov(fov: number): number {
+    return MathUtils.clamp(fov, this.minimumFov, this.maximumFov);
+  }
 
   public getLegalAzimuthAngle(azimuthAngle: number): number {
     return MathUtils.clamp(azimuthAngle, this.minAzimuthAngle, this.maxAzimuthAngle);

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
@@ -81,6 +81,10 @@ export class FlexibleControlsOptions {
 
   public orthographicCameraDollyFactor = 0.3;
 
+  // For when it is isStationary
+  public minimumFov: number = 5;
+  public defaultFov: number = 60;
+
   // Shaw target as a Marker settings
   public showTarget = true;
   public relativeMarkerSize = 0.018;

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControlsRotationHelper.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControlsRotationHelper.ts
@@ -19,6 +19,9 @@ export class FlexibleControlsRotationHelper {
   private readonly oldCameraVectorEnd: Spherical = new Spherical();
 
   public begin(controls: FlexibleControls): void {
+    if (controls.isStationary) {
+      return;
+    }
     if (controls.controlsType === FlexibleControlsType.Orbit) {
       this.oldOffset.subVectors(controls.target.end, controls.cameraPosition.end);
       this.oldCameraVectorEnd.copy(controls.cameraVector.end);
@@ -26,6 +29,10 @@ export class FlexibleControlsRotationHelper {
   }
 
   public end(controls: FlexibleControls): void {
+    if (controls.isStationary) {
+      return;
+    }
+
     if (controls.controlsType === FlexibleControlsType.OrbitInCenter) {
       // Adust the camera position by
       // CameraPosition = Target - CameraVector * DistanceToTarget

--- a/viewer/packages/camera-manager/src/Flexible/IFlexibleCameraManager.ts
+++ b/viewer/packages/camera-manager/src/Flexible/IFlexibleCameraManager.ts
@@ -50,3 +50,9 @@ export interface IFlexibleCameraManager extends CameraManager {
    */
   removeControlsTypeChangeListener(callback: FlexibleControlsTypeChangeDelegate): void;
 }
+
+export function asFlexibleCameraManager(manager: CameraManager): IFlexibleCameraManager | undefined {
+  // instanceof don't work within React, so using safeguarding
+  const flexibleCameraManager = manager as IFlexibleCameraManager;
+  return flexibleCameraManager.controlsType === undefined ? undefined : flexibleCameraManager;
+}

--- a/viewer/packages/camera-manager/src/Flexible/moveCamera.ts
+++ b/viewer/packages/camera-manager/src/Flexible/moveCamera.ts
@@ -128,60 +128,6 @@ export function moveCameraTargetTo(manager: FlexibleCameraManager, target: Vecto
     .start(TWEEN.now());
 }
 
-export function moveCameraPositionTo(manager: FlexibleCameraManager, position: Vector3, duration: number): void {
-  if (manager.isDisposed) {
-    return;
-  }
-  const cameraPosition = manager.camera.position;
-  const from = {
-    x: cameraPosition.x,
-    y: cameraPosition.y,
-    z: cameraPosition.z
-  };
-  const to = {
-    x: position.x,
-    y: position.y,
-    z: position.z
-  };
-
-  const tempPosition = new Vector3();
-  manager.controls.temporarlyDisableKeyboard = true;
-
-  new TWEEN.Tween(from)
-    .to(to, duration)
-    .onUpdate(() => {
-      tempPosition.set(from.x, from.y, from.z);
-      manager.setPosition(tempPosition);
-    })
-    .easing(num => TWEEN.Easing.Quintic.InOut(num))
-    .onStop(() => {
-      manager.setPosition(tempPosition);
-      manager.controls.temporarlyDisableKeyboard = false;
-    })
-    .onComplete(() => {
-      manager.setPosition(position);
-      manager.controls.temporarlyDisableKeyboard = false;
-    })
-    .start(TWEEN.now());
-}
-
-export function tweenCameraToDefaultFov(manager: FlexibleCameraManager, duration: number): void {
-  const from = { fov: manager.controls.fov };
-  const to = { fov: manager.controls.options.defaultFov };
-  const delay = duration * 0.25;
-  new TWEEN.Tween(from)
-    .to(to, duration * 0.5)
-    .onUpdate(() => {
-      manager.controls.setFov(from.fov);
-    })
-    .onComplete(() => {
-      manager.controls.setFov(to.fov);
-    })
-    .delay(delay)
-    .easing(num => TWEEN.Easing.Quintic.InOut(num))
-    .start(TWEEN.now());
-}
-
 function createTweenAnimationWithStop<T>(
   manager: FlexibleCameraManager,
   from: T,

--- a/viewer/packages/tools/src/AxisGizmo/AxisGizmoTool.ts
+++ b/viewer/packages/tools/src/AxisGizmo/AxisGizmoTool.ts
@@ -7,7 +7,7 @@ import { AxisGizmoOptions } from './AxisGizmoOptions';
 import { CDF_TO_VIEWER_TRANSFORMATION } from '@reveal/utilities';
 import { Cognite3DViewer } from '@reveal/api';
 import { OneGizmoAxis } from './OneGizmoAxis';
-import { CameraManager, IFlexibleCameraManager } from '@reveal/camera-manager';
+import { asFlexibleCameraManager } from '@reveal/camera-manager';
 import { moveCameraTo } from '../utilities/moveCameraTo';
 import { Corner } from '../utilities/Corner';
 import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
@@ -465,10 +465,4 @@ function initializeStyle(element: HTMLElement, options: AxisGizmoOptions) {
       style.left = xMargin;
       style.top = yMargin;
   }
-}
-
-function asFlexibleCameraManager(manager: CameraManager): IFlexibleCameraManager | undefined {
-  // instanceof don't work within React, so using safeguarding
-  const flexibleCameraManager = manager as IFlexibleCameraManager;
-  return flexibleCameraManager.controlsType === undefined ? undefined : flexibleCameraManager;
 }

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -889,6 +889,8 @@ export class FlexibleControlsOptions {
     // (undocumented)
     dampingFactor: number;
     // (undocumented)
+    defaultFov: number;
+    // (undocumented)
     enableChangeControlsTypeOn123Key: boolean;
     // (undocumented)
     enableDamping: boolean;
@@ -896,6 +898,8 @@ export class FlexibleControlsOptions {
     enableKeyboardNavigation: boolean;
     // (undocumented)
     getLegalAzimuthAngle(azimuthAngle: number): number;
+    // (undocumented)
+    getLegalFov(fov: number): number;
     // (undocumented)
     getLegalPolarAngle(polarAngle: number): number;
     // (undocumented)
@@ -915,6 +919,8 @@ export class FlexibleControlsOptions {
     // (undocumented)
     maxAzimuthAngle: number;
     // (undocumented)
+    maximumFov: number;
+    // (undocumented)
     maximumTimeBetweenRaycasts: number;
     // (undocumented)
     maxOrthographicZoom: number;
@@ -924,6 +930,8 @@ export class FlexibleControlsOptions {
     maxSensitivity: number;
     // (undocumented)
     minAzimuthAngle: number;
+    // (undocumented)
+    minimumFov: number;
     // (undocumented)
     minimumTimeBetweenRaycasts: number;
     // (undocumented)


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->

#### Jira ticket :blue_book:

No Jira ticket

https://cognitedata.atlassian.net/browse/

## Description :pencil:

This is a refactor to get rid of the Stationary Camera manager, since it behaved a little different then the FlexibleCamera Manager. Now the Use arrows and AxisGizmo is working inside the 360 image.

## How has this been tested? :mag:

Use a model with 3D images. Jump in and out of the images. Zoom and pan. Use arrows and AxisGizmo to navigate.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
