### PR TITLE
fix(react-components): slider UI issue and exposed logMetrics option in RevealContext props

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.73.11",
+  "version": "0.73.12",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/RevealContext/RevealContext.tsx
+++ b/react-components/src/components/RevealContext/RevealContext.tsx
@@ -33,6 +33,7 @@ export type RevealContextProps = {
     | 'pointCloudEffects'
     | 'enableEdges'
     | 'onLoading'
+    | 'logMetrics'
   >;
 };
 

--- a/react-components/src/components/RevealToolbar/SlicerButton.tsx
+++ b/react-components/src/components/RevealToolbar/SlicerButton.tsx
@@ -102,7 +102,7 @@ export const SlicerButton = (): ReactElement => {
           <Button {...props} type="ghost" icon=<SliceIcon /> aria-label="Slice models" />
         </CogsTooltip>
       )}>
-      <RangeSlider
+      <StyledRangeSlider
         min={0}
         max={1}
         step={0.01}
@@ -122,4 +122,21 @@ const StyledMenu = styled(Menu)`
   min-width: 32px !important;
   padding: 12px 8px 12px 8px !important;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  .cogs-v10.cogs-slider .rc-slider-rail {
+    height: 100% !important;
+    width: 4px !important;
+`;
+
+const StyledRangeSlider = styled(RangeSlider)`
+  height: 100% !important;
+  width: 4px !important;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
 `;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->
https://cognitedata.atlassian.net/browse/BND3D-5051

## Description :pencil:
Fixed slider UI issue and also exposed logMetrics option in RevealContext props as PowerBI has throwing error due to security restrictions.

## How has this been tested? :mag:
In storybook


## Test instructions :information_source:

Run Toolbar storybook and select Slider button

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
