### PR TITLE
(fix): Update recalculateBoundingBox  in Cognite3DViewer

### DIFF
--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1323,7 +1323,7 @@ export class Cognite3DViewer {
   }
 
   /**
-   * Move camera to a place where a all objects in the scene are visible
+   * Move camera to a place where a all objects in the scene are visible.
    * @param duration The duration of the animation moving the camera. Set this to 0 (zero) to disable animation.
    */
   fitCameraToVisualSceneBoundingBox(duration?: number): void {

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1893,6 +1893,51 @@ export class Cognite3DViewer {
     nearFarPlaneBoundingBox.makeEmpty();
     sceneBoundingBox.makeEmpty();
 
+    this._models.forEach(model => {
+      model.getModelBoundingBox(temporaryBox);
+      if (temporaryBox.isEmpty()) {
+        return;
+      }
+      nearFarPlaneBoundingBox.union(temporaryBox);
+
+      // The getModelBoundingBox is using restrictToMostGeometry = true
+      model.getModelBoundingBox(temporaryBox, true);
+      if (temporaryBox.isEmpty()) {
+        return;
+      }
+      sceneBoundingBox.union(temporaryBox);
+    });
+    this._sceneHandler.customObjects.forEach(customObject => {
+      if (!customObject.object.visible) {
+        return;
+      }
+      customObject.getBoundingBox(temporaryBox);
+      if (temporaryBox.isEmpty()) {
+        return;
+      }
+      nearFarPlaneBoundingBox.union(temporaryBox);
+      if (!customObject.isPartOfBoundingBox) {
+        return;
+      }
+      sceneBoundingBox.union(temporaryBox);
+    });
+    console.log('old:');
+    console.log('nearFarPlaneBoundingBox: ', nearFarPlaneBoundingBox);
+    console.log('sceneBoundingBox: ', sceneBoundingBox);
+  }
+
+  /*
+  /** @private *
+  private recalculateBoundingBox() {
+    // See https://stackoverflow.com/questions/8101119/how-do-i-methodically-choose-the-near-clip-plane-distance-for-a-perspective-proj
+    if (this.isDisposed) {
+      return;
+    }
+
+    const { nearFarPlaneBoundingBox, sceneBoundingBox, temporaryBox } = this._boundingBoxes;
+    nearFarPlaneBoundingBox.makeEmpty();
+    sceneBoundingBox.makeEmpty();
+
     for (let pass = 0; pass < 2; pass++) {
       // On the first pass, use visible models only
       // If no bounding box is found, use all models on the second pass
@@ -1932,7 +1977,10 @@ export class Cognite3DViewer {
         break;
       }
     }
+    console.log('nearFarPlaneBoundingBox: ', nearFarPlaneBoundingBox);
+    console.log('sceneBoundingBox: ', sceneBoundingBox);
   }
+  */
 
   /** @private */
   private setupDomElementResizeListener(domElement: HTMLElement): ResizeObserver {

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1218,6 +1218,45 @@ export class Cognite3DViewer {
   }
 
   /**
+   * Get the union of bounding box of all visual objects in the Cognite3DViewer.
+   * @returns The visual bounding box of the Cognite3DViewer.
+   * @beta
+   */
+  getVisualSceneBoundingBox(): THREE.Box3 {
+    const boundingBox = new THREE.Box3();
+    boundingBox.makeEmpty();
+
+    if (this.isDisposed) {
+      return boundingBox;
+    }
+    const temporaryBox = new THREE.Box3();
+    for (const model of this.models) {
+      if (!model.visible) {
+        continue;
+      }
+      model.getModelBoundingBox(temporaryBox, true);
+      if (temporaryBox.isEmpty()) {
+        continue;
+      }
+      boundingBox.union(temporaryBox);
+    }
+    for (const customObject of this._sceneHandler.customObjects) {
+      if (!customObject.object.visible) {
+        continue;
+      }
+      customObject.getBoundingBox(temporaryBox);
+      if (temporaryBox.isEmpty()) {
+        continue;
+      }
+      if (!customObject.isPartOfBoundingBox) {
+        continue;
+      }
+      boundingBox.union(temporaryBox);
+    }
+    return boundingBox;
+  }
+
+  /**
    * Attempts to load the camera settings from the settings stored for the
    * provided model. See {@link https://docs.cognite.com/api/v1/#operation/get3DRevision}
    * and {@link https://docs.cognite.com/api/v1/#operation/update3DRevisions} for
@@ -1257,6 +1296,9 @@ export class Cognite3DViewer {
    */
   fitCameraToModel(model: CogniteModel, duration?: number): void {
     const boundingBox = model.getModelBoundingBox(new THREE.Box3(), true);
+    if (boundingBox.isEmpty()) {
+      return;
+    }
     this._activeCameraManager.fitCameraToBoundingBox(boundingBox, duration);
   }
 
@@ -1268,7 +1310,6 @@ export class Cognite3DViewer {
    */
   fitCameraToModels(models?: CogniteModel[], duration?: number, restrictToMostGeometry = false): void {
     const cogniteModels = models ?? this.models;
-
     if (cogniteModels.length < 1) {
       return;
     }
@@ -1285,18 +1326,14 @@ export class Cognite3DViewer {
    * Move camera to a place where a all objects in the scene are visible
    * @param duration The duration of the animation moving the camera. Set this to 0 (zero) to disable animation.
    */
-  fitCameraToSceneBoundingBox(duration?: number): void {
-    this.recalculateBoundingBox();
-    const boundingBox = this.getSceneBoundingBox();
-    if (boundingBox.isEmpty()) {
-      return;
-    }
+  fitCameraToVisualSceneBoundingBox(duration?: number): void {
+    const boundingBox = this.getVisualSceneBoundingBox();
     this.fitCameraToBoundingBox(boundingBox, duration);
   }
 
   /**
    * Move camera to a place where the content of a bounding box is visible to the camera.
-   * @param box The bounding box in world space.
+   * @param boundingBox The bounding box in world space.
    * @param duration The duration of the animation moving the camera. Set this to 0 (zero) to disable animation.
    * @param radiusFactor The ratio of the distance from camera to center of box and radius of the box.
    * @example
@@ -1313,8 +1350,11 @@ export class Cognite3DViewer {
    * viewer.fitCameraToBoundingBox(boundingBox, 500, 2);
    * ```
    */
-  fitCameraToBoundingBox(box: THREE.Box3, duration?: number, radiusFactor: number = 2): void {
-    this._activeCameraManager.fitCameraToBoundingBox(box, duration, radiusFactor);
+  fitCameraToBoundingBox(boundingBox: THREE.Box3, duration?: number, radiusFactor: number = 2): void {
+    if (boundingBox.isEmpty()) {
+      return;
+    }
+    this._activeCameraManager.fitCameraToBoundingBox(boundingBox, duration, radiusFactor);
   }
 
   /**
@@ -1897,37 +1937,37 @@ export class Cognite3DViewer {
       // On the first pass, use visible models only
       // If no bounding box is found, use all models on the second pass
       // By this way, a bounding box is forced to be calculated
-      this._models.forEach(model => {
+      for (const model of this.models) {
         if (pass === 0 && !model.visible) {
-          return;
+          continue;
         }
         model.getModelBoundingBox(temporaryBox);
         if (temporaryBox.isEmpty()) {
-          return;
+          continue;
         }
         nearFarPlaneBoundingBox.union(temporaryBox);
 
         // The getModelBoundingBox is using restrictToMostGeometry = true
         model.getModelBoundingBox(temporaryBox, true);
         if (temporaryBox.isEmpty()) {
-          return;
+          continue;
         }
         sceneBoundingBox.union(temporaryBox);
-      });
-      this._sceneHandler.customObjects.forEach(customObject => {
+      }
+      for (const customObject of this._sceneHandler.customObjects) {
         if (!customObject.object.visible) {
-          return;
+          continue;
         }
         customObject.getBoundingBox(temporaryBox);
         if (temporaryBox.isEmpty()) {
-          return;
+          continue;
         }
         nearFarPlaneBoundingBox.union(temporaryBox);
         if (!customObject.isPartOfBoundingBox) {
-          return;
+          continue;
         }
         sceneBoundingBox.union(temporaryBox);
-      });
+      }
       if (!sceneBoundingBox.isEmpty()) {
         break;
       }

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1893,51 +1893,6 @@ export class Cognite3DViewer {
     nearFarPlaneBoundingBox.makeEmpty();
     sceneBoundingBox.makeEmpty();
 
-    this._models.forEach(model => {
-      model.getModelBoundingBox(temporaryBox);
-      if (temporaryBox.isEmpty()) {
-        return;
-      }
-      nearFarPlaneBoundingBox.union(temporaryBox);
-
-      // The getModelBoundingBox is using restrictToMostGeometry = true
-      model.getModelBoundingBox(temporaryBox, true);
-      if (temporaryBox.isEmpty()) {
-        return;
-      }
-      sceneBoundingBox.union(temporaryBox);
-    });
-    this._sceneHandler.customObjects.forEach(customObject => {
-      if (!customObject.object.visible) {
-        return;
-      }
-      customObject.getBoundingBox(temporaryBox);
-      if (temporaryBox.isEmpty()) {
-        return;
-      }
-      nearFarPlaneBoundingBox.union(temporaryBox);
-      if (!customObject.isPartOfBoundingBox) {
-        return;
-      }
-      sceneBoundingBox.union(temporaryBox);
-    });
-    console.log('old:');
-    console.log('nearFarPlaneBoundingBox: ', nearFarPlaneBoundingBox);
-    console.log('sceneBoundingBox: ', sceneBoundingBox);
-  }
-
-  /*
-  /** @private *
-  private recalculateBoundingBox() {
-    // See https://stackoverflow.com/questions/8101119/how-do-i-methodically-choose-the-near-clip-plane-distance-for-a-perspective-proj
-    if (this.isDisposed) {
-      return;
-    }
-
-    const { nearFarPlaneBoundingBox, sceneBoundingBox, temporaryBox } = this._boundingBoxes;
-    nearFarPlaneBoundingBox.makeEmpty();
-    sceneBoundingBox.makeEmpty();
-
     for (let pass = 0; pass < 2; pass++) {
       // On the first pass, use visible models only
       // If no bounding box is found, use all models on the second pass
@@ -1977,10 +1932,7 @@ export class Cognite3DViewer {
         break;
       }
     }
-    console.log('nearFarPlaneBoundingBox: ', nearFarPlaneBoundingBox);
-    console.log('sceneBoundingBox: ', sceneBoundingBox);
   }
-  */
 
   /** @private */
   private setupDomElementResizeListener(domElement: HTMLElement): ResizeObserver {

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -438,6 +438,7 @@ export class Cognite3DViewer {
     fitCameraToBoundingBox(box: THREE.Box3, duration?: number, radiusFactor?: number): void;
     fitCameraToModel(model: CogniteModel, duration?: number): void;
     fitCameraToModels(models?: CogniteModel[], duration?: number, restrictToMostGeometry?: boolean): void;
+    fitCameraToSceneBoundingBox(duration?: number): void;
     get360AnnotationIntersectionFromPixel(offsetX: number, offsetY: number): Promise<null | Image360AnnotationIntersection>;
     get360ImageCollections(): Image360Collection[];
     getActive360ImageInfo(): Image360WithCollection | undefined;

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -435,10 +435,10 @@ export class Cognite3DViewer {
     get domElement(): HTMLElement;
     enter360Image(image360: Image360, revision?: Image360Revision): Promise<void>;
     exit360Image(): void;
-    fitCameraToBoundingBox(box: THREE.Box3, duration?: number, radiusFactor?: number): void;
+    fitCameraToBoundingBox(boundingBox: THREE.Box3, duration?: number, radiusFactor?: number): void;
     fitCameraToModel(model: CogniteModel, duration?: number): void;
     fitCameraToModels(models?: CogniteModel[], duration?: number, restrictToMostGeometry?: boolean): void;
-    fitCameraToSceneBoundingBox(duration?: number): void;
+    fitCameraToVisualSceneBoundingBox(duration?: number): void;
     get360AnnotationIntersectionFromPixel(offsetX: number, offsetY: number): Promise<null | Image360AnnotationIntersection>;
     get360ImageCollections(): Image360Collection[];
     getActive360ImageInfo(): Image360WithCollection | undefined;
@@ -458,6 +458,8 @@ export class Cognite3DViewer {
     getScreenshot(width?: number, height?: number, includeUI?: boolean): Promise<string>;
     getVersion(): string;
     getViewState(): ViewerState;
+    // @beta
+    getVisualSceneBoundingBox(): THREE.Box3;
     loadCameraFromModel(model: CogniteModel): void;
     get models(): CogniteModel[];
     // (undocumented)


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->


## Description :pencil:

the function `fitCameraToModels `only take all the models, even invisible and doesn't use the `customobject `at all. In order not to break the code, I made an alternative which is `fitCameraToSceneBoundingBox`.  This uses the getSceneBoundingBox.


I also change the `recalculateBoundingBox `to use only visible object. See comment in that function. I believe that was the intension of the original code. It might break the code.... An alternative would be to make another function for doing this.

I saw this bug during a demo today. The user had many models, but only one was visible. The navigation was pretty hard and the fit all button didn't work as expected.

