### PR TITLE
feat: Make the camera manager marker better

### DIFF
--- a/viewer/packages/camera-manager/src/Flexible/FlexibleCameraMarkers.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleCameraMarkers.ts
@@ -5,10 +5,12 @@
 import { Scene, Object3D, Vector3, Sprite, SpriteMaterial, CanvasTexture } from 'three';
 import { FlexibleCameraManager } from './FlexibleCameraManager';
 import { FlexibleControlsType } from './FlexibleControlsType';
+import { FlexibleControlsOptions } from './FlexibleControlsOptions';
 
 export class FlexibleCameraMarkers {
   private readonly _scene: Scene;
-  private _targetMarker: Sprite | undefined;
+  private _targetMarker1: Sprite | undefined;
+  private _targetMarker2: Sprite | undefined;
 
   //================================================
   // CONSTRUCTOR
@@ -24,29 +26,38 @@ export class FlexibleCameraMarkers {
 
   public update(manager: FlexibleCameraManager): void {
     if (this.isVisible(manager)) {
-      if (!this._targetMarker) {
-        this._targetMarker = createSprite(manager.options.outerMarkerColor, manager.options.innerMarkerColor);
-        this._scene.add(this._targetMarker);
-        this._targetMarker.visible = true;
-      } else if (!this._targetMarker.visible) {
-        this._targetMarker.visible = true;
+      if (this._targetMarker1 === undefined) {
+        this._targetMarker1 = createSprite(manager.options, true);
+        this._scene.add(this._targetMarker1);
       }
-      setPosition(this._targetMarker, manager.controls.getTarget(), manager);
+      if (this._targetMarker2 === undefined) {
+        this._targetMarker2 = createSprite(manager.options, false);
+        this._scene.add(this._targetMarker2);
+      }
+      for (const marker of this.getMarkers()) {
+        setPosition(marker, manager.controls.getTarget(), manager);
+        if (!marker.visible) {
+          marker.visible = true;
+        }
+      }
     } else {
-      if (this._targetMarker && this._targetMarker.visible) {
-        this._targetMarker.visible = false;
+      for (const marker of this.getMarkers()) {
+        if (marker.visible) {
+          marker.visible = false;
+        }
       }
     }
   }
 
   public dispose(): void {
-    if (this._targetMarker) {
-      this._scene.remove(this._targetMarker);
-      this._targetMarker.material.map?.dispose();
-      this._targetMarker.material.dispose();
-      this._targetMarker.geometry.dispose();
-      this._targetMarker = undefined;
+    for (const marker of this.getMarkers()) {
+      this._scene.remove(marker);
+      marker.material.map?.dispose();
+      marker.material.dispose();
+      marker.geometry.dispose();
     }
+    this._targetMarker1 = undefined;
+    this._targetMarker2 = undefined;
   }
 
   private isVisible(manager: FlexibleCameraManager): boolean {
@@ -64,6 +75,11 @@ export class FlexibleCameraMarkers {
     }
     return true;
   }
+
+  private *getMarkers(): Generator<Sprite> {
+    if (this._targetMarker1 !== undefined) yield this._targetMarker1;
+    if (this._targetMarker2 !== undefined) yield this._targetMarker2;
+  }
 }
 
 function setPosition(object3D: Object3D, position: Vector3, manager: FlexibleCameraManager): void {
@@ -75,9 +91,13 @@ function setPosition(object3D: Object3D, position: Vector3, manager: FlexibleCam
   object3D.updateMatrixWorld();
 }
 
-function createSprite(outerColor: string, innerColor: string): Sprite {
-  const texture = createTexture(25, 3, outerColor, innerColor);
-  const material = new SpriteMaterial({ map: texture, depthTest: false });
+function createSprite(options: FlexibleControlsOptions, depthTest: boolean): Sprite {
+  const texture = createTexture(25, 3, options.outerMarkerColor, options.innerMarkerColor);
+  const material = new SpriteMaterial({ map: texture, depthTest });
+  if (!depthTest) {
+    material.transparent = true;
+    material.opacity = 0.5;
+  }
   const sprite = new Sprite(material);
   sprite.updateMatrixWorld();
   sprite.visible = true;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->


## Description :pencil:

Now, the marker will be render with a weaker color when it is behind something in the scene.

![image](https://github.com/user-attachments/assets/1bc62645-06d1-4017-ba2e-35524bd271a3)

![image](https://github.com/user-attachments/assets/9567a272-59cd-4259-b98a-20939b05b4c5)



## Test instructions :information_source:

Go to reveal/examples
Run.

