### PR TITLE
fix(react-compoenents): Fix hasPanelInfo

### DIFF
--- a/react-components/src/architecture/base/commands/BaseTool.ts
+++ b/react-components/src/architecture/base/commands/BaseTool.ts
@@ -24,15 +24,6 @@ import { CommandChanges } from '../domainObjectsHelpers/CommandChanges';
 import { ContextMenuUpdater } from '../reactUpdaters/ContextMenuUpdater';
 
 /**
- * AnchorDialog
- */
-export type AnchoredDialogContent = {
-  position: Vector3;
-  onCloseCallback: () => void;
-  contentCommands: BaseCommand[];
-};
-
-/**
  * Base class for interactions in the 3D viewer
  * Provides common functionality and virtual methods to be overridden by derived classes.
  */
@@ -286,3 +277,12 @@ export abstract class BaseTool extends RenderTargetCommand {
     return this._renderTarget?.contextMenuController.contextMenuPositionData !== undefined;
   }
 }
+
+/**
+ * AnchorDialog
+ */
+export type AnchoredDialogContent = {
+  position: Vector3;
+  onCloseCallback: () => void;
+  contentCommands: BaseCommand[];
+};

--- a/react-components/src/architecture/concrete/annotation360/Image360AnnotationDomainObject.ts
+++ b/react-components/src/architecture/concrete/annotation360/Image360AnnotationDomainObject.ts
@@ -45,6 +45,10 @@ export class Image360AnnotationDomainObject extends LineDomainObject {
     return { untranslated: '360 image annotation' };
   }
 
+  public override get hasPanelInfo(): boolean {
+    return false;
+  }
+
   public override clone(what?: symbol): DomainObject {
     const clone = new Image360AnnotationDomainObject(this.connectedImageId);
     clone.copyFrom(this, what);

--- a/react-components/src/architecture/concrete/annotations/BoxGizmoDomainObject.ts
+++ b/react-components/src/architecture/concrete/annotations/BoxGizmoDomainObject.ts
@@ -43,10 +43,6 @@ export class BoxGizmoDomainObject extends BoxDomainObject {
     return style;
   }
 
-  public override get hasPanelInfo(): boolean {
-    return true;
-  }
-
   public override clone(what?: symbol): DomainObject {
     const clone = new BoxGizmoDomainObject();
     clone.copyFrom(this, what);

--- a/react-components/src/architecture/concrete/annotations/CylinderGizmoDomainObject.ts
+++ b/react-components/src/architecture/concrete/annotations/CylinderGizmoDomainObject.ts
@@ -43,10 +43,6 @@ export class CylinderGizmoDomainObject extends CylinderDomainObject {
     return style;
   }
 
-  public override get hasPanelInfo(): boolean {
-    return true;
-  }
-
   public override clone(what?: symbol): DomainObject {
     const clone = new CylinderGizmoDomainObject();
     clone.copyFrom(this, what);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:

The function `hasPanelInfo `was accidental removed from Image360AnnotationDomainObject.
Also remove d2 that was not necessary anymore