### PR TITLE
fix(react-components): Fix issue with outside click of the settings menu used by the settings button

### DIFF
--- a/react-components/src/components/Architecture/FilterButton.tsx
+++ b/react-components/src/components/Architecture/FilterButton.tsx
@@ -108,7 +108,7 @@ export const FilterButton = ({
       <Dropdown
         visible={isOpen}
         hideOnSelect={false}
-        appendTo={document.body}
+        appendTo={'parent'}
         placement={usedInSettings ? 'bottom-end' : 'auto-start'}
         content={
           <div ref={menuRef}>

--- a/react-components/src/components/Architecture/OptionButton.tsx
+++ b/react-components/src/components/Architecture/OptionButton.tsx
@@ -96,7 +96,7 @@ export const OptionButton = ({
       <Dropdown
         visible={isOpen}
         hideOnSelect={true}
-        appendTo={document.body}
+        appendTo={'parent'}
         placement={usedInSettings ? 'bottom-end' : 'auto-start'}
         content={
           <div ref={menuRef}>

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -2,7 +2,15 @@
  * Copyright 2024 Cognite AS
  */
 
-import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement
+} from 'react';
 import {
   Button,
   Dropdown,
@@ -30,6 +38,7 @@ import { OptionButton } from './OptionButton';
 import { BaseSliderCommand } from '../../architecture/base/commands/BaseSliderCommand';
 import { BaseFilterCommand } from '../../architecture/base/commands/BaseFilterCommand';
 import { FilterButton } from './FilterButton';
+import { useClickOutside } from './useClickOutside';
 
 export const SettingsButton = ({
   inputCommand,
@@ -66,6 +75,22 @@ export const SettingsButton = ({
     };
   }, [command]);
 
+  const outsideAction = (): boolean => {
+    if (!isOpen) {
+      return false;
+    }
+    postAction();
+    return false;
+  };
+
+  const postAction = (): void => {
+    setOpen(false);
+    renderTarget.domElement.focus();
+  };
+
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  useClickOutside(menuRef, outsideAction);
+
   if (!isVisible || !command.hasChildren) {
     return <></>;
   }
@@ -83,18 +108,20 @@ export const SettingsButton = ({
       <Dropdown
         visible={isOpen}
         hideOnSelect={false}
-        appendTo={document.body}
+        appendTo={'parent'}
         placement="auto-start"
         content={
-          <Menu
-            style={{
-              flexDirection,
-              padding: '4px 4px'
-            }}>
-            {children.map((child, _index): ReactElement | undefined => {
-              return createMenuItem(child, t);
-            })}
-          </Menu>
+          <div ref={menuRef}>
+            <Menu
+              style={{
+                flexDirection,
+                padding: '4px 4px'
+              }}>
+              {children.map((child, _index): ReactElement | undefined => {
+                return createMenuItem(child, t);
+              })}
+            </Menu>
+          </div>
         }>
         <Button
           type={getButtonType(command)}
@@ -104,7 +131,9 @@ export const SettingsButton = ({
           toggled={isOpen}
           aria-label={label}
           iconPlacement="right"
-          onClick={() => {
+          onClick={(event: MouseEvent<HTMLElement>) => {
+            event.stopPropagation();
+            event.preventDefault();
             setOpen((prevState) => !prevState);
           }}
         />

--- a/react-components/src/components/Architecture/useClickOutside.tsx
+++ b/react-components/src/components/Architecture/useClickOutside.tsx
@@ -8,7 +8,8 @@ export function useClickOutside(ref: RefObject<HTMLElement>, callback: () => boo
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent): void => {
       const current = ref.current;
-      if (current !== null && !current.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (current !== null && !current.contains(target)) {
         if (callback()) {
           event.stopPropagation();
           event.preventDefault();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## How has this been tested? :mag:

Open storybook
Open mock settings (bug icon)
When the settings is open, click outside: Then the drop down should disappear.
Open some of the dropdown in the settings. Selection here should not caused the setting to disappear.

## Checklist :ballot_box_with_check:

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
