### PR TITLE
fix: Change to XYZ view in the Axis Gizmo as default, just like blender

### DIFF
--- a/viewer/packages/tools/src/AxisGizmo/AxisGizmoOptions.ts
+++ b/viewer/packages/tools/src/AxisGizmo/AxisGizmoOptions.ts
@@ -18,7 +18,7 @@ export class AxisGizmoOptions {
   public primaryLineWidth = 3; // If 0 invisible
   public secondaryLineWidth = 0; // If 0 invisible
   public bobbleLineWidth = 2; // If 0 invisible, only used on secondary axis
-  public useGeoLabels = true; // If true use EW-NS-UD, otherwise use XYZ or -XYZ
+  public useGeoLabels = false; // If true use EW-NS-UD, otherwise use XYZ or -XYZ
   public yUp = false;
   public fontSize = '12px';
   public fontFamily = 'arial';


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:

Change to XYZ view in the Axis Gizmo. Just like blender. As in blender the negative axis don't have any label. That is done by purpose.

![image](https://github.com/user-attachments/assets/32221f86-fef8-4e24-96df-17d8502ee809)

Blender:

![image](https://github.com/user-attachments/assets/74d266e8-d1af-4375-8727-110d21a33bb1)


## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

run examples on viewer and you will see.


