### PR TITLE
fix(react-components): Fix update issue when open SettingsButton and fix slow hover on 360 images

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/architecture/base/commands/BaseTool.ts
+++ b/react-components/src/architecture/base/commands/BaseTool.ts
@@ -85,7 +85,14 @@ export abstract class BaseTool extends RenderTargetCommand {
     // Override this to clear any temporary objects in the tool, like the dragger
   }
 
-  public onHover(_event: PointerEvent): void {}
+  public onHover(_event: MouseEvent): void {
+    // Debounce version, fast. Use this for hover effects when not
+    // doing intersection with CAD models and other large models
+  }
+
+  public onHoverByDebounce(_event: PointerEvent): void {
+    // Debounce version. Use this when doing intersection with CAD models and other large models
+  }
 
   public async onClick(_event: PointerEvent): Promise<void> {
     await Promise.resolve();

--- a/react-components/src/architecture/base/commands/BaseTool.ts
+++ b/react-components/src/architecture/base/commands/BaseTool.ts
@@ -86,7 +86,7 @@ export abstract class BaseTool extends RenderTargetCommand {
   }
 
   public onHover(_event: MouseEvent): void {
-    // Debounce version, fast. Use this for hover effects when not
+    // Fast. Use this for hover effects when not
     // doing intersection with CAD models and other large models
   }
 

--- a/react-components/src/architecture/base/concreteCommands/NavigationTool.ts
+++ b/react-components/src/architecture/base/concreteCommands/NavigationTool.ts
@@ -33,8 +33,12 @@ export class NavigationTool extends BaseTool {
     return { key: 'NAVIGATION', fallback: 'Navigation' };
   }
 
-  public override onHover(event: PointerEvent): void {
+  public override onHoverByDebounce(event: PointerEvent): void {
     this.renderTarget.viewer.onHover360Images(event);
+  }
+
+  public override onHover(event: MouseEvent): void {
+    this.renderTarget.viewer.onHover360Images(event as PointerEvent);
   }
 
   public override async onClick(event: PointerEvent): Promise<void> {

--- a/react-components/src/architecture/base/concreteCommands/NavigationTool.ts
+++ b/react-components/src/architecture/base/concreteCommands/NavigationTool.ts
@@ -33,9 +33,7 @@ export class NavigationTool extends BaseTool {
     return { key: 'NAVIGATION', fallback: 'Navigation' };
   }
 
-  public override onHoverByDebounce(event: PointerEvent): void {
-    this.renderTarget.viewer.onHover360Images(event);
-  }
+  public override onHoverByDebounce(_event: PointerEvent): void {}
 
   public override onHover(event: MouseEvent): void {
     this.renderTarget.viewer.onHover360Images(event as PointerEvent);

--- a/react-components/src/architecture/base/renderTarget/CommandsController.ts
+++ b/react-components/src/architecture/base/renderTarget/CommandsController.ts
@@ -55,7 +55,8 @@ export class CommandsController extends PointerEvents {
   }
 
   public override onHover(event: PointerEvent): void {
-    this.activeTool?.onHover(event);
+    // This override is actually with Debounce
+    this.activeTool?.onHoverByDebounce(event);
   }
 
   public override async onClick(event: PointerEvent): Promise<void> {
@@ -206,6 +207,7 @@ export class CommandsController extends PointerEvents {
   public addEventListeners(): void {
     // https://www.w3schools.com/jsref/obj_mouseevent.asp
     const domElement = this._domElement;
+    domElement.addEventListener('mousemove', this._onMouseMove);
     domElement.addEventListener('keydown', this._onKeyDown);
     domElement.addEventListener('keyup', this._onKeyUp);
     domElement.addEventListener('wheel', this._onWheel);
@@ -217,6 +219,7 @@ export class CommandsController extends PointerEvents {
 
   public removeEventListeners(): void {
     const domElement = this._domElement;
+    domElement.removeEventListener('mousemove', this._onMouseMove);
     domElement.removeEventListener('keydown', this._onKeyDown);
     domElement.removeEventListener('keyup', this._onKeyUp);
     domElement.removeEventListener('wheel', this._onWheel);
@@ -232,6 +235,12 @@ export class CommandsController extends PointerEvents {
   // ==================================================
   // INSTANCE METHODS: Events
   // ==================================================
+
+  private readonly _onMouseMove = (event: MouseEvent): void => {
+    if (event.buttons === 0) {
+      this.activeTool?.onHover(event);
+    }
+  };
 
   private readonly _onKeyDown = (event: KeyboardEvent): void => {
     this.onKey(event, true);

--- a/react-components/src/architecture/concrete/annotations/commands/AnnotationsCreateTool.ts
+++ b/react-components/src/architecture/concrete/annotations/commands/AnnotationsCreateTool.ts
@@ -87,7 +87,7 @@ export class AnnotationsCreateTool extends NavigationTool {
     }
   }
 
-  public override async onHover(event: PointerEvent): Promise<void> {
+  public override async onHoverByDebounce(event: PointerEvent): Promise<void> {
     const { _creator: creator } = this;
     if (creator !== undefined) {
       const ray = this.getRay(event);

--- a/react-components/src/architecture/concrete/annotations/commands/AnnotationsSelectTool.ts
+++ b/react-components/src/architecture/concrete/annotations/commands/AnnotationsSelectTool.ts
@@ -80,7 +80,7 @@ export class AnnotationsSelectTool extends BaseEditTool {
     this.deselectedAnnotationInteractive();
   }
 
-  public override async onHover(event: PointerEvent): Promise<void> {
+  public override async onHoverByDebounce(event: PointerEvent): Promise<void> {
     const intersection = this.getSpecificIntersection(event, isAnnotationsOrGizmo);
     const domainObject = AnnotationsSelectTool.getIntersectedAnnotationsDomainObject(intersection);
     const intersectInfo = getIntersectedAnnotation(intersection);

--- a/react-components/src/architecture/concrete/example/ExampleTool.ts
+++ b/react-components/src/architecture/concrete/example/ExampleTool.ts
@@ -78,7 +78,7 @@ export class ExampleTool extends BaseEditTool {
     }
   }
 
-  public override async onHover(event: PointerEvent): Promise<void> {
+  public override async onHoverByDebounce(event: PointerEvent): Promise<void> {
     const intersection = await this.getIntersection(event);
     // Just set the cursor
     const domainObject = this.getIntersectedSelectableDomainObject(intersection);

--- a/react-components/src/architecture/concrete/primitives/tools/PrimitiveEditTool.ts
+++ b/react-components/src/architecture/concrete/primitives/tools/PrimitiveEditTool.ts
@@ -71,7 +71,7 @@ export abstract class PrimitiveEditTool extends BaseEditTool {
     }
   }
 
-  public override async onHover(event: PointerEvent): Promise<void> {
+  public override async onHoverByDebounce(event: PointerEvent): Promise<void> {
     // Handle when creator is set first
     if (!this.isEdit) {
       if (this._creator !== undefined) {

--- a/react-components/src/components/Architecture/FilterButton.tsx
+++ b/react-components/src/components/Architecture/FilterButton.tsx
@@ -155,6 +155,7 @@ const FilterMenu = ({
               event.stopPropagation();
               event.preventDefault();
               props.onClick(event);
+              setOpen(!isOpen);
             }}
           />
         </CogsTooltip>

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -74,6 +74,9 @@ export const SettingsButton = ({
     <StyledMenu
       hideOnSelect={false}
       onOpenChange={(open: boolean) => {
+        for (const child of children) {
+          child.update();
+        }
         setOpen(open);
       }}
       floatingProps={{ middleware: [offset(TOOLBAR_HORIZONTAL_PANEL_OFFSET)] }}


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:


## Description :pencil:

* New version 0.64.2
* Rename onHover to onHoverByDebounce, since it was like that.
* Make a new onHover  without debounce. 
* Use the new on NavigationTool to hover on the 360 markers.
* Fix updating issue when open settingsbutton. 
* Fix closing when click on open settingsbutton.

## How has this been tested? :mag:

1. Open settingsbutton with a point cloud location. Check that it has all settings
2. Show some 360 markers and hover around. 


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
