### PR TITLE
fix(react-components): Update fit view so it uses only visual object

### DIFF
--- a/react-components/src/architecture/base/concreteCommands/ToggleAllModelsVisibleCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/ToggleAllModelsVisibleCommand.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { RenderTargetCommand } from '../commands/RenderTargetCommand';
+import { type TranslateKey } from '../utilities/TranslateKey';
+
+export class ToggleAllModelsVisibleCommand extends RenderTargetCommand {
+  public override get tooltip(): TranslateKey {
+    return { fallback: 'Show or hide all models' };
+  }
+
+  public override get icon(): string {
+    return 'EyeShow';
+  }
+
+  public override get isToggle(): boolean {
+    return true;
+  }
+
+  public override get isChecked(): boolean {
+    return this.isAnyVisible();
+  }
+
+  public override get isEnabled(): boolean {
+    return this.renderTarget.viewer.models.length > 0;
+  }
+
+  protected override invokeCore(): boolean {
+    const isVisible = this.isAnyVisible();
+    for (const model of this.renderTarget.viewer.models) {
+      model.visible = !isVisible;
+    }
+    this.renderTarget.invalidate();
+    return true;
+  }
+
+  // ==================================================
+  // INSTANCE METHODS
+  // ==================================================
+
+  private isAnyVisible(): boolean {
+    for (const model of this.renderTarget.viewer.models) {
+      if (model.visible) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/react-components/src/architecture/base/utilities/geometry/Range1.ts
+++ b/react-components/src/architecture/base/utilities/geometry/Range1.ts
@@ -181,7 +181,7 @@ export class Range1 {
   // INSTANCE METHODS: Operations
   // ==================================================
 
-  public clear(): void {
+  public makeEmpty(): void {
     this._min = 0;
     this._max = 0;
     this._isEmpty = true;

--- a/react-components/src/architecture/base/utilities/geometry/Range3.ts
+++ b/react-components/src/architecture/base/utilities/geometry/Range3.ts
@@ -220,8 +220,18 @@ export class Range3 {
   // INSTANCE METHODS: Operations
   // ==================================================
 
+  public makeEmpty(): void {
+    this.x.makeEmpty();
+    this.y.makeEmpty();
+    this.z.makeEmpty();
+  }
+
   public copy(box: Box3): void {
-    this.set(box.min, box.max);
+    if (box.isEmpty()) {
+      this.makeEmpty();
+    } else {
+      this.set(box.min, box.max);
+    }
   }
 
   public set(min: Vector3, max: Vector3): void {

--- a/react-components/src/architecture/base/views/GroupThreeView.ts
+++ b/react-components/src/architecture/base/views/GroupThreeView.ts
@@ -34,6 +34,7 @@ export abstract class GroupThreeView<DomainObjectType extends DomainObject = Dom
   // ==================================================
 
   protected readonly _group: Group = new Group();
+  private _inNeedsUpdate = false; // True if inside needsUpdate. This is to avoid infinite recursion.
 
   protected get isEmpty(): boolean {
     return this._group.children.length === 0;
@@ -189,13 +190,23 @@ export abstract class GroupThreeView<DomainObjectType extends DomainObject = Dom
    * When it returns true, the view will be rebuild by addChildren().
    * @returns A boolean value indicating whether the view needs to be updated.
    */
-  protected get needsUpdate(): boolean {
+  protected needsUpdateCore(): boolean {
     return false;
   }
 
   // ==================================================
   // INSTANCE METHODS
   // ==================================================
+
+  protected get needsUpdate(): boolean {
+    if (this._inNeedsUpdate) {
+      return false;
+    }
+    this._inNeedsUpdate = true;
+    const result = this.needsUpdateCore();
+    this._inNeedsUpdate = false;
+    return result;
+  }
 
   private makeChildren(): void {
     if (!this.isEmpty) {

--- a/react-components/src/architecture/concrete/axis/AxisThreeView.ts
+++ b/react-components/src/architecture/concrete/axis/AxisThreeView.ts
@@ -109,25 +109,24 @@ export class AxisThreeView extends GroupThreeView {
     return false;
   }
 
-  protected override get needsUpdate(): boolean {
+  protected override needsUpdateCore(): boolean {
     const target = this.renderTarget;
 
     // Check if bounding box is different
-    const sceneBoundingBox = target.clippedSceneBoundingBox;
-    if (sceneBoundingBox.equals(this._sceneBoundingBox)) {
+    const boundingBox = target.clippedVisualSceneBoundingBox;
+    if (boundingBox.equals(this._sceneBoundingBox)) {
       return false;
     }
-    this._sceneBoundingBox.copy(sceneBoundingBox);
-    this._expandedSceneBoundingBox.copy(sceneBoundingBox);
-    this._expandedSceneBoundingBox.expandByFraction(0.02);
+    this._sceneBoundingBox.copy(boundingBox);
+    this._expandedSceneBoundingBox.copy(boundingBox);
+    if (!this._expandedSceneBoundingBox.isEmpty) {
+      this._expandedSceneBoundingBox.expandByFraction(0.02);
+    }
     return true;
   }
 
   protected override addChildren(): void {
     const boundingBox = this._expandedSceneBoundingBox;
-    if (boundingBox === undefined) {
-      return;
-    }
     if (boundingBox.isEmpty) {
       return;
     }

--- a/react-components/src/architecture/concrete/config/StoryBookConfig.ts
+++ b/react-components/src/architecture/concrete/config/StoryBookConfig.ts
@@ -24,6 +24,7 @@ import { ObservationsTool } from '../observations/ObservationsTool';
 import { SettingsCommand } from '../../base/concreteCommands/SettingsCommand';
 import { MockSettingsCommand } from '../../base/commands/mocks/MockSettingsCommand';
 import { MockFilterCommand } from '../../base/commands/mocks/MockFilterCommand';
+import { ToggleAllModelsVisibleCommand } from '../../base/concreteCommands/ToggleAllModelsVisibleCommand';
 
 export class StoryBookConfig extends BaseRevealConfig {
   // ==================================================
@@ -41,6 +42,7 @@ export class StoryBookConfig extends BaseRevealConfig {
       undefined,
       new FitViewCommand(),
       new SetAxisVisibleCommand(),
+      new ToggleAllModelsVisibleCommand(),
       new ToggleMetricUnitsCommand(),
       new KeyboardSpeedCommand(),
       new SettingsCommand(),

--- a/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
+++ b/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
@@ -63,7 +63,7 @@ export class MeasurementTool extends PrimitiveEditTool {
       this.setAllVisible(true);
       return;
     }
-    const sceneBoundingBox = this.renderTarget.clippedSceneBoundingBox;
+    const sceneBoundingBox = this.renderTarget.clippedVisualSceneBoundingBox;
     for (const domainObject of this.getSelectable()) {
       if (domainObject instanceof MeasureBoxDomainObject) {
         const boundingBox = domainObject.getBoundingBox();

--- a/react-components/src/architecture/concrete/primitives/plane/PlaneView.ts
+++ b/react-components/src/architecture/concrete/primitives/plane/PlaneView.ts
@@ -89,7 +89,7 @@ export class PlaneView extends GroupThreeView<PlaneDomainObject> {
     return this.style.depthTest;
   }
 
-  protected override get needsUpdate(): boolean {
+  protected override needsUpdateCore(): boolean {
     const target = this.renderTarget;
 
     // Check if bounding box is different
@@ -98,7 +98,7 @@ export class PlaneView extends GroupThreeView<PlaneDomainObject> {
       return false;
     }
     this._sceneBoundingBox.copy(sceneBoundingBox);
-    this._sceneRange.copy(this._sceneBoundingBox);
+    this._sceneRange.copy(sceneBoundingBox);
     return true;
   }
 
@@ -106,10 +106,13 @@ export class PlaneView extends GroupThreeView<PlaneDomainObject> {
     const { domainObject, style } = this;
     const plane = domainObject.plane;
 
-    const sceneBoundingBox = this._sceneBoundingBox.clone();
-    sceneBoundingBox.applyMatrix4(CDF_TO_VIEWER_TRANSFORMATION.clone().invert());
+    if (this._sceneBoundingBox.isEmpty()) {
+      return;
+    }
+    const boundingBox = this._sceneBoundingBox.clone();
+    boundingBox.applyMatrix4(CDF_TO_VIEWER_TRANSFORMATION.clone().invert());
     const range = new Range3();
-    range.copy(sceneBoundingBox);
+    range.copy(boundingBox);
 
     let p0: Vector3 | undefined;
     let p1: Vector3 | undefined;

--- a/react-components/src/components/RevealToolbar/FitModelsButton.tsx
+++ b/react-components/src/components/RevealToolbar/FitModelsButton.tsx
@@ -13,7 +13,7 @@ export const FitModelsButton = (): ReactElement => {
   const { t } = useTranslation();
 
   const updateCamera = useCallback(() => {
-    cameraNavigation.fitCameraToSceneBoundingBox();
+    cameraNavigation.fitCameraToVisualSceneBoundingBox();
   }, []);
 
   return (

--- a/react-components/src/components/RevealToolbar/FitModelsButton.tsx
+++ b/react-components/src/components/RevealToolbar/FitModelsButton.tsx
@@ -13,7 +13,7 @@ export const FitModelsButton = (): ReactElement => {
   const { t } = useTranslation();
 
   const updateCamera = useCallback(() => {
-    cameraNavigation.fitCameraToAllModels();
+    cameraNavigation.fitCameraToSceneBoundingBox();
   }, []);
 
   return (

--- a/react-components/src/hooks/useCameraNavigation.tsx
+++ b/react-components/src/hooks/useCameraNavigation.tsx
@@ -8,7 +8,7 @@ import { useFdmNodeCache } from '../components/CacheProvider/NodeCacheProvider';
 import { Box3 } from 'three';
 
 export type CameraNavigationActions = {
-  fitCameraToSceneBoundingBox: (duration?: number) => void;
+  fitCameraToVisualSceneBoundingBox: (duration?: number) => void;
   fitCameraToAllModels: (duration?: number) => void;
   fitCameraToModelNode: (revisionId: number, nodeId: number) => Promise<void>;
   fitCameraToModelNodes: (revisionId: number, nodeids: number[]) => Promise<void>;
@@ -21,8 +21,8 @@ export const useCameraNavigation = (): CameraNavigationActions => {
   const fdmNodeCache = useFdmNodeCache();
   const viewer = useReveal();
 
-  const fitCameraToSceneBoundingBox = (duration?: number): void => {
-    viewer.fitCameraToSceneBoundingBox(duration);
+  const fitCameraToVisualSceneBoundingBox = (duration?: number): void => {
+    viewer.fitCameraToVisualSceneBoundingBox(duration);
   };
 
   const fitCameraToAllModels = (duration?: number): void => {
@@ -41,11 +41,11 @@ export const useCameraNavigation = (): CameraNavigationActions => {
     }
 
     const nodeBoundingBoxes = await (model as CogniteCadModel).getBoundingBoxesByNodeIds(nodeIds);
-    const unionedBox = nodeBoundingBoxes.reduce(
+    const boundingBox = nodeBoundingBoxes.reduce(
       (currentBox, nextBox) => currentBox.union(nextBox),
       new Box3()
     );
-    viewer.cameraManager.fitCameraToBoundingBox(unionedBox);
+    viewer.cameraManager.fitCameraToBoundingBox(boundingBox);
   };
 
   const fitCameraToModelNode = async (revisionId: number, nodeId: number): Promise<void> => {
@@ -83,7 +83,7 @@ export const useCameraNavigation = (): CameraNavigationActions => {
   };
 
   return {
-    fitCameraToSceneBoundingBox,
+    fitCameraToVisualSceneBoundingBox,
     fitCameraToAllModels,
     fitCameraToInstance,
     fitCameraToInstances,

--- a/react-components/src/hooks/useCameraNavigation.tsx
+++ b/react-components/src/hooks/useCameraNavigation.tsx
@@ -8,6 +8,7 @@ import { useFdmNodeCache } from '../components/CacheProvider/NodeCacheProvider';
 import { Box3 } from 'three';
 
 export type CameraNavigationActions = {
+  fitCameraToSceneBoundingBox: (duration?: number) => void;
   fitCameraToAllModels: (duration?: number) => void;
   fitCameraToModelNode: (revisionId: number, nodeId: number) => Promise<void>;
   fitCameraToModelNodes: (revisionId: number, nodeids: number[]) => Promise<void>;
@@ -19,6 +20,10 @@ export type CameraNavigationActions = {
 export const useCameraNavigation = (): CameraNavigationActions => {
   const fdmNodeCache = useFdmNodeCache();
   const viewer = useReveal();
+
+  const fitCameraToSceneBoundingBox = (duration?: number): void => {
+    viewer.fitCameraToSceneBoundingBox(duration);
+  };
 
   const fitCameraToAllModels = (duration?: number): void => {
     const models = viewer.models;
@@ -78,6 +83,7 @@ export const useCameraNavigation = (): CameraNavigationActions => {
   };
 
   return {
+    fitCameraToSceneBoundingBox,
     fitCameraToAllModels,
     fitCameraToInstance,
     fitCameraToInstances,


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:

* Added `ToggleAllModelsVisibleCommand`. For time being only used for testing.
* In `RevealRenderTarget`, made several bounding box function for different usage, changed some naming. Update `fitView `to only take the visual object in the scene.
* In `Range1/Range3`, added `makeEmpty `function., That was missing. Fix empty box when copy()
* In `GroupTreeView`, added fix for infinite recursion. Renamed old `needsUpdate()` to `needsUpdateCore()`
* In `AxisTreeView `and `PlaneTreeView `, updated code to handle empty bounding boxes.
* In `FitModelsButton`, use the new `fitCameraToSceneBoundingBox `in Reveal.
* iIn `useCameraNavigation.tsx`, added `fitCameraToVisualSceneBoundingBox`, to be used in fusion





## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
