### PR TITLE
feat(react-components): Adding domain objects of Cad, PointCloud and 3D images

### DIFF
--- a/react-components/src/architecture/concrete/cad/CadDomainObject.ts
+++ b/react-components/src/architecture/concrete/cad/CadDomainObject.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { type CogniteCadModel } from '@cognite/reveal';
+import { VisualDomainObject } from '../../base/domainObjects/VisualDomainObject';
+import { type RenderStyle } from '../../base/renderStyles/RenderStyle';
+import { type IconName } from '../../base/utilities/IconName';
+import { type TranslationInput } from '../../base/utilities/TranslateInput';
+import { type ThreeView } from '../../base/views/ThreeView';
+import { CadRenderStyle } from './CadRenderStyle';
+import { CadThreeView } from './CadThreeView';
+
+export class CadDomainObject extends VisualDomainObject {
+  // ==================================================
+  // INSTANCE FIELDS
+  // ==================================================
+
+  readonly modelId: number;
+  readonly revisionId: number;
+
+  // ==================================================
+  // INSTANCE PROPERTIES
+  // ==================================================
+
+  public get model(): CogniteCadModel | undefined {
+    const root = this.rootDomainObject;
+    if (root === undefined) {
+      return undefined;
+    }
+    for (const model of root.renderTarget.getCadModels()) {
+      if (model.modelId === this.modelId && model.revisionId === this.revisionId) {
+        return model;
+      }
+    }
+    return undefined;
+  }
+
+  // ==================================================
+  // CONSTRUCTORS
+  // ==================================================
+
+  public constructor(modelId: number, revisionId: number) {
+    super();
+    this.modelId = modelId;
+    this.revisionId = revisionId;
+  }
+
+  // ==================================================
+  // OVERRIDES of DomainObject
+  // ==================================================
+
+  public override get typeName(): TranslationInput {
+    return { untranslated: 'Cad' };
+  }
+
+  public override get icon(): IconName {
+    return 'Cubes';
+  }
+
+  public override createRenderStyle(): RenderStyle | undefined {
+    return new CadRenderStyle();
+  }
+
+  // ==================================================
+  // OVERRIDES of VisualDomainObject
+  // ==================================================
+
+  protected override createThreeView(): ThreeView | undefined {
+    return new CadThreeView();
+  }
+}

--- a/react-components/src/architecture/concrete/cad/CadRenderStyle.ts
+++ b/react-components/src/architecture/concrete/cad/CadRenderStyle.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { cloneDeep } from 'lodash';
+import { RenderStyle } from '../../base/renderStyles/RenderStyle';
+
+export class CadRenderStyle extends RenderStyle {
+  public override clone(): RenderStyle {
+    return cloneDeep<CadRenderStyle>(this);
+  }
+}

--- a/react-components/src/architecture/concrete/cad/CadThreeView.ts
+++ b/react-components/src/architecture/concrete/cad/CadThreeView.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { type CadRenderStyle } from './CadRenderStyle';
+import { type DomainObjectChange } from '../../base/domainObjectsHelpers/DomainObjectChange';
+import { Changes } from '../../base/domainObjectsHelpers/Changes';
+import { type CadDomainObject } from './CadDomainObject';
+import { ThreeView } from '../../base/views/ThreeView';
+import { Box3 } from 'three';
+import { type CogniteCadModel } from '@cognite/reveal';
+
+export class CadThreeView extends ThreeView<CadDomainObject> {
+  // ==================================================
+  // INSTANCE PROPERTIES
+  // ==================================================
+
+  protected override get style(): CadRenderStyle {
+    return super.style as CadRenderStyle;
+  }
+
+  public get model(): CogniteCadModel | undefined {
+    const domainObject = this.domainObject;
+    return domainObject.model;
+  }
+
+  // ==================================================
+  // OVERRIDES of BaseView
+  // ==================================================
+
+  public override update(change: DomainObjectChange): void {
+    super.update(change);
+    if (change.isChanged(Changes.renderStyle)) {
+      this.invalidateRenderTarget();
+    }
+  }
+
+  public override onShow(): void {
+    const model = this.model;
+    if (model === undefined) {
+      return;
+    }
+    super.onShow();
+    model.visible = true;
+  }
+
+  public override onHide(): void {
+    const model = this.model;
+    if (model === undefined) {
+      return;
+    }
+    model.visible = false;
+    super.onHide();
+  }
+
+  // ==================================================
+  // OVERRIDES of ThreeView
+  // ==================================================
+
+  protected override calculateBoundingBox(): Box3 {
+    const model = this.model;
+    if (model === undefined) {
+      return new Box3().makeEmpty();
+    }
+    const boundingBox = new Box3();
+    return model.getModelBoundingBox(boundingBox, true);
+  }
+}

--- a/react-components/src/architecture/concrete/pointCloud/PointCloudDomainObject.ts
+++ b/react-components/src/architecture/concrete/pointCloud/PointCloudDomainObject.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { type CognitePointCloudModel, type DataSourceType } from '@cognite/reveal';
+import { VisualDomainObject } from '../../base/domainObjects/VisualDomainObject';
+import { type RenderStyle } from '../../base/renderStyles/RenderStyle';
+import { type IconName } from '../../base/utilities/IconName';
+import { type TranslationInput } from '../../base/utilities/TranslateInput';
+import { type ThreeView } from '../../base/views/ThreeView';
+import { PointCloudRenderStyle } from './PointCloudRenderStyle';
+import { PointCloudThreeView } from './PointCloudThreeView';
+
+type PointCloud = CognitePointCloudModel<DataSourceType>;
+
+export class PointCloudDomainObject extends VisualDomainObject {
+  // ==================================================
+  // INSTANCE PROPERTIES
+  // ==================================================
+
+  public get pointCloud(): PointCloud | undefined {
+    const root = this.rootDomainObject;
+    if (root === undefined) {
+      return undefined;
+    }
+    for (const pointCloud of root.renderTarget.getPointClouds()) {
+      if (pointCloud !== undefined) {
+        return pointCloud;
+      }
+    }
+    return undefined;
+  }
+
+  // ==================================================
+  // CONSTRUCTORS
+  // ==================================================
+
+  public constructor() {
+    super();
+  }
+
+  // ==================================================
+  // OVERRIDES of DomainObject
+  // ==================================================
+
+  public override get typeName(): TranslationInput {
+    return { untranslated: 'PointCloud' };
+  }
+
+  public override get icon(): IconName {
+    return 'PointCloud';
+  }
+
+  public override createRenderStyle(): RenderStyle | undefined {
+    return new PointCloudRenderStyle();
+  }
+
+  // ==================================================
+  // OVERRIDES of VisualDomainObject
+  // ==================================================
+
+  protected override createThreeView(): ThreeView | undefined {
+    return new PointCloudThreeView();
+  }
+}

--- a/react-components/src/architecture/concrete/pointCloud/PointCloudRenderStyle.ts
+++ b/react-components/src/architecture/concrete/pointCloud/PointCloudRenderStyle.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { cloneDeep } from 'lodash';
+import { RenderStyle } from '../../base/renderStyles/RenderStyle';
+
+export class PointCloudRenderStyle extends RenderStyle {
+  public override clone(): RenderStyle {
+    return cloneDeep<PointCloudRenderStyle>(this);
+  }
+}

--- a/react-components/src/architecture/concrete/pointCloud/PointCloudThreeView.ts
+++ b/react-components/src/architecture/concrete/pointCloud/PointCloudThreeView.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { type PointCloudRenderStyle } from './PointCloudRenderStyle';
+import { type DomainObjectChange } from '../../base/domainObjectsHelpers/DomainObjectChange';
+import { Changes } from '../../base/domainObjectsHelpers/Changes';
+import { type PointCloudDomainObject } from './PointCloudDomainObject';
+import { ThreeView } from '../../base/views/ThreeView';
+import { Box3 } from 'three';
+import { type CognitePointCloudModel, type DataSourceType } from '@cognite/reveal';
+
+export class PointCloudThreeView extends ThreeView<PointCloudDomainObject> {
+  // ==================================================
+  // INSTANCE PROPERTIES
+  // ==================================================
+
+  protected override get style(): PointCloudRenderStyle {
+    return super.style as PointCloudRenderStyle;
+  }
+
+  public get pointCloud(): CognitePointCloudModel<DataSourceType> | undefined {
+    const domainObject = this.domainObject;
+    return domainObject.pointCloud;
+  }
+
+  // ==================================================
+  // OVERRIDES of BaseView
+  // ==================================================
+
+  public override update(change: DomainObjectChange): void {
+    super.update(change);
+    if (change.isChanged(Changes.renderStyle)) {
+      this.invalidateRenderTarget();
+    }
+  }
+
+  public override onShow(): void {
+    const pointCloud = this.pointCloud;
+    if (pointCloud === undefined) {
+      return;
+    }
+    super.onShow();
+    pointCloud.visible = true;
+  }
+
+  public override onHide(): void {
+    const pointCloud = this.pointCloud;
+    if (pointCloud === undefined) {
+      return;
+    }
+    pointCloud.visible = false;
+    super.onHide();
+  }
+
+  // ==================================================
+  // OVERRIDES of ThreeView
+  // ==================================================
+
+  protected override calculateBoundingBox(): Box3 {
+    const pointCloud = this.pointCloud;
+    if (pointCloud === undefined) {
+      return new Box3().makeEmpty();
+    }
+    const boundingBox = new Box3();
+    return pointCloud.getModelBoundingBox(boundingBox);
+  }
+}

--- a/react-components/src/components/Architecture/Factories/DefaultIcons.tsx
+++ b/react-components/src/components/Architecture/Factories/DefaultIcons.tsx
@@ -55,7 +55,8 @@ import {
   VectorLineIcon,
   VectorZigzagIcon,
   View360Icon,
-  WaypointIcon
+  WaypointIcon,
+  CubesIcon
 } from '@cognite/cogs.js';
 
 import { type IconName } from '../../../architecture/base/utilities/IconName';
@@ -76,6 +77,7 @@ export const DefaultIcons: Array<[IconName, IconType]> = [
   ['Copy', CopyIcon],
   ['Crop', CropIcon],
   ['Cube', CubeIcon],
+  ['Cubes', CubesIcon],
   ['CubeFrontLeft', CubeFrontLeftIcon],
   ['CubeFrontRight', CubeFrontRightIcon],
   ['CubeTop', CubeTopIcon],


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:

https://cognitedata.atlassian.net/browse/

## Description :pencil:

* `CadDomainObject `represent `CogniteCadModel`
* `PointCloudDomainObject `represent `PointCloud`

## How has this been tested? :mag:

Not possible to test this yet.

## Test instructions :information_source:

