### PR TITLE
fix(react-components): make poi-tool an edit tool++

### DIFF
--- a/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestTool.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestTool.ts
@@ -10,7 +10,6 @@ import { type Vector3 } from 'three';
 import { type PointsOfInterestProvider } from './PointsOfInterestProvider';
 import { type AnchoredDialogContent } from '../../base/commands/BaseTool';
 import { AnchoredDialogUpdater } from '../../base/reactUpdaters/AnchoredDialogUpdater';
-import { NavigationTool } from '../../base/concreteCommands/NavigationTool';
 import { CreatePointsOfInterestWithDescriptionCommand } from './CreatePointsOfInterestWithDescriptionCommand';
 import { type RevealRenderTarget } from '../../base/renderTarget/RevealRenderTarget';
 import { BaseEditTool } from '../../base/commands/BaseEditTool';

--- a/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestTool.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestTool.ts
@@ -13,8 +13,9 @@ import { AnchoredDialogUpdater } from '../../base/reactUpdaters/AnchoredDialogUp
 import { NavigationTool } from '../../base/concreteCommands/NavigationTool';
 import { CreatePointsOfInterestWithDescriptionCommand } from './CreatePointsOfInterestWithDescriptionCommand';
 import { type RevealRenderTarget } from '../../base/renderTarget/RevealRenderTarget';
+import { BaseEditTool } from '../../base/commands/BaseEditTool';
 
-export class PointsOfInterestTool<PoiIdType> extends NavigationTool {
+export class PointsOfInterestTool<PoiIdType> extends BaseEditTool {
   private _isCreating: boolean = false;
 
   private _anchoredDialogContent: AnchoredDialogContent | undefined;

--- a/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestView.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestView.ts
@@ -25,7 +25,7 @@ export class PointsOfInterestView<PoiIdType> extends GroupThreeView<
   PointsOfInterestDomainObject<PoiIdType>
 > {
   private readonly _overlayCollection: PointsOfInterestCollection<PoiIdType> =
-    new Overlay3DCollection([]);
+    new Overlay3DCollection([], { maxPointSize: 32 });
 
   protected override calculateBoundingBox(): Box3 {
     const boundingBox = new Box3().makeEmpty();

--- a/react-components/src/architecture/concrete/pointsOfInterest/color.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/color.ts
@@ -7,7 +7,7 @@ import { PointsOfInterestStatus } from './types';
 
 export const DEFAULT_OVERLAY_COLOR = new Color('#C945DB');
 export const PENDING_OVERLAY_COLOR = new Color('#33AA33');
-export const SELECTED_COLOR = new Color(0.392, 0.392, 1.0);
+export const SELECTED_COLOR = new Color('##6464FF');
 export const PENDING_DELETION_OVERLAY_COLOR = new Color('#AA3333');
 
 export function convertToSelectedColor(color: Color): Color {

--- a/react-components/src/architecture/concrete/pointsOfInterest/color.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/color.ts
@@ -7,6 +7,7 @@ import { PointsOfInterestStatus } from './types';
 
 export const DEFAULT_OVERLAY_COLOR = new Color('#C945DB');
 export const PENDING_OVERLAY_COLOR = new Color('#33AA33');
+export const SELECTED_COLOR = new Color(0.392, 0.392, 1.0);
 export const PENDING_DELETION_OVERLAY_COLOR = new Color('#AA3333');
 
 export function convertToSelectedColor(color: Color): Color {
@@ -17,13 +18,11 @@ export function convertToSelectedColor(color: Color): Color {
 }
 
 export function getColorFromStatus(status: PointsOfInterestStatus, selected: boolean): Color {
-  const baseColor = getBaseColor(status);
-
   if (selected) {
-    return convertToSelectedColor(baseColor);
+    return SELECTED_COLOR;
   }
 
-  return baseColor;
+  return getBaseColor(status);
 
   function getBaseColor(status: PointsOfInterestStatus): Color {
     switch (status) {

--- a/react-components/src/components/Architecture/pointsOfInterest/PoiInfoPanelContent.tsx
+++ b/react-components/src/components/Architecture/pointsOfInterest/PoiInfoPanelContent.tsx
@@ -61,6 +61,7 @@ const PanelHeader = (): ReactNode => {
         <RevealButtons.DeleteSelectedPointOfInterest toolbarPlacement={'top'} />
         <Button
           icon=<CloseIcon />
+          type="ghost"
           onClick={() => poiDomainObject?.setSelectedPointOfInterest(undefined)}
         />
       </Flex>


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

This has the implication that `useClickedNodeData` will not be activated by default when clicking to create a PoI, which means it won't open any side panel in e.g. Search.

Also:
- Reduced PoI size by 50 %
- Made selected PoI blue
- made close button ghosted

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
