### PR TITLE
fix(react-components): No result when single character search input in asset search hook

### DIFF
--- a/react-components/src/components/CacheProvider/AnnotationModelUtils.ts
+++ b/react-components/src/components/CacheProvider/AnnotationModelUtils.ts
@@ -23,7 +23,10 @@ export async function fetchPointCloudAnnotationAssets(
   });
   const filteredAnnotationMapping = annotationMapping.filter(isDefined);
 
-  const uniqueAnnotationMapping = uniqBy(filteredAnnotationMapping, 'assetId');
+  const uniqueAnnotationMapping = uniqBy(
+    filteredAnnotationMapping,
+    (annotationMapping) => annotationMapping.assetId
+  );
   const assetIds = uniqueAnnotationMapping.map((mapping) => mapping.assetId);
   const assets = await fetchAssetForAssetIds(assetIds, sdk);
 

--- a/react-components/src/components/RuleBasedOutputs/hooks/useExtractUniqueAssetIdsFromMapped.tsx
+++ b/react-components/src/components/RuleBasedOutputs/hooks/useExtractUniqueAssetIdsFromMapped.tsx
@@ -17,7 +17,7 @@ export const useExtractUniqueAssetIdsFromMapped = (
         id: item.assetId
       };
     });
-    const uniqueAssetIds = uniqBy(assetIds, 'id');
+    const uniqueAssetIds = uniqBy(assetIds, (assetId) => assetId.id);
     return uniqueAssetIds;
   }, [assetMappings]);
 };

--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -114,7 +114,8 @@ export {
   type AddImage360CollectionOptions,
   type AddResourceOptions,
   type AddCadResourceOptions,
-  type AddPointCloudResourceOptions
+  type AddPointCloudResourceOptions,
+  type CadModelOptions
 } from './components/Reveal3DResources/types';
 export {
   type PointCloudAnnotationMappedAssetData,

--- a/react-components/src/query/useSearchAssetsMapped360Annotations.tsx
+++ b/react-components/src/query/useSearchAssetsMapped360Annotations.tsx
@@ -116,7 +116,10 @@ async function get360AnnotationAssets(
     })
     .filter(isDefined);
 
-  const uniqueAnnotationMapping = uniqBy(filteredAnnotationMappings, 'assetId');
+  const uniqueAnnotationMapping = uniqBy(
+    filteredAnnotationMappings,
+    (annotationMapping) => annotationMapping.assetId
+  );
 
   const assets = await retrieveAssets(sdk, uniqueAnnotationMapping);
   const flatAssets = assets.flat();

--- a/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
@@ -57,12 +57,10 @@ export const useSearchMappedEquipmentAssetMappings = (
       ...models.map((model) => [model.modelId, model.revisionId])
     ],
     queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
-      if (query === '') {
+      if (query === '' || assetMappingList === undefined) {
         return { assets: [], nextCursor: undefined };
       }
-      if (assetMappingList === undefined) {
-        return { assets: [], nextCursor: undefined };
-      }
+
       const fetchAssets = async (
         cursor: string | undefined,
         accumulatedAssets: Asset[]

--- a/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
@@ -17,7 +17,7 @@ import { useSDK } from '../components/RevealCanvas/SDKProvider';
 import { getAssetsList } from '../hooks/network/getAssetsList';
 import { useAssetMappedNodesForRevisions } from '../components/CacheProvider/AssetMappingAndNode3DCacheProvider';
 import { isDefined } from '../utilities/isDefined';
-import { uniq } from 'lodash';
+import { uniqBy } from 'lodash';
 
 export type ModelMappings = {
   model: AddModelOptions;
@@ -81,7 +81,10 @@ export const useSearchMappedEquipmentAssetMappings = (
             .filter(isDefined);
         });
 
-        const uniqueAssets = uniq([...accumulatedAssets, ...filteredSearchedAssets]);
+        const uniqueAssets = uniqBy(
+          [...accumulatedAssets, ...filteredSearchedAssets],
+          (asset) => asset.id
+        );
 
         if (uniqueAssets.length >= limit || assetsResponse.nextCursor === undefined) {
           return { assets: uniqueAssets, nextCursor: assetsResponse.nextCursor };

--- a/react-components/src/utilities/buildFilter.ts
+++ b/react-components/src/utilities/buildFilter.ts
@@ -6,27 +6,16 @@ export const buildFilter = (query: string): any => {
   if (query === '') {
     return undefined;
   }
-  const conditions = ['search']
-    .map((condition) => [
-      {
-        [condition]: {
-          property: ['name'],
-          value: query
-        }
-      },
-      {
-        [condition]: {
-          property: ['description'],
-          value: query
-        }
-      }
-    ])
-    .flat();
+
+  const searchConditions = [
+    { search: { property: ['name'], value: query } },
+    { search: { property: ['description'], value: query } }
+  ];
 
   return {
     and: [
       {
-        or: conditions
+        or: searchConditions
       }
     ]
   };

--- a/react-components/stories/SearchHooks.stories.tsx
+++ b/react-components/stories/SearchHooks.stories.tsx
@@ -126,7 +126,15 @@ const StoryContent = ({ resources }: { resources: AddResourceOptions[] }): React
     } else if (searchMethod === 'assetSearch' && !isAssetSearchFetching && assetSearchHasNextPage) {
       void fetchAssetSearchNextPage();
     }
-  }, []);
+  }, [
+    searchMethod,
+    isFetching,
+    hasNextPage,
+    fetchNextPage,
+    isAssetSearchFetching,
+    assetSearchHasNextPage,
+    fetchAssetSearchNextPage
+  ]);
 
   const filteredEquipment = useMemo(() => {
     if (searchMethod === 'allFdm') {
@@ -152,9 +160,7 @@ const StoryContent = ({ resources }: { resources: AddResourceOptions[] }): React
       const transformedAssets =
         allAssets?.pages
           .flat()
-          .map((modelsAssetPage) =>
-            modelsAssetPage.modelsAssets.flatMap((modelsAsset) => modelsAsset.assets)
-          )
+          .map((mapping) => mapping.assets)
           .flat() ?? [];
 
       const all360ImageAssets =
@@ -372,8 +378,8 @@ export const Main: Story = {
         siteId: 'celanese1'
       },
       {
-        modelId: 5653798104332258,
-        revisionId: 5045518244111296
+        modelId: 7646043527629245,
+        revisionId: 6059566106376463
       }
     ]
   },


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
When a single character in provided as search input key, Asset search hook was returning no result if the Project contains very large number of Assets as the hook would filter the Asset based on 3D model asset mapping. This PR fixes the issue.
Here I have also removed initialAssetMapping call and it should be handle in application to list the initial 1000 asset mapping in the search list

## How has this been tested? :mag:

In `storybook` and `Search`


## Test instructions :information_source:

- Run `Search` example in `storybook`
- Input `Node-` key string and click on `Search` button after `Asset contextualized` button is active
- Yalc link react-components to search code in fusion and can test in the search input


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
