### PR TITLE
fix: renderlayers get updated with stale data from material manager

### DIFF
--- a/viewer/packages/cad-model/src/wrappers/CadNode.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadNode.ts
@@ -91,7 +91,7 @@ export class CadNode extends Object3D {
     this._sourceTransform = new Matrix4().copy(model.modelMatrix);
     this._customTransform = new Matrix4();
 
-    this.nodeAppearanceProvider.on('changed', this._setModelRenderLayers);
+    this.materialManager.on('materialsChanged', this._setModelRenderLayers);
   }
 
   get needsRedraw(): boolean {
@@ -210,7 +210,7 @@ export class CadNode extends Object3D {
 
   public dispose(): void {
     this.nodeAppearanceProvider.dispose();
-    this.nodeAppearanceProvider.off('changed', this._setModelRenderLayers);
+    this.materialManager.off('materialsChanged', this._setModelRenderLayers);
     this._sectorRepository.clearCache();
     this._materialManager.removeModelMaterials(this._cadModelMetadata.modelIdentifier);
     this._geometryBatchingManager?.dispose();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4264

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Cad node is updating the renderlayers based on when the node appearance provider triggers a change, but the material manager throttles (yields), and may have stale data when the render layers are computed. So correct behaviour is to rather listen for when the material manager updates.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Can be reproduced with the follow visual test setup (Default.VisualTest.ts)

```ts
export default class DefaultVisualTest extends ViewerVisualTestFixture {
  public async setup({ models, viewer }: ViewerTestFixtureComponents): Promise<void> {
    const model = models[0] as CogniteCadModel;
    const a = new TreeIndexNodeCollection([1]);
    const b = new TreeIndexNodeCollection([2]);
    const appearance: NodeAppearance = { renderInFront: true, color: new Color('red') };
    model.assignStyledNodeCollection(b, appearance);
    model.unassignStyledNodeCollection(b);
    await new Promise(resolve => setTimeout(resolve, 0));
    model.assignStyledNodeCollection(a, appearance);
  }
}
```