### PR TITLE
fix(react-components): return all views for clicked DM mapped asset

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.59.2",
+  "version": "0.60.0",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/CacheProvider/NodeCacheProvider.tsx
+++ b/react-components/src/components/CacheProvider/NodeCacheProvider.tsx
@@ -34,7 +34,7 @@ export const useFdmNodeCache = (): FdmNodeCacheContent => {
 
 export const useMappedEdgesForRevisions = (
   modelRevisionIds: Array<{ modelId: number; revisionId: number }>,
-  fetchViews = true,
+  fetchViews = false,
   enabled = true
 ): UseQueryResult<ModelRevisionToConnectionMap> => {
   const content = useFdmNodeCache();

--- a/react-components/src/components/CacheProvider/NodeCacheProvider.tsx
+++ b/react-components/src/components/CacheProvider/NodeCacheProvider.tsx
@@ -34,7 +34,7 @@ export const useFdmNodeCache = (): FdmNodeCacheContent => {
 
 export const useMappedEdgesForRevisions = (
   modelRevisionIds: Array<{ modelId: number; revisionId: number }>,
-  fetchViews = false,
+  fetchViews = true,
   enabled = true
 ): UseQueryResult<ModelRevisionToConnectionMap> => {
   const content = useFdmNodeCache();

--- a/react-components/src/components/CacheProvider/requests.ts
+++ b/react-components/src/components/CacheProvider/requests.ts
@@ -40,7 +40,7 @@ export async function inspectNodes(
 
   for (const nodesChunk of chunkedNodes) {
     const chunkInspectionResults = await fdmClient.inspectInstances({
-      inspectionOperations: { involvedViews: {} },
+      inspectionOperations: { involvedViews: { allVersions: true } },
       items: nodesChunk.map((node) => ({
         instanceType: 'node',
         externalId: node.externalId,


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4726

## Description :pencil:

In Search, when an DM mapped 3D node is clicked, it was unable to list the details in Preview panel due to mismatch in the data model version loaded in Search and react-components. Here I have enabled to return all views associated with the clicked asset so that in Search we can filter to match the data model version.

## How has this been tested? :mag:
In Search

## Test instructions :information_source:

- yalc link to Search


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
