### PR TITLE
fix(react-components): camera state when Home button is clicked in active 360 image mode

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.55.7",
+  "version": "0.55.8",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/RevealToolbar/ResetCameraButton.tsx
+++ b/react-components/src/components/RevealToolbar/ResetCameraButton.tsx
@@ -7,6 +7,7 @@ import { Button, Tooltip as CogsTooltip } from '@cognite/cogs.js';
 import { useTranslation } from '../i18n/I18n';
 import { useCameraNavigation } from '../../hooks/useCameraNavigation';
 import { useSceneDefaultCamera } from '../../hooks/useSceneDefaultCamera';
+import { useReveal } from '../RevealCanvas/ViewerContext';
 
 type ResetCameraButtonProps = {
   sceneExternalId?: string;
@@ -18,16 +19,20 @@ export const ResetCameraButton = ({
   sceneSpaceId
 }: ResetCameraButtonProps): ReactElement => {
   const { t } = useTranslation();
+  const viewer = useReveal();
   const cameraNavigation = useCameraNavigation();
   const resetToDefaultSceneCamera = useSceneDefaultCamera(sceneExternalId, sceneSpaceId);
 
   const resetCameraToHomePosition = useCallback(() => {
+    if (viewer.get360ImageCollections() !== undefined) {
+      viewer.exit360Image();
+    }
     if (sceneExternalId !== undefined && sceneSpaceId !== undefined) {
       resetToDefaultSceneCamera.fitCameraToSceneDefault();
       return;
     }
     cameraNavigation.fitCameraToAllModels();
-  }, [sceneExternalId, sceneSpaceId, cameraNavigation, resetToDefaultSceneCamera]);
+  }, [sceneExternalId, sceneSpaceId, cameraNavigation, resetToDefaultSceneCamera, viewer]);
 
   return (
     <CogsTooltip

--- a/react-components/src/components/RevealTopbar/RevealTopbar.tsx
+++ b/react-components/src/components/RevealTopbar/RevealTopbar.tsx
@@ -36,8 +36,8 @@ const DefaultContentWrapper = (props: CustomTopbarContent): ReactElement => {
           lowQualitySettings={props.lowFidelitySettings}
           highQualitySettings={props.highFidelitySettings}
         />
+        <ResetCameraButton />
       </FlexSection>
-      <ResetCameraButton />
     </>
   );
 };

--- a/react-components/src/components/RevealTopbar/RevealTopbar.tsx
+++ b/react-components/src/components/RevealTopbar/RevealTopbar.tsx
@@ -12,6 +12,7 @@ import { Divider } from '@cognite/cogs.js';
 import { SetOrbitOrFirstPersonControlsType } from '../RevealToolbar/SetFlexibleControlsType';
 import { RuleBasedOutputsButton } from '../RevealToolbar/RuleBasedOutputsButton';
 import { LayersButtonStrip } from '../RevealToolbar/LayersContainer/LayersButtonsStrip';
+import { ResetCameraButton } from '../RevealToolbar/ResetCameraButton';
 
 export type CustomTopbarContent = CustomToolbarContent & { topbarContent?: ReactNode };
 
@@ -36,6 +37,7 @@ const DefaultContentWrapper = (props: CustomTopbarContent): ReactElement => {
           highQualitySettings={props.highFidelitySettings}
         />
       </FlexSection>
+      <ResetCameraButton />
     </>
   );
 };


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4506

## Description :pencil:
When in 360 Image mode and Home button is clicked, though the camera position resets to Scene Default position, the camera state would still be 360 image mode, this PR fixes the issue 

## How has this been tested? :mag:

In storybook


## Test instructions :information_source:

- `yarn && yarn build && yarn storybook` in react-component
- Run `Topbar` example
- Enter into `360 Image mode` & click on `Home` button at top right


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
