### PR TITLE
fix(react-components): Smaller adjustment in clipping and measurement after meeting with user

### DIFF
--- a/react-components/src/architecture/concrete/clipping/SliceDomainObject.ts
+++ b/react-components/src/architecture/concrete/clipping/SliceDomainObject.ts
@@ -21,8 +21,8 @@ export class SliceDomainObject extends PlaneDomainObject {
 
   public constructor(primitiveType: PrimitiveType) {
     super(primitiveType);
-    this.color = new Color(Color.NAMES.greenyellow);
-    this.backSideColor = new Color(Color.NAMES.red);
+    this.color = new Color(Color.NAMES.orangered);
+    this.backSideColor = new Color(Color.NAMES.palegreen);
   }
 
   // ==================================================

--- a/react-components/src/architecture/concrete/primitives/line/LineView.ts
+++ b/react-components/src/architecture/concrete/primitives/line/LineView.ts
@@ -108,7 +108,7 @@ export class LineView extends GroupThreeView<LineDomainObject> {
     const thisPoint = new Vector3();
     const intersection = new Vector3();
 
-    const radiusSquared = square(radius); // Add more to make it easier to pick
+    const radiusSquared = square(radius);
     const ray = intersectInput.raycaster.ray;
     const closestFinder = new ClosestGeometryFinder<DomainObjectIntersection>(ray.origin);
 
@@ -343,5 +343,5 @@ function getRadius(domainObject: LineDomainObject, style: LineRenderStyle): numb
 }
 
 function getSelectRadius(domainObject: LineDomainObject, style: LineRenderStyle): number {
-  return 1.5 * style.selectedPipeRadius;
+  return 1.5 * style.selectedPipeRadius; // Added more to make it easier to pick
 }

--- a/react-components/src/architecture/concrete/primitives/line/LineView.ts
+++ b/react-components/src/architecture/concrete/primitives/line/LineView.ts
@@ -94,7 +94,7 @@ export class LineView extends GroupThreeView<LineDomainObject> {
       return undefined; // Should never be picked
     }
     // Implement the intersection logic here, because of bug in tree.js
-    const radius = getRadius(domainObject, style);
+    const radius = getSelectRadius(domainObject, style);
     if (radius <= 0) {
       return;
     }
@@ -108,7 +108,7 @@ export class LineView extends GroupThreeView<LineDomainObject> {
     const thisPoint = new Vector3();
     const intersection = new Vector3();
 
-    const radiusSquared = square(1.5 * radius); // Add 50% more to make it easier to pick
+    const radiusSquared = square(radius); // Add more to make it easier to pick
     const ray = intersectInput.raycaster.ray;
     const closestFinder = new ClosestGeometryFinder<DomainObjectIntersection>(ray.origin);
 
@@ -340,4 +340,8 @@ function adjustLabel(
 
 function getRadius(domainObject: LineDomainObject, style: LineRenderStyle): number {
   return domainObject.isSelected ? style.selectedPipeRadius : style.pipeRadius;
+}
+
+function getSelectRadius(domainObject: LineDomainObject, style: LineRenderStyle): number {
+  return 1.5 * style.selectedPipeRadius;
 }

--- a/react-components/src/architecture/concrete/primitives/plane/PlaneCreator.ts
+++ b/react-components/src/architecture/concrete/primitives/plane/PlaneCreator.ts
@@ -89,29 +89,36 @@ export class PlaneCreator extends BaseCreator {
       throw new Error('Cannot create a plane without points');
     }
     const domainObject = this._domainObject;
+    let normal: Vector3;
     switch (domainObject.primitiveType) {
       case PrimitiveType.PlaneX:
-        domainObject.plane.setFromNormalAndCoplanarPoint(new Vector3(1, 0, 0), this.firstPoint);
+        normal = new Vector3(1, 0, 0);
         break;
 
       case PrimitiveType.PlaneY:
-        domainObject.plane.setFromNormalAndCoplanarPoint(new Vector3(0, 1, 0), this.firstPoint);
+        normal = new Vector3(0, 1, 0);
         break;
 
       case PrimitiveType.PlaneZ:
-        domainObject.plane.setFromNormalAndCoplanarPoint(new Vector3(0, 0, 1), this.firstPoint);
+        normal = new Vector3(0, 0, 1);
         break;
 
       case PrimitiveType.PlaneXY:
         if (this.pointCount === 1) {
-          const normal = ray.direction.clone().normalize();
-          domainObject.plane.setFromNormalAndCoplanarPoint(normal, this.firstPoint);
-        } else if (this.pointCount === 2) {
-          const normal = new Vector3().subVectors(this.lastPoint, this.firstPoint).normalize();
+          normal = ray.direction.clone().normalize();
+        } else {
+          normal = new Vector3().subVectors(this.lastPoint, this.firstPoint).normalize();
           rotatePiHalf(normal);
-          domainObject.plane.setFromNormalAndCoplanarPoint(normal, this.firstPoint);
         }
         break;
+
+      default:
+        return;
     }
+    // Make sure that the normal is pointing towards the camera
+    if (ray.direction.dot(normal) < 0) {
+      normal.negate();
+    }
+    domainObject.plane.setFromNormalAndCoplanarPoint(normal, this.firstPoint);
   }
 }

--- a/react-components/src/architecture/concrete/primitives/plane/PlaneRenderStyle.ts
+++ b/react-components/src/architecture/concrete/primitives/plane/PlaneRenderStyle.ts
@@ -17,8 +17,8 @@ export class PlaneRenderStyle extends CommonRenderStyle {
   public linesColor = BLACK_COLOR.clone();
   public selectedLinesColor = WHITE_COLOR.clone();
   public opacityUse = true;
-  public opacity = 0.5;
-  public selectedOpacity = 0.8;
+  public opacity = 0.25;
+  public selectedOpacity = 0.5;
 
   // ==================================================
   // OVERRIDES of BaseStyle


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:

This is based on feedback on a meeting today:

* Increase selection radius for lines. Before it was hard to pick them.
* Increate transparence of the clipping planes.
* Change color of the clipping planes to be less saturated. Also switch the side colors.
* When new plane is made, make sur that it is clipped in front of you.

