### PR TITLE
fix(react-components): Fix wrong color type in image360 annotation domain object

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.75.2",
+  "version": "0.75.3",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/architecture/concrete/annotation360/Image360AnnotationDomainObject.ts
+++ b/react-components/src/architecture/concrete/annotation360/Image360AnnotationDomainObject.ts
@@ -50,9 +50,9 @@ export class Image360AnnotationDomainObject extends LineDomainObject {
       case 'suggested':
         return new Color(Color.NAMES.yellow);
       case 'saved':
-        return new Color('0xd46ae2');
+        return new Color(0xd46ae2);
       case 'pending':
-        return new Color('0x4da6ff');
+        return new Color(0x4da6ff);
       case 'deleted':
         return new Color(Color.NAMES.red);
       default:


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
Fixes bug where Three JS color was instantiated using a string instead of a number thus making the color default to white

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
