### PR TITLE
feat(react-components): Move m/ft button to the domain object card

### DIFF
--- a/react-components/src/architecture/base/domainObjects/DomainObject.ts
+++ b/react-components/src/architecture/base/domainObjects/DomainObject.ts
@@ -25,6 +25,7 @@ import { DeleteDomainObjectCommand } from '../concreteCommands/DeleteDomainObjec
 import { CopyToClipboardCommand } from '../concreteCommands/CopyToClipboardCommand';
 import { type BaseCommand } from '../commands/BaseCommand';
 import { type Transaction } from '../undo/Transaction';
+import { ToggleMetricUnitsCommand } from '../concreteCommands/ToggleMetricUnitsCommand';
 
 /**
  * Represents an abstract base class for domain objects.
@@ -369,7 +370,11 @@ export abstract class DomainObject {
   }
 
   public getPanelToolbar(): BaseCommand[] {
-    return [new DeleteDomainObjectCommand(this), new CopyToClipboardCommand()];
+    return [
+      new DeleteDomainObjectCommand(this),
+      new CopyToClipboardCommand(),
+      new ToggleMetricUnitsCommand()
+    ];
   }
 
   // ==================================================

--- a/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
+++ b/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
@@ -7,7 +7,6 @@ import { type BaseCreator } from '../../base/domainObjectsHelpers/BaseCreator';
 import { ShowMeasurementsOnTopCommand } from './commands/ShowMeasurementsOnTopCommand';
 import { SetMeasurementTypeCommand } from './commands/SetMeasurementTypeCommand';
 import { type TranslateKey } from '../../base/utilities/TranslateKey';
-// import { ToggleMetricUnitsCommand } from '../../base/concreteCommands/ToggleMetricUnitsCommand';
 import { PrimitiveEditTool } from '../primitives/PrimitiveEditTool';
 import { MeasureLineDomainObject } from './MeasureLineDomainObject';
 import { MeasureBoxDomainObject } from './MeasureBoxDomainObject';
@@ -49,7 +48,6 @@ export class MeasurementTool extends PrimitiveEditTool {
       new SetMeasurementTypeCommand(PrimitiveType.Box),
       undefined, // Separator
       new UndoCommand(),
-      //      new ToggleMetricUnitsCommand(),
       new ShowMeasurementsOnTopCommand()
     ];
   }

--- a/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
+++ b/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
@@ -49,7 +49,6 @@ export class MeasurementTool extends PrimitiveEditTool {
       new SetMeasurementTypeCommand(PrimitiveType.Box),
       undefined, // Separator
       new UndoCommand(),
-      new ToggleMetricUnitsCommand(),
       new ShowMeasurementsOnTopCommand()
     ];
   }

--- a/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
+++ b/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
@@ -7,7 +7,7 @@ import { type BaseCreator } from '../../base/domainObjectsHelpers/BaseCreator';
 import { ShowMeasurementsOnTopCommand } from './commands/ShowMeasurementsOnTopCommand';
 import { SetMeasurementTypeCommand } from './commands/SetMeasurementTypeCommand';
 import { type TranslateKey } from '../../base/utilities/TranslateKey';
-import { ToggleMetricUnitsCommand } from '../../base/concreteCommands/ToggleMetricUnitsCommand';
+// import { ToggleMetricUnitsCommand } from '../../base/concreteCommands/ToggleMetricUnitsCommand';
 import { PrimitiveEditTool } from '../primitives/PrimitiveEditTool';
 import { MeasureLineDomainObject } from './MeasureLineDomainObject';
 import { MeasureBoxDomainObject } from './MeasureBoxDomainObject';
@@ -49,6 +49,7 @@ export class MeasurementTool extends PrimitiveEditTool {
       new SetMeasurementTypeCommand(PrimitiveType.Box),
       undefined, // Separator
       new UndoCommand(),
+      //      new ToggleMetricUnitsCommand(),
       new ShowMeasurementsOnTopCommand()
     ];
   }

--- a/react-components/src/architecture/concrete/observations/ObservationsDomainObject.ts
+++ b/react-components/src/architecture/concrete/observations/ObservationsDomainObject.ts
@@ -12,6 +12,7 @@ import { PanelInfo } from '../../base/domainObjectsHelpers/PanelInfo';
 import { type Observation, ObservationStatus } from './types';
 import { partition, remove } from 'lodash';
 import { type ObservationProperties } from './models';
+import { Quantity } from '../../base/domainObjectsHelpers/Quantity';
 
 export class ObservationsDomainObject extends VisualDomainObject {
   private _selectedObservation: Observation | undefined;
@@ -54,10 +55,12 @@ export class ObservationsDomainObject extends VisualDomainObject {
     const header = { fallback: 'Observation' };
     info.setHeader(header);
 
-    info.add({ fallback: 'X', value: this._selectedObservation?.properties.positionX });
-    info.add({ fallback: 'Y', value: this._selectedObservation?.properties.positionY });
-    info.add({ fallback: 'Z', value: this._selectedObservation?.properties.positionZ });
-
+    if (this._selectedObservation !== undefined) {
+      const properties = this._selectedObservation.properties;
+      info.add({ fallback: 'X', value: properties.positionX, quantity: Quantity.Length });
+      info.add({ fallback: 'Y', value: properties.positionY, quantity: Quantity.Length });
+      info.add({ fallback: 'Z', value: properties.positionZ, quantity: Quantity.Length });
+    }
     return info;
   }
 

--- a/react-components/src/components/Architecture/DomainObjectPanel.tsx
+++ b/react-components/src/components/Architecture/DomainObjectPanel.tsx
@@ -37,16 +37,16 @@ export const DomainObjectPanel = (): ReactElement => {
   useEffect(() => {
     DomainObjectPanelUpdater.setDomainObjectDelegate(setCurrentDomainObjectInfo);
 
-    if (commands === undefined || info === undefined) {
-      return;
-    }
-
     // Set in the get string on the copy command if any
+  }, [setCurrentDomainObjectInfo, commands]);
+
+  // Fore the getString to be updated
+  if (commands !== undefined && info !== undefined) {
     for (const command of commands) {
       if (command instanceof CopyToClipboardCommand)
         command.getString = () => toString(info, t, unitSystem);
     }
-  }, [setCurrentDomainObjectInfo, commands]);
+  }
 
   const { t } = useTranslation();
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:

See this conversation: https://cognitedata.slack.com/archives/G0115JQ8JM8/p1724831633376919

* I also did some refactoring in the `ObservationsDomainObject`, because the `Quantity `was missing
* Fix missing "Copy to clipboard" button.

## How has this been tested? :mag:

Open storybook/architecture
Make a crop box or a measurement.

