### PR TITLE
fix: adding label into HTMLOverlayTool while loading viewer with URL state through measurement

### DIFF
--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.test.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.test.ts
@@ -16,12 +16,14 @@ import { Cognite3DViewer } from '@reveal/api';
 import { jest } from '@jest/globals';
 import { fakeGetBoundingClientRect, mockViewerComponents } from '../../../../test-utilities';
 
+const TIMER_ADVANCE_MS = 50;
 describe(HtmlOverlayTool.name, () => {
   let canvasContainer: HTMLElement;
   let viewer: Cognite3DViewer;
   let renderer: THREE.WebGLRenderer;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     const components = mockViewerComponents();
     viewer = components.viewer;
     renderer = components.renderer;
@@ -37,7 +39,10 @@ describe(HtmlOverlayTool.name, () => {
     const position = new THREE.Vector3();
 
     // Act & Assert
-    expect(() => helper.add(htmlElement, position)).toThrowError();
+    expect(() => {
+      helper.add(htmlElement, position);
+      jest.advanceTimersByTime(TIMER_ADVANCE_MS);
+    }).toThrowError();
   });
 
   test('add() accepts position set to absolute through cssText', () => {
@@ -62,6 +67,7 @@ describe(HtmlOverlayTool.name, () => {
 
     // Act
     helper.add(htmlElement, position);
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
     helper.forceUpdate();
 
     // Assert
@@ -95,6 +101,8 @@ describe(HtmlOverlayTool.name, () => {
     const position = new THREE.Vector3(0, 0, 0.5);
 
     helper.add(htmlElement, position);
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
+
     helper.forceUpdate();
 
     expect(htmlElement.style.visibility).toBe('visible');
@@ -121,11 +129,15 @@ describe(HtmlOverlayTool.name, () => {
 
     // Act
     helper.add(behindCameraElement, new THREE.Vector3(0, 0, -1), { ...options, userData: 'behindCameraElement' });
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
     helper.add(behindFarPlaneElement, new THREE.Vector3(0, 0, 10), { ...options, userData: 'behindFarPlaneElement' });
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
     helper.add(withinNearAndFarPlaneElement, new THREE.Vector3(0, 0, 0.5), {
       ...options,
       userData: 'withinNearAndFarPlaneElement'
     });
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
+
     helper.forceUpdate();
 
     // Assert
@@ -160,6 +172,7 @@ describe(HtmlOverlayTool.name, () => {
       const element = document.createElement('div');
       element.style.position = 'absolute';
       helper.add(element, new THREE.Vector3(0, 0, 0));
+      jest.advanceTimersByTime(TIMER_ADVANCE_MS);
     }
     expect(canvasContainer.children.length).toBe(initialNumberOfElements + 10);
 
@@ -178,6 +191,7 @@ describe(HtmlOverlayTool.name, () => {
       const element = document.createElement('div');
       element.style.position = 'absolute';
       helper.add(element, new THREE.Vector3(0, 0, 0));
+      jest.advanceTimersByTime(TIMER_ADVANCE_MS);
     }
 
     // Act
@@ -206,7 +220,11 @@ describe(HtmlOverlayTool.name, () => {
 
     // Act
     helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
+
     helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
+
     helper.forceUpdate();
 
     // Assert
@@ -233,8 +251,13 @@ describe(HtmlOverlayTool.name, () => {
 
     // Act
     helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
+
     helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    jest.advanceTimersByTime(TIMER_ADVANCE_MS);
+
     helper.forceUpdate();
+
     expect(div1.parentElement).not.toBeNull();
     expect(div2.parentElement).not.toBeNull();
     expect(compositeElement.parentElement).not.toBeNull();

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -141,6 +141,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   private readonly _htmlOverlays: Map<HTMLElement, HtmlOverlayElement> = new Map();
   private readonly _compositeOverlays: HTMLElement[] = [];
   private _visible: boolean;
+  private readonly TIMER_ADVANCE_MS = 50;
 
   private readonly _onSceneRenderedHandler: SceneRenderedDelegate;
   private readonly _onViewerDisposedHandler: DisposedDelegate;
@@ -243,7 +244,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
       this._htmlOverlays.set(htmlElement, element);
 
       this.scheduleUpdate();
-    }, 50);
+    }, this.TIMER_ADVANCE_MS);
   }
 
   /**

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -223,25 +223,27 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
 
     // Note! Must be part of DOM tree before we do getComputedStyle(), so add before check
     this.viewerDomElement.appendChild(htmlElement);
-    const style = getComputedStyle(htmlElement);
-    if (style.position !== 'absolute') {
-      this.viewerDomElement.removeChild(htmlElement);
-      throw new Error(`htmlElement style must have a position of absolute. but was '${style.position}'`);
-    }
-
-    const element: HtmlOverlayElement = {
-      position3D,
-      options,
-      state: {
-        position2D: new THREE.Vector2(),
-        width: -1,
-        height: -1,
-        visible: true
+    setTimeout(() => {
+      const style = getComputedStyle(htmlElement);
+      if (!style.position || style.position !== 'absolute') {
+        this.viewerDomElement.removeChild(htmlElement);
+        throw new Error(`htmlElement style must have a position of absolute. but was '${style.position}'`);
       }
-    };
-    this._htmlOverlays.set(htmlElement, element);
 
-    this.scheduleUpdate();
+      const element: HtmlOverlayElement = {
+        position3D,
+        options,
+        state: {
+          position2D: new THREE.Vector2(),
+          width: -1,
+          height: -1,
+          visible: true
+        }
+      };
+      this._htmlOverlays.set(htmlElement, element);
+
+      this.scheduleUpdate();
+    }, 50);
   }
 
   /**


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4109, check parent bug ticket for details

## Description :pencil:
DOM has not been updated to reflect the changes to `htmlElement` before `getComputedStyle()` is called in `HTMLOverlayTool` while adding `htmlElement` which was causing issue when loading `measurement label` from `URL` link in `Search` application.
Have added a `timeout` to make sure the DOM has updated to reflect the changes.

## How has this been tested? :mag:

In `Search`

## Test instructions :information_source:

- `yalc` push `viewer`
- `yalc` add in `fusion`
- Load Search and Browse to 3D page
- Select Distance measuring tool from Toolbar
- Create a point to point measurement
- Select Copy URL to share from Toolbar
- Open new browser tab/window and paste the url and Enter


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
