### PR TITLE
fix(react-components): Improve Scene home camera button and bump to 0.55.2

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/hooks/useSceneDefaultCamera.tsx
+++ b/react-components/src/hooks/useSceneDefaultCamera.tsx
@@ -47,6 +47,8 @@ export const useSceneDefaultCamera = (
       return {
         fitCameraToSceneDefault: () => {
           if (viewer.models.length === 0) {
+            // If no models are loaded, set a default camera position
+            // This is the same default position that have been used in SceneBuilder
             const position = new Vector3(-100, 200, 400);
             const target = new Vector3();
             viewer.cameraManager.setCameraState({ position, target });

--- a/react-components/src/hooks/useSceneDefaultCamera.tsx
+++ b/react-components/src/hooks/useSceneDefaultCamera.tsx
@@ -4,8 +4,8 @@
 
 import { useMemo } from 'react';
 import { useSceneConfig } from '../query/useSceneConfig';
-import { Vector3, Quaternion, Euler, MathUtils, Box3 } from 'three';
-import { CDF_TO_VIEWER_TRANSFORMATION, type Cognite3DViewer } from '@cognite/reveal';
+import { Vector3, Quaternion, Euler, MathUtils, Matrix4 } from 'three';
+import { CDF_TO_VIEWER_TRANSFORMATION } from '@cognite/reveal';
 import { type SceneConfiguration } from '../components/SceneContainer/sceneTypes';
 import { useReveal } from '../components/RevealCanvas/ViewerContext';
 
@@ -32,13 +32,39 @@ export const useSceneDefaultCamera = (
       };
     }
 
+    // Use a good default camera position if no camera configuration is provided
+    if (
+      data.sceneConfiguration.cameraTranslationX === 0 &&
+      data.sceneConfiguration.cameraTranslationY === 0 &&
+      data.sceneConfiguration.cameraTranslationZ === 0 &&
+      data.sceneConfiguration.cameraEulerRotationX === 0 &&
+      data.sceneConfiguration.cameraEulerRotationY === 0 &&
+      data.sceneConfiguration.cameraEulerRotationZ === 0 &&
+      data.sceneConfiguration.cameraTargetX === undefined &&
+      data.sceneConfiguration.cameraTargetY === undefined &&
+      data.sceneConfiguration.cameraTargetZ === undefined
+    ) {
+      return {
+        fitCameraToSceneDefault: () => {
+          if (viewer.models.length === 0) {
+            const position = new Vector3(-100, 200, 400);
+            const target = new Vector3();
+            viewer.cameraManager.setCameraState({ position, target });
+          } else {
+            viewer.fitCameraToModels(viewer.models);
+          }
+        },
+        isFetched: false
+      };
+    }
+
     const position = new Vector3(
       data.sceneConfiguration.cameraTranslationX,
       data.sceneConfiguration.cameraTranslationY,
       data.sceneConfiguration.cameraTranslationZ
     );
 
-    const target = extractCameraTarget(data.sceneConfiguration, viewer);
+    const target = extractCameraTarget(data.sceneConfiguration);
     position.applyMatrix4(CDF_TO_VIEWER_TRANSFORMATION);
     target.applyMatrix4(CDF_TO_VIEWER_TRANSFORMATION);
 
@@ -58,8 +84,12 @@ export const useSceneDefaultCamera = (
           viewer.cameraManager.setCameraState({ position, target });
         } else {
           const direction = new Vector3().subVectors(position, target).normalize();
-          const rotation = new Euler().setFromVector3(direction);
-          const quaternion = new Quaternion().setFromEuler(rotation);
+          const up = new Vector3(0, 1, 0);
+          const right = new Vector3().crossVectors(up, direction).normalize();
+          const recomputedUp = new Vector3().crossVectors(direction, right).normalize();
+          const rotationMatrix = new Matrix4();
+          rotationMatrix.makeBasis(right, recomputedUp, direction);
+          const quaternion = new Quaternion().setFromRotationMatrix(rotationMatrix);
 
           viewer.cameraManager.setCameraState({ position, rotation: quaternion });
         }
@@ -69,7 +99,7 @@ export const useSceneDefaultCamera = (
   }, [viewer, data?.sceneConfiguration]);
 };
 
-function extractCameraTarget(scene: SceneConfiguration, viewer: Cognite3DViewer): Vector3 {
+function extractCameraTarget(scene: SceneConfiguration): Vector3 {
   if (scene.cameraTargetX !== undefined) {
     return new Vector3(scene.cameraTargetX, scene.cameraTargetY, scene.cameraTargetZ);
   } else {
@@ -87,15 +117,6 @@ function extractCameraTarget(scene: SceneConfiguration, viewer: Cognite3DViewer)
       scene.cameraTranslationY,
       scene.cameraTranslationZ
     );
-    // As a heuristic, use distance to center of all models' bounding
-    // boxes as target distance
-    const positionToSceneCenterDistance = position.distanceTo(
-      viewer.models
-        .reduce((acc, m) => acc.union(m.getModelBoundingBox()), new Box3())
-        .getCenter(new Vector3())
-    );
-    return position
-      .clone()
-      .add(new Vector3(0, 0, -positionToSceneCenterDistance).applyQuaternion(rotation));
+    return position.clone().add(new Vector3(0, 0, -50).applyQuaternion(rotation));
   }
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:
Improves Scene home camera position.
* If default camera position is not provided, use a default if no models are present, of not, fit to models
* Fixes bug where rotation was not calculated correctly when rotating camera instead of providing camera target

## How has this been tested? :mag:
Have built the package locally and tested it in Fusion

## Test instructions :information_source:
Build locally and use in Fusion. Verify that Scene home camera is correct

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
