### PR TITLE
chore: remove renovate PR throttle

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,6 @@
       "automerge": false,
       "stabilityDays": 10,
       "internalChecksFilter": "strict",
-      "prConcurrentLimit": 5,
       "enabled": true
     },
     {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

As we are now batching minor/patch updates, there should not be any reason to throttle renovate PRs anymore.