### PR TITLE
chore: only run changes step on PR

### DIFF
--- a/.github/workflows/react-components-ci.yml
+++ b/.github/workflows/react-components-ci.yml
@@ -18,6 +18,7 @@ jobs:
       # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@v3
         id: filter
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           filters: |
             should-run:


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5450

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

This makes the dorny/paths-filter@v3 step only run during PRs. For CD codecov reports(and rest of steps) should be done regardless. Currently updating the base commit for codecov never happens due to the step failing in during CD. This PR attempts to rectify this. 
