### PR TITLE
fix(react-components): Transform of 360 in Scene

### DIFF
--- a/react-components/src/hooks/useReveal3dResourcesFromScene.ts
+++ b/react-components/src/hooks/useReveal3dResourcesFromScene.ts
@@ -53,7 +53,7 @@ export const useReveal3dResourcesFromScene = (
         space: collection.image360CollectionSpace
       };
 
-      addResourceOptions.push({ ...addModelOptions, ...transform });
+      addResourceOptions.push({ ...addModelOptions, transform });
     });
     setResourceOptions(addResourceOptions);
   }, [scene.data]);


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
360 image transform should not be unpacked into it's components when added to type `AddResourceOptions`. This makes all 360 image collections added from Scene to have the identity transform

## How has this been tested? :mag:
Have aligned a 360 collection and verified that the position is correct.

## Test instructions :information_source:
Open `Anders Ground Plane Scene` in the `Scenecontainer` storybook and see that it has a position in the corner of the groundplane. Open it in master and see that it is in the center

Image of correct placement
![image](https://github.com/cognitedata/reveal/assets/25608141/3047fec8-cb3f-47ca-b688-1314d21c1973)


## Checklist :ballot_box_with_check:

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
