### PR TITLE
fix(react-components): empty/blank menu item rendering for zero models in a resource type for Layer Button

### DIFF
--- a/react-components/src/components/RevealToolbar/LayersContainer/LayersContainer.tsx
+++ b/react-components/src/components/RevealToolbar/LayersContainer/LayersContainer.tsx
@@ -30,27 +30,21 @@ export const LayersContainer = ({
               onClick={(event: MouseEvent<HTMLElement>) => {
                 event.stopPropagation();
               }}>
-              {modelHandlers.cadHandlers.length > 0 && (
-                <LayerToggleDropdown
-                  layerHandlers={modelHandlers.cadHandlers}
-                  update={update}
-                  label={t('CAD_MODELS', 'CAD models')}
-                />
-              )}
-              {modelHandlers.pointCloudHandlers.length > 0 && (
-                <LayerToggleDropdown
-                  layerHandlers={modelHandlers.pointCloudHandlers}
-                  update={update}
-                  label={t('POINT_CLOUDS', 'Pointclouds')}
-                />
-              )}
-              {modelHandlers.image360Handlers.length > 0 && (
-                <LayerToggleDropdown
-                  layerHandlers={modelHandlers.image360Handlers}
-                  update={update}
-                  label={t('360_IMAGES', '360 images')}
-                />
-              )}
+              <LayerToggleDropdown
+                layerHandlers={modelHandlers.cadHandlers}
+                update={update}
+                label={t('CAD_MODELS', 'CAD models')}
+              />
+              <LayerToggleDropdown
+                layerHandlers={modelHandlers.pointCloudHandlers}
+                update={update}
+                label={t('POINT_CLOUDS', 'Pointclouds')}
+              />
+              <LayerToggleDropdown
+                layerHandlers={modelHandlers.image360Handlers}
+                update={update}
+                label={t('360_IMAGES', '360 images')}
+              />
             </StyledMenu>
           </Container>
         </>

--- a/react-components/src/components/RevealToolbar/LayersContainer/LayersContainer.tsx
+++ b/react-components/src/components/RevealToolbar/LayersContainer/LayersContainer.tsx
@@ -30,21 +30,27 @@ export const LayersContainer = ({
               onClick={(event: MouseEvent<HTMLElement>) => {
                 event.stopPropagation();
               }}>
-              <LayerToggleDropdown
-                layerHandlers={modelHandlers.cadHandlers}
-                update={update}
-                label={t('CAD_MODELS', 'CAD models')}
-              />
-              <LayerToggleDropdown
-                layerHandlers={modelHandlers.pointCloudHandlers}
-                update={update}
-                label={t('POINT_CLOUDS', 'Pointclouds')}
-              />
-              <LayerToggleDropdown
-                layerHandlers={modelHandlers.image360Handlers}
-                update={update}
-                label={t('360_IMAGES', '360 images')}
-              />
+              {modelHandlers.cadHandlers.length > 0 && (
+                <LayerToggleDropdown
+                  layerHandlers={modelHandlers.cadHandlers}
+                  update={update}
+                  label={t('CAD_MODELS', 'CAD models')}
+                />
+              )}
+              {modelHandlers.pointCloudHandlers.length > 0 && (
+                <LayerToggleDropdown
+                  layerHandlers={modelHandlers.pointCloudHandlers}
+                  update={update}
+                  label={t('POINT_CLOUDS', 'Pointclouds')}
+                />
+              )}
+              {modelHandlers.image360Handlers.length > 0 && (
+                <LayerToggleDropdown
+                  layerHandlers={modelHandlers.image360Handlers}
+                  update={update}
+                  label={t('360_IMAGES', '360 images')}
+                />
+              )}
             </StyledMenu>
           </Container>
         </>

--- a/react-components/src/components/RevealToolbar/LayersContainer/ModelLayersList.tsx
+++ b/react-components/src/components/RevealToolbar/LayersContainer/ModelLayersList.tsx
@@ -21,6 +21,9 @@ export const ModelLayersList = ({
   update: UpdateModelHandlersCallback;
   label?: string;
 }): ReactElement => {
+  if (modelHandlers.length === 0) {
+    return <></>;
+  }
   return (
     <SuppressedMenu>
       {label !== undefined && (


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
When zero model is added into viewer for a specific type (`cad/point-cloud/360 image`), then `Layer Button` submenu for this specific type would render a empty item was shown (ref: below image)
![image](https://github.com/cognitedata/reveal/assets/87521752/6f42d187-2bba-4f0e-987a-fc78aafd189f)
 In this PR, an empty element is returned to fix the issue

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
