### PR TITLE
feat(react-components): expose new types for the Single Model and Scene Resources features used by FDX

### DIFF
--- a/react-components/src/hooks/index.ts
+++ b/react-components/src/hooks/index.ts
@@ -24,6 +24,5 @@ export type { ClickedNodeData, FdmNodeDataResult } from './useClickedNode';
 export type {
   PointCloudAnnotationMappedAssetData,
   Image360AnnotationMappedAssetData,
-  ThreeDModelFdmMappings,
+  ThreeDModelFdmMappings
 } from './types';
-

--- a/react-components/src/hooks/index.ts
+++ b/react-components/src/hooks/index.ts
@@ -17,10 +17,13 @@ export { use3dScenes } from './scenes/use3dScenes';
 export { useSceneConfig } from './scenes/useSceneConfig';
 export { useGhostMode } from './useGhostMode';
 
+export type { SceneData } from './scenes/types';
+
 export type { CameraNavigationActions } from './useCameraNavigation';
 export type { ClickedNodeData, FdmNodeDataResult } from './useClickedNode';
 export type {
   PointCloudAnnotationMappedAssetData,
   Image360AnnotationMappedAssetData,
-  ThreeDModelFdmMappings
+  ThreeDModelFdmMappings,
 } from './types';
+

--- a/react-components/src/hooks/scenes/types.ts
+++ b/react-components/src/hooks/scenes/types.ts
@@ -3,6 +3,12 @@
  */
 import { type SourceSelectorV3 } from '@cognite/sdk/dist/src';
 import { type DmsUniqueIdentifier } from '../../data-providers/FdmSDK';
+import {
+  type AddCadResourceOptions,
+  type AddImage360CollectionDatamodelsOptions,
+  type AddPointCloudResourceOptions
+} from '../../components';
+import { type GroundPlane, type Skybox } from '../../components/SceneContainer/sceneTypes';
 
 export type Transformation3d = {
   translationX: number;
@@ -14,6 +20,20 @@ export type Transformation3d = {
   scaleX: number;
   scaleY: number;
   scaleZ: number;
+};
+
+export type SceneData = {
+  name: string;
+  cameraTranslationX: number;
+  cameraTranslationY: number;
+  cameraTranslationZ: number;
+  cameraEulerRotationX: number;
+  cameraEulerRotationY: number;
+  cameraEulerRotationZ: number;
+  cadModelOptions: Array<AddCadResourceOptions | AddPointCloudResourceOptions>;
+  image360CollectionOptions: AddImage360CollectionDatamodelsOptions[];
+  groundPlanes: GroundPlane[];
+  skybox?: Skybox;
 };
 
 export type SceneModelsProperties = Transformation3d & {

--- a/react-components/src/hooks/scenes/use3dScenes.tsx
+++ b/react-components/src/hooks/scenes/use3dScenes.tsx
@@ -9,12 +9,8 @@ import { useMemo } from 'react';
 import { type EdgeItem, FdmSDK, type NodeItem } from '../../data-providers/FdmSDK';
 import { Euler, MathUtils, Matrix4 } from 'three';
 import { CDF_TO_VIEWER_TRANSFORMATION } from '@cognite/reveal';
-import { type GroundPlane, type Skybox } from '../../components/SceneContainer/sceneTypes';
-import {
-  type AddCadResourceOptions,
-  type AddPointCloudResourceOptions,
-  type AddImage360CollectionDatamodelsOptions
-} from '../../components/Reveal3DResources/types';
+import { type GroundPlane } from '../../components/SceneContainer/sceneTypes';
+import { type AddImage360CollectionDatamodelsOptions } from '../../components/Reveal3DResources/types';
 import {
   type Cdf3dImage360CollectionProperties,
   type Cdf3dRevisionProperties,
@@ -29,6 +25,7 @@ import {
   revisionSourceWithProperties,
   type SCENE_SOURCE,
   type SceneConfigurationProperties,
+  type SceneData,
   sceneSourceWithProperties,
   type SkyboxProperties,
   type Transformation3d,
@@ -39,20 +36,6 @@ import { tryGetModelIdFromExternalId } from '../../utilities/tryGetModelIdFromEx
 
 export type Space = string;
 export type ExternalId = string;
-
-export type SceneData = {
-  name: string;
-  cameraTranslationX: number;
-  cameraTranslationY: number;
-  cameraTranslationZ: number;
-  cameraEulerRotationX: number;
-  cameraEulerRotationY: number;
-  cameraEulerRotationZ: number;
-  cadModelOptions: Array<AddCadResourceOptions | AddPointCloudResourceOptions>;
-  image360CollectionOptions: AddImage360CollectionDatamodelsOptions[];
-  groundPlanes: GroundPlane[];
-  skybox?: Skybox;
-};
 
 type Use3dScenesQueryResult = {
   scenes: Array<NodeItem<SceneConfigurationProperties>>;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
Exposes some other types used by the Single Model and Scene Resources feature in FDX.
Also, it moves the SceneData type into the types file. 

It is going along with the PR: 
https://github.com/cognitedata/fusion/pull/8080

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [X] I have performed a self-review of my own code.
- [X I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
