### PR TITLE
feat(react-components) Fix tooltip placement and make it possible to set it outside react components

### DIFF
--- a/react-components/src/architecture/base/domainObjectsHelpers/PopupStyle.ts
+++ b/react-components/src/architecture/base/domainObjectsHelpers/PopupStyle.ts
@@ -13,19 +13,19 @@ type PopupProps = {
 };
 
 export class PopupStyle {
-  private readonly _left?: number = undefined;
-  private readonly _right?: number = undefined;
-  private readonly _top?: number = undefined;
-  private readonly _bottom?: number = undefined;
+  public readonly left?: number = undefined;
+  public readonly right?: number = undefined;
+  public readonly top?: number = undefined;
+  public readonly bottom?: number = undefined;
   private readonly _margin: number = 8; // margin outside the popup
   private readonly _padding: number = 6; // margin inside the popup
   private readonly _horizontal: boolean = true; // Used for toolbars only
 
   public constructor(props: PopupProps) {
-    this._left = props.left;
-    this._right = props.right;
-    this._top = props.top;
-    this._bottom = props.bottom;
+    this.left = props.left;
+    this.right = props.right;
+    this.top = props.top;
+    this.bottom = props.bottom;
     if (props.margin !== undefined) {
       this._margin = props.margin;
     }
@@ -38,19 +38,19 @@ export class PopupStyle {
   }
 
   public get leftPx(): string {
-    return PopupStyle.getStringWithPx(this._left);
+    return PopupStyle.getStringWithPx(this.left);
   }
 
   public get rightPx(): string {
-    return PopupStyle.getStringWithPx(this._right);
+    return PopupStyle.getStringWithPx(this.right);
   }
 
   public get topPx(): string {
-    return PopupStyle.getStringWithPx(this._top);
+    return PopupStyle.getStringWithPx(this.top);
   }
 
   public get bottomPx(): string {
-    return PopupStyle.getStringWithPx(this._bottom);
+    return PopupStyle.getStringWithPx(this.bottom);
   }
 
   public get marginPx(): string {

--- a/react-components/src/components/Architecture/CommandButton.tsx
+++ b/react-components/src/components/Architecture/CommandButton.tsx
@@ -12,13 +12,14 @@ import { LabelWithShortcut } from './LabelWithShortcut';
 import { type IconName } from '../../architecture/base/utilities/IconName';
 import { IconComponent } from './IconComponentMapper';
 import { useOnUpdate } from './useOnUpdate';
+import { type PlacementType } from './types';
 
 export const CommandButton = ({
   inputCommand,
-  isHorizontal = false
+  placement
 }: {
   inputCommand: BaseCommand;
-  isHorizontal: boolean;
+  placement: PlacementType;
 }): ReactElement => {
   const renderTarget = useRenderTarget();
   const { t } = useTranslation();
@@ -43,7 +44,6 @@ export const CommandButton = ({
   if (!isVisible) {
     return <></>;
   }
-  const placement = getTooltipPlacement(isHorizontal);
   const label = command.getLabel(t);
 
   return (
@@ -51,7 +51,7 @@ export const CommandButton = ({
       content={<LabelWithShortcut label={label} command={command} />}
       disabled={label === undefined}
       appendTo={document.body}
-      placement={placement}>
+      placement={getTooltipPlacement(placement)}>
       <Button
         type={getButtonType(command)}
         icon={<IconComponent iconName={icon} />}

--- a/react-components/src/components/Architecture/CommandButton.tsx
+++ b/react-components/src/components/Architecture/CommandButton.tsx
@@ -13,6 +13,7 @@ import { type IconName } from '../../architecture/base/utilities/IconName';
 import { IconComponent } from './IconComponentMapper';
 import { useOnUpdate } from './useOnUpdate';
 import { type PlacementType } from './types';
+import { TOOLTIP_DELAY } from './constants';
 
 export const CommandButton = ({
   inputCommand,
@@ -51,6 +52,7 @@ export const CommandButton = ({
       content={<LabelWithShortcut label={label} command={command} />}
       disabled={label === undefined}
       appendTo={document.body}
+      enterDelay={TOOLTIP_DELAY}
       placement={getTooltipPlacement(placement)}>
       <Button
         type={getButtonType(command)}

--- a/react-components/src/components/Architecture/CommandButtons.tsx
+++ b/react-components/src/components/Architecture/CommandButtons.tsx
@@ -17,6 +17,7 @@ import { DividerCommand } from '../../architecture/base/commands/DividerCommand'
 import { SectionCommand } from '../../architecture/base/commands/SectionCommand';
 import { type PlacementType } from './types';
 import { type ButtonProp } from './RevealButtons';
+import { getDividerDirection } from './utilities';
 
 export function createButton(command: BaseCommand, placement: PlacementType): ReactElement {
   if (command instanceof BaseFilterCommand) {
@@ -87,7 +88,7 @@ function CommandButtonWrapper({
     command instanceof SectionCommand ||
     command === undefined
   ) {
-    const direction = placement === 'left' || placement === 'right' ? 'horizontal' : 'vertical';
+    const direction = getDividerDirection(placement);
     return <Divider weight="2px" length="24px" direction={direction} />;
   }
   return createButton(command, placement);

--- a/react-components/src/components/Architecture/CommandButtons.tsx
+++ b/react-components/src/components/Architecture/CommandButtons.tsx
@@ -15,41 +15,43 @@ import { FilterButton } from './FilterButton';
 import { SegmentedButtons } from './SegmentedButtons';
 import { DividerCommand } from '../../architecture/base/commands/DividerCommand';
 import { SectionCommand } from '../../architecture/base/commands/SectionCommand';
+import { type PlacementType } from './types';
+import { type ButtonProp } from './RevealButtons';
 
-export function createButton(command: BaseCommand, isHorizontal = false): ReactElement {
+export function createButton(command: BaseCommand, placement: PlacementType): ReactElement {
   if (command instanceof BaseFilterCommand) {
-    return <FilterButton inputCommand={command} isHorizontal={isHorizontal} />;
+    return <FilterButton inputCommand={command} placement={placement} />;
   }
   if (command instanceof BaseSettingsCommand) {
-    return <SettingsButton inputCommand={command} isHorizontal={isHorizontal} />;
+    return <SettingsButton inputCommand={command} placement={placement} />;
   }
   if (command instanceof BaseOptionCommand) {
     switch (command.optionType) {
       case OptionType.Dropdown:
-        return <DropdownButton inputCommand={command} isHorizontal={isHorizontal} />;
+        return <DropdownButton inputCommand={command} placement={placement} />;
       case OptionType.Segmented:
-        return <SegmentedButtons inputCommand={command} isHorizontal={isHorizontal} />;
+        return <SegmentedButtons inputCommand={command} placement={placement} />;
       default:
         return <></>;
     }
   }
-  return <CommandButton inputCommand={command} isHorizontal={isHorizontal} />;
+  return <CommandButton inputCommand={command} placement={placement} />;
 }
 
 export function createButtonFromCommandConstructor(
   commandConstructor: () => BaseCommand,
-  isHorizontal = false
+  prop: ButtonProp
 ): ReactElement {
   const command = useMemo(commandConstructor, []);
-  return createButton(command, isHorizontal);
+  return createButton(command, prop.toolbarPlacement ?? 'left');
 }
 
 export const CommandButtons = ({
   commands,
-  isHorizontal = false
+  placement
 }: {
   commands: Array<BaseCommand | undefined>;
-  isHorizontal: boolean;
+  placement: PlacementType;
 }): ReactElement => {
   return (
     <>
@@ -57,7 +59,7 @@ export const CommandButtons = ({
         (command, index): ReactElement => (
           <CommandButtonWrapper
             command={command}
-            isHorizontal={isHorizontal}
+            placement={placement}
             key={getKey(command, index)}
           />
         )
@@ -75,18 +77,18 @@ function getKey(command: BaseCommand | undefined, index: number): number {
 
 function CommandButtonWrapper({
   command,
-  isHorizontal
+  placement
 }: {
   command: BaseCommand | undefined;
-  isHorizontal: boolean;
+  placement: PlacementType;
 }): ReactElement {
   if (
     command instanceof DividerCommand ||
     command instanceof SectionCommand ||
     command === undefined
   ) {
-    const direction = !isHorizontal ? 'horizontal' : 'vertical';
+    const direction = placement === 'left' || placement === 'right' ? 'horizontal' : 'vertical';
     return <Divider weight="2px" length="24px" direction={direction} />;
   }
-  return createButton(command, isHorizontal);
+  return createButton(command, placement);
 }

--- a/react-components/src/components/Architecture/DomainObjectPanel.tsx
+++ b/react-components/src/components/Architecture/DomainObjectPanel.tsx
@@ -81,7 +81,7 @@ export const DomainObjectPanel = (): ReactElement => {
           {text !== undefined && <Body size={HEADER_SIZE}>{text}</Body>}
         </Flex>
         <Flex>
-          <CommandButtons commands={commands} isHorizontal={true} />
+          <CommandButtons commands={commands} placement={'bottom'} />
         </Flex>
       </Flex>
       <table>

--- a/react-components/src/components/Architecture/DropdownButton.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.tsx
@@ -17,14 +17,15 @@ import { DEFAULT_PADDING, OPTION_MIN_WIDTH } from './constants';
 
 import styled from 'styled-components';
 import { useOnUpdate } from './useOnUpdate';
+import { type PlacementType } from './types';
 
 export const DropdownButton = ({
   inputCommand,
-  isHorizontal = false,
+  placement,
   usedInSettings = false
 }: {
   inputCommand: BaseOptionCommand;
-  isHorizontal: boolean;
+  placement: PlacementType;
   usedInSettings?: boolean;
 }): ReactElement => {
   const renderTarget = useRenderTarget();
@@ -58,7 +59,7 @@ export const DropdownButton = ({
       isOpen={isOpen}
       setOpen={setOpen}
       isEnabled={isEnabled}
-      isHorizontal={isHorizontal}
+      placement={placement}
       uniqueId={uniqueId}
     />
   );
@@ -70,7 +71,7 @@ const DropdownElement = ({
   isOpen,
   setOpen,
   isEnabled,
-  isHorizontal,
+  placement,
   uniqueId
 }: {
   command: BaseOptionCommand;
@@ -78,14 +79,12 @@ const DropdownElement = ({
   isOpen: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
   isEnabled: boolean;
-  isHorizontal: boolean;
+  placement: PlacementType;
   uniqueId: number;
 }): ReactElement => {
   const { t } = useTranslation();
   const label = command.getLabel(t);
   const selectedLabel = command.selectedChild?.getLabel(t);
-
-  const placement = getTooltipPlacement(isHorizontal);
 
   const OpenButtonIcon = isOpen ? ChevronUpIcon : ChevronDownIcon;
 
@@ -106,7 +105,7 @@ const DropdownElement = ({
           content={<LabelWithShortcut label={label} command={command} />}
           disabled={label === undefined}
           appendTo={document.body}
-          placement={placement}>
+          placement={getTooltipPlacement(placement)}>
           <Button
             style={{
               padding: '8px 4px'

--- a/react-components/src/components/Architecture/DropdownButton.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.tsx
@@ -13,7 +13,7 @@ import { type BaseOptionCommand } from '../../architecture/base/commands/BaseOpt
 import { getButtonType, getDefaultCommand, getTooltipPlacement, getIcon } from './utilities';
 import { LabelWithShortcut } from './LabelWithShortcut';
 import { type TranslateDelegate } from '../../architecture/base/utilities/TranslateKey';
-import { DEFAULT_PADDING, OPTION_MIN_WIDTH } from './constants';
+import { DEFAULT_PADDING, OPTION_MIN_WIDTH, TOOLTIP_DELAY } from './constants';
 
 import styled from 'styled-components';
 import { useOnUpdate } from './useOnUpdate';
@@ -105,6 +105,7 @@ const DropdownElement = ({
           content={<LabelWithShortcut label={label} command={command} />}
           disabled={label === undefined}
           appendTo={document.body}
+          enterDelay={TOOLTIP_DELAY}
           placement={getTooltipPlacement(placement)}>
           <Button
             style={{

--- a/react-components/src/components/Architecture/FilterButton.tsx
+++ b/react-components/src/components/Architecture/FilterButton.tsx
@@ -30,11 +30,11 @@ import { useOnUpdate } from './useOnUpdate';
 
 export const FilterButton = ({
   inputCommand,
-  isHorizontal = false,
+  placement,
   usedInSettings = false
 }: {
   inputCommand: BaseFilterCommand;
-  isHorizontal: boolean;
+  placement: PlacementType;
   usedInSettings?: boolean;
 }): ReactElement => {
   const renderTarget = useRenderTarget();
@@ -75,8 +75,6 @@ export const FilterButton = ({
   if (!isVisible || children === undefined || children.length === 0) {
     return <></>;
   }
-  const placement = getTooltipPlacement(isHorizontal);
-
   const PanelContent = (
     <FilterSelectPanelContent
       command={command}
@@ -96,7 +94,7 @@ export const FilterButton = ({
   ) : (
     <FilterMenu
       command={command}
-      placement={placement}
+      placement={getTooltipPlacement(placement)}
       iconName={icon}
       label={label}
       isOpen={isOpen}

--- a/react-components/src/components/Architecture/RevealButtons.tsx
+++ b/react-components/src/components/Architecture/RevealButtons.tsx
@@ -24,18 +24,6 @@ import { AnnotationsSelectTool } from '../../architecture/concrete/annotations/c
 import { Image360ActionCommand } from '../../architecture/base/concreteCommands/image360Collection/Image360ActionCommand';
 import { type PlacementType } from './types';
 
-export type ButtonProp = {
-  toolbarPlacement?: PlacementType;
-};
-
-export type SettingsProp = ButtonProp & {
-  include360Images?: boolean;
-};
-
-export type Image360Prop = ButtonProp & {
-  action: Image360Action;
-};
-
 export class RevealButtons {
   static Settings = (props: SettingsProp): ReactElement =>
     createButtonFromCommandConstructor(
@@ -110,3 +98,15 @@ export class RevealButtons {
   static AnnotationsShowOnTop = (prop: ButtonProp): ReactElement =>
     createButtonFromCommandConstructor(() => new AnnotationsShowOnTopCommand(), prop);
 }
+
+export type ButtonProp = {
+  toolbarPlacement?: PlacementType;
+};
+
+type SettingsProp = ButtonProp & {
+  include360Images?: boolean;
+};
+
+type Image360Prop = ButtonProp & {
+  action: Image360Action;
+};

--- a/react-components/src/components/Architecture/RevealButtons.tsx
+++ b/react-components/src/components/Architecture/RevealButtons.tsx
@@ -22,72 +22,91 @@ import { AnnotationsShowOnTopCommand } from '../../architecture/concrete/annotat
 import { AnnotationsCreateTool } from '../../architecture/concrete/annotations/commands/AnnotationsCreateTool';
 import { AnnotationsSelectTool } from '../../architecture/concrete/annotations/commands/AnnotationsSelectTool';
 import { Image360ActionCommand } from '../../architecture/base/concreteCommands/image360Collection/Image360ActionCommand';
+import { type PlacementType } from './types';
+
+export type ButtonProp = {
+  toolbarPlacement?: PlacementType;
+};
+
+export type SettingsProp = ButtonProp & {
+  include360Images?: boolean;
+};
+
+export type Image360Prop = ButtonProp & {
+  action: Image360Action;
+};
 
 export class RevealButtons {
-  static Settings = ({ include360Images = true }: { include360Images?: boolean }): ReactElement =>
-    createButtonFromCommandConstructor(() => new SettingsCommand(include360Images));
-
-  static PointCloudFilter = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new PointCloudFilterCommand());
-
-  static FitView = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new FitViewCommand());
-
-  static NavigationTool = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new NavigationTool());
-
-  static SetAxisVisible = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new SetAxisVisibleCommand());
-
-  static Measurement = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new MeasurementTool());
-
-  static Clip = (): ReactElement => createButtonFromCommandConstructor(() => new ClipTool());
-
-  static SetOrbitOrFirstPersonMode = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new SetOrbitOrFirstPersonModeCommand());
-
-  static SetOrbitMode = (): ReactElement =>
+  static Settings = (props: SettingsProp): ReactElement =>
     createButtonFromCommandConstructor(
-      () => new SetFlexibleControlsTypeCommand(FlexibleControlsType.Orbit)
+      () => new SettingsCommand(props.include360Images ?? true),
+      props
     );
 
-  static SetFirstPersonMode = (): ReactElement =>
+  static PointCloudFilter = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new PointCloudFilterCommand(), prop);
+
+  static FitView = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new FitViewCommand(), prop);
+
+  static NavigationTool = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new NavigationTool(), prop);
+
+  static SetAxisVisible = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new SetAxisVisibleCommand(), prop);
+
+  static Measurement = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new MeasurementTool(), prop);
+
+  static Clip = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new ClipTool(), prop);
+
+  static SetOrbitOrFirstPersonMode = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new SetOrbitOrFirstPersonModeCommand(), prop);
+
+  static SetOrbitMode = (prop: ButtonProp): ReactElement =>
     createButtonFromCommandConstructor(
-      () => new SetFlexibleControlsTypeCommand(FlexibleControlsType.FirstPerson)
+      () => new SetFlexibleControlsTypeCommand(FlexibleControlsType.Orbit),
+      prop
     );
 
-  static PointsOfInterest = (): ReactElement => {
-    return createButtonFromCommandConstructor(() => new PointsOfInterestTool());
+  static SetFirstPersonMode = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(
+      () => new SetFlexibleControlsTypeCommand(FlexibleControlsType.FirstPerson),
+      prop
+    );
+
+  static PointsOfInterest = (prop: ButtonProp): ReactElement => {
+    return createButtonFromCommandConstructor(() => new PointsOfInterestTool(), prop);
   };
 
-  static KeyboardSpeed = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new KeyboardSpeedCommand());
+  static KeyboardSpeed = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new KeyboardSpeedCommand(), prop);
 
-  static Image360Button = ({ action }: { action: Image360Action }): ReactElement =>
-    createButtonFromCommandConstructor(() => new Image360ActionCommand(action));
+  static Image360Button = (prop: Image360Prop): ReactElement =>
+    createButtonFromCommandConstructor(() => new Image360ActionCommand(prop.action), prop);
 
-  static Image360Buttons = (): ReactElement => {
+  static Image360Buttons = (prop: ButtonProp): ReactElement => {
     return (
       <>
-        <RevealButtons.Image360Button action={Image360Action.Enter} />
-        <RevealButtons.Image360Button action={Image360Action.Backward} />
-        <RevealButtons.Image360Button action={Image360Action.Forward} />
-        <RevealButtons.Image360Button action={Image360Action.Exit} />
+        <RevealButtons.Image360Button {...prop} action={Image360Action.Enter} />
+        <RevealButtons.Image360Button {...prop} action={Image360Action.Backward} />
+        <RevealButtons.Image360Button {...prop} action={Image360Action.Forward} />
+        <RevealButtons.Image360Button {...prop} action={Image360Action.Exit} />
       </>
     );
   };
 
   // Annotations
-  static AnnotationsSelect = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new AnnotationsSelectTool());
+  static AnnotationsSelect = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new AnnotationsSelectTool(), prop);
 
-  static AnnotationsCreate = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new AnnotationsCreateTool());
+  static AnnotationsCreate = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new AnnotationsCreateTool(), prop);
 
-  static AnnotationsShow = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new AnnotationsShowCommand());
+  static AnnotationsShow = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new AnnotationsShowCommand(), prop);
 
-  static AnnotationsShowOnTop = (): ReactElement =>
-    createButtonFromCommandConstructor(() => new AnnotationsShowOnTopCommand());
+  static AnnotationsShowOnTop = (prop: ButtonProp): ReactElement =>
+    createButtonFromCommandConstructor(() => new AnnotationsShowOnTopCommand(), prop);
 }

--- a/react-components/src/components/Architecture/SegmentedButtons.tsx
+++ b/react-components/src/components/Architecture/SegmentedButtons.tsx
@@ -13,6 +13,7 @@ import { LabelWithShortcut } from './LabelWithShortcut';
 import { IconComponent } from './IconComponentMapper';
 import { useOnUpdate } from './useOnUpdate';
 import { type PlacementType } from './types';
+import { TOOLTIP_DELAY } from './constants';
 
 export const SegmentedButtons = ({
   inputCommand,
@@ -54,6 +55,7 @@ export const SegmentedButtons = ({
       content={<LabelWithShortcut label={label} command={command} />}
       disabled={label === undefined}
       appendTo={document.body}
+      enterDelay={TOOLTIP_DELAY}
       placement={getTooltipPlacement(placement)}>
       <SegmentedControl
         key={uniqueId}

--- a/react-components/src/components/Architecture/SegmentedButtons.tsx
+++ b/react-components/src/components/Architecture/SegmentedButtons.tsx
@@ -12,13 +12,14 @@ import { BaseOptionCommand } from '../../architecture/base/commands/BaseOptionCo
 import { LabelWithShortcut } from './LabelWithShortcut';
 import { IconComponent } from './IconComponentMapper';
 import { useOnUpdate } from './useOnUpdate';
+import { type PlacementType } from './types';
 
 export const SegmentedButtons = ({
   inputCommand,
-  isHorizontal = false
+  placement
 }: {
   inputCommand: BaseOptionCommand;
-  isHorizontal: boolean;
+  placement: PlacementType;
 }): ReactElement => {
   const renderTarget = useRenderTarget();
   const { t } = useTranslation();
@@ -46,7 +47,6 @@ export const SegmentedButtons = ({
   if (!isVisible || command.children === undefined) {
     return <></>;
   }
-  const placement = getTooltipPlacement(isHorizontal);
   const label = command.getLabel(t);
 
   return (
@@ -54,7 +54,7 @@ export const SegmentedButtons = ({
       content={<LabelWithShortcut label={label} command={command} />}
       disabled={label === undefined}
       appendTo={document.body}
-      placement={placement}>
+      placement={getTooltipPlacement(placement)}>
       <SegmentedControl
         key={uniqueId}
         disabled={!isEnabled}

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -34,13 +34,14 @@ import { offset } from '@floating-ui/dom';
 import { DividerCommand } from '../../architecture/base/commands/DividerCommand';
 import { SectionCommand } from '../../architecture/base/commands/SectionCommand';
 import { useOnUpdate } from './useOnUpdate';
+import { type PlacementType } from './types';
 
 export const SettingsButton = ({
   inputCommand,
-  isHorizontal = false
+  placement
 }: {
   inputCommand: BaseSettingsCommand;
-  isHorizontal: boolean;
+  placement: PlacementType;
 }): ReactElement => {
   const renderTarget = useRenderTarget();
   const { t } = useTranslation();
@@ -67,9 +68,8 @@ export const SettingsButton = ({
   if (!isVisible || !command.hasChildren) {
     return <></>;
   }
-  const placement = getTooltipPlacement(isHorizontal);
   const label = command.getLabel(t);
-  const flexDirection = getFlexDirection(isHorizontal);
+  const flexDirection = getFlexDirection(placement);
   const children = command.children;
 
   return (
@@ -91,7 +91,7 @@ export const SettingsButton = ({
           content={<LabelWithShortcut label={label} command={command} />}
           disabled={isOpen || label === undefined}
           appendTo={document.body}
-          placement={placement}>
+          placement={getTooltipPlacement(placement)}>
           <Button
             type={getButtonType(command)}
             icon={<IconComponent iconName={icon} />}
@@ -298,7 +298,7 @@ function createDropdownButton(command: BaseOptionCommand): ReactElement {
     <DropdownButton
       key={uniqueId}
       inputCommand={command}
-      isHorizontal={false}
+      placement={'bottom'}
       usedInSettings={true}
     />
   );
@@ -324,7 +324,7 @@ function createFilterButton(command: BaseFilterCommand): ReactElement {
     <FilterButton
       key={uniqueId}
       inputCommand={command}
-      isHorizontal={false}
+      placement={'bottom'}
       usedInSettings={true}
     />
   );

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -24,7 +24,7 @@ import { DropdownButton } from './DropdownButton';
 import { BaseSliderCommand } from '../../architecture/base/commands/BaseSliderCommand';
 import { BaseFilterCommand } from '../../architecture/base/commands/BaseFilterCommand';
 import { FilterButton } from './FilterButton';
-import { DEFAULT_PADDING } from './constants';
+import { DEFAULT_PADDING, TOOLTIP_DELAY } from './constants';
 import { type IconName } from '../../architecture/base/utilities/IconName';
 import { IconComponent } from './IconComponentMapper';
 
@@ -91,6 +91,7 @@ export const SettingsButton = ({
           content={<LabelWithShortcut label={label} command={command} />}
           disabled={isOpen || label === undefined}
           appendTo={document.body}
+          enterDelay={TOOLTIP_DELAY}
           placement={getTooltipPlacement(placement)}>
           <Button
             type={getButtonType(command)}

--- a/react-components/src/components/Architecture/Toolbar.tsx
+++ b/react-components/src/components/Architecture/Toolbar.tsx
@@ -10,6 +10,7 @@ import { type BaseCommand } from '../../architecture/base/commands/BaseCommand';
 import { useRenderTarget } from '../RevealCanvas/ViewerContext';
 import { ActiveToolUpdater } from '../../architecture/base/reactUpdaters/ActiveToolUpdater';
 import { type PopupStyle } from '../../architecture/base/domainObjectsHelpers/PopupStyle';
+import { type PlacementType } from './types';
 
 export const TopToolbar = (): ReactElement => {
   const renderTarget = useRenderTarget();
@@ -74,6 +75,7 @@ const ToolbarContent = ({
   if (commands.length === 0) {
     return <></>;
   }
+  const placement = getPlacement(style);
   return (
     <Container
       style={{
@@ -88,11 +90,18 @@ const ToolbarContent = ({
           flexFlow: style.flexFlow,
           padding: 2
         }}>
-        <CommandButtons commands={commands} isHorizontal={style.isHorizontal} />
+        <CommandButtons commands={commands} placement={placement} />
       </MyCustomToolbar>
     </Container>
   );
 };
+
+function getPlacement(style: PopupStyle): PlacementType {
+  if (style.isHorizontal) {
+    return style.top !== undefined ? 'top' : 'bottom';
+  }
+  return style.left !== undefined ? 'left' : 'right';
+}
 
 const Container = styled.div`
   zindex: 1000px;

--- a/react-components/src/components/Architecture/constants.ts
+++ b/react-components/src/components/Architecture/constants.ts
@@ -5,3 +5,4 @@
 export const OPTION_MIN_WIDTH = '125px';
 export const DEFAULT_PADDING = '4px 8px';
 export const SELECT_DROPDOWN_ICON_COLOR = 'rgba(0, 0, 0, 0.7)';
+export const TOOLTIP_DELAY = 500;

--- a/react-components/src/components/Architecture/index.ts
+++ b/react-components/src/components/Architecture/index.ts
@@ -5,4 +5,5 @@
 export { ActiveToolToolbar } from './Toolbar';
 export { DomainObjectPanel } from './DomainObjectPanel';
 export { RevealButtons } from './RevealButtons';
+export type { PlacementType } from './types';
 export { IconComponentMapper } from './IconComponentMapper';

--- a/react-components/src/components/Architecture/types.ts
+++ b/react-components/src/components/Architecture/types.ts
@@ -4,6 +4,6 @@
 
 export type ButtonType = 'ghost' | 'ghost-destructive' | 'primary';
 
-export type PlacementType = 'top' | 'right';
+export type PlacementType = 'top' | 'right' | 'left' | 'bottom';
 
 export type FlexDirection = 'row' | 'column';

--- a/react-components/src/components/Architecture/utilities.ts
+++ b/react-components/src/components/Architecture/utilities.ts
@@ -23,8 +23,9 @@ export function getDividerDirection(placement: PlacementType): string {
   return placement === 'top' || placement === 'bottom' ? 'vertical' : 'horizontal';
 }
 
-export function getTooltipPlacement(placement: PlacementType): PlacementType {
-  switch (placement) {
+export function getTooltipPlacement(toolbarPlacement: PlacementType): PlacementType {
+  // Try to keep the tooltip on the opposite side of the toolbar
+  switch (toolbarPlacement) {
     case 'top':
       return 'bottom';
     case 'bottom':

--- a/react-components/src/components/Architecture/utilities.ts
+++ b/react-components/src/components/Architecture/utilities.ts
@@ -15,12 +15,23 @@ export function getIcon(command: BaseCommand): IconName | undefined {
   return command.icon;
 }
 
-export function getFlexDirection(isHorizontal: boolean): FlexDirection {
-  return isHorizontal ? 'row' : 'column';
+export function getFlexDirection(placement: PlacementType): FlexDirection {
+  return placement === 'top' || placement === 'bottom' ? 'row' : 'column';
 }
 
-export function getTooltipPlacement(isHorizontal: boolean): PlacementType {
-  return isHorizontal ? 'top' : 'right';
+export function getTooltipPlacement(placement: PlacementType): PlacementType {
+  switch (placement) {
+    case 'top':
+      return 'bottom';
+    case 'bottom':
+      return 'top';
+    case 'left':
+      return 'right';
+    case 'right':
+      return 'left';
+    default:
+      return 'top';
+  }
 }
 
 export function getButtonType(command: BaseCommand): ButtonType {

--- a/react-components/src/components/Architecture/utilities.ts
+++ b/react-components/src/components/Architecture/utilities.ts
@@ -19,6 +19,10 @@ export function getFlexDirection(placement: PlacementType): FlexDirection {
   return placement === 'top' || placement === 'bottom' ? 'row' : 'column';
 }
 
+export function getDividerDirection(placement: PlacementType): string {
+  return placement === 'top' || placement === 'bottom' ? 'vertical' : 'horizontal';
+}
+
 export function getTooltipPlacement(placement: PlacementType): PlacementType {
   switch (placement) {
     case 'top':


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:

The placement variable is now used instead of isHorizontal. It means the placement of the toolbar the button is in.
This will automatically set the tooltip at correct position.

Default is left, so in fusion we have to set this property at the top toolbar only. That what it was before, so no real changes.

The toolbar that will be generated automatically based on position will be correct now.

Also set tooltip delay to 500ms, which is normal.


## How has this been tested? :mag:

Open storybook/architecture
Check the tooltips.
Open Measurement
Check also the tooltip there

## Checklist :ballot_box_with_check:

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [x] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [x] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
