### PR TITLE
fix(react-components): deduplicate result models from `useModelsForInstanceQuery`

### DIFF
--- a/react-components/src/query/useModelsForInstanceQuery.ts
+++ b/react-components/src/query/useModelsForInstanceQuery.ts
@@ -17,10 +17,6 @@ import {
   isDmsInstance
 } from '../utilities/types';
 import { uniqBy } from 'lodash';
-import {
-  is360ImageDataModelAddOptions,
-  is360ImageEventsAddOptions
-} from '../components/Reveal3DResources/typeGuards';
 import { createAddOptionsKey } from '../utilities/createAddOptionsKey';
 
 export const useModelsForInstanceQuery = (

--- a/react-components/src/query/useModelsForInstanceQuery.ts
+++ b/react-components/src/query/useModelsForInstanceQuery.ts
@@ -21,7 +21,6 @@ import {
   is360ImageDataModelAddOptions,
   is360ImageEventsAddOptions
 } from '../components/Reveal3DResources/typeGuards';
-import { assertNever } from '../utilities/assertNever';
 
 export const useModelsForInstanceQuery = (
   instance: InstanceReference | undefined

--- a/react-components/src/query/useModelsForInstanceQuery.ts
+++ b/react-components/src/query/useModelsForInstanceQuery.ts
@@ -21,6 +21,7 @@ import {
   is360ImageDataModelAddOptions,
   is360ImageEventsAddOptions
 } from '../components/Reveal3DResources/typeGuards';
+import { createAddOptionsKey } from '../utilities/createAddOptionsKey';
 
 export const useModelsForInstanceQuery = (
   instance: InstanceReference | undefined
@@ -58,27 +59,11 @@ async function getModelsForAssetInstance(
     cogniteClient
   );
 
-  return deduplicateModels(
-    (
-      await Promise.all([cadModelsPromise, pointCloudModelsPromise, image360CollectionsPromise])
-    ).flat()
-  );
-}
+  const results = (
+    await Promise.all([cadModelsPromise, pointCloudModelsPromise, image360CollectionsPromise])
+  ).flat();
 
-function deduplicateModels(models: TaggedAddResourceOptions[]): TaggedAddResourceOptions[] {
-  return uniqBy(models, getAddOptionsKey);
-}
-
-function getAddOptionsKey(model: TaggedAddResourceOptions): string {
-  if (model.type === 'cad' || model.type === 'pointcloud') {
-    return `${model.type}-${model.addOptions.modelId}-${model.addOptions.revisionId}`;
-  } else if (model.type === 'image360' && is360ImageDataModelAddOptions(model.addOptions)) {
-    return `${model.type}-${model.addOptions.externalId}/${model.addOptions.space}`;
-  } else if (model.type === 'image360' && is360ImageEventsAddOptions(model.addOptions)) {
-    return `${model.type}-${model.addOptions.siteId}`;
-  } else {
-    throw Error('Unrecognized add option type');
-  }
+  return uniqBy(results, createAddOptionsKey);
 }
 
 async function getModelsForFdmInstance(

--- a/react-components/src/utilities/createAddOptionsKey.ts
+++ b/react-components/src/utilities/createAddOptionsKey.ts
@@ -1,0 +1,17 @@
+import {
+  is360ImageDataModelAddOptions,
+  is360ImageEventsAddOptions
+} from '../components/Reveal3DResources/typeGuards';
+import { TaggedAddResourceOptions } from '../components/Reveal3DResources/types';
+
+export function createAddOptionsKey(model: TaggedAddResourceOptions): string {
+  if (model.type === 'cad' || model.type === 'pointcloud') {
+    return `${model.type}-${model.addOptions.modelId}-${model.addOptions.revisionId}`;
+  } else if (model.type === 'image360' && is360ImageDataModelAddOptions(model.addOptions)) {
+    return `${model.type}-${model.addOptions.externalId}/${model.addOptions.space}`;
+  } else if (model.type === 'image360' && is360ImageEventsAddOptions(model.addOptions)) {
+    return `${model.type}-${model.addOptions.siteId}`;
+  } else {
+    throw Error('Unrecognized add option type');
+  }
+}

--- a/react-components/src/utilities/createAddOptionsKey.ts
+++ b/react-components/src/utilities/createAddOptionsKey.ts
@@ -1,8 +1,11 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
 import {
   is360ImageDataModelAddOptions,
   is360ImageEventsAddOptions
 } from '../components/Reveal3DResources/typeGuards';
-import { TaggedAddResourceOptions } from '../components/Reveal3DResources/types';
+import { type TaggedAddResourceOptions } from '../components/Reveal3DResources/types';
 
 export function createAddOptionsKey(model: TaggedAddResourceOptions): string {
   if (model.type === 'cad' || model.type === 'pointcloud') {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. 
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4461

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Some asset queries have a lot of mappings to the same model, all of which are returned individually from the hook. This deduplicates the result before that happens

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

Tested with asset `multipleModelAssetWith2000Nodes` in 3d-test (instance page 3D widget previously threw 429's all over the place)

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
