### PR TITLE
feat(react-components): distinguish whether clicked node data is pending or empty, bump 0.73.6

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.73.5",
+  "version": "0.73.6",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestSectionCommand.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/PointsOfInterestSectionCommand.ts
@@ -6,10 +6,6 @@ import { SectionCommand } from '../../base/commands/SectionCommand';
 import { type TranslationInput } from '../../base/utilities/TranslateInput';
 
 export class PointsOfInterestSectionCommand extends SectionCommand {
-  public override get isVisible(): boolean {
-    return this.renderTarget.get360ImageCollections().next().value !== undefined;
-  }
-
   public override get tooltip(): TranslationInput {
     return { key: 'POINT_OF_INTEREST_PLURAL' };
   }

--- a/react-components/src/architecture/concrete/pointsOfInterest/index.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/index.ts
@@ -2,4 +2,5 @@
  * Copyright 2024 Cognite AS
  */
 export { PointsOfInterestDomainObject } from './PointsOfInterestDomainObject';
+export { PointsOfInterestView } from './PointsOfInterestView';
 export { isPointsOfInterestIntersection, type PointOfInterest } from './types';

--- a/react-components/src/hooks/useClickedNode.tsx
+++ b/react-components/src/hooks/useClickedNode.tsx
@@ -185,14 +185,6 @@ const useCombinedClickedNodeData = (
               assetIds: assetMappings.mappings.map((mapping) => mapping.assetId)
             };
 
-    function normalizeListDataResult<T>(result: UseQueryResult<T[]>): T[] | undefined | null {
-      return result.isFetching
-        ? undefined
-        : result.data === undefined || result.data.length === 0
-          ? null
-          : result.data;
-    }
-
     const pointCloudAssetMappings = normalizeListDataResult(pointCloudAssetMappingsResult);
     const pointCloudFdmVolumeMappings = normalizeListDataResult(pointCloudFdmVolumeMappingsResult);
 
@@ -214,6 +206,14 @@ const useCombinedClickedNodeData = (
     pointCloudFdmVolumeMappingsResult.data,
     pointCloudFdmVolumeMappingsResult.isFetching
   ]);
+
+  function normalizeListDataResult<T>(result: UseQueryResult<T[]>): T[] | undefined | null {
+    return result.isFetching
+      ? undefined
+      : result.data === undefined || result.data.length === 0
+        ? null
+        : result.data;
+  }
 };
 
 const useFdmData = (

--- a/react-components/src/hooks/useClickedNode.tsx
+++ b/react-components/src/hooks/useClickedNode.tsx
@@ -22,7 +22,7 @@ import {
   usePointCloudFdmVolumeMappingForIntersection
 } from '../query/core-dm/usePointCloudVolumeMappingForAssetInstances';
 import { useAssetMappingForTreeIndex, useFdm3dNodeDataPromises } from './cad';
-import { UseQueryResult } from '@tanstack/react-query';
+import { type UseQueryResult } from '@tanstack/react-query';
 
 export type AssetMappingDataResult = {
   cadNode: Node3D;

--- a/react-components/src/hooks/useClickedNode.tsx
+++ b/react-components/src/hooks/useClickedNode.tsx
@@ -185,26 +185,16 @@ const useCombinedClickedNodeData = (
               assetIds: assetMappings.mappings.map((mapping) => mapping.assetId)
             };
 
-    console.log(
-      'Point cloud asset mappings: ',
-      pointCloudAssetMappingsResult,
-      ', fdm mappings = ',
-      pointCloudFdmVolumeMappingsResult
-    );
+    function normalizeListDataResult<T>(result: UseQueryResult<T[]>): T[] | undefined | null {
+      return result.isFetching
+        ? undefined
+        : result.data === undefined || result.data.length === 0
+          ? null
+          : result.data;
+    }
 
-    const pointCloudAssetMappings = pointCloudAssetMappingsResult.isFetching
-      ? undefined
-      : pointCloudAssetMappingsResult.data === undefined ||
-          pointCloudAssetMappingsResult.data.length === 0
-        ? null
-        : pointCloudAssetMappingsResult.data;
-
-    const pointCloudFdmVolumeMappings = pointCloudFdmVolumeMappingsResult.isFetching
-      ? undefined
-      : pointCloudFdmVolumeMappingsResult.data === undefined ||
-          pointCloudFdmVolumeMappingsResult.data.length === 0
-        ? null
-        : pointCloudFdmVolumeMappingsResult.data;
+    const pointCloudAssetMappings = normalizeListDataResult(pointCloudAssetMappingsResult);
+    const pointCloudFdmVolumeMappings = normalizeListDataResult(pointCloudFdmVolumeMappingsResult);
 
     return {
       mouseButton,

--- a/react-components/stories/HighlightNode.stories.tsx
+++ b/react-components/stories/HighlightNode.stories.tsx
@@ -83,7 +83,7 @@ const StoryContent = ({ resources }: { resources: AddResourceOptions[] }): React
   const nodeData = useClickedNodeData();
 
   useEffect(() => {
-    if (nodeData?.fdmResult !== undefined) {
+    if (nodeData?.fdmResult !== undefined && nodeData?.fdmResult !== null) {
       setStylingGroups([
         {
           fdmAssetExternalIds: [
@@ -100,7 +100,10 @@ const StoryContent = ({ resources }: { resources: AddResourceOptions[] }): React
         nodeData.fdmResult.fdmNodes[0].externalId,
         nodeData.fdmResult.fdmNodes[0].space
       );
-    } else if (nodeData?.assetMappingResult !== undefined) {
+    } else if (
+      nodeData?.assetMappingResult !== undefined &&
+      nodeData?.assetMappingResult !== null
+    ) {
       setStylingGroups([
         {
           assetIds: nodeData.assetMappingResult.assetIds,
@@ -112,7 +115,10 @@ const StoryContent = ({ resources }: { resources: AddResourceOptions[] }): React
         (nodeData.intersection as CadIntersection).model.revisionId,
         nodeData.assetMappingResult.cadNode.id
       );
-    } else if (nodeData?.pointCloudAnnotationMappingResult !== undefined) {
+    } else if (
+      nodeData?.pointCloudAnnotationMappingResult !== undefined &&
+      nodeData.pointCloudAnnotationMappingResult !== null
+    ) {
       setStylingGroups([
         {
           assetIds: [nodeData.pointCloudAnnotationMappingResult[0].asset.id],


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Up to now, it's been impossible to know if the fields of the `useClickedNodeData` return value have been pending, or if there was no result, as the fields would be `undefined` in both cases.

This PR encances useClickedNodeData to return `null` for fields that evaluates to no result.

This is used for a usability improvement in Fusion, where we wait with closing the side panel on click until we're sure whether the new click gave a new instance for the panel.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
