### PR TITLE
fix: find annotation for selected asset for data model source

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "4.23.1",
+  "version": "4.23.2",
   "description": "WebGL based 3D viewer for CAD and point clouds processed in Cognite Data Fusion.",
   "homepage": "https://github.com/cognitedata/reveal/tree/master/viewer",
   "repository": {

--- a/viewer/packages/data-providers/src/DataSourceType.ts
+++ b/viewer/packages/data-providers/src/DataSourceType.ts
@@ -141,3 +141,7 @@ export function isDMIdentifier(identifier: InternalModelIdentifier): identifier 
 export function isLocalIdentifier(identifier: InternalModelIdentifier): identifier is LocalModelIdentifierType {
   return (identifier as LocalModelIdentifierType).localPath !== undefined;
 }
+
+export function isSameDMIdentifier(id0: DMInstanceRef, id1: DMInstanceRef): boolean {
+  return id0.externalId === id1.externalId && id0.space === id1.space;
+}

--- a/viewer/packages/data-providers/src/image-360-data-providers/cdm/fetchAnnotationsForInstance.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/cdm/fetchAnnotationsForInstance.ts
@@ -59,12 +59,12 @@ function getImage360AnnotationsForInstanceQuery(instance: DMInstanceRef) {
       },
       object3ds: {
         nodes: {
-          from: 'instance_objects',
+          from: 'instance_object',
           through: { view: COGNITE_VISUALIZABLE_SOURCE, identifier: 'object3D' },
           direction: 'outwards'
         }
       },
-      annotation_dges: {
+      annotation_edges: {
         edges: {
           from: 'object3ds',
           direction: 'outwards',


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
Find annotation objects would return all annotation object within the Image entity (station) for selected asset in data model source type, this PR fixes the issue by filter the annotation for selected asset identifier

## How has this been tested? :mag:

In Search application


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have performed a self-review of my own code.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
