### PR TITLE
fix(react-components): loading of camera position & rotation on scene load not triggering

### DIFF
--- a/react-components/src/components/SceneContainer/SceneContainer.tsx
+++ b/react-components/src/components/SceneContainer/SceneContainer.tsx
@@ -38,7 +38,7 @@ export function SceneContainer({
 
   useEffect(() => {
     defaultCamera.fitCameraToSceneDefault();
-  }, [sceneExternalId, sceneSpaceId]);
+  }, [sceneExternalId, sceneSpaceId, defaultCamera]);
 
   return (
     <Reveal3DResources


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:

When `scene` is changed, new scene's camera position & rotation were not loaded as `useEffect` was not getting trigger due to related dependency missing.

## How has this been tested? :mag:

In Fusion

## Test instructions :information_source:

- `yalc` link to fusion
- Change the scene in `Search`


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
