### PR TITLE
fix(react-components): react query triggers refetching when window is focused

### DIFF
--- a/react-components/src/components/RevealContext/RevealContext.tsx
+++ b/react-components/src/components/RevealContext/RevealContext.tsx
@@ -44,7 +44,13 @@ export const RevealContext = (props: RevealContextProps): ReactElement => {
   const viewer = useRevealFromKeepAlive(props);
 
   const queryClient = useMemo(() => {
-    return new QueryClient();
+    return new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false
+        }
+      }
+    });
   }, []);
 
   if (viewer === null) return <></>;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4635

## Description :pencil:
The react query would refetch data when page/window/tab was focused causing unnecessary request, this caused an issue in `Search` application when `Bowser` tab is switched, which would trigger fetching again even when `queryKey` has not changed

## How has this been tested? :mag:

In `Search` application


## Test instructions :information_source:

`yalc` link to `Search`


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
