### PR TITLE
fix: Fix bug in intersection between ray and 360 image icon [BND3D-5179]

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "4.23.2",
+  "version": "4.23.3",
   "description": "WebGL based 3D viewer for CAD and point clouds processed in Cognite Data Fusion.",
   "homepage": "https://github.com/cognitedata/reveal/tree/master/viewer",
   "repository": {

--- a/viewer/packages/360-images/src/Image360Facade.ts
+++ b/viewer/packages/360-images/src/Image360Facade.ts
@@ -216,11 +216,13 @@ export class Image360Facade<T extends DataSourceType> {
       intersectionPoint: THREE.Vector3,
       cameraPosition: THREE.Vector3
     ): Image360IconIntersectionData<T> {
+      const matrix = image360Collection.getModelTransformation();
+      const point = intersectionPoint.clone().add(cameraPosition).applyMatrix4(matrix);
       return {
         image360,
         image360Collection,
-        point: intersectionPoint,
-        distanceToCamera: intersectionPoint.distanceTo(cameraPosition)
+        point,
+        distanceToCamera: point.distanceTo(cameraPosition)
       };
     }
   }

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1684,7 +1684,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     }
   ): Promise<AnyIntersection<DataSourceT> | undefined> {
     const image360IconIntersection = this.intersect360Icons(pixelCoords);
-    if (this.intersect360Icons(pixelCoords) !== undefined) {
+    if (image360IconIntersection !== undefined) {
       return image360IconIntersection;
     }
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
](https://cognitedata.atlassian.net/browse/BND3D-5179)

## Description :pencil:

The intersection point was calculated wrong (wrong coordinate system and also substracted the camera position)

## How has this been tested? :mag:


Use example app in Reveal and scroll mouse when mouse hover over the 360 icons.