### PR TITLE
fix: cone rendering sometimes overshooting

### DIFF
--- a/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
+++ b/viewer/packages/rendering/src/glsl/sector/primitives/cone.frag
@@ -98,6 +98,7 @@ void main()
   vec3 intersectionPoint = E + dist * D;
   float theta = atan(intersectionPoint.y, intersectionPoint.x);
   if (theta < v_angle) theta += 2.0 * PI;
+  if (theta < v_angle) theta += 2.0 * PI;
 
   // Intersection point in camera space
   vec3 p = rayTarget + dist * rayDirection;
@@ -116,7 +117,10 @@ void main()
       intersectionPoint = E + dist * D;
       theta = atan(intersectionPoint.y, intersectionPoint.x);
       p = rayTarget + dist * rayDirection;
+
       if (theta < v_angle) theta += 2.0 * PI;
+      if (theta < v_angle) theta += 2.0 * PI;
+
       if (intersectionPoint.z <= 0.0 ||
         intersectionPoint.z > height ||
         theta > v_angle + v_arcAngle ||


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fix a bug where cones would sometimes have too large arc angle.

Before: 
![bg1](https://github.com/cognitedata/reveal/assets/70905152/531ee018-b519-4eae-849a-281f6bc4af0d)

After: 
![bg0](https://github.com/cognitedata/reveal/assets/70905152/ef9107b3-fc9c-443d-877a-f22f54de4f8d)

In technical terms, the variable `theta` is initialized to a number between `-pi` and `pi`. The code would then add `2 pi` if it was less than the starting angle of the arc, to ensure that it is larger than that starting angle. However, there is a chance that `theta` can be e.g. `-pi/2` and the starting angle could be `7/4 pi`, in which case adding `2 pi` will not make `theta` large enough. Thus, we run the same computation again to be sure that `theta` is larger that the starting angle.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In react-components storybook. Model 
```
    modelId: 1728775548730849,
    revisionId: 3207495738912031,
```
in 3d-test, greenfield

camera parameters
```
      position: new Vector3(366.85257310981, 526.1938224394785, -84.046445931295669),
      target: new Vector3(366.98927413563297, 525.5736676178238, -86.10111922871693)
```

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
