### PR TITLE
feat(react-components): Added asset contextualize button and improved asset contextualization caching

### DIFF
--- a/react-components/src/components/CacheProvider/AssetMappingCache.ts
+++ b/react-components/src/components/CacheProvider/AssetMappingCache.ts
@@ -8,11 +8,17 @@ import {
   type Node3D,
   type CogniteInternalId
 } from '@cognite/sdk';
-import { type AssetId, type ModelId, type ModelRevisionKey, type RevisionId } from './types';
-import { maxBy } from 'lodash';
+import {
+  type ModelNodeIdKey,
+  type AssetId,
+  type ModelId,
+  type ModelRevisionKey,
+  type RevisionId
+} from './types';
+import { chunk, maxBy } from 'lodash';
 import assert from 'assert';
 import { fetchNodesForNodeIds } from './requests';
-import { modelRevisionToKey } from './utils';
+import { modelRevisionNodesToKey, modelRevisionToKey } from './utils';
 
 export type NodeAssetMappingResult = { node?: Node3D; mappings: AssetMapping[] };
 
@@ -22,6 +28,10 @@ export class AssetMappingCache {
   private readonly _sdk: CogniteClient;
 
   private readonly _modelToAssetMappings = new Map<ModelRevisionKey, Promise<AssetMapping[]>>();
+  private readonly _nodeAssetIdsToAssetMappings = new Map<
+    ModelNodeIdKey,
+    Promise<AssetMapping[]>
+  >();
 
   constructor(sdk: CogniteClient) {
     this._sdk = sdk;
@@ -37,9 +47,9 @@ export class AssetMappingCache {
     }
 
     const searchTreeIndices = new Set(ancestors.map((ancestor) => ancestor.treeIndex));
-    const allModelMappings = await this.getAssetMappingsForModel(modelId, revisionId);
+    const allNodeMappings = await this.getAssetMappingsForNodes(modelId, revisionId, ancestors);
 
-    const relevantMappings = allModelMappings.filter((mapping) =>
+    const relevantMappings = allNodeMappings.filter((mapping) =>
       searchTreeIndices.has(mapping.treeIndex)
     );
 
@@ -66,48 +76,12 @@ export class AssetMappingCache {
     return { node: nearestMappedAncestor, mappings: mappingsOfNearestAncestor };
   }
 
-  public async getAssetMappingsForModel(
-    modelId: ModelId,
-    revisionId: RevisionId
-  ): Promise<AssetMapping[]> {
-    const key = modelRevisionToKey(modelId, revisionId);
-    const cachedResult = this._modelToAssetMappings.get(key);
-
-    if (cachedResult !== undefined) {
-      return await cachedResult;
-    }
-
-    return await this.fetchAndCacheMappingsForModel(modelId, revisionId);
-  }
-
-  private async fetchAndCacheMappingsForModel(
-    modelId: ModelId,
-    revisionId: RevisionId
-  ): Promise<AssetMapping[]> {
-    const key = modelRevisionToKey(modelId, revisionId);
-    const assetMappings = this.fetchAssetMappingsForModel(modelId, revisionId);
-
-    this._modelToAssetMappings.set(key, assetMappings);
-    return await assetMappings;
-  }
-
-  private async fetchAssetMappingsForModel(
-    modelId: ModelId,
-    revisionId: RevisionId
-  ): Promise<AssetMapping[]> {
-    const assetMapping3D = await this._sdk.assetMappings3D
-      .list(modelId, revisionId, { limit: 1000 })
-      .autoPagingToArray({ limit: Infinity });
-
-    return assetMapping3D.filter(isValidAssetMapping);
-  }
-
   public async getNodesForAssetIds(
     modelId: ModelId,
     revisionId: RevisionId,
     assetIds: CogniteInternalId[]
   ): Promise<Map<AssetId, Node3D[]>> {
-    const assetMappings = await this.getAssetMappingsForModel(modelId, revisionId);
+    const assetMappings = await this.getAssetMappingsForAssetIds(modelId, revisionId, assetIds);
     const relevantAssetIds = new Set(assetIds);
 
     const relevantAssetMappings = assetMappings.filter((mapping) =>
@@ -133,6 +107,94 @@ export class AssetMappingCache {
 
       return acc;
     }, new Map<AssetId, Node3D[]>());
+  }
+
+  public async getAssetMappingsForModel(
+    modelId: ModelId,
+    revisionId: RevisionId
+  ): Promise<AssetMapping[]> {
+    const key = modelRevisionToKey(modelId, revisionId);
+    const cachedResult = this._modelToAssetMappings.get(key);
+
+    if (cachedResult !== undefined) {
+      return await cachedResult;
+    }
+
+    return await this.fetchAndCacheMappingsForModel(modelId, revisionId);
+  }
+
+  private async fetchAndCacheMappingsForIds(
+    modelId: ModelId,
+    revisionId: RevisionId,
+    ids: number[],
+    filterType: string
+  ): Promise<AssetMapping[]> {
+    const key: ModelNodeIdKey = modelRevisionNodesToKey(modelId, revisionId, ids);
+    const idChunks = chunk(ids, 100);
+    const assetMappingsPromises = idChunks.map(async (idChunk) => {
+      const filter = filterType === 'nodeIds' ? { nodeIds: idChunk } : { assetIds: idChunk };
+      return await this._sdk.assetMappings3D
+        .filter(modelId, revisionId, {
+          limit: 1000,
+          filter
+        })
+        .autoPagingToArray({ limit: Infinity });
+    });
+    const assetMappingsArrays = await Promise.all(assetMappingsPromises);
+    const assetMappings = assetMappingsArrays.flat();
+    this._nodeAssetIdsToAssetMappings.set(key, Promise.resolve(assetMappings));
+    return assetMappings;
+  }
+
+  private async getAssetMappingsForNodes(
+    modelId: ModelId,
+    revisionId: RevisionId,
+    nodes: Node3D[]
+  ): Promise<AssetMapping[]> {
+    const nodeIds = nodes.map((node) => node.id);
+    const key: ModelNodeIdKey = modelRevisionNodesToKey(modelId, revisionId, nodeIds);
+    const cachedResult = this._nodeAssetIdsToAssetMappings.get(key);
+
+    if (cachedResult !== undefined) {
+      return await cachedResult;
+    }
+    return await this.fetchAndCacheMappingsForIds(modelId, revisionId, nodeIds, 'nodeIds');
+  }
+
+  private async getAssetMappingsForAssetIds(
+    modelId: ModelId,
+    revisionId: RevisionId,
+    assetIds: number[]
+  ): Promise<AssetMapping[]> {
+    const key: ModelNodeIdKey = modelRevisionNodesToKey(modelId, revisionId, assetIds);
+    const cachedResult = this._nodeAssetIdsToAssetMappings.get(key);
+
+    if (cachedResult !== undefined) {
+      return await cachedResult;
+    }
+    return await this.fetchAndCacheMappingsForIds(modelId, revisionId, assetIds, 'assetIds');
+  }
+
+  private async fetchAndCacheMappingsForModel(
+    modelId: ModelId,
+    revisionId: RevisionId
+  ): Promise<AssetMapping[]> {
+    const key = modelRevisionToKey(modelId, revisionId);
+    const assetMappings = this.fetchAssetMappingsForModel(modelId, revisionId);
+
+    this._modelToAssetMappings.set(key, assetMappings);
+    return await assetMappings;
+  }
+
+  private async fetchAssetMappingsForModel(
+    modelId: ModelId,
+    revisionId: RevisionId
+  ): Promise<AssetMapping[]> {
+    const assetMapping3D = await this._sdk.assetMappings3D
+      .list(modelId, revisionId, { limit: 1000 })
+      .autoPagingToArray({ limit: Infinity });
+
+    return assetMapping3D.filter(isValidAssetMapping);
   }
 }
 

--- a/react-components/src/components/CacheProvider/utils.ts
+++ b/react-components/src/components/CacheProvider/utils.ts
@@ -13,11 +13,21 @@ import {
   type ModelAssetIdKey,
   type ModelId,
   type ModelRevisionKey,
-  type RevisionId
+  type RevisionId,
+  type ModelNodeIdKey
 } from './types';
 
 export function modelRevisionToKey(modelId: ModelId, revisionId: RevisionId): ModelRevisionKey {
   return `${modelId}/${revisionId}`;
+}
+
+export function modelRevisionNodesToKey(
+  modelId: ModelId,
+  revisionId: RevisionId,
+  nodeIds: number[]
+): ModelNodeIdKey {
+  const nodeIdsSerialized = nodeIds.reduce((a, b) => a + b, 0);
+  return `${modelId}/${revisionId}/${nodeIdsSerialized}`;
 }
 
 export function modelRevisionAssetIdsToKey(

--- a/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
+++ b/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
@@ -37,9 +37,9 @@ export const Reveal3DResources = ({
   onResourcesAdded,
   onResourceLoadError
 }: Reveal3DResourcesProps): ReactElement => {
+  const viewer = useReveal();
   const [reveal3DModels, setReveal3DModels] = useState<TypedReveal3DModel[]>([]);
 
-  const viewer = useReveal();
   const numModelsLoaded = useRef(0);
 
   useEffect(() => {

--- a/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
+++ b/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
@@ -1,0 +1,48 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+import { useState, type ReactElement } from 'react';
+
+import { Button, Tooltip as CogsTooltip } from '@cognite/cogs.js';
+import { useTranslation } from '../i18n/I18n';
+import { use3dModels } from '../../hooks/use3dModels';
+import { useAssetMappedNodesForRevisions } from '../CacheProvider/AssetMappingCacheProvider';
+import { type CadModelOptions } from '../Reveal3DResources/types';
+
+type AssetContextualizedButtonProps = {
+  setEnableCustomDefaultStyling: (enabled: boolean) => void;
+};
+
+export const AssetContextualizedButton = ({
+  setEnableCustomDefaultStyling
+}: AssetContextualizedButtonProps): ReactElement => {
+  const { t } = useTranslation();
+  const models = use3dModels();
+  const cadModels = models.filter((model) => model.type === 'cad') as CadModelOptions[];
+  const [enableContextualizedStyling, setEnableContextualizedStyling] = useState<boolean>(false);
+  const { isLoading } = useAssetMappedNodesForRevisions(cadModels);
+
+  const onClick = (): void => {
+    setEnableContextualizedStyling((prevState) => !prevState);
+    setEnableCustomDefaultStyling(!enableContextualizedStyling);
+  };
+
+  return (
+    <CogsTooltip
+      content={t(
+        'CONTEXTUALIZED_ASSETS_TOOLTIP',
+        isLoading ? 'Loading contextualized assets' : 'Contextualized assets'
+      )}
+      placement="right"
+      appendTo={document.body}>
+      <Button
+        type="ghost"
+        icon="Assets"
+        toggled={enableContextualizedStyling}
+        aria-label="asset-labels-button"
+        onClick={onClick}
+        disabled={isLoading}
+      />
+    </CogsTooltip>
+  );
+};

--- a/react-components/src/components/RevealToolbar/RevealToolbar.tsx
+++ b/react-components/src/components/RevealToolbar/RevealToolbar.tsx
@@ -21,6 +21,7 @@ import {
   SetFlexibleControlsType,
   SetOrbitOrFirstPersonControlsType
 } from './SetFlexibleControlsType';
+import { AssetContextualizedButton } from './AssetContextualizedButton';
 
 const StyledToolBar = styled(ToolBar)`
   position: absolute;
@@ -111,6 +112,7 @@ export const RevealToolbar = withSuppressRevealEvents(
   ResetCameraButton: typeof ResetCameraButton;
   SelectSceneButton: typeof SelectSceneButton;
   RuleBasedOutputsButton: typeof RuleBasedOutputsButton;
+  AssetContextualizedButton: typeof AssetContextualizedButton;
   SetOrbitOrFirstPersonControlsType: typeof SetOrbitOrFirstPersonControlsType;
   SetFlexibleControlsType: typeof SetFlexibleControlsType;
 };
@@ -125,5 +127,6 @@ RevealToolbar.HelpButton = HelpButton;
 RevealToolbar.ResetCameraButton = ResetCameraButton;
 RevealToolbar.SelectSceneButton = SelectSceneButton;
 RevealToolbar.RuleBasedOutputsButton = RuleBasedOutputsButton;
+RevealToolbar.AssetContextualizedButton = AssetContextualizedButton;
 RevealToolbar.SetOrbitOrFirstPersonControlsType = SetOrbitOrFirstPersonControlsType;
 RevealToolbar.SetFlexibleControlsType = SetFlexibleControlsType;

--- a/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
+++ b/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
@@ -20,7 +20,10 @@ import {
 } from '../RuleBasedOutputs/types';
 import { useTranslation } from '../i18n/I18n';
 import { useFetchRuleInstances } from '../RuleBasedOutputs/hooks/useFetchRuleInstances';
+import { use3dModels } from '../../hooks/use3dModels';
 import { type AssetStylingGroup } from '../..';
+import { type CadModelOptions } from '../Reveal3DResources/types';
+import { useAssetMappedNodesForRevisions } from '../CacheProvider/AssetMappingCacheProvider';
 
 type RuleBasedOutputsButtonProps = {
   onRuleSetStylingChanged?: (stylings: AssetStylingGroup[] | undefined) => void;
@@ -31,6 +34,9 @@ export const RuleBasedOutputsButton = ({
   const [currentRuleSetEnabled, setCurrentRuleSetEnabled] = useState<RuleAndEnabled>();
   const [ruleInstances, setRuleInstances] = useState<RuleAndEnabled[]>();
   const { t } = useTranslation();
+  const models = use3dModels();
+  const cadModels = models.filter((model) => model.type === 'cad') as CadModelOptions[];
+  const { isLoading } = useAssetMappedNodesForRevisions(cadModels);
 
   const ruleInstancesResult = useFetchRuleInstances();
 
@@ -69,6 +75,7 @@ export const RuleBasedOutputsButton = ({
         appendTo={document.body}>
         <Dropdown
           placement="right-start"
+          disabled={isLoading}
           content={
             <Menu
               style={{

--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -63,6 +63,7 @@ export {
 export {
   useSearchMappedEquipmentAssetMappings,
   useAllMappedEquipmentAssetMappings,
+  useMappingsForAssetIds,
   type ModelMappings,
   type ModelMappingsWithAssets
 } from './query/useSearchMappedEquipmentAssetMappings';

--- a/react-components/stories/ModelsStyling.stories.tsx
+++ b/react-components/stories/ModelsStyling.stories.tsx
@@ -2,14 +2,14 @@
  * Copyright 2023 Cognite AS
  */
 import type { Meta, StoryObj } from '@storybook/react';
-import { Reveal3DResources, RevealCanvas, RevealContext } from '../src';
+import { Reveal3DResources, RevealCanvas, RevealContext, RevealToolbar } from '../src';
 import { Color, Matrix4 } from 'three';
 import { createSdkByUrlToken } from './utilities/createSdkByUrlToken';
 import { RevealResourcesFitCameraOnLoad } from './utilities/with3dResoursesFitCameraOnLoad';
 
 const model = {
-  modelId: 2231774635735416,
-  revisionId: 912809199849811,
+  modelId: 7646043527629245,
+  revisionId: 6059566106376463,
   transform: new Matrix4().makeTranslation(-340, -480, 80)
 };
 
@@ -86,6 +86,7 @@ export const Main: Story = {
             resources={resources}
             defaultResourceStyling={defaultResourceStyling}
           />
+          <RevealToolbar />
         </RevealCanvas>
       </RevealContext>
     );


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4197

## Description :pencil:
In Search, loading huge number of assets (> 1 million) would freeze the application and enable to use further.
This PR solves the issue by
- Load all asset mapping of the model in background and enable `Asset Contextualized` button when all asset is loaded which will give asset mapped node highlighting option.
- User can still click 3D nodes while maintaining separate cache for selected assets and nodes
- Have also enabled default coloring of nodes

## How has this been tested? :mag:

Majorly in `Search` but also storybook


## Test instructions :information_source:

- yalc link `react-components` to fusion [branch](https://github.com/cognitedata/fusion/tree/pramodcog/BND3D-4197) 
- Run `ModelsStyling` story example


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
