### PR TITLE
chore: make react-components CI trigger during CD for codecov updates

### DIFF
--- a/.github/workflows/react-components-ci.yml
+++ b/.github/workflows/react-components-ci.yml
@@ -1,6 +1,8 @@
 name: React Components CI
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/react-components-ci.yml
+++ b/.github/workflows/react-components-ci.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      should-run: ${{ steps.filter.outputs.should-run }}
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.should-run }}
     steps:
       # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5450

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Trigger react components CI step in CD as well to update codecov base branch. Currently the base commit on codecov is very old, due to coverage reports being connected to a specific commit which gets squashed away. Simply running the codecov in CD should tag commits in the master branch with codecov info.