### PR TITLE
refactor: harmonise viewer.getViewState().camera with cameraManager.getCameraState()

### DIFF
--- a/viewer/packages/api/src/utilities/ViewStateHelper.ts
+++ b/viewer/packages/api/src/utilities/ViewStateHelper.ts
@@ -20,6 +20,7 @@ export type ViewerState = {
   camera?: {
     position: { x: number; y: number; z: number };
     target: { x: number; y: number; z: number };
+    rotation?: { x: number; y: number; z: number };
   };
   models?: ModelState[];
   clippingPlanes?: ClippingPlanesState[];
@@ -52,14 +53,15 @@ export class ViewStateHelper {
   }
 
   public getCurrentState(): ViewerState {
-    const { position: cameraPosition, target: cameraTarget } = this._cameraManager.getCameraState();
+    const { position: cameraPosition, target: cameraTarget, rotation: cameraRotation } = this._cameraManager.getCameraState();
     const modelStates = this.getModelsState();
     const clippingPlanesState = this.getClippingPlanesState();
 
     return {
       camera: {
         position: cameraPosition,
-        target: cameraTarget
+        target: cameraTarget,
+        rotation: cameraRotation,
       },
       models: modelStates,
       clippingPlanes: clippingPlanesState

--- a/viewer/packages/api/src/utilities/ViewStateHelper.ts
+++ b/viewer/packages/api/src/utilities/ViewStateHelper.ts
@@ -53,7 +53,11 @@ export class ViewStateHelper {
   }
 
   public getCurrentState(): ViewerState {
-    const { position: cameraPosition, target: cameraTarget, rotation: cameraRotation } = this._cameraManager.getCameraState();
+    const {
+      position: cameraPosition,
+      target: cameraTarget,
+      rotation: cameraRotation
+    } = this._cameraManager.getCameraState();
     const modelStates = this.getModelsState();
     const clippingPlanesState = this.getClippingPlanesState();
 
@@ -61,7 +65,7 @@ export class ViewStateHelper {
       camera: {
         position: cameraPosition,
         target: cameraTarget,
-        rotation: cameraRotation,
+        rotation: cameraRotation
       },
       models: modelStates,
       clippingPlanes: clippingPlanesState


### PR DESCRIPTION
…ger.getCameraState

#### Type of change

![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->

#### Jira ticket :blue_book:

https://cognitedata.atlassian.net/browse/

## Description :pencil:

For Cognite3DViewer.getViewState().camera, we do not return the rotation, whereas for cameraManager.getCameraState() we include the rotation. 

Harmonise these here for less confusion 

https://cognitedata.slack.com/archives/C8A0QGMLN/p1718824099346349

## How has this been tested? :mag:

Has not

## Test instructions :information_source:


