### PR TITLE
Feat(react-components): Prepare the existing domain object for the tree view

### DIFF
--- a/react-components/src/architecture/base/domainObjects/DomainObject.ts
+++ b/react-components/src/architecture/base/domainObjects/DomainObject.ts
@@ -83,7 +83,6 @@ export abstract class DomainObject {
     DomainObject._counter++;
     this._uniqueId = DomainObject._counter;
   }
-
   // ==================================================
   // INSTANCE/VIRTUAL PROPERTIES
   // ==================================================
@@ -252,6 +251,10 @@ export abstract class DomainObject {
   // ==================================================
   // VIRTUAL METHODS: Appearance in the tree view
   // ==================================================
+
+  public get isVisibleInTree(): boolean {
+    return true; // to be overridden
+  }
 
   public get canBeRemoved(): boolean {
     return true; // to be overridden

--- a/react-components/src/architecture/concrete/annotation360/Image360AnnotationDomainObject.ts
+++ b/react-components/src/architecture/concrete/annotation360/Image360AnnotationDomainObject.ts
@@ -12,6 +12,7 @@ import { LineRenderStyle } from '../primitives/line/LineRenderStyle';
 import { createTriangleIndexesFromVectors } from './createTriangleIndexesFromVectors';
 import { type AnnotationIdentifier, type AssetIdentifier, type AnnotationStatus } from './types';
 import { type DmsUniqueIdentifier } from '../../../data-providers';
+import { type IconName } from '../../base/utilities/IconName';
 
 const DEFAULT_VECTOR_LENGTH = 5;
 
@@ -33,13 +34,31 @@ export class Image360AnnotationDomainObject extends LineDomainObject {
 
   public constructor(connectedImageId: string | DmsUniqueIdentifier) {
     super(PrimitiveType.Polygon);
-    this.color = new Color(Color.NAMES.yellow);
     this.connectedImageId = connectedImageId;
   }
 
   // ==================================================
   // OVERRIDES
   // ==================================================
+
+  public override get icon(): IconName {
+    return 'Polygon';
+  }
+
+  public override get color(): Color {
+    switch (this.status) {
+      case 'suggested':
+        return new Color(Color.NAMES.yellow);
+      case 'saved':
+        return new Color('0xd46ae2');
+      case 'pending':
+        return new Color('0x4da6ff');
+      case 'deleted':
+        return new Color(Color.NAMES.red);
+      default:
+        return new Color(Color.NAMES.gray);
+    }
+  }
 
   public override get typeName(): TranslationInput {
     return { untranslated: '360 image annotation' };

--- a/react-components/src/architecture/concrete/annotations/BoxGizmoDomainObject.ts
+++ b/react-components/src/architecture/concrete/annotations/BoxGizmoDomainObject.ts
@@ -65,6 +65,10 @@ export class BoxGizmoDomainObject extends BoxDomainObject {
     return [new CopyToClipboardCommand(), new ToggleMetricUnitsCommand()];
   }
 
+  public override get isVisibleInTree(): boolean {
+    return false;
+  }
+
   // ==================================================
   // OVERRIDES of VisualDomainObject
   // ==================================================

--- a/react-components/src/architecture/concrete/annotations/CylinderGizmoDomainObject.ts
+++ b/react-components/src/architecture/concrete/annotations/CylinderGizmoDomainObject.ts
@@ -65,6 +65,10 @@ export class CylinderGizmoDomainObject extends CylinderDomainObject {
     return [new CopyToClipboardCommand(), new ToggleMetricUnitsCommand()];
   }
 
+  public override get isVisibleInTree(): boolean {
+    return false;
+  }
+
   // ==================================================
   // OVERRIDES of VisualDomainObject
   // ==================================================

--- a/react-components/src/architecture/concrete/axis/AxisDomainObject.ts
+++ b/react-components/src/architecture/concrete/axis/AxisDomainObject.ts
@@ -4,6 +4,7 @@
 
 import { VisualDomainObject } from '../../base/domainObjects/VisualDomainObject';
 import { type RenderStyle } from '../../base/renderStyles/RenderStyle';
+import { type IconName } from '../../base/utilities/IconName';
 import { type TranslationInput } from '../../base/utilities/TranslateInput';
 import { type ThreeView } from '../../base/views/ThreeView';
 import { AxisRenderStyle } from './AxisRenderStyle';
@@ -16,6 +17,10 @@ export class AxisDomainObject extends VisualDomainObject {
 
   public override get typeName(): TranslationInput {
     return { untranslated: 'Axis' };
+  }
+
+  public override get icon(): IconName {
+    return 'Axis3D';
   }
 
   public override createRenderStyle(): RenderStyle | undefined {

--- a/react-components/src/architecture/concrete/clipping/ClipFolder.ts
+++ b/react-components/src/architecture/concrete/clipping/ClipFolder.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright 2025 Cognite AS
+ */
+
+import { FolderDomainObject } from '../../base/domainObjects/FolderDomainObject';
+import { type TranslationInput } from '../../base/utilities/TranslateInput';
+
+export class ClipFolder extends FolderDomainObject {
+  public override get typeName(): TranslationInput {
+    return { untranslated: 'Crop boxes and clipping planes' };
+  }
+}

--- a/react-components/src/architecture/concrete/clipping/ClipTool.ts
+++ b/react-components/src/architecture/concrete/clipping/ClipTool.ts
@@ -20,7 +20,7 @@ import { UndoCommand } from '../../base/concreteCommands/UndoCommand';
 import { NextOrPrevClippingCommand } from './commands/NextClippingCommand';
 import { type IconName } from '../../base/utilities/IconName';
 import { ClipFolder } from './ClipFolder';
-import { DomainObject } from '../../base/domainObjects/DomainObject';
+import { type DomainObject } from '../../base/domainObjects/DomainObject';
 
 export class ClipTool extends PrimitiveEditTool {
   // ==================================================

--- a/react-components/src/architecture/concrete/clipping/ClipTool.ts
+++ b/react-components/src/architecture/concrete/clipping/ClipTool.ts
@@ -19,6 +19,8 @@ import { SliceDomainObject } from './SliceDomainObject';
 import { UndoCommand } from '../../base/concreteCommands/UndoCommand';
 import { NextOrPrevClippingCommand } from './commands/NextClippingCommand';
 import { type IconName } from '../../base/utilities/IconName';
+import { ClipFolder } from './ClipFolder';
+import { DomainObject } from '../../base/domainObjects/DomainObject';
 
 export class ClipTool extends PrimitiveEditTool {
   // ==================================================
@@ -83,6 +85,16 @@ export class ClipTool extends PrimitiveEditTool {
   // ==================================================
   // OVERRIDES of PrimitiveEditTool
   // ==================================================
+
+  protected override getOrCreateParent(): DomainObject {
+    const parent = this.rootDomainObject.getDescendantByType(ClipFolder);
+    if (parent !== undefined) {
+      return parent;
+    }
+    const newParent = new ClipFolder();
+    this.renderTarget.rootDomainObject.addChildInteractive(newParent);
+    return newParent;
+  }
 
   protected override createCreator(): BaseCreator | undefined {
     switch (this.primitiveType) {

--- a/react-components/src/architecture/concrete/measurements/MeasurementFolder.ts
+++ b/react-components/src/architecture/concrete/measurements/MeasurementFolder.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright 2025 Cognite AS
+ */
+
+import { FolderDomainObject } from '../../base/domainObjects/FolderDomainObject';
+import { type TranslationInput } from '../../base/utilities/TranslateInput';
+
+export class MeasurementFolder extends FolderDomainObject {
+  public override get typeName(): TranslationInput {
+    return { untranslated: 'Measurements' };
+  }
+}

--- a/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
+++ b/react-components/src/architecture/concrete/measurements/MeasurementTool.ts
@@ -18,6 +18,8 @@ import { CDF_TO_VIEWER_TRANSFORMATION } from '@cognite/reveal';
 import { UndoCommand } from '../../base/concreteCommands/UndoCommand';
 import { type IconName } from '../../base/utilities/IconName';
 import { Box3 } from 'three';
+import { type DomainObject } from '../../base/domainObjects/DomainObject';
+import { MeasurementFolder } from './MeasurementFolder';
 
 export class MeasurementTool extends PrimitiveEditTool {
   // ==================================================
@@ -98,6 +100,16 @@ export class MeasurementTool extends PrimitiveEditTool {
   // ==================================================
   // OVERRIDES of PrimitiveEditTool
   // ==================================================
+
+  protected override getOrCreateParent(): DomainObject {
+    const parent = this.rootDomainObject.getDescendantByType(MeasurementFolder);
+    if (parent !== undefined) {
+      return parent;
+    }
+    const newParent = new MeasurementFolder();
+    this.renderTarget.rootDomainObject.addChildInteractive(newParent);
+    return newParent;
+  }
 
   protected override createCreator(): BaseCreator | undefined {
     switch (this.primitiveType) {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:

https://cognitedata.atlassian.net/browse/

## Description :pencil:

Measurement and Crop box get a specific parent.
Add icon where it was missing so correct icon show up in the tree

