### PR TITLE
fix: return simple pojo and not Vector3

### DIFF
--- a/viewer/packages/api/src/utilities/ViewStateHelper.ts
+++ b/viewer/packages/api/src/utilities/ViewStateHelper.ts
@@ -58,8 +58,16 @@ export class ViewStateHelper {
 
     return {
       camera: {
-        position: cameraPosition,
-        target: cameraTarget
+        position: {
+          x: cameraPosition.x,
+          y: cameraPosition.y,
+          z: cameraPosition.z
+        },
+        target: {
+          x: cameraPosition.x,
+          y: cameraPosition.y,
+          z: cameraPosition.z
+        }
       },
       models: modelStates,
       clippingPlanes: clippingPlanesState

--- a/viewer/packages/api/src/utilities/ViewStateHelper.ts
+++ b/viewer/packages/api/src/utilities/ViewStateHelper.ts
@@ -64,9 +64,9 @@ export class ViewStateHelper {
           z: cameraPosition.z
         },
         target: {
-          x: cameraPosition.x,
-          y: cameraPosition.y,
-          z: cameraPosition.z
+          x: cameraTarget.x,
+          y: cameraTarget.y,
+          z: cameraTarget.z
         }
       },
       models: modelStates,


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:

Thread: https://cognitedata.slack.com/archives/C8A0QGMLN/p1721723669208189

## Description :pencil:

TLDR: `getCurrentState` was returning sets of Vector3 with the required fields rather than simple POJOs. IMHO this is slightly bad form even though Typescript allows it, so this PR remaps the Vector3s to POJOs. 

## How has this been tested? :mag:

Didn't

## Test instructions :information_source:



## Checklist :ballot_box_with_check:

