### PR TITLE
fix(react-components): resources count when unreferenced model is removed

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.58.2",
+  "version": "0.58.3",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/Reveal3DResources/useRemoveNonReferencedModels.ts
+++ b/react-components/src/components/Reveal3DResources/useRemoveNonReferencedModels.ts
@@ -10,11 +10,14 @@ import {
 } from './typeGuards';
 import { useEffect } from 'react';
 import { isSameModel } from '../../utilities/isSameModel';
+import { useReveal3DResourcesCount } from './Reveal3DResourcesInfoContext';
+import { getViewerResourceCount } from '../../utilities/getViewerResourceCount';
 
 export function useRemoveNonReferencedModels(
   addOptions: AddResourceOptions[],
   viewer: Cognite3DViewer
 ): void {
+  const { setRevealResourcesCount } = useReveal3DResourcesCount();
   useEffect(() => {
     const nonReferencedModels = findNonReferencedModels(addOptions, viewer);
 
@@ -27,6 +30,7 @@ export function useRemoveNonReferencedModels(
     nonReferencedCollections.forEach((collection) => {
       viewer.remove360ImageSet(collection);
     });
+    setRevealResourcesCount(getViewerResourceCount(viewer));
   }, [addOptions]);
 }
 

--- a/react-components/tests/unit-tests/components/Reveal3DResources/useRemoveNonReferencedModels.test.tsx
+++ b/react-components/tests/unit-tests/components/Reveal3DResources/useRemoveNonReferencedModels.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-
-import { Mock } from 'moq.ts';
+import React, { type JSX } from 'react';
 
 import { renderHook } from '@testing-library/react';
 
@@ -12,36 +11,54 @@ import {
   viewerModelsMock,
   viewerRemoveModelsMock
 } from '../../fixtures/viewer';
+import { Reveal3DResourcesInfoContextProvider } from '../../../../src/components/Reveal3DResources/Reveal3DResourcesInfoContext';
 import { cadMock, cadModelOptions } from '../../fixtures/cadModel';
 import { pointCloudMock, pointCloudModelOptions } from '../../fixtures/pointCloud';
 import { image360Mock, image360Options } from '../../fixtures/image360';
+import { EMPTY_ARRAY } from '../../../../src/utilities/constants';
 
 describe(useRemoveNonReferencedModels.name, () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
+  const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+    <Reveal3DResourcesInfoContextProvider>{children}</Reveal3DResourcesInfoContextProvider>
+  );
   test('does not crash when no models are added', () => {
     viewerModelsMock.mockReturnValue([]);
     viewerImage360CollectionsMock.mockReturnValue([]);
-    expect(() => renderHook(() => useRemoveNonReferencedModels([], viewerMock))).not.toThrow();
+    expect(() =>
+      renderHook(
+        () => {
+          useRemoveNonReferencedModels(EMPTY_ARRAY, viewerMock);
+        },
+        { wrapper }
+      )
+    ).not.toThrow();
   });
 
   test('removes models when empty ', () => {
     viewerModelsMock.mockReturnValue([cadMock]);
     viewerImage360CollectionsMock.mockReturnValue([]);
-    renderHook(() => useRemoveNonReferencedModels([], viewerMock));
+    renderHook(
+      () => {
+        useRemoveNonReferencedModels(EMPTY_ARRAY, viewerMock);
+      },
+      { wrapper }
+    );
     expect(viewerRemoveModelsMock).toHaveBeenCalledOnce();
   });
 
   test('does not remove models when in addOptions', () => {
     viewerModelsMock.mockReturnValue([pointCloudMock, cadMock]);
     viewerImage360CollectionsMock.mockReturnValue([image360Mock]);
-    renderHook(() =>
-      useRemoveNonReferencedModels(
-        [cadModelOptions, pointCloudModelOptions, image360Options],
-        viewerMock
-      )
+    const mockAddOptions = [pointCloudModelOptions, cadModelOptions, image360Options];
+    renderHook(
+      () => {
+        useRemoveNonReferencedModels(mockAddOptions, viewerMock);
+      },
+      { wrapper }
     );
     expect(viewerRemoveModelsMock).not.toHaveBeenCalled();
   });
@@ -49,7 +66,13 @@ describe(useRemoveNonReferencedModels.name, () => {
   test('removes only relevant model', () => {
     viewerModelsMock.mockReturnValue([pointCloudMock, cadMock]);
     viewerImage360CollectionsMock.mockReturnValue([image360Mock]);
-    renderHook(() => useRemoveNonReferencedModels([cadModelOptions, image360Options], viewerMock));
+    const mockAddOptions = [cadModelOptions, image360Options];
+    renderHook(
+      () => {
+        useRemoveNonReferencedModels(mockAddOptions, viewerMock);
+      },
+      { wrapper }
+    );
     expect(viewerRemoveModelsMock).toHaveBeenCalledWith(pointCloudMock);
   });
 });

--- a/react-components/tests/unit-tests/components/RevealCanvas/hooks/useCameraStateControl.test.ts
+++ b/react-components/tests/unit-tests/components/RevealCanvas/hooks/useCameraStateControl.test.ts
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react';
 
 import { viewerMock } from '../../../fixtures/viewer';
 import {
-  CameraStateParameters,
+  type CameraStateParameters,
   useCameraStateControl
 } from '../../../../../src/components/RevealCanvas/hooks/useCameraStateControl';
 import { Vector3 } from 'three';
@@ -28,20 +28,24 @@ describe(useCameraStateControl.name, () => {
   });
 
   test('does nothing when inputs are undefined', () => {
-    const { rerender } = renderHook(() => useCameraStateControl());
+    const { rerender } = renderHook(() => {
+      useCameraStateControl();
+    });
 
     vi.runAllTimers();
     rerender();
     vi.runAllTimers();
 
-    cameraManagerGlobalCameraEvents.cameraStop.forEach((mockCallback) =>
-      expect(mockCallback).not.toBeCalled()
-    );
+    cameraManagerGlobalCameraEvents.cameraStop.forEach((mockCallback) => {
+      expect(mockCallback).not.toBeCalled();
+    });
   });
 
   test('does nothing if external camera state is undefined', () => {
     const setter = vi.fn();
-    const { rerender } = renderHook(() => useCameraStateControl(undefined, setter));
+    const { rerender } = renderHook(() => {
+      useCameraStateControl(undefined, setter);
+    });
 
     vi.runAllTimers();
     rerender();
@@ -54,8 +58,9 @@ describe(useCameraStateControl.name, () => {
     const setter = vi.fn<[CameraStateParameters | undefined], void>();
 
     const { rerender } = renderHook(
-      ({ position }: { position: Vector3 }) =>
-        useCameraStateControl({ position: position.clone(), target: new Vector3(1, 1, 1) }, setter),
+      ({ position }: { position: Vector3 }) => {
+        useCameraStateControl({ position: position.clone(), target: new Vector3(1, 1, 1) }, setter);
+      },
       { initialProps: { position: new Vector3(0, 0, 0) } }
     );
 
@@ -65,20 +70,20 @@ describe(useCameraStateControl.name, () => {
     vi.runAllTimers();
     expect(setter).not.toBeCalled();
 
-    cameraManagerGlobalCameraEvents.cameraStop.forEach((mockCallback) =>
-      expect(mockCallback).toBeCalledTimes(1)
-    );
+    cameraManagerGlobalCameraEvents.cameraStop.forEach((mockCallback) => {
+      expect(mockCallback).toBeCalledTimes(1);
+    });
   });
 
   test('provided setter is called after updating camera state internally', () => {
     const setter = vi.fn<[CameraStateParameters | undefined], void>();
 
-    const { rerender } = renderHook(() =>
+    const { rerender } = renderHook(() => {
       useCameraStateControl(
         { position: new Vector3(0, 0, 0), target: new Vector3(1, 1, 1) },
         setter
-      )
-    );
+      );
+    });
 
     vi.runAllTimers();
 

--- a/react-components/tests/unit-tests/fixtures/cadModel.ts
+++ b/react-components/tests/unit-tests/fixtures/cadModel.ts
@@ -1,4 +1,4 @@
-import { CogniteCadModel } from '@cognite/reveal';
+import { type CogniteCadModel } from '@cognite/reveal';
 import { Mock } from 'moq.ts';
 import { Matrix4 } from 'three';
 

--- a/react-components/tests/unit-tests/fixtures/viewer.ts
+++ b/react-components/tests/unit-tests/fixtures/viewer.ts
@@ -1,14 +1,7 @@
-import { vi, Mock as viMock } from 'vitest';
+import { vi } from 'vitest';
 
-import {
-  CameraManagerEventType,
-  Cognite3DViewer,
-  CogniteModel,
-  Image360Collection
-} from '@cognite/reveal';
+import { type Cognite3DViewer, type CogniteModel, type Image360Collection } from '@cognite/reveal';
 import { Mock, It } from 'moq.ts';
-import { Vector3 } from 'three';
-import { remove } from 'lodash';
 import { cameraManagerMock } from './cameraManager';
 
 const domElement = document.createElement('div').appendChild(document.createElement('canvas'));
@@ -18,7 +11,9 @@ export const viewerRemoveModelsMock = vi.fn<[CogniteModel], void>();
 export const viewerImage360CollectionsMock = vi.fn<[], Image360Collection[]>();
 
 export const viewerMock = new Mock<Cognite3DViewer>()
-  .setup((viewer) => viewer.setBackgroundColor(It.IsAny()))
+  .setup((viewer) => {
+    viewer.setBackgroundColor(It.IsAny());
+  })
   .returns()
   .setup((viewer) => viewer.domElement)
   .returns(domElement)


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4613

## Description :pencil:
use3dModel was not returning updated value when unreferenced model was removed.

## How has this been tested? :mag:

In Search


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
