### PR TITLE
Smaller fixes on the flexible camera control

### DIFF
--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -64,11 +64,6 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
   private readonly _touchEvents: Array<PointerEvent> = [];
   private _getPickedPointByPixelCoordinates: GetPickedPointByPixelCoordinates | undefined;
 
-  // This is a hack for overcome problems with the setting the Quaternion direction.
-  // This is normally done in animation of movements using setCameraState,
-  // which arguments does not fit into this control. (no direction is given for instance)
-  private _rawCameraRotation: Quaternion | undefined = undefined;
-
   // Temporary objects used for calculations to avoid allocations
   private readonly _reusableVector3s = new ReusableVector3s();
   private readonly _rotationHelper = new FlexibleControlsRotationHelper();
@@ -299,13 +294,11 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     const vector = this.newVector3().subVectors(target, position);
     vector.normalize();
     this._cameraVector.copy(vector);
-    this._rawCameraRotation = undefined;
     this.updateCameraAndTriggerCameraChangeEvent();
   }
 
   public setPosition(position: Vector3): void {
     this._cameraPosition.copy(position);
-    this._rawCameraRotation = undefined;
     this.updateCameraAndTriggerCameraChangeEvent();
   }
 
@@ -313,8 +306,6 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     this.isInitialized = true;
     this._cameraPosition.copy(position);
     this._cameraVector.copy(direction);
-    this._rawCameraRotation = undefined;
-
     this.updateCameraAndTriggerCameraChangeEvent();
   }
 
@@ -324,8 +315,6 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
 
     const cameraVector = this.newVector3().set(0, 0, -1);
     cameraVector.applyQuaternion(rotation);
-
-    this._rawCameraRotation = rotation.clone();
 
     if (DampedSpherical.isVertical(cameraVector)) {
       // Looking from top or bottom, the theta must be defined in a proper way
@@ -654,13 +643,8 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     this._camera.position.copy(this._cameraPosition.value);
     this._camera.updateProjectionMatrix();
 
-    if (this._rawCameraRotation) {
-      this._camera.setRotationFromQuaternion(this._rawCameraRotation);
-      this._camera.updateProjectionMatrix();
-    } else {
-      this._camera.lookAt(this.getLookAt());
-      this._camera.updateProjectionMatrix();
-    }
+    this._camera.lookAt(this.getLookAt());
+    this._camera.updateProjectionMatrix();
     if (!isChange) {
       return false;
     }
@@ -676,8 +660,7 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     let prevPosition = getMousePosition(this._domElement, initialEvent.clientX, initialEvent.clientY);
 
     const onTouchMove = (event: PointerEvent) => {
-      if (!this.isEnabled) return;
-      if (this._touchEvents.length !== 1) {
+      if (!this.isEnabled || this._touchEvents.length !== 1) {
         return;
       }
       const position = this.getMousePosition(event);
@@ -686,9 +669,8 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
     };
 
     const onTouchStart = (_event: PointerEvent) => {
-      if (!this.isEnabled) return;
       // if num fingers used don't equal 1 then we stop touch rotation
-      if (this._touchEvents.length !== 1) {
+      if (!this.isEnabled || this._touchEvents.length !== 1) {
         removeEventListeners();
       }
     };
@@ -953,21 +935,22 @@ export class FlexibleControls extends EventDispatcher<FlexibleControlsEvent> {
   }
 
   private handleRotationFromKeyboard(timeScale: number): boolean {
+    const speedFactor = this._keyboard.isShiftPressed() ? this._options.keyboardFastRotationFactor : 1;
+
     const deltaAzimuthAngle =
       this._options.keyboardRotationSpeedAzimuth *
+      speedFactor *
       this._keyboard.getKeyboardMovementValue('ArrowLeft', 'ArrowRight') *
       timeScale;
 
     const deltaPolarAngle =
       this._options.keyboardRotationSpeedPolar *
+      speedFactor *
       this._keyboard.getKeyboardMovementValue('ArrowUp', 'ArrowDown') *
       timeScale;
 
     if (deltaAzimuthAngle === 0 && deltaPolarAngle === 0) {
       return false;
-    }
-    if (!this.isStationary) {
-      this.setControlsType(FlexibleControlsType.FirstPerson);
     }
     this.rotateByAngles(-deltaAzimuthAngle, -deltaPolarAngle);
     return true;

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
@@ -8,7 +8,7 @@ import { FlexibleMouseActionType } from './FlexibleMouseActionType';
 import { FlexibleWheelZoomType } from './FlexibleWheelZoomType';
 
 const DEFAULT_POINTER_ROTATION_SPEED = (0.5 * Math.PI) / 360; // half degree per pixel
-const DEFAULT_KEYBOARD_ROTATION_SPEED = DEFAULT_POINTER_ROTATION_SPEED * 2.5;
+const DEFAULT_KEYBOARD_ROTATION_SPEED = DEFAULT_POINTER_ROTATION_SPEED * 5;
 const DEFAULT_MIN_POLAR_ANGLE = 0.0001;
 
 /**
@@ -59,6 +59,7 @@ export class FlexibleControlsOptions {
   public mouseRotationSpeedPolar = DEFAULT_POINTER_ROTATION_SPEED;
   public keyboardRotationSpeedAzimuth = DEFAULT_KEYBOARD_ROTATION_SPEED;
   public keyboardRotationSpeedPolar = DEFAULT_KEYBOARD_ROTATION_SPEED * 0.8;
+  public keyboardFastRotationFactor = 4;
 
   // Wheel settings
   public zoomFraction = 0.05;

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
@@ -59,7 +59,7 @@ export class FlexibleControlsOptions {
   public mouseRotationSpeedPolar = DEFAULT_POINTER_ROTATION_SPEED;
   public keyboardRotationSpeedAzimuth = DEFAULT_KEYBOARD_ROTATION_SPEED;
   public keyboardRotationSpeedPolar = DEFAULT_KEYBOARD_ROTATION_SPEED * 0.8;
-  public keyboardFastRotationFactor = 4;
+  public keyboardFastRotationFactor = 2;
 
   // Wheel settings
   public zoomFraction = 0.05;

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -911,6 +911,8 @@ export class FlexibleControlsOptions {
     // (undocumented)
     keyboardFastMoveFactor: number;
     // (undocumented)
+    keyboardFastRotationFactor: number;
+    // (undocumented)
     keyboardPanSpeed: number;
     // (undocumented)
     keyboardRotationSpeedAzimuth: number;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->


## Description :pencil:
@greenbech found a few issues and suggestions:

* Bug: When camera state uses a rotation, the navigation do not work properly afterwards. This was caused by a old hack in the code, and is now removed. The hack is not longer necessary because the old AxisTool is not in used anymore. 
* Increase speed rotation x 2 with keyboard
* Increase speed rotation x 4 with keyboard + shift
* Do not need to automatically switch to first person mode when using the keyboard arrows only. 

