### PR TITLE
fix(react-component): Tiny fix to visualize the point cloud filter in the settings drop down

### DIFF
--- a/react-components/src/architecture/index.ts
+++ b/react-components/src/architecture/index.ts
@@ -5,6 +5,7 @@
 export type { CommandUpdateDelegate } from './base/commands/BaseCommand';
 export { BaseCommand } from './base/commands/BaseCommand';
 export { BaseFilterCommand } from './base/commands/BaseFilterCommand';
+export { BaseFilterItemCommand } from './base/commands/BaseFilterCommand';
 export { BaseOptionCommand } from './base/commands/BaseOptionCommand';
 export { BaseSliderCommand } from './base/commands/BaseSliderCommand';
 export { BaseTool } from './base/commands/BaseTool';

--- a/react-components/src/components/Architecture/RevealButtons.tsx
+++ b/react-components/src/components/Architecture/RevealButtons.tsx
@@ -14,10 +14,14 @@ import { KeyboardSpeedCommand } from '../../architecture/base/concreteCommands/K
 import { ObservationsTool } from '../../architecture/concrete/observations/ObservationsTool';
 import { createButtonFromCommandConstructor } from './CommandButtons';
 import { SettingsCommand } from '../../architecture/base/concreteCommands/SettingsCommand';
+import { PointCloudFilterCommand } from '../../architecture';
 
 export class RevealButtons {
   static Settings = (): ReactElement =>
     createButtonFromCommandConstructor(() => new SettingsCommand());
+
+  static PointCloudFilter = (): ReactElement =>
+    createButtonFromCommandConstructor(() => new PointCloudFilterCommand());
 
   static FitView = (): ReactElement =>
     createButtonFromCommandConstructor(() => new FitViewCommand());

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -209,6 +209,7 @@ function createOptionButton(command: BaseOptionCommand, t: TranslateDelegate): R
 }
 
 function createFilterButton(command: BaseFilterCommand, t: TranslateDelegate): ReactElement {
+  command.initializeChildrenIfNeeded();
   if (!command.isVisible) {
     return <></>;
   }


### PR DESCRIPTION
* Fix to show the  point cloud filter in the settings drop down
* Add a class in the index file 8forgot this class)
* Expose RevealButtons.PointCloudFilter so it can be reused