### PR TITLE
fix(react-components): added hook to get coreDM point cloud volume data for clicked asset

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.71.1",
+  "version": "0.71.2",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/hooks/useClickedNode.tsx
+++ b/react-components/src/hooks/useClickedNode.tsx
@@ -19,6 +19,10 @@ import { MOUSE, Vector2, type Vector3 } from 'three';
 import { type DmsUniqueIdentifier, type Source } from '../data-providers/FdmSDK';
 import { useRenderTarget, useReveal } from '../components/RevealCanvas/ViewerContext';
 import { isActiveEditTool } from '../architecture/base/commands/BaseEditTool';
+import {
+  type PointCloudVolumeAssetWithViews,
+  usePointCloudVolumeMappingForIntersection
+} from '../query/core-dm/usePointCloudVolumeMappingForAssetInstances';
 
 export type AssetMappingDataResult = {
   cadNode: Node3D;
@@ -37,6 +41,7 @@ export type ClickedNodeData = {
   fdmResult?: FdmNodeDataResult;
   assetMappingResult?: AssetMappingDataResult;
   pointCloudAnnotationMappingResult?: PointCloudAnnotationMappedAssetData[];
+  pointCloudVolumeAssetMappingResult?: PointCloudVolumeAssetWithViews[];
   intersection: AnyIntersection | Image360AnnotationIntersection;
 };
 
@@ -116,12 +121,16 @@ export const useClickedNodeData = (options?: {
   const { data: pointCloudAssetMappingResult } =
     usePointCloudAnnotationMappingForAssetId(intersection);
 
+  const { data: pointCloudAssetMappingVolumeResult } =
+    usePointCloudVolumeMappingForIntersection(intersection);
+
   return useCombinedClickedNodeData(
     mouseButton,
     position,
     nodeDataPromises,
     assetMappingResult,
     pointCloudAssetMappingResult,
+    pointCloudAssetMappingVolumeResult,
     annotationIntersection ?? intersection
   );
 };
@@ -132,6 +141,7 @@ const useCombinedClickedNodeData = (
   fdmPromises: FdmNodeDataPromises | undefined,
   assetMappings: NodeAssetMappingResult | undefined,
   pointCloudAssetMappings: PointCloudAnnotationMappedAssetData[] | undefined,
+  pointCloudVolumeAssetMappings: PointCloudVolumeAssetWithViews[] | undefined,
   intersection: AnyIntersection | Image360AnnotationIntersection | undefined
 ): ClickedNodeData | undefined => {
   const [clickedNodeData, setClickedNodeData] = useState<ClickedNodeData | undefined>();
@@ -157,9 +167,16 @@ const useCombinedClickedNodeData = (
       fdmResult: fdmData,
       assetMappingResult: assetMappingData,
       pointCloudAnnotationMappingResult: pointCloudAssetMappings,
+      pointCloudVolumeAssetMappingResult: pointCloudVolumeAssetMappings,
       intersection
     });
-  }, [intersection, fdmData, assetMappings?.node, pointCloudAssetMappings]);
+  }, [
+    intersection,
+    fdmData,
+    assetMappings?.node,
+    pointCloudAssetMappings,
+    pointCloudVolumeAssetMappings
+  ]);
 
   return clickedNodeData;
 };

--- a/react-components/src/query/core-dm/typeGuards.ts
+++ b/react-components/src/query/core-dm/typeGuards.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+import {
+  type PointCloudIntersection,
+  type AnyIntersection,
+  type DMDataSourceType
+} from '@cognite/reveal';
+
+export const isPointCloudVolumeIntersection = (
+  intersection: AnyIntersection | undefined
+): intersection is PointCloudIntersection<DMDataSourceType> => {
+  return (
+    intersection?.type === 'pointcloud' &&
+    intersection.volumeMetadata !== undefined &&
+    'assetRef' in intersection.volumeMetadata &&
+    'volumeInstanceRef' in intersection.volumeMetadata
+  );
+};

--- a/react-components/src/query/core-dm/usePointCloudVolumeMappingForAssetInstances.ts
+++ b/react-components/src/query/core-dm/usePointCloudVolumeMappingForAssetInstances.ts
@@ -14,6 +14,7 @@ import { usePointCloudModelRevisionIdsFromReveal } from '../usePointCloudModelRe
 import { EMPTY_ARRAY } from '../../utilities/constants';
 import { useFdmSdk } from '../../components/RevealCanvas/SDKProvider';
 import { inspectNodes } from '../../components/CacheProvider/requests';
+import { isPointCloudVolumeIntersection } from './typeGuards';
 
 export type PointCloudVolumeMappedAssetData = {
   volumeInstanceRef: DMInstanceRef;
@@ -92,20 +93,16 @@ export const usePointCloudVolumeMappingForIntersection = (
   intersection: AnyIntersection | undefined
 ): UseQueryResult<PointCloudVolumeAssetWithViews[]> => {
   const fdmSdk = useFdmSdk();
-  const isPointCloudIntersection =
-    intersection?.type === 'pointcloud' &&
-    intersection.volumeMetadata !== undefined &&
-    'assetRef' in intersection.volumeMetadata &&
-    'volumeInstanceRef' in intersection.volumeMetadata;
-  const assetInstanceRefs = useMemo<DMInstanceRef[]>(() => {
-    if (isPointCloudIntersection) {
+
+  const assetInstanceRefs = useMemo(() => {
+    if (isPointCloudVolumeIntersection(intersection)) {
       const assetRef = intersection.volumeMetadata?.assetRef;
-      if (assetRef !== undefined && 'externalId' in assetRef) {
-        return [assetRef as DMInstanceRef];
+      if (assetRef !== undefined) {
+        return [assetRef];
       }
     }
     return [];
-  }, [isPointCloudIntersection, intersection]);
+  }, [intersection]);
 
   const { data: volumeMappings, isLoading } =
     usePointCloudVolumeMappingForAssetInstances(assetInstanceRefs);

--- a/react-components/src/utilities/queryKeys.ts
+++ b/react-components/src/utilities/queryKeys.ts
@@ -34,6 +34,8 @@ export const queryKeys = {
     ] as const,
   pointCloudDMModelIdRevisionIds: (modelKeys: string[]) =>
     [...models, 'point-cloud-dm-model-id-revision-ids', modelKeys] as const,
+  pointCloudDMVolumeAssetMappingsWithViews: (assetRefKeys: string[]) =>
+    [...assets, 'point-cloud-dm-volume-asset-mappings-with-views', assetRefKeys] as const,
   modelRevisionId: (revisionKeys: string[]) =>
     [...revisions, 'model-revision-id', revisionKeys] as const,
   timeseriesFromRelationship: () => [...timeseries, 'timeseries-relationship'] as const


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4716

## Description :pencil:
Hook to get asset instance and it's view

## How has this been tested? :mag:

In storybook and `Search` application


## Test instructions :information_source:

- `yalc` link to `fusion` branch `pramodcog/BND3D-4712
`

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
