### PR TITLE
fix: same timestamp/date for all 360 image revision for data-models

### DIFF
--- a/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/Cdf360DataModelsDescriptorProvider.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/Cdf360DataModelsDescriptorProvider.ts
@@ -160,15 +160,21 @@ export class Cdf360DataModelsDescriptorProvider implements Image360DescriptorPro
     collectionLabel: string,
     imageFileDescriptors: { image: ImageInstanceResult; fileDescriptors: FileInfo[] }[]
   ): Historical360ImageSet {
-    const mainImageProps = imageFileDescriptors[0].image.properties.cdf_360_image_schema['Image360/v1'];
+    const mainImagePropsArray = imageFileDescriptors.map(
+      descriptor => descriptor.image.properties.cdf_360_image_schema['Image360/v1']
+    );
+
     const id = imageFileDescriptors[0].image.externalId;
+
     return {
       collectionId,
       collectionLabel,
       id,
-      imageRevisions: imageFileDescriptors.map(p => this.getImageRevision(mainImageProps, p.fileDescriptors)),
-      label: mainImageProps.label as string,
-      transform: this.getRevisionTransform(mainImageProps as any)
+      imageRevisions: imageFileDescriptors.map((p, index) =>
+        this.getImageRevision(mainImagePropsArray[index], p.fileDescriptors)
+      ),
+      label: mainImagePropsArray[0].label as string,
+      transform: this.getRevisionTransform(mainImagePropsArray[0] as any)
     };
   }
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4853

## Description :pencil:
For data-model 360 image revision, timestamp/date was same for all revisions, this PR fixes the issue

## How has this been tested? :mag:

In Search app


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
