### PR TITLE
feat(react-components): add callback when a model is loaded

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.65.3",
+  "version": "0.65.4",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/CacheProvider/index.ts
+++ b/react-components/src/components/CacheProvider/index.ts
@@ -4,7 +4,11 @@
 
 export type { Image360AnnotationAssetInfo } from './types';
 
-export { useAssetMappedNodesForRevisions } from './AssetMappingAndNode3DCacheProvider';
+export {
+  useAssetMappedNodesForRevisions,
+  useGenerateAssetMappingCachePerItemFromModelCache,
+  useGenerateNode3DCache
+} from './AssetMappingAndNode3DCacheProvider';
 export { useFdmAssetMappings } from './NodeCacheProvider';
 export {
   usePointCloudAnnotationMappingsForModels,

--- a/react-components/src/components/CacheProvider/index.ts
+++ b/react-components/src/components/CacheProvider/index.ts
@@ -4,11 +4,7 @@
 
 export type { Image360AnnotationAssetInfo } from './types';
 
-export {
-  useAssetMappedNodesForRevisions,
-  useGenerateAssetMappingCachePerItemFromModelCache,
-  useGenerateNode3DCache
-} from './AssetMappingAndNode3DCacheProvider';
+export { useAssetMappedNodesForRevisions } from './AssetMappingAndNode3DCacheProvider';
 export { useFdmAssetMappings } from './NodeCacheProvider';
 export {
   usePointCloudAnnotationMappingsForModels,

--- a/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
+++ b/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
@@ -2,7 +2,12 @@
  * Copyright 2023 Cognite AS
  */
 import { useRef, type ReactElement, useState, useEffect, useMemo } from 'react';
-import { type Cognite3DViewer } from '@cognite/reveal';
+import {
+  type CogniteCadModel,
+  type CognitePointCloudModel,
+  type Image360Collection,
+  type Cognite3DViewer
+} from '@cognite/reveal';
 import { CadModelContainer } from '../CadModelContainer/CadModelContainer';
 import { PointCloudContainer } from '../PointCloudContainer/PointCloudContainer';
 import { Image360CollectionContainer } from '../Image360CollectionContainer/Image360CollectionContainer';
@@ -116,9 +121,11 @@ export const Reveal3DResources = ({
           group.style !== undefined
       ) ?? EMPTY_ARRAY;
 
-  const onModelLoaded = (): void => {
+  const onModelLoaded = (
+    model: CogniteCadModel | CognitePointCloudModel | Image360Collection
+  ): void => {
     onModelFailOrSucceed();
-    onResourceIsLoaded?.();
+    onResourceIsLoaded?.(model);
   };
 
   const onModelLoadedError = (addOptions: AddResourceOptions, error: any): void => {

--- a/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
+++ b/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
@@ -45,6 +45,7 @@ export const Reveal3DResources = ({
   instanceStyling,
   onResourcesAdded,
   onResourceLoadError,
+  onResourceIsLoaded,
   image360Settings
 }: Reveal3DResourcesProps): ReactElement => {
   const viewer = useReveal();
@@ -117,6 +118,7 @@ export const Reveal3DResources = ({
 
   const onModelLoaded = (): void => {
     onModelFailOrSucceed();
+    onResourceIsLoaded?.();
   };
 
   const onModelLoadedError = (addOptions: AddResourceOptions, error: any): void => {

--- a/react-components/src/components/Reveal3DResources/types.ts
+++ b/react-components/src/components/Reveal3DResources/types.ts
@@ -121,4 +121,5 @@ export type CommonResourceContainerProps = {
   image360Settings?: CommonImage360Settings;
   onResourcesAdded?: () => void;
   onResourceLoadError?: (failedResource: AddResourceOptions, error: any) => void;
+  onResourceIsLoaded?: () => void;
 };

--- a/react-components/src/components/Reveal3DResources/types.ts
+++ b/react-components/src/components/Reveal3DResources/types.ts
@@ -5,7 +5,10 @@
 import {
   type NodeAppearance,
   type AddModelOptions,
-  type Image360AnnotationAppearance
+  type Image360AnnotationAppearance,
+  type CogniteCadModel,
+  type CognitePointCloudModel,
+  type Image360Collection
 } from '@cognite/reveal';
 
 import { type Matrix4 } from 'three';
@@ -121,5 +124,7 @@ export type CommonResourceContainerProps = {
   image360Settings?: CommonImage360Settings;
   onResourcesAdded?: () => void;
   onResourceLoadError?: (failedResource: AddResourceOptions, error: any) => void;
-  onResourceIsLoaded?: () => void;
+  onResourceIsLoaded?: (
+    model: CogniteCadModel | CognitePointCloudModel | Image360Collection
+  ) => void;
 };


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

Adds an optional onResourcesIsLoaded callback for when a model is loaded regardless of the count to identify whether it was added or not, as used in the other onResourcesAdded callback.

This initiative is initially being used to execute cameraNavigation.fitCameraToAllModels(); when a model is loaded via Single Model Selection at SingleModelResourceContainer that is being implemented in the PR: https://github.com/cognitedata/fusion/pull/8080


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [X] I have performed a self-review of my own code.
- [X] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [X] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
