### PR TITLE
fix(react-components): remove setting camera position, rotation from SceneContainer

### DIFF
--- a/react-components/src/components/SceneContainer/SceneContainer.tsx
+++ b/react-components/src/components/SceneContainer/SceneContainer.tsx
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2023 Cognite AS
  */
-import { useEffect, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import {
   type Image360AssetStylingGroup,
   type AssetStylingGroup,
@@ -12,8 +12,6 @@ import { useReveal3dResourcesFromScene } from '../../hooks/useReveal3dResourcesF
 import { useGroundPlaneFromScene } from '../../hooks/useGroundPlaneFromScene';
 import { useSkyboxFromScene } from '../../hooks/useSkyboxFromScene';
 import { Reveal3DResources } from '../Reveal3DResources/Reveal3DResources';
-import { useLoadedScene } from './LoadedSceneContext';
-import { useSceneDefaultCamera } from '../../hooks/useSceneDefaultCamera';
 
 export type SceneContainerProps = {
   sceneExternalId: string;
@@ -33,19 +31,6 @@ export function SceneContainer({
   onResourceLoadError
 }: SceneContainerProps): ReactElement {
   const resourceOptions = useReveal3dResourcesFromScene(sceneExternalId, sceneSpaceId);
-  const { loadedScene, setScene } = useLoadedScene();
-  const defaultSceneCamera = useSceneDefaultCamera(sceneExternalId, sceneSpaceId);
-
-  useEffect(() => {
-    if (
-      !defaultSceneCamera.isFetched ||
-      (loadedScene?.externalId === sceneExternalId && loadedScene?.spaceId === sceneSpaceId)
-    ) {
-      return;
-    }
-    defaultSceneCamera.fitCameraToSceneDefault();
-    setScene({ externalId: sceneExternalId, spaceId: sceneSpaceId });
-  }, [defaultSceneCamera]);
 
   useGroundPlaneFromScene(sceneExternalId, sceneSpaceId);
   useSkyboxFromScene(sceneExternalId, sceneSpaceId);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
Loading `Search` with `Copy URL` is not positioning the camera to URL value and was setting the camera to `SceneConfiguration` position and rotation, In this PR, I have removed loading scene default camera position, rotation and moved it to be handled in the application (`Search`).

## How has this been tested? :mag:

In `Search`

## Test instructions :information_source:

- `yalc` link `react-component` to `fusion`
- Load `Search` and `Browse to 3D` page
- Switch between different `scenes`, camera should be positioned to `Scene's default camera position & rotation`
- Select `List view` & back to `3D view`, camera position & rotation should be maintained as previous.
- Select `Copy URL to share` from Toolbar and load it in New tab/window, camera position & rotation should be maintained as in URL.


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
