### PR TITLE
feat (react-components): Use primary button for cropping and do not show measurements completely outside the bounding box

### DIFF
--- a/react-components/src/architecture/concrete/clipping/commands/ApplyClipCommand.ts
+++ b/react-components/src/architecture/concrete/clipping/commands/ApplyClipCommand.ts
@@ -26,6 +26,10 @@ export class ApplyClipCommand extends RenderTargetCommand {
     return 'Crop';
   }
 
+  public override get buttonType(): string {
+    return 'primary';
+  }
+
   public override get isEnabled(): boolean {
     if (this.getSelectedCropBoxDomainObject() !== undefined) {
       return true;

--- a/react-components/src/architecture/concrete/primitives/line/LineDomainObject.ts
+++ b/react-components/src/architecture/concrete/primitives/line/LineDomainObject.ts
@@ -5,7 +5,7 @@
 import { type RenderStyle } from '../../../base/renderStyles/RenderStyle';
 import { type ThreeView } from '../../../base/views/ThreeView';
 import { LineView } from './LineView';
-import { Vector3 } from 'three';
+import { Box3, Vector3 } from 'three';
 import { PrimitiveType } from '../PrimitiveType';
 import { LineRenderStyle } from './LineRenderStyle';
 import {
@@ -195,6 +195,14 @@ export abstract class LineDomainObject extends VisualDomainObject {
       p0.copy(p1);
     }
     return Math.abs(sum) / 2;
+  }
+
+  public getBoundingBox(): Box3 {
+    const boundingBox = new Box3().makeEmpty();
+    for (const point of this.points) {
+      boundingBox.expandByPoint(point);
+    }
+    return boundingBox;
   }
 
   public setFocusInteractive(focusType: FocusType): boolean {

--- a/react-components/src/components/Architecture/CommandButton.tsx
+++ b/react-components/src/components/Architecture/CommandButton.tsx
@@ -69,7 +69,7 @@ export const CommandButton = ({
   const { key, fallback } = newCommand.tooltip;
   // This was the only way it went through compiler: (more button types will be added in the future)
   const type = newCommand.buttonType;
-  if (type !== 'ghost' && type !== 'ghost-destructive') {
+  if (type !== 'ghost' && type !== 'ghost-destructive' && type !== 'primary') {
     return <></>;
   }
   const text = key === undefined ? fallback : t(key, fallback);


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:

## Description :pencil:

- If using clipping, do not show measurements that do not overlap with the clip box
- Use primary  to toggle on or off the cropping, since this is the most important in the toolbar



![image](https://github.com/cognitedata/reveal/assets/35219649/cb740db4-1621-4e54-a4fa-774ade6516b4)
![image](https://github.com/cognitedata/reveal/assets/35219649/063fafc2-e2c2-4e6f-88e4-2605d9afe512)

