### PR TITLE
fix(react-components): search hook to consider data model version

### DIFF
--- a/react-components/src/components/RevealToolbar/LayersContainer/useModelHandlers.tsx
+++ b/react-components/src/components/RevealToolbar/LayersContainer/useModelHandlers.tsx
@@ -131,6 +131,8 @@ function setDefaultConfigOnNewHandlers(
   modelHandlers: ModelLayerHandlers,
   defaultLayersConfig: DefaultLayersConfiguration | undefined
 ): void {
+  const containsCadModel = newHandlers.cadHandlers.length > 0;
+  const containsPointCloudModel = newHandlers.pointCloudHandlers.length > 0;
   newHandlers.cadHandlers.forEach((newHandler) => {
     if (!modelHandlers.cadHandlers.some((oldHandler) => oldHandler.isSame(newHandler))) {
       newHandler.setVisibility(defaultLayersConfig?.cad ?? true);
@@ -139,13 +141,17 @@ function setDefaultConfigOnNewHandlers(
 
   newHandlers.pointCloudHandlers.forEach((newHandler) => {
     if (!modelHandlers.pointCloudHandlers.some((oldHandler) => oldHandler.isSame(newHandler))) {
-      newHandler.setVisibility(defaultLayersConfig?.pointcloud ?? true);
+      newHandler.setVisibility(containsCadModel ? defaultLayersConfig?.pointcloud ?? true : true);
     }
   });
 
   newHandlers.image360Handlers.forEach((newHandler) => {
     if (!modelHandlers.image360Handlers.some((oldHandler) => oldHandler.isSame(newHandler))) {
-      newHandler.setVisibility(defaultLayersConfig?.image360 ?? true);
+      if (!containsCadModel && !containsPointCloudModel) {
+        newHandler.setVisibility(true);
+      } else {
+        newHandler.setVisibility(defaultLayersConfig?.image360 ?? true);
+      }
     }
   });
 }

--- a/react-components/src/data-providers/index.ts
+++ b/react-components/src/data-providers/index.ts
@@ -3,4 +3,4 @@
  */
 
 export type { FdmInstanceWithView, InstanceReference, AssetInstanceReference } from './types';
-export type { Source, DmsUniqueIdentifier } from './FdmSDK';
+export type { Source, DmsUniqueIdentifier, SimpleSource } from './FdmSDK';

--- a/react-components/src/query/useSearchMappedEquipmentFDM.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentFDM.tsx
@@ -6,8 +6,8 @@ import {
   type NodeItem,
   type FdmSDK,
   type Source,
-  type DmsUniqueIdentifier,
-  type InstanceFilter
+  type InstanceFilter,
+  type SimpleSource
 } from '../data-providers/FdmSDK';
 import { useFdm3dDataProvider, useFdmSdk } from '../components/RevealCanvas/SDKProvider';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
@@ -21,7 +21,7 @@ export type InstancesWithView = { view: Source; instances: NodeItem[] };
 
 export const useSearchMappedEquipmentFDM = (
   query: string,
-  viewsToSearch: DmsUniqueIdentifier[],
+  viewsToSearch: SimpleSource[],
   models: AddModelOptions[],
   instancesFilter: InstanceFilter | undefined,
   limit: number = 100
@@ -53,7 +53,7 @@ export const useSearchMappedEquipmentFDM = (
       if (models.length === 0) {
         return [];
       }
-      const sources = await createSourcesFromViews(viewsToSearch, fdmSdk);
+      const sources = await createSourcesFromViews(viewsToSearch);
       const chunkedSources = chunk(sources, 10);
       if (chunkedSources.length === 0) {
         chunkedSources.push([]);
@@ -127,15 +127,14 @@ const searchNodesWithViewsAndModels = async (
 
 export const useAllMappedEquipmentFDM = (
   models: AddModelOptions[],
-  viewsToSearch: DmsUniqueIdentifier[]
+  viewsToSearch: SimpleSource[]
 ): UseQueryResult<NodeItem[]> => {
-  const fdmSdk = useFdmSdk();
   const fdmDataProvider = useFdm3dDataProvider();
 
   return useQuery({
     queryKey: ['reveal', 'react-components', 'all-mapped-equipment-fdm', viewsToSearch, models],
     queryFn: async () => {
-      const viewSources = await createSourcesFromViews(viewsToSearch, fdmSdk);
+      const viewSources = await createSourcesFromViews(viewsToSearch);
 
       return await fdmDataProvider.listAllMappedFdmNodes(models, viewSources, undefined);
     },
@@ -189,24 +188,11 @@ function convertQueryNodeItemsToSearchResultsWithViews(
   }, []);
 }
 
-async function createSourcesFromViews(
-  viewsToSearch: DmsUniqueIdentifier[],
-  fdmSdk: FdmSDK
-): Promise<Source[]> {
+async function createSourcesFromViews(viewsToSearch: SimpleSource[]): Promise<Source[]> {
   try {
-    const dataModelResult = await fdmSdk.listDataModels();
-    const viewToVersionMap = new Map<string, string>(
-      dataModelResult.items.flatMap((dataModel: { views: Source[] }) => {
-        return dataModel.views.map(
-          (view: Source) => [`${view.space}/${view.externalId}`, view.version] as const
-        );
-      })
-    );
-
     return viewsToSearch
       .map((view) => {
-        const version = viewToVersionMap.get(`${view.space}/${view.externalId}`);
-        if (version === undefined) {
+        if (view.version === undefined) {
           console.error(
             `Could not find version for view with space/externalId ${view.space}/${view.externalId}`
           );
@@ -214,8 +200,7 @@ async function createSourcesFromViews(
         }
         return {
           ...view,
-          type: 'view' as const,
-          version
+          type: 'view' as const
         };
       })
       .filter(isDefined);

--- a/react-components/src/query/useSearchMappedEquipmentFDM.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentFDM.tsx
@@ -15,7 +15,6 @@ import { type AddModelOptions } from '@cognite/reveal';
 import { isEqual, uniq, chunk } from 'lodash';
 import { type Fdm3dDataProvider } from '../data-providers/Fdm3dDataProvider';
 import { removeEmptyProperties } from '../utilities/removeEmptyProperties';
-import { isDefined } from '../utilities/isDefined';
 
 export type InstancesWithView = { view: Source; instances: NodeItem[] };
 
@@ -53,7 +52,7 @@ export const useSearchMappedEquipmentFDM = (
       if (models.length === 0) {
         return [];
       }
-      const sources = await createSourcesFromViews(viewsToSearch);
+      const sources = createSourcesFromViews(viewsToSearch);
       const chunkedSources = chunk(sources, 10);
       if (chunkedSources.length === 0) {
         chunkedSources.push([]);
@@ -134,7 +133,7 @@ export const useAllMappedEquipmentFDM = (
   return useQuery({
     queryKey: ['reveal', 'react-components', 'all-mapped-equipment-fdm', viewsToSearch, models],
     queryFn: async () => {
-      const viewSources = await createSourcesFromViews(viewsToSearch);
+      const viewSources = createSourcesFromViews(viewsToSearch);
 
       return await fdmDataProvider.listAllMappedFdmNodes(models, viewSources, undefined);
     },
@@ -188,24 +187,9 @@ function convertQueryNodeItemsToSearchResultsWithViews(
   }, []);
 }
 
-async function createSourcesFromViews(viewsToSearch: SimpleSource[]): Promise<Source[]> {
-  try {
-    return viewsToSearch
-      .map((view) => {
-        if (view.version === undefined) {
-          console.error(
-            `Could not find version for view with space/externalId ${view.space}/${view.externalId}`
-          );
-          return undefined;
-        }
-        return {
-          ...view,
-          type: 'view' as const
-        };
-      })
-      .filter(isDefined);
-  } catch (e) {
-    console.error('Error when fetching sources from views', e);
-    throw e;
-  }
+function createSourcesFromViews(viewsToSearch: SimpleSource[]): Source[] {
+  return viewsToSearch.map((view) => ({
+    ...view,
+    type: 'view'
+  }));
 }

--- a/react-components/stories/SearchHooks.stories.tsx
+++ b/react-components/stories/SearchHooks.stories.tsx
@@ -42,9 +42,9 @@ import { is360ImageAddOptions } from '../src/components/Reveal3DResources/typeGu
 const queryClient = new QueryClient();
 const sdk = createSdkByUrlToken();
 const viewsToSearch = [
-  { externalId: 'Equipment', space: 'fdx-boys' },
-  { externalId: 'WorkOrderMultiple', space: 'fdx-boys' },
-  { externalId: 'WorkOrderSingle', space: 'fdx-boys' }
+  { externalId: 'Equipment', space: 'fdx-boys', version: 'e040583320d31a' },
+  { externalId: 'WorkOrderMultiple', space: 'fdx-boys', version: 'e040583320d31a' },
+  { externalId: 'WorkOrderSingle', space: 'fdx-boys', version: 'e040583320d31a' }
 ];
 
 type Equipment = {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4651
https://cognitedata.atlassian.net/browse/BND3D-4597

## Description :pencil:
While fetching datamodel search data, hook was returning data with latest version while would cause issue if application chooses specific version, this PR fixes issue by accepting datamodel version along with externalId & space.

And have also addressed, enabling point cloud model visibility when no CAD model is in the Scene, same for 360 Image as well.

## How has this been tested? :mag:

In `Search`


## Test instructions :information_source:

`Yalc` link to `fusion` repo and run `Search` application with `cog-demo` project


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
