### PR TITLE
fix(react-components): export useAssetMappedNodesForRevisions hook to check for loading state of asset mapping

### DIFF
--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -48,6 +48,7 @@ export {
 export { useImage360AnnotationMappingsForAssetIds } from './components/CacheProvider/Image360AnnotationCacheProvider';
 export { useLoadedScene } from './components/SceneContainer/LoadedSceneContext';
 export { useIsDraggingOnViewer } from './hooks/useIsDraggingOnViewer';
+export { useAssetMappedNodesForRevisions } from './components/CacheProvider/AssetMappingAndNode3DCacheProvider';
 
 // Queries
 export { use3DModelName } from './query/use3DModelName';

--- a/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
@@ -49,7 +49,8 @@ export const useSearchMappedEquipmentAssetMappings = (
   const { data: assetMappingList, isFetched } = useAssetMappedNodesForRevisions(
     models.map((model) => ({ ...model, type: 'cad' }))
   );
-  const initialAssetMappings = useAllMappedEquipmentAssetMappings(models, sdk);
+  const { data: initialAssetMappings, isLoading: isInitialAssetMappingsLoading } =
+    useAllMappedEquipmentAssetMappings(models, sdk);
 
   return useInfiniteQuery({
     queryKey: [
@@ -60,11 +61,11 @@ export const useSearchMappedEquipmentAssetMappings = (
       ...models.map((model) => [model.modelId, model.revisionId])
     ],
     queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
-      if (initialAssetMappings.data === undefined) {
+      if (initialAssetMappings === undefined) {
         return { assets: [], nextCursor: undefined };
       }
       if (query === '') {
-        const assets = initialAssetMappings.data?.pages.flatMap((modelWithAssets) =>
+        const assets = initialAssetMappings.pages.flatMap((modelWithAssets) =>
           modelWithAssets.modelsAssets.flatMap((modelsAsset) => modelsAsset.assets).flat()
         );
         return { assets, nextCursor: undefined };
@@ -100,7 +101,11 @@ export const useSearchMappedEquipmentAssetMappings = (
       const lastPageData = allPages[allPages.length - 1];
       return lastPageData.nextCursor;
     },
-    enabled: isFetched && assetMappingList !== undefined && assetMappingList.length > 0
+    enabled:
+      !isInitialAssetMappingsLoading &&
+      isFetched &&
+      assetMappingList !== undefined &&
+      assetMappingList.length > 0
   });
 };
 

--- a/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
@@ -46,9 +46,8 @@ export const useSearchMappedEquipmentAssetMappings = (
   userSdk?: CogniteClient
 ): UseInfiniteQueryResult<InfiniteData<AssetPage>, Error> => {
   const sdk = useSDK(userSdk);
-  const { data: assetMappingList, isFetched } = useAssetMappedNodesForRevisions(
-    models.map((model) => ({ ...model, type: 'cad' }))
-  );
+  const { data: assetMappingList, isFetched: isAssetMappingNodesFetched } =
+    useAssetMappedNodesForRevisions(models.map((model) => ({ ...model, type: 'cad' })));
   const { data: initialAssetMappings, isLoading: isInitialAssetMappingsLoading } =
     useAllMappedEquipmentAssetMappings(models, sdk);
 
@@ -103,7 +102,7 @@ export const useSearchMappedEquipmentAssetMappings = (
     },
     enabled:
       !isInitialAssetMappingsLoading &&
-      isFetched &&
+      isAssetMappingNodesFetched &&
       assetMappingList !== undefined &&
       assetMappingList.length > 0
   });


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4550

## Description :pencil:
Exported `useAssetMappedNodesForRevisions` hook to solve `No search result` in `Search`, where loading state from the hook is used to add loading screen message

## How has this been tested? :mag:

In `Search`


## Test instructions :information_source:
- yalc link `react-components` to `Search` fusion code in `pramodcog/BND3D-4460` branch
- Load 3D page and expand `Asset Search` panel in left

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
