### PR TITLE
fix: layers drop down mounting outside of layers button parent

### DIFF
--- a/react-components/src/components/Architecture/BannerComponent.test.tsx
+++ b/react-components/src/components/Architecture/BannerComponent.test.tsx
@@ -39,7 +39,7 @@ describe(BannerComponent.name, () => {
     const testCommand = new TestBannerCommand({ status });
     render(<BannerComponent command={testCommand} t={getTranslationKeyOrString} />, { wrapper });
 
-    const bannerElement = (await screen.findAllByRole('alert'))[1];
+    const bannerElement = await screen.findByRole('alert');
     expect([...bannerElement.classList]).toContain('cogs-lab-infobox-critical');
   });
 });

--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2025 Cognite AS
  */
-import { render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import type { ReactElement, ReactNode } from 'react';
 import { LayersButton } from './LayersButton';
@@ -58,13 +58,34 @@ describe(LayersButton.name, () => {
 
   test('renders without crashing', () => {
     const { getByRole } = render(<LayersButton {...defaultProps} />, {
-      wrapper: ({ children }: { children: ReactNode }) => wrapper({ children })
+      wrapper
     });
 
     // Validate the presence of specific UI elements
     expect(
       getByRole('button', { name: 'Filter 3D resource layers' }).className.includes('cogs-button')
     ).toBe(true);
+  });
+
+  test('Layers drop down should mount under the same parent as button', async () => {
+    render(
+      <div data-test-id="layers-button">
+        <LayersButton {...defaultProps} />
+      </div>,
+      {
+        wrapper
+      }
+    );
+
+    // find button with aria-label Filter 3D resource layers and click it
+    const button = screen.getByRole('button', { name: 'Filter 3D resource layers' });
+    await act(async () => {
+      button.click();
+    });
+
+    const cadModels = screen.getByText('CAD models');
+
+    expect(cadModels.closest('[data-test-id="layers-button"]')).not.toBeNull();
   });
 
   test('should update viewer models visibility when layersState changes', () => {
@@ -87,7 +108,7 @@ describe(LayersButton.name, () => {
     };
 
     const { rerender } = render(<LayersButton {...defaultProps} />, {
-      wrapper: ({ children }) => wrapper({ children, dependencies: newProps })
+      wrapper
     });
 
     // Change layersState

--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
@@ -81,7 +81,6 @@ describe(LayersButton.name, () => {
     await userEvent.click(screen.getByRole('button', { name: 'Filter 3D resource layers' }));
 
     const cadModels = screen.getByText('CAD models');
-
     expect(cadModels.closest('[data-test-id="layers-button"]')).not.toBeNull();
   });
 

--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
@@ -77,7 +77,6 @@ describe(LayersButton.name, () => {
       }
     );
 
-    // find button with aria-label Filter 3D resource layers and click it
     const button = screen.getByRole('button', { name: 'Filter 3D resource layers' });
     await act(async () => {
       button.click();

--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2025 Cognite AS
  */
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import type { ReactElement, ReactNode } from 'react';
 import { LayersButton } from './LayersButton';

--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.test.tsx
@@ -7,6 +7,7 @@ import type { ReactElement, ReactNode } from 'react';
 import { LayersButton } from './LayersButton';
 import type { LayersButtonProps } from './LayersButton';
 import { LayersButtonContext, type LayersButtonDependencies } from './LayersButton.context';
+import userEvent from '@testing-library/user-event';
 
 import { type ModelLayerHandlers } from './types';
 import { cadMock } from '#test-utils/fixtures/cadModel';
@@ -77,10 +78,7 @@ describe(LayersButton.name, () => {
       }
     );
 
-    const button = screen.getByRole('button', { name: 'Filter 3D resource layers' });
-    await act(async () => {
-      button.click();
-    });
+    await userEvent.click(screen.getByRole('button', { name: 'Filter 3D resource layers' }));
 
     const cadModels = screen.getByText('CAD models');
 

--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.tsx
@@ -31,11 +31,7 @@ export const LayersButton = ({
 
   return (
     <>
-      <SelectPanel
-        placement="right"
-        appendTo={'parent'}
-        hideOnOutsideClick
-        offset={TOOLBAR_HORIZONTAL_PANEL_OFFSET}>
+      <SelectPanel placement="right" hideOnOutsideClick offset={TOOLBAR_HORIZONTAL_PANEL_OFFSET}>
         <SelectPanel.Trigger>
           <Tooltip
             content={<LabelWithShortcut label={t({ key: 'LAYERS_FILTER_TOOLTIP' })} />}

--- a/react-components/vite.config.ts
+++ b/react-components/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(({ command }) => {
     test: {
       include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
       environment: 'happy-dom',
+      globals: true,
       reporters: ['default'],
       coverage: {
         reportsDirectory: '../coverage/reveal-react-components',


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an issue where the drop down spawned from the Layers Button mounts outside of the dom hierachy of the component. In Unified-3d, this causes it to mount outside of the style scope which breaks styles.
Is needed for [BND3D-5620](https://cognitedata.atlassian.net/browse/BND3D-5620)

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Added unit test.

[BND3D-5620]: https://cognitedata.atlassian.net/browse/BND3D-5620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ