### PR TITLE
chore(react-components): removed lint warning in test files

### DIFF
--- a/react-components/tests/unit-tests/fixtures/fdmNodeCache.ts
+++ b/react-components/tests/unit-tests/fixtures/fdmNodeCache.ts
@@ -9,7 +9,7 @@ import {
 import { type DmsUniqueIdentifier } from '../../../src/data-providers';
 
 const fdmNodeCacheMock = new Mock<FdmNodeCache>()
-  .setup((instance) => instance.getAllMappingExternalIds)
+  .setup((instance) => instance.getAllMappingExternalIds.bind(instance))
   .returns(
     async (
       modelRevisionIds: Array<{ modelId: number; revisionId: number }>,
@@ -40,7 +40,7 @@ const fdmNodeCacheMock = new Mock<FdmNodeCache>()
       );
     }
   )
-  .setup((instance) => instance.getClosestParentDataPromises)
+  .setup((instance) => instance.getClosestParentDataPromises.bind(instance))
   .returns((modelId: number, revisionId: number, treeIndex: number) => {
     return {
       modelId,
@@ -51,7 +51,7 @@ const fdmNodeCacheMock = new Mock<FdmNodeCache>()
       viewsPromise: Promise.resolve([])
     };
   })
-  .setup((instance) => instance.getMappingsForFdmInstances)
+  .setup((instance) => instance.getMappingsForFdmInstances.bind(instance))
   .returns(
     async (fdmAssetExternalIds: DmsUniqueIdentifier[], modelRevisionIds: ModelRevisionId[]) => {
       return modelRevisionIds.map((model) => ({

--- a/react-components/tests/unit-tests/fixtures/renderTarget.ts
+++ b/react-components/tests/unit-tests/fixtures/renderTarget.ts
@@ -16,13 +16,13 @@ const cdfCachesMock = new Mock<CdfCaches>()
   .object();
 
 const commandsControllerMock = new Mock<CommandsController>()
-  .setup((p) => p.update)
+  .setup((p) => p.update.bind(p))
   .returns(vi.fn())
-  .setup((p) => p.addEventListeners)
+  .setup((p) => p.addEventListeners.bind(p))
   .returns(vi.fn())
-  .setup((p) => p.removeEventListeners)
+  .setup((p) => p.removeEventListeners.bind(p))
   .returns(vi.fn())
-  .setup((p) => p.dispose)
+  .setup((p) => p.dispose.bind(p))
   .returns(vi.fn())
   .object();
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
Remove `lint` warning in test files in `react-components`

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am proud of this feature.
- [ ] I have performed a self-review of my own code.
- [ ] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.
- [ ] I have manually tested this for different scenarios (different models, formats, devices, browsers).
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the public documentation.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have refactored the code for readability to the best of my ability.
- [ ] I have checked that my changes do not introduce regressions in the public documentation.
- [ ] I have outlined any known defects / lacking capabilities in the contents of this PR.
- [ ] I have listed any remaining work that should follow this PR in the description or jira/miro/etc.
- [ ] I have added TSDoc to any public facing changes.
- [ ] I have added "developer documentation" in any package README.md that is related / applicable to this PR.
- [ ] I have noted down and am currently tracking any technical debt introduced in this PR.
- [ ] I have thoroughly thought about the architecture of this implementation.
- [ ] I have asked peers to test this feature.
