### PR TITLE
fix(react-components): cad & point cloud models getting added multiple time due to incorrect transforms

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.73.12",
+  "version": "0.73.13",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/CadModelContainer/CadModelContainer.tsx
+++ b/react-components/src/components/CadModelContainer/CadModelContainer.tsx
@@ -21,7 +21,6 @@ import { getViewerResourceCount } from '../../utilities/getViewerResourceCount';
 import { type CadModelStyling } from './types';
 import { useApplyCadModelStyling } from './useApplyCadModelStyling';
 import { isSameGeometryFilter, isSameModel } from '../../utilities/isSameModel';
-import { AddResourceOptions } from '../Reveal3DResources';
 
 export type CogniteCadModelProps = {
   addModelOptions: AddModelOptions<ClassicDataSourceType>;

--- a/react-components/src/components/CadModelContainer/CadModelContainer.tsx
+++ b/react-components/src/components/CadModelContainer/CadModelContainer.tsx
@@ -21,6 +21,7 @@ import { getViewerResourceCount } from '../../utilities/getViewerResourceCount';
 import { type CadModelStyling } from './types';
 import { useApplyCadModelStyling } from './useApplyCadModelStyling';
 import { isSameGeometryFilter, isSameModel } from '../../utilities/isSameModel';
+import { AddResourceOptions } from '../Reveal3DResources';
 
 export type CogniteCadModelProps = {
   addModelOptions: AddModelOptions<ClassicDataSourceType>;
@@ -100,11 +101,13 @@ export function CadModelContainer({
     return cadModel;
 
     async function getOrAddModel(): Promise<CogniteCadModel> {
-      const viewerModel = viewer.models.find(
-        (model) =>
-          isSameModel(model, addModelOptions) &&
+      const viewerModel = viewer.models.find((model) => {
+        const cadModel = { ...model, transform: model.getModelTransformation() };
+        return (
+          isSameModel(cadModel, addModelOptions) &&
           isSameGeometryFilter(geometryFilter, initializingModelsGeometryFilter.current)
-      );
+        );
+      });
 
       if (viewerModel !== undefined) {
         return await Promise.resolve(viewerModel as CogniteCadModel);

--- a/react-components/src/components/PointCloudContainer/PointCloudContainer.tsx
+++ b/react-components/src/components/PointCloudContainer/PointCloudContainer.tsx
@@ -107,9 +107,13 @@ export function PointCloudContainer({
     return pointCloudModel;
 
     async function getOrAddModel(): Promise<CognitePointCloudModel<DataSourceType>> {
-      const viewerModel = viewer.models.find((pointCloudModel) =>
-        isSameModel(pointCloudModel, addModelOptions)
-      );
+      const viewerModel = viewer.models.find((pointCloudModel) => {
+        const pointCloudModelClone = {
+          ...pointCloudModel,
+          transform: pointCloudModel.getModelTransformation()
+        };
+        return isSameModel(pointCloudModelClone, addModelOptions);
+      });
 
       if (viewerModel !== undefined) {
         return await Promise.resolve(viewerModel as CognitePointCloudModel<DataSourceType>);

--- a/react-components/src/components/RevealToolbar/SlicerButton.tsx
+++ b/react-components/src/components/RevealToolbar/SlicerButton.tsx
@@ -130,6 +130,15 @@ const StyledMenu = styled(Menu)`
   .cogs-v10.cogs-slider .rc-slider-rail {
     height: 100% !important;
     width: 4px !important;
+  }
+
+  .cogs-v10.cogs-slider .rc-slider-track {
+    left: auto !important;
+  }
+
+  .cogs-v10.cogs-slider .rc-slider-handle {
+    margin-left: 0.75px !important;
+  }
 `;
 
 const StyledRangeSlider = styled(RangeSlider)`

--- a/react-components/src/components/RevealToolbar/SlicerButton.tsx
+++ b/react-components/src/components/RevealToolbar/SlicerButton.tsx
@@ -121,11 +121,11 @@ const StyledMenu = styled(Menu)`
   max-width: 32px !important;
   min-width: 32px !important;
   padding: 12px 8px 12px 8px !important;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  overflow: hidden !important;
+  display: flex !important;
+  flex-direction: column !important;
+  justify-content: center !important;
+  align-items: center !important;
 
   .cogs-v10.cogs-slider .rc-slider-rail {
     height: 100% !important;
@@ -135,8 +135,8 @@ const StyledMenu = styled(Menu)`
 const StyledRangeSlider = styled(RangeSlider)`
   height: 100% !important;
   width: 4px !important;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
+  display: flex !important;
+  flex-direction: row !important;
+  justify-content: center !important;
 }
 `;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-4996

## Description :pencil:
In `Search` app, when switching between list view to 3D, all Cad and point-cloud model was added each time. The issue was related to check in `isSameModel` where `transform` value from `viewer.model` passed was incorrect.

## How has this been tested? :mag:

In `Search` app


## Test instructions :information_source:

Use `yalc` link

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
