### PR TITLE
feat (react-components): Export the base classes and some utility from the new architecture

### DIFF
--- a/react-components/src/architecture/base/commands/BaseCommand.ts
+++ b/react-components/src/architecture/base/commands/BaseCommand.ts
@@ -5,7 +5,14 @@
 import { type TranslateDelegate, type TranslateKey } from '../utilities/TranslateKey';
 import { clear, remove } from '../utilities/extensions/arrayExtensions';
 
-type UpdateDelegate = (command: BaseCommand) => void;
+/**
+ * Represents a delegate function for updating a command.
+ *
+ * @param command - The command to be updated.
+ * @param change - An optional symbol representing the change made to the command.
+ * if not set, anything can be changed. See changes is CommandChanges for common legal changes.
+ */
+export type CommandUpdateDelegate = (command: BaseCommand, change?: symbol) => void;
 
 /**
  * Base class for all command and tools. These are object that can do a
@@ -20,7 +27,7 @@ export abstract class BaseCommand {
   // INSTANCE FIELDS
   // ==================================================
 
-  private readonly _listeners: UpdateDelegate[] = [];
+  private readonly _listeners: CommandUpdateDelegate[] = [];
 
   // Unique id for the command, used by in React to force rerender
   // when the command changes for a button.
@@ -130,11 +137,11 @@ export abstract class BaseCommand {
   // INSTANCE METHODS: Event listeners
   // ==================================================
 
-  public addEventListener(listener: UpdateDelegate): void {
+  public addEventListener(listener: CommandUpdateDelegate): void {
     this._listeners.push(listener);
   }
 
-  public removeEventListener(listener: UpdateDelegate): void {
+  public removeEventListener(listener: CommandUpdateDelegate): void {
     remove(this._listeners, listener);
   }
 
@@ -142,12 +149,12 @@ export abstract class BaseCommand {
     clear(this._listeners);
   }
 
-  public update(): void {
+  public update(change?: symbol): void {
     for (const listener of this._listeners) {
-      listener(this);
+      listener(this, change);
     }
     for (const child of this.getChildren()) {
-      child.update();
+      child.update(change);
     }
   }
 

--- a/react-components/src/architecture/base/commands/BaseTool.ts
+++ b/react-components/src/architecture/base/commands/BaseTool.ts
@@ -22,6 +22,7 @@ import { ActiveToolUpdater } from '../reactUpdaters/ActiveToolUpdater';
 import { PopupStyle } from '../domainObjectsHelpers/PopupStyle';
 import { ThreeView } from '../views/ThreeView';
 import { UndoManager } from '../undo/UndoManager';
+import { CommandChanges } from '../domainObjectsHelpers/CommandChanges';
 
 /**
  * Base class for interactions in the 3D viewer
@@ -70,14 +71,14 @@ export abstract class BaseTool extends RenderTargetCommand {
   }
 
   public onActivate(): void {
-    this.update();
+    this.update(CommandChanges.active);
     this.setDefaultCursor();
     this.clearDragging();
     ActiveToolUpdater.update();
   }
 
   public onDeactivate(): void {
-    this.update();
+    this.update(CommandChanges.deactive);
     this.clearDragging();
     ActiveToolUpdater.update();
   }

--- a/react-components/src/architecture/base/domainObjectsHelpers/CommandChanges.ts
+++ b/react-components/src/architecture/base/domainObjectsHelpers/CommandChanges.ts
@@ -1,0 +1,8 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+export class CommandChanges {
+  public static readonly active: symbol = Symbol('active');
+  public static readonly deactive: symbol = Symbol('deactive');
+}

--- a/react-components/src/architecture/concrete/observations/ObservationsTool.ts
+++ b/react-components/src/architecture/concrete/observations/ObservationsTool.ts
@@ -36,6 +36,7 @@ export class ObservationsTool extends BaseEditTool {
   }
 
   public override onActivate(): void {
+    super.onActivate();
     let domainObject = this.getObservationsDomainObject();
     if (domainObject === undefined) {
       domainObject = new ObservationsDomainObject(this.renderTarget.fdmSdk);
@@ -45,6 +46,7 @@ export class ObservationsTool extends BaseEditTool {
   }
 
   public override onDeactivate(): void {
+    super.onDeactivate();
     const domainObject = this.getObservationsDomainObject();
     domainObject?.setSelectedObservation(undefined);
   }

--- a/react-components/src/architecture/index.ts
+++ b/react-components/src/architecture/index.ts
@@ -1,13 +1,6 @@
 /*!
  * Copyright 2023 Cognite AS
  */
-
-// New architecture: components
-
-export { ActiveToolToolbar } from '../components/Architecture/Toolbar';
-export { DomainObjectPanel } from '../components/Architecture/DomainObjectPanel';
-export { RevealButtons } from '../components/Architecture/RevealButtons';
-
 // New architecture: commands
 export { BaseCommand } from './base/commands/BaseCommand';
 export type { CommandUpdateDelegate } from './base/commands/BaseCommand';

--- a/react-components/src/architecture/index.ts
+++ b/react-components/src/architecture/index.ts
@@ -1,0 +1,93 @@
+/*!
+ * Copyright 2023 Cognite AS
+ */
+
+// New architecture: components
+
+export { ActiveToolToolbar } from '../components/Architecture/Toolbar';
+export { DomainObjectPanel } from '../components/Architecture/DomainObjectPanel';
+export { RevealButtons } from '../components/Architecture/RevealButtons';
+
+// New architecture: commands
+export { BaseCommand } from './base/commands/BaseCommand';
+export type { CommandUpdateDelegate } from './base/commands/BaseCommand';
+export { BaseFilterCommand } from './base/commands/BaseFilterCommand';
+export { BaseOptionCommand } from './base/commands/BaseOptionCommand';
+export { BaseSliderCommand } from './base/commands/BaseSliderCommand';
+export { BaseTool } from './base/commands/BaseTool';
+export { DomainObjectCommand } from './base/commands/DomainObjectCommand';
+export { InstanceCommand } from './base/commands/InstanceCommand';
+export { RenderTargetCommand } from './base/commands/RenderTargetCommand';
+export { BaseEditTool } from './base/commands/BaseEditTool';
+export { SettingsCommand } from './base/commands/SettingsCommand';
+export { ShowAllDomainObjectsCommand } from './base/commands/ShowAllDomainObjectsCommand';
+export { ShowDomainObjectsOnTopCommand } from './base/commands/ShowDomainObjectsOnTopCommand';
+
+// New architecture: concreteCommands
+export { CopyToClipboardCommand } from './base/concreteCommands/CopyToClipboardCommand';
+export { DeleteDomainObjectCommand } from './base/concreteCommands/DeleteDomainObjectCommand';
+export { FitViewCommand } from './base/concreteCommands/FitViewCommand';
+export { KeyboardSpeedCommand } from './base/concreteCommands/KeyboardSpeedCommand';
+export { NavigationTool } from './base/concreteCommands/NavigationTool';
+export { PointCloudFilterCommand } from './base/concreteCommands/PointCloudFilterCommand';
+export { SetPointColorTypeCommand } from './base/concreteCommands/SetPointColorTypeCommand';
+export { SetPointShapeCommand } from './base/concreteCommands/SetPointShapeCommand';
+export { SetPointSizeCommand } from './base/concreteCommands/SetPointSizeCommand';
+export { SetQualityCommand } from './base/concreteCommands/SetQualityCommand';
+export { ToggleMetricUnitsCommand } from './base/concreteCommands/ToggleMetricUnitsCommand';
+export { UndoCommand } from './base/concreteCommands/UndoCommand';
+
+// New architecture: domainObjects
+export { DomainObject } from './base/domainObjects/DomainObject';
+export { FolderDomainObject } from './base/domainObjects/FolderDomainObject';
+export { RootDomainObject } from './base/domainObjects/RootDomainObject';
+export { VisualDomainObject } from './base/domainObjects/VisualDomainObject';
+
+export { BaseRevealConfig } from './base/renderTarget/BaseRevealConfig';
+export { CommandsController } from './base/renderTarget/CommandsController';
+export { DefaultRevealConfig } from './base/renderTarget/DefaultRevealConfig';
+export { RevealRenderTarget } from './base/renderTarget/RevealRenderTarget';
+export { UnitSystem } from './base/renderTarget/UnitSystem';
+
+// New architecture: renderStyles
+export { RenderStyle } from './base/renderStyles/RenderStyle';
+export { CommonRenderStyle } from './base/renderStyles/CommonRenderStyle';
+
+// New architecture: domainObjectsHelpers
+export { BaseCreator } from './base/domainObjectsHelpers/BaseCreator';
+export { BaseDragger } from './base/domainObjectsHelpers/BaseDragger';
+export { Changes } from './base/domainObjectsHelpers/Changes';
+export { CommandChanges } from './base/domainObjectsHelpers/CommandChanges';
+export { ColorType } from './base/domainObjectsHelpers/ColorType';
+export { DomainObjectChange } from './base/domainObjectsHelpers/DomainObjectChange';
+export { FocusType } from './base/domainObjectsHelpers/FocusType';
+export { PanelInfo } from './base/domainObjectsHelpers/PanelInfo';
+export { PopupStyle } from './base/domainObjectsHelpers/PopupStyle';
+export { Quantity } from './base/domainObjectsHelpers/Quantity';
+export { Views } from './base/domainObjectsHelpers/Views';
+export { VisibleState } from './base/domainObjectsHelpers/VisibleState';
+export type { DomainObjectIntersection } from './base/domainObjectsHelpers/DomainObjectIntersection';
+export { isDomainObjectIntersection } from './base/domainObjectsHelpers/DomainObjectIntersection';
+export { isCustomObjectIntersection } from './base/domainObjectsHelpers/DomainObjectIntersection';
+
+// New architecture: undo
+export { DomainObjectTransaction } from './base/undo/DomainObjectTransaction';
+export { Transaction } from './base/undo/Transaction';
+export { UndoManager } from './base/undo/UndoManager';
+
+// New architecture: utilities
+export { ClosestGeometryFinder } from './base/utilities/geometry/ClosestGeometryFinder';
+export { Index2 } from './base/utilities/geometry/Index2';
+export { Range1 } from './base/utilities/geometry/Range1';
+export { Range3 } from './base/utilities/geometry/Range3';
+export { TrianglesBuffers } from './base/utilities/geometry/TrianglesBuffers';
+export { getNextColor } from './base/utilities/colors/getNextColor';
+export { getNextColorByIndex } from './base/utilities/colors/getNextColor';
+export { getResizeCursor } from './base/utilities/geometry/getResizeCursor';
+export type { TranslateDelegate } from './base/utilities/TranslateKey';
+export type { TranslateKey } from './base/utilities/TranslateKey';
+
+// New architecture: views
+export { BaseView } from './base/views/BaseView';
+export { GroupThreeView } from './base/views/GroupThreeView';
+export { ThreeView } from './base/views/ThreeView';

--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -169,10 +169,13 @@ export { getRuleTriggerTypes } from './components/RuleBasedOutputs/utils';
 
 export type { InstanceReference, AssetInstanceReference } from './data-providers/types';
 
+export { ActiveToolToolbar } from './components/Architecture/Toolbar';
+export { DomainObjectPanel } from './components/Architecture/DomainObjectPanel';
+export { RevealButtons } from './components/Architecture/RevealButtons';
+
 /**
  * Export classes and types from architecture
  * Note: This is not stable code yet and is subject to change.
  * @beta
  */
-
 export * as Architecture from './architecture/index';

--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -29,6 +29,7 @@ export { type Image360AnnotationAssetInfo } from './components/CacheProvider/typ
 
 // Hooks
 export { useReveal } from './components/RevealCanvas/ViewerContext';
+export { useRenderTarget } from './components/RevealCanvas/ViewerContext';
 export { useFdmAssetMappings } from './components/CacheProvider/NodeCacheProvider';
 export { useSceneDefaultCamera } from './hooks/useSceneDefaultCamera';
 export {
@@ -161,13 +162,89 @@ export type {
   CriteriaTypes
 } from './components/RuleBasedOutputs/types';
 
-export { ActiveToolToolbar } from './components/Architecture/Toolbar';
-export { DomainObjectPanel } from './components/Architecture/DomainObjectPanel';
-export { RevealButtons } from './components/Architecture/RevealButtons';
-
 export { RuleBasedOutputsPanel } from './components/RuleBasedOutputs/RuleBasedOutputsPanel';
 
 // Functions
 export { getRuleTriggerTypes } from './components/RuleBasedOutputs/utils';
 
 export type { InstanceReference, AssetInstanceReference } from './data-providers/types';
+
+// ==================================================
+// NEW ARCHITECTURE
+// ==================================================
+
+// New architecture: components
+export { ActiveToolToolbar } from './components/Architecture/Toolbar';
+export { DomainObjectPanel } from './components/Architecture/DomainObjectPanel';
+export { RevealButtons } from './components/Architecture/RevealButtons';
+
+// New architecture: commands
+export { BaseCommand } from './architecture/base/commands/BaseCommand';
+export type { CommandUpdateDelegate } from './architecture/base/commands/BaseCommand';
+export { BaseFilterCommand } from './architecture/base/commands/BaseFilterCommand';
+export { BaseOptionCommand } from './architecture/base/commands/BaseOptionCommand';
+export { BaseSliderCommand } from './architecture/base/commands/BaseSliderCommand';
+export { BaseTool } from './architecture/base/commands/BaseTool';
+export { DomainObjectCommand } from './architecture/base/commands/DomainObjectCommand';
+export { InstanceCommand } from './architecture/base/commands/InstanceCommand';
+export { RenderTargetCommand } from './architecture/base/commands/RenderTargetCommand';
+export { BaseEditTool } from './architecture/base/commands/BaseEditTool';
+export { SettingsCommand } from './architecture/base/commands/SettingsCommand';
+export { ShowAllDomainObjectsCommand } from './architecture/base/commands/ShowAllDomainObjectsCommand';
+export { ShowDomainObjectsOnTopCommand } from './architecture/base/commands/ShowDomainObjectsOnTopCommand';
+export { NavigationTool } from './architecture/base/concreteCommands/NavigationTool';
+
+// New architecture: domainObjects
+export { DomainObject } from './architecture/base/domainObjects/DomainObject';
+export { FolderDomainObject } from './architecture/base/domainObjects/FolderDomainObject';
+export { RootDomainObject } from './architecture/base/domainObjects/RootDomainObject';
+export { VisualDomainObject } from './architecture/base/domainObjects/VisualDomainObject';
+
+export { BaseRevealConfig } from './architecture/base/renderTarget/BaseRevealConfig';
+export { CommandsController } from './architecture/base/renderTarget/CommandsController';
+export { DefaultRevealConfig } from './architecture/base/renderTarget/DefaultRevealConfig';
+export { RevealRenderTarget } from './architecture/base/renderTarget/RevealRenderTarget';
+export { UnitSystem } from './architecture/base/renderTarget/UnitSystem';
+
+// New architecture: renderStyles
+export { RenderStyle } from './architecture/base/renderStyles/RenderStyle';
+export { CommonRenderStyle } from './architecture/base/renderStyles/CommonRenderStyle';
+
+// New architecture: domainObjectsHelpers
+export { BaseCreator } from './architecture/base/domainObjectsHelpers/BaseCreator';
+export { BaseDragger } from './architecture/base/domainObjectsHelpers/BaseDragger';
+export { Changes } from './architecture/base/domainObjectsHelpers/Changes';
+export { CommandChanges } from './architecture/base/domainObjectsHelpers/CommandChanges';
+export { ColorType } from './architecture/base/domainObjectsHelpers/ColorType';
+export { DomainObjectChange } from './architecture/base/domainObjectsHelpers/DomainObjectChange';
+export { FocusType } from './architecture/base/domainObjectsHelpers/FocusType';
+export { PanelInfo } from './architecture/base/domainObjectsHelpers/PanelInfo';
+export { PopupStyle } from './architecture/base/domainObjectsHelpers/PopupStyle';
+export { Quantity } from './architecture/base/domainObjectsHelpers/Quantity';
+export { Views } from './architecture/base/domainObjectsHelpers/Views';
+export { VisibleState } from './architecture/base/domainObjectsHelpers/VisibleState';
+export type { DomainObjectIntersection } from './architecture/base/domainObjectsHelpers/DomainObjectIntersection';
+export { isDomainObjectIntersection } from './architecture/base/domainObjectsHelpers/DomainObjectIntersection';
+export { isCustomObjectIntersection } from './architecture/base/domainObjectsHelpers/DomainObjectIntersection';
+
+// New architecture: undo
+export { DomainObjectTransaction } from './architecture/base/undo/DomainObjectTransaction';
+export { Transaction } from './architecture/base/undo/Transaction';
+export { UndoManager } from './architecture/base/undo/UndoManager';
+
+// New architecture: utilities
+export { ClosestGeometryFinder } from './architecture/base/utilities/geometry/ClosestGeometryFinder';
+export { Index2 } from './architecture/base/utilities/geometry/Index2';
+export { Range1 } from './architecture/base/utilities/geometry/Range1';
+export { Range3 } from './architecture/base/utilities/geometry/Range3';
+export { TrianglesBuffers } from './architecture/base/utilities/geometry/TrianglesBuffers';
+export { getNextColor } from './architecture/base/utilities/colors/getNextColor';
+export { getNextColorByIndex } from './architecture/base/utilities/colors/getNextColor';
+export { getResizeCursor } from './architecture/base/utilities/geometry/getResizeCursor';
+export type { TranslateDelegate } from './architecture/base/utilities/TranslateKey';
+export type { TranslateKey } from './architecture/base/utilities/TranslateKey';
+
+// New architecture: views
+export { BaseView } from './architecture/base/views/BaseView';
+export { GroupThreeView } from './architecture/base/views/GroupThreeView';
+export { ThreeView } from './architecture/base/views/ThreeView';

--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -192,7 +192,20 @@ export { BaseEditTool } from './architecture/base/commands/BaseEditTool';
 export { SettingsCommand } from './architecture/base/commands/SettingsCommand';
 export { ShowAllDomainObjectsCommand } from './architecture/base/commands/ShowAllDomainObjectsCommand';
 export { ShowDomainObjectsOnTopCommand } from './architecture/base/commands/ShowDomainObjectsOnTopCommand';
+
+// New architecture: concreteCommands
+export { CopyToClipboardCommand } from './architecture/base/concreteCommands/CopyToClipboardCommand';
+export { DeleteDomainObjectCommand } from './architecture/base/concreteCommands/DeleteDomainObjectCommand';
+export { FitViewCommand } from './architecture/base/concreteCommands/FitViewCommand';
+export { KeyboardSpeedCommand } from './architecture/base/concreteCommands/KeyboardSpeedCommand';
 export { NavigationTool } from './architecture/base/concreteCommands/NavigationTool';
+export { PointCloudFilterCommand } from './architecture/base/concreteCommands/PointCloudFilterCommand';
+export { SetPointColorTypeCommand } from './architecture/base/concreteCommands/SetPointColorTypeCommand';
+export { SetPointShapeCommand } from './architecture/base/concreteCommands/SetPointShapeCommand';
+export { SetPointSizeCommand } from './architecture/base/concreteCommands/SetPointSizeCommand';
+export { SetQualityCommand } from './architecture/base/concreteCommands/SetQualityCommand';
+export { ToggleMetricUnitsCommand } from './architecture/base/concreteCommands/ToggleMetricUnitsCommand';
+export { UndoCommand } from './architecture/base/concreteCommands/UndoCommand';
 
 // New architecture: domainObjects
 export { DomainObject } from './architecture/base/domainObjects/DomainObject';

--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -169,95 +169,10 @@ export { getRuleTriggerTypes } from './components/RuleBasedOutputs/utils';
 
 export type { InstanceReference, AssetInstanceReference } from './data-providers/types';
 
-// ==================================================
-// NEW ARCHITECTURE
-// ==================================================
+/**
+ * Export classes and types from architecture
+ * Note: This is not stable code yet and is subject to change.
+ * @beta
+ */
 
-// New architecture: components
-export { ActiveToolToolbar } from './components/Architecture/Toolbar';
-export { DomainObjectPanel } from './components/Architecture/DomainObjectPanel';
-export { RevealButtons } from './components/Architecture/RevealButtons';
-
-// New architecture: commands
-export { BaseCommand } from './architecture/base/commands/BaseCommand';
-export type { CommandUpdateDelegate } from './architecture/base/commands/BaseCommand';
-export { BaseFilterCommand } from './architecture/base/commands/BaseFilterCommand';
-export { BaseOptionCommand } from './architecture/base/commands/BaseOptionCommand';
-export { BaseSliderCommand } from './architecture/base/commands/BaseSliderCommand';
-export { BaseTool } from './architecture/base/commands/BaseTool';
-export { DomainObjectCommand } from './architecture/base/commands/DomainObjectCommand';
-export { InstanceCommand } from './architecture/base/commands/InstanceCommand';
-export { RenderTargetCommand } from './architecture/base/commands/RenderTargetCommand';
-export { BaseEditTool } from './architecture/base/commands/BaseEditTool';
-export { SettingsCommand } from './architecture/base/commands/SettingsCommand';
-export { ShowAllDomainObjectsCommand } from './architecture/base/commands/ShowAllDomainObjectsCommand';
-export { ShowDomainObjectsOnTopCommand } from './architecture/base/commands/ShowDomainObjectsOnTopCommand';
-
-// New architecture: concreteCommands
-export { CopyToClipboardCommand } from './architecture/base/concreteCommands/CopyToClipboardCommand';
-export { DeleteDomainObjectCommand } from './architecture/base/concreteCommands/DeleteDomainObjectCommand';
-export { FitViewCommand } from './architecture/base/concreteCommands/FitViewCommand';
-export { KeyboardSpeedCommand } from './architecture/base/concreteCommands/KeyboardSpeedCommand';
-export { NavigationTool } from './architecture/base/concreteCommands/NavigationTool';
-export { PointCloudFilterCommand } from './architecture/base/concreteCommands/PointCloudFilterCommand';
-export { SetPointColorTypeCommand } from './architecture/base/concreteCommands/SetPointColorTypeCommand';
-export { SetPointShapeCommand } from './architecture/base/concreteCommands/SetPointShapeCommand';
-export { SetPointSizeCommand } from './architecture/base/concreteCommands/SetPointSizeCommand';
-export { SetQualityCommand } from './architecture/base/concreteCommands/SetQualityCommand';
-export { ToggleMetricUnitsCommand } from './architecture/base/concreteCommands/ToggleMetricUnitsCommand';
-export { UndoCommand } from './architecture/base/concreteCommands/UndoCommand';
-
-// New architecture: domainObjects
-export { DomainObject } from './architecture/base/domainObjects/DomainObject';
-export { FolderDomainObject } from './architecture/base/domainObjects/FolderDomainObject';
-export { RootDomainObject } from './architecture/base/domainObjects/RootDomainObject';
-export { VisualDomainObject } from './architecture/base/domainObjects/VisualDomainObject';
-
-export { BaseRevealConfig } from './architecture/base/renderTarget/BaseRevealConfig';
-export { CommandsController } from './architecture/base/renderTarget/CommandsController';
-export { DefaultRevealConfig } from './architecture/base/renderTarget/DefaultRevealConfig';
-export { RevealRenderTarget } from './architecture/base/renderTarget/RevealRenderTarget';
-export { UnitSystem } from './architecture/base/renderTarget/UnitSystem';
-
-// New architecture: renderStyles
-export { RenderStyle } from './architecture/base/renderStyles/RenderStyle';
-export { CommonRenderStyle } from './architecture/base/renderStyles/CommonRenderStyle';
-
-// New architecture: domainObjectsHelpers
-export { BaseCreator } from './architecture/base/domainObjectsHelpers/BaseCreator';
-export { BaseDragger } from './architecture/base/domainObjectsHelpers/BaseDragger';
-export { Changes } from './architecture/base/domainObjectsHelpers/Changes';
-export { CommandChanges } from './architecture/base/domainObjectsHelpers/CommandChanges';
-export { ColorType } from './architecture/base/domainObjectsHelpers/ColorType';
-export { DomainObjectChange } from './architecture/base/domainObjectsHelpers/DomainObjectChange';
-export { FocusType } from './architecture/base/domainObjectsHelpers/FocusType';
-export { PanelInfo } from './architecture/base/domainObjectsHelpers/PanelInfo';
-export { PopupStyle } from './architecture/base/domainObjectsHelpers/PopupStyle';
-export { Quantity } from './architecture/base/domainObjectsHelpers/Quantity';
-export { Views } from './architecture/base/domainObjectsHelpers/Views';
-export { VisibleState } from './architecture/base/domainObjectsHelpers/VisibleState';
-export type { DomainObjectIntersection } from './architecture/base/domainObjectsHelpers/DomainObjectIntersection';
-export { isDomainObjectIntersection } from './architecture/base/domainObjectsHelpers/DomainObjectIntersection';
-export { isCustomObjectIntersection } from './architecture/base/domainObjectsHelpers/DomainObjectIntersection';
-
-// New architecture: undo
-export { DomainObjectTransaction } from './architecture/base/undo/DomainObjectTransaction';
-export { Transaction } from './architecture/base/undo/Transaction';
-export { UndoManager } from './architecture/base/undo/UndoManager';
-
-// New architecture: utilities
-export { ClosestGeometryFinder } from './architecture/base/utilities/geometry/ClosestGeometryFinder';
-export { Index2 } from './architecture/base/utilities/geometry/Index2';
-export { Range1 } from './architecture/base/utilities/geometry/Range1';
-export { Range3 } from './architecture/base/utilities/geometry/Range3';
-export { TrianglesBuffers } from './architecture/base/utilities/geometry/TrianglesBuffers';
-export { getNextColor } from './architecture/base/utilities/colors/getNextColor';
-export { getNextColorByIndex } from './architecture/base/utilities/colors/getNextColor';
-export { getResizeCursor } from './architecture/base/utilities/geometry/getResizeCursor';
-export type { TranslateDelegate } from './architecture/base/utilities/TranslateKey';
-export type { TranslateKey } from './architecture/base/utilities/TranslateKey';
-
-// New architecture: views
-export { BaseView } from './architecture/base/views/BaseView';
-export { GroupThreeView } from './architecture/base/views/GroupThreeView';
-export { ThreeView } from './architecture/base/views/ThreeView';
+export * as Architecture from './architecture/index';

--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -29,7 +29,6 @@ export { type Image360AnnotationAssetInfo } from './components/CacheProvider/typ
 
 // Hooks
 export { useReveal } from './components/RevealCanvas/ViewerContext';
-export { useRenderTarget } from './components/RevealCanvas/ViewerContext';
 export { useFdmAssetMappings } from './components/CacheProvider/NodeCacheProvider';
 export { useSceneDefaultCamera } from './hooks/useSceneDefaultCamera';
 export {
@@ -172,6 +171,7 @@ export type { InstanceReference, AssetInstanceReference } from './data-providers
 export { ActiveToolToolbar } from './components/Architecture/Toolbar';
 export { DomainObjectPanel } from './components/Architecture/DomainObjectPanel';
 export { RevealButtons } from './components/Architecture/RevealButtons';
+export { useRenderTarget } from './components/RevealCanvas/ViewerContext';
 
 /**
  * Export classes and types from architecture


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->


## Description :pencil:

* 3D management need to use some of the basics in the architecture, so I exported all base classes and some of the utility classes/functions used by the actitecture.

* Also updated the listeners for commands. The reason for this is that you can listen to if a tool is activated or deactivated.

