### PR TITLE
fix(react-components): improved performance of asset search slowness

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.73.13",
+  "version": "0.73.14",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
@@ -18,7 +18,7 @@ import { getAssetsList } from '../hooks/network/getAssetsList';
 import { isDefined } from '../utilities/isDefined';
 import { uniqBy } from 'lodash';
 import { useAssetMappedNodesForRevisions } from '../hooks/cad';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef } from 'react';
 
 export type ModelMappings = {
   model: AddModelOptions;
@@ -58,7 +58,7 @@ export const useSearchMappedEquipmentAssetMappings = (
     );
   }, [assetMappingList]);
 
-  const [unmappedAssetIds, setUnmappedAssetIds] = useState(new Set<number>());
+  const unmappedAssetIdsRef = useRef(new Set<number>());
 
   const queryKey = useMemo(
     () => [
@@ -83,7 +83,7 @@ export const useSearchMappedEquipmentAssetMappings = (
 
     const fetchedAssets = assetsResponse.items.filter(isDefined);
     const filteredSearchedAssets = fetchedAssets.filter(
-      (asset) => assetIds.has(asset.id) && !unmappedAssetIds.has(asset.id)
+      (asset) => assetIds.has(asset.id) && !unmappedAssetIdsRef.current.has(asset.id)
     );
 
     const uniqueAssets = uniqBy(
@@ -95,13 +95,11 @@ export const useSearchMappedEquipmentAssetMappings = (
       return { assets: uniqueAssets, nextCursor: assetsResponse.nextCursor };
     }
 
-    const newUnmappedAssetIds = new Set(unmappedAssetIds);
     fetchedAssets.forEach((asset) => {
       if (!assetIds.has(asset.id)) {
-        newUnmappedAssetIds.add(asset.id);
+        unmappedAssetIdsRef.current.add(asset.id);
       }
     });
-    setUnmappedAssetIds(newUnmappedAssetIds);
 
     return await fetchAssets(assetsResponse.nextCursor, uniqueAssets);
   };


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5057

## Description :pencil:
When there are `100000` or more assets in the project and user `search` for a specific `asset` with string `query` in search inputs in 3D page of `Search` application, it is taking long duration to filter the `assets`, this PR improves the filtering of searched query assets in the search hook

## How has this been tested? :mag:

In Search application


## Test instructions :information_source:

- `yarn build` react-components
- update `package.json` file in `fusion` repo with  `"@cognite/reveal-react-components": "file:../reveal/react-components"`
- `run pnpm install && pnpm nx serve flexible-data-explorer`
- Open 3D page in `Search` application with more than `40000` assets in project ( like `cog-3d`)
- search for a string in 3D search, results should be listed much quicker than production build


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
