### PR TITLE
fix(react-components): asset contextualized button in disable state when clicked

### DIFF
--- a/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
+++ b/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
@@ -32,7 +32,7 @@ export const AssetContextualizedButton = ({
   const cadModels = models.filter((model) => model.type === 'cad') as CadModelOptions[];
   const [enableContextualizedStyling, setEnableContextualizedStyling] = useState<boolean>(false);
   const { isLoading, isFetched } = useAssetMappedNodesForRevisions(cadModels);
-  const disabled = isFetched ? false : isLoading;
+  const disabled = isLoading && !isFetched;
 
   const tooltip = disabled ? tooltipMapping.true : tooltipMapping.false;
 

--- a/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
+++ b/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
@@ -31,9 +31,10 @@ export const AssetContextualizedButton = ({
   const models = use3dModels();
   const cadModels = models.filter((model) => model.type === 'cad') as CadModelOptions[];
   const [enableContextualizedStyling, setEnableContextualizedStyling] = useState<boolean>(false);
-  const { isLoading } = useAssetMappedNodesForRevisions(cadModels);
+  const { isLoading, isFetched } = useAssetMappedNodesForRevisions(cadModels);
+  const disabled = isFetched ? false : isLoading;
 
-  const tooltip = isLoading ? tooltipMapping.true : tooltipMapping.false;
+  const tooltip = disabled ? tooltipMapping.true : tooltipMapping.false;
 
   const onClick = useCallback((): void => {
     setEnableContextualizedStyling((prevState) => !prevState);
@@ -51,7 +52,7 @@ export const AssetContextualizedButton = ({
         toggled={enableContextualizedStyling}
         aria-label="asset-labels-button"
         onClick={onClick}
-        disabled={isLoading}
+        disabled={disabled}
       />
     </CogsTooltip>
   );

--- a/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
+++ b/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
@@ -52,7 +52,7 @@ export const RuleBasedOutputsButton = ({
 
   const { data: ruleInstancesResult } = useFetchRuleInstances();
 
-  const disabled = isAssetMappingsFetched ? false : isAssetMappingsLoading;
+  const disabled = isAssetMappingsLoading && !isAssetMappingsFetched;
 
   useEffect(() => {
     setRuleInstances(ruleInstancesResult);

--- a/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
+++ b/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
@@ -42,7 +42,8 @@ export const RuleBasedOutputsButton = ({
 
   const [isRuleLoading, setIsRuleLoading] = useState(false);
 
-  const { isLoading: isAssetMappingsLoading } = useAssetMappedNodesForRevisions(cadModels);
+  const { isLoading: isAssetMappingsLoading, isFetched: isAssetMappingsFetched } =
+    useAssetMappedNodesForRevisions(cadModels);
 
   const [newRuleSetEnabled, setNewRuleSetEnabled] = useState<RuleAndEnabled>();
   const isRuleLoadingFromContext = useReveal3DResourcesStylingLoading();
@@ -50,6 +51,8 @@ export const RuleBasedOutputsButton = ({
   const [isAllMappingsFetched, setIsAllMappingsFetched] = useState(false);
 
   const { data: ruleInstancesResult } = useFetchRuleInstances();
+
+  const disabled = isAssetMappingsFetched ? false : isAssetMappingsLoading;
 
   useEffect(() => {
     setRuleInstances(ruleInstancesResult);
@@ -125,7 +128,7 @@ export const RuleBasedOutputsButton = ({
     <>
       <Dropdown
         placement="right-start"
-        disabled={isAssetMappingsLoading}
+        disabled={disabled}
         content={
           <Menu
             style={{
@@ -161,7 +164,7 @@ export const RuleBasedOutputsButton = ({
           placement="right"
           appendTo={document.body}>
           <Button
-            disabled={isAssetMappingsLoading}
+            disabled={disabled}
             icon="ColorPalette"
             aria-label="Select RuleSet"
             type="ghost"


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4620

## Description :pencil:
For only data model assets in `Search`, when `Asset contextualized` button is clicked, it would go to disable state, this PR fixes the issue

## How has this been tested? :mag:

In `Search`

## Test instructions :information_source:

- `yalc` link to `fusion` repo and run `Search` application
- Load `cog-quickstart` and browse to 3D page
- Click on `Show asset contextualized` button


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
