### PR TITLE
(fix): Fix an event bug in StationaryCameraManager [BND3D-3992]

### DIFF
--- a/viewer/packages/camera-manager/src/StationaryCameraManager.ts
+++ b/viewer/packages/camera-manager/src/StationaryCameraManager.ts
@@ -76,7 +76,7 @@ export class StationaryCameraManager implements CameraManager {
     this._camera.aspect = cameraManager.getCamera().aspect;
     this._camera.updateProjectionMatrix();
 
-    window.addEventListener('pointerdown', this.onPointerDown);
+    this._domElement.addEventListener('pointerdown', this.onPointerDown);
     window.addEventListener('pointermove', this.onPointerMove, { passive: false });
     this._domElement.addEventListener('wheel', this.zoomCamera);
     // The handler for pointerup is used for the pointercancel, pointerout
@@ -86,7 +86,7 @@ export class StationaryCameraManager implements CameraManager {
   }
 
   deactivate(): void {
-    window.removeEventListener('pointerdown', this.onPointerDown);
+    this._domElement.removeEventListener('pointerdown', this.onPointerDown);
     window.removeEventListener('pointermove', this.onPointerMove);
     window.removeEventListener('pointerup', this.onPointerUp);
     this._domElement.removeEventListener('pointercancel', this.onPointerUp);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/BND3D-3992

## Description :pencil:
Start dragging only if inside the dom element of the stationary camera manager

## How has this been tested? :mag:

