### PR TITLE
feat: Make options for  FlexibleControls available outside Reveal + Add speed option

### DIFF
--- a/viewer/packages/camera-manager/src/Flexible/FlexibleCameraManager.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleCameraManager.ts
@@ -235,6 +235,10 @@ export class FlexibleCameraManager extends PointerEvents implements IFlexibleCam
     this.updateControlsSensitivity(modelBoundingBox);
   }
 
+  public get options(): FlexibleControlsOptions {
+    return this._controls.options;
+  }
+
   //================================================
   // OVERRIDES of PointerEvents
   //================================================
@@ -292,10 +296,6 @@ export class FlexibleCameraManager extends PointerEvents implements IFlexibleCam
   //================================================
   // INSTANCE METHODS: Setters and getters
   //================================================
-
-  public get options(): FlexibleControlsOptions {
-    return this._controls.options;
-  }
 
   public get controls(): FlexibleControls {
     return this._controls;

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -975,9 +975,9 @@ export class FlexibleControls {
     if (!this.isStationary) {
       this.setControlsType(FlexibleControlsType.FirstPerson);
     }
-    const speedFactor = this._keyboard.isShiftPressed() ? this._options.keyboardFastMoveFactor : 1;
-    const speedXY = timeScale * speedFactor * this._options.keyboardPanSpeed;
-    const speedZ = timeScale * speedFactor * this._options.keyboardDollySpeed;
+    const speedSpeed = this._options.getKeyboardSpeed(this._keyboard.isShiftPressed());
+    const speedXY = timeScale * speedSpeed * this._options.keyboardPanSpeed;
+    const speedZ = timeScale * speedSpeed * this._options.keyboardDollySpeed;
 
     this.pan(speedXY * deltaX, speedXY * deltaY, speedZ * deltaZ, true);
     return true;

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -975,9 +975,9 @@ export class FlexibleControls {
     if (!this.isStationary) {
       this.setControlsType(FlexibleControlsType.FirstPerson);
     }
-    const speedSpeed = this._options.getKeyboardSpeed(this._keyboard.isShiftPressed());
-    const speedXY = timeScale * speedSpeed * this._options.keyboardPanSpeed;
-    const speedZ = timeScale * speedSpeed * this._options.keyboardDollySpeed;
+    const keyboardSpeed = this._options.getKeyboardSpeed(this._keyboard.isShiftPressed());
+    const speedXY = timeScale * keyboardSpeed * this._options.keyboardPanSpeed;
+    const speedZ = timeScale * keyboardSpeed * this._options.keyboardDollySpeed;
 
     this.pan(speedXY * deltaX, speedXY * deltaY, speedZ * deltaZ, true);
     return true;

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControlsOptions.ts
@@ -19,10 +19,10 @@ export class FlexibleControlsOptions {
   // INSTANCE FIELDS
   //================================================
 
-  // Main behaivor
+  // Main behavior
   public controlsType = FlexibleControlsType.Orbit;
 
-  // Mouse click, double click and wheel behaivor
+  // Mouse click, double click and wheel behavior
   public mouseWheelAction = FlexibleWheelZoomType.Auto;
   public mouseClickType = FlexibleMouseActionType.SetTarget;
   public mouseDoubleClickType = FlexibleMouseActionType.SetTargetAndCameraPosition;
@@ -41,7 +41,7 @@ export class FlexibleControlsOptions {
   public minAzimuthAngle = -Infinity;
   public maxAzimuthAngle = Infinity;
 
-  // Dampning
+  // Damping
   public enableDamping = true;
   public dampingFactor = 0.25;
 
@@ -72,6 +72,7 @@ export class FlexibleControlsOptions {
   public mouseDollySpeed = 100;
 
   // Keyboard speed for dolly and pan
+  public keyboardSpeed = 1;
   public keyboardPanSpeed = 100;
   public keyboardDollySpeed = 200;
   public keyboardFastMoveFactor = 5;
@@ -115,6 +116,13 @@ export class FlexibleControlsOptions {
       default:
         return false;
     }
+  }
+
+  public getKeyboardSpeed(shift: boolean): number {
+    if (!shift) {
+      return this.keyboardSpeed;
+    }
+    return this.keyboardFastMoveFactor * this.keyboardSpeed;
   }
 
   //================================================

--- a/viewer/packages/camera-manager/src/Flexible/IFlexibleCameraManager.ts
+++ b/viewer/packages/camera-manager/src/Flexible/IFlexibleCameraManager.ts
@@ -3,6 +3,7 @@
  */
 
 import { CameraManager } from '../CameraManager';
+import { FlexibleControlsOptions } from './FlexibleControlsOptions';
 import { FlexibleControlsType } from './FlexibleControlsType';
 import { Vector3 } from 'three';
 
@@ -12,7 +13,7 @@ import { Vector3 } from 'three';
 export type FlexibleControlsTypeChangeDelegate = (controlsType: FlexibleControlsType) => void;
 
 /**
- * Flexible implementation of {@link CameraManager}. The user can switch between Orbit, FirstPersion or OrbitInCenter
+ * Flexible implementation of {@link CameraManager}. The user can switch between Orbit, FirstPerson or OrbitInCenter
  * Supports automatic update of camera near and far planes and animated change of camera position and target.
  * It provides additional functionality for controlling camera behavior and rotation.
  * @beta
@@ -20,14 +21,20 @@ export type FlexibleControlsTypeChangeDelegate = (controlsType: FlexibleControls
 
 export interface IFlexibleCameraManager extends CameraManager {
   /**
-   * Get curent FlexibleControlsType type
+   * Get current FlexibleControlsType type
    */
   get controlsType(): FlexibleControlsType;
 
   /**
-   * Set curent FlexibleControlsType type
+   * Set current FlexibleControlsType type
    */
   set controlsType(value: FlexibleControlsType);
+
+  /**
+   * Set the options for the camera manager
+   * @beta
+   */
+  get options(): FlexibleControlsOptions;
 
   /**
    * Rotates the camera to look in the specified direction.

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -920,6 +920,8 @@ export class FlexibleControlsOptions {
     // (undocumented)
     enableKeyboardNavigation: boolean;
     // (undocumented)
+    getKeyboardSpeed(shift: boolean): number;
+    // (undocumented)
     getLegalAzimuthAngle(azimuthAngle: number): number;
     // (undocumented)
     getLegalFov(fov: number): number;
@@ -941,6 +943,8 @@ export class FlexibleControlsOptions {
     keyboardRotationSpeedAzimuth: number;
     // (undocumented)
     keyboardRotationSpeedPolar: number;
+    // (undocumented)
+    keyboardSpeed: number;
     // (undocumented)
     maxAzimuthAngle: number;
     // (undocumented)
@@ -1126,6 +1130,7 @@ export interface IFlexibleCameraManager extends CameraManager {
     onPointerDrag(event: PointerEvent, leftButton: boolean): Promise<void>;
     onPointerUp(event: PointerEvent, leftButton: boolean): Promise<void>;
     onWheel(event: WheelEvent, delta: number): Promise<void>;
+    get options(): FlexibleControlsOptions;
     removeControlsTypeChangeListener(callback: FlexibleControlsTypeChangeDelegate): void;
     rotateCameraTo(direction: Vector3, animationDuration: number): void;
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:

* Expose the options out of Reveal
* Made a new speed option. Default this is 0

## How has this been tested? :mag:

Can not test this yet. Another PR in components

