### PR TITLE
chore(react-components): make signals a dependency

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.75.5",
+  "version": "0.75.6",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -34,7 +34,6 @@
   },
   "peerDependencies": {
     "@cognite/reveal": "4.23.2",
-    "@cognite/signals": "^0.0.4",
     "react": ">=18",
     "react-dom": ">=18",
     "styled-components": "^6.1.12"
@@ -42,6 +41,7 @@
   "dependencies": {
     "@cognite/cogs-lab": "^9.0.0-alpha.153",
     "@cognite/cogs.js": "^10.36.0",
+    "@cognite/signals": "^0.0.4",
     "@floating-ui/dom": "^1.0.0",
     "@tanstack/react-query": "^5.32.0",
     "assert": "^2.1.0",
@@ -54,7 +54,6 @@
     "@cognite/cdf-utilities": "^3.6.0",
     "@cognite/reveal": "^4.23.2",
     "@cognite/sdk": "^9.13.0",
-    "@cognite/signals": "^0.0.4",
     "@playwright/test": "1.49.0",
     "@storybook/addon-essentials": "8.4.5",
     "@storybook/addon-interactions": "8.4.5",

--- a/react-components/yarn.lock
+++ b/react-components/yarn.lock
@@ -679,7 +679,6 @@ __metadata:
     vitest: "npm:^3.0.6"
   peerDependencies:
     "@cognite/reveal": 4.23.2
-    "@cognite/signals": ^0.0.4
     react: ">=18"
     react-dom: ">=18"
     styled-components: ^6.1.12


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

~~Due to inconceivable shenaniganery in the `@cognite/signals` package, we're just making it a regular dependency.~~

`@cognite/reveal-react-components` has problems with resolving `@cognite/signals` properly as a peer dependency in Fusion. We make it a `dependency` again to simplify the setup for now, but we will bring this up with the `signals` developers in the future to see if there's a way around this.

Follow-up task: https://cognitedata.atlassian.net/browse/BND3D-5489

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am proud of this feature.
- [x] I have added PR type (Feat, Bug, Chore, Test, Docs, Style, Refactor) to the PR title.

