### PR TITLE
refactor(react-components): more test util import path replacements

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -8,7 +8,8 @@
     }
   },
   "imports": {
-    "#test-utils/*": "./tests/tests-utilities/*.ts"
+    "#test-utils/*": "./tests/tests-utilities/*.ts",
+    "#test-components/*": "./tests/tests-utilities/*.tsx"
   },
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/react-components/src/architecture/base/utilities/extensions/rayExtensions.test.ts
+++ b/react-components/src/architecture/base/utilities/extensions/rayExtensions.test.ts
@@ -1,7 +1,7 @@
 import { Ray, Vector3 } from 'three';
 import { describe, test } from 'vitest';
 import { getClosestPointOnLine } from './rayExtensions';
-import { expectEqualVector3 } from '../../../../../tests/tests-utilities/primitives/primitiveTestUtil';
+import { expectEqualVector3 } from '#test-utils/primitives/primitiveTestUtil';
 
 describe('getClosestPointOnLine', () => {
   test('should get closest when orthogonal', () => {

--- a/react-components/src/architecture/base/utilities/extensions/vectorExtensions.test.ts
+++ b/react-components/src/architecture/base/utilities/extensions/vectorExtensions.test.ts
@@ -10,7 +10,7 @@ import {
   rotatePiHalf,
   verticalDistanceTo
 } from './vectorExtensions';
-import { expectEqualVector3 } from '../../../../../tests/tests-utilities/primitives/primitiveTestUtil';
+import { expectEqualVector3 } from '#test-utils/primitives/primitiveTestUtil';
 
 describe('vectorExtensions', () => {
   test('should calculate horizontal angle', () => {

--- a/react-components/src/architecture/concrete/primitives/box/BoxView.test.ts
+++ b/react-components/src/architecture/concrete/primitives/box/BoxView.test.ts
@@ -10,12 +10,12 @@ import { FocusType } from '../../../base/domainObjectsHelpers/FocusType';
 import { Changes } from '../../../base/domainObjectsHelpers/Changes';
 import { DomainObjectChange } from '../../../base/domainObjectsHelpers/DomainObjectChange';
 import { CDF_TO_VIEWER_TRANSFORMATION, type CustomObjectIntersectInput } from '@cognite/reveal';
-import { expectEqualVector3 } from '../../../../../tests/tests-utilities/primitives/primitiveTestUtil';
+import { expectEqualVector3 } from '#test-utils/primitives/primitiveTestUtil';
 import {
   addView,
   createIntersectInput,
   expectChildrenLength
-} from '../../../../../tests/tests-utilities/architecture/viewUtil';
+} from '#test-utils/architecture/viewUtil';
 import { isDomainObjectIntersection } from '../../../base/domainObjectsHelpers/DomainObjectIntersection';
 import { PrimitivePickInfo } from '../common/PrimitivePickInfo';
 import { MeasureBoxDomainObject } from '../../measurements/MeasureBoxDomainObject';

--- a/react-components/src/components/Reveal3DResources/hooks/useRemoveNonReferencedModels.test.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useRemoveNonReferencedModels.test.tsx
@@ -14,21 +14,11 @@ import {
   viewerImage360CollectionsMock,
   viewerModelsMock,
   viewerRemoveModelsMock
-} from '../../../../tests/tests-utilities/fixtures/viewer';
-import { createRenderTargetMock } from '../../../../tests/tests-utilities/fixtures/renderTarget';
-import {
-  cadMock,
-  cadModelOptions,
-  createCadMock
-} from '../../../../tests/tests-utilities/fixtures/cadModel';
-import {
-  createImage360ClassicMock,
-  image360ClassicOptions
-} from '../../../../tests/tests-utilities/fixtures/image360';
-import {
-  createPointCloudMock,
-  pointCloudModelOptions
-} from '../../../../tests/tests-utilities/fixtures/pointCloud';
+} from '#test-utils/fixtures/viewer';
+import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
+import { cadMock, cadModelOptions, createCadMock } from '#test-utils/fixtures/cadModel';
+import { createImage360ClassicMock, image360ClassicOptions } from '#test-utils/fixtures/image360';
+import { createPointCloudMock, pointCloudModelOptions } from '#test-utils/fixtures/pointCloud';
 
 describe(useRemoveNonReferencedModels.name, () => {
   beforeEach(() => {

--- a/react-components/src/components/RevealCanvas/ViewerContext.test.tsx
+++ b/react-components/src/components/RevealCanvas/ViewerContext.test.tsx
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeEach } from 'vitest';
 import { useRenderTarget, useReveal, ViewerContextProvider } from './ViewerContext';
 import { type Cognite3DViewer, type DataSourceType } from '@cognite/reveal';
 import { cleanup, render } from '@testing-library/react';
-import { createRenderTargetMock } from '../../../tests/tests-utilities/fixtures/renderTarget';
+import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
 import { type RevealRenderTarget } from '../../architecture';
 import { type ReactElement } from 'react';
 

--- a/react-components/src/components/RevealToolbar/LayersButton/components/LayersButtonsStrip.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/components/LayersButtonsStrip.test.tsx
@@ -9,15 +9,15 @@ import {
   createCadHandlerMock,
   createPointCloudHandlerMock,
   createImage360HandlerMock
-} from '../../../../../tests/tests-utilities/fixtures/modelHandler';
+} from '#test-utils/fixtures/modelHandler';
 import {
   viewerMock,
   viewerImage360CollectionsMock,
   viewerModelsMock
-} from '../../../../../tests/tests-utilities/fixtures/viewer';
+} from '#test-utils/fixtures/viewer';
 import { type CogniteModel } from '@cognite/reveal';
-import { cadMock } from '../../../../../tests/tests-utilities/fixtures/cadModel';
-import { createImage360ClassicMock } from '../../../../../tests/tests-utilities/fixtures/image360';
+import { cadMock } from '#test-utils/fixtures/cadModel';
+import { createImage360ClassicMock } from '#test-utils/fixtures/image360';
 import { LayersButtonStrip } from './LayersButtonsStrip';
 import { type ModelLayerHandlers } from '../types';
 import { type ReactNode, type ReactElement } from 'react';

--- a/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayerSelection.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayerSelection.test.tsx
@@ -4,7 +4,7 @@
 import { render, fireEvent } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { ModelLayerSelection } from './ModelLayerSelection';
-import { createCadHandlerMock } from '../../../../../tests/tests-utilities/fixtures/modelHandler';
+import { createCadHandlerMock } from '#test-utils/fixtures/modelHandler';
 import { SelectPanel } from '@cognite/cogs-lab';
 
 describe(ModelLayerSelection.name, () => {

--- a/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayersButton.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayersButton.test.tsx
@@ -4,7 +4,7 @@
 import { render, fireEvent } from '@testing-library/react';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { ModelLayersButton } from './ModelLayersButton';
-import { createCadHandlerMock } from '../../../../../tests/tests-utilities/fixtures/modelHandler';
+import { createCadHandlerMock } from '#test-utils/fixtures/modelHandler';
 import { type ModelHandler } from '../ModelHandler';
 
 describe(ModelLayersButton.name, () => {

--- a/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayersList.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayersList.test.tsx
@@ -4,7 +4,7 @@
 import { render } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { ModelLayersList } from './ModelLayersList';
-import { createCadHandlerMock } from '../../../../../tests/tests-utilities/fixtures/modelHandler';
+import { createCadHandlerMock } from '#test-utils/fixtures/modelHandler';
 import { SelectPanel } from '@cognite/cogs-lab';
 
 describe(ModelLayersList.name, () => {

--- a/react-components/src/components/RevealToolbar/LayersButton/components/WholeLayerVisibilitySelectItem.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/components/WholeLayerVisibilitySelectItem.test.tsx
@@ -4,7 +4,7 @@
 import { render, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { WholeLayerVisibilitySelectItem } from './WholeLayerVisibilitySelectItem';
-import { createCadHandlerMock } from '../../../../../tests/tests-utilities/fixtures/modelHandler';
+import { createCadHandlerMock } from '#test-utils/fixtures/modelHandler';
 import { SelectPanel } from '@cognite/cogs-lab';
 import { type ModelHandler } from '../ModelHandler';
 

--- a/react-components/src/components/RevealToolbar/LayersButton/hooks/useModelHandlers.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/hooks/useModelHandlers.test.tsx
@@ -12,7 +12,7 @@ import {
 import { type CogniteModel } from '@cognite/reveal';
 import { cadMock, createCadMock } from '#test-utils/fixtures/cadModel';
 import { createImage360ClassicMock } from '#test-utils/fixtures/image360';
-import { wrapper } from '#test-utils/fixtures/wrapper';
+import { wrapper } from '#test-components/fixtures/wrapper';
 import { type LayersUrlStateParam } from '../types';
 import { type Dispatch, type SetStateAction } from 'react';
 import { createPointCloudMock } from '#test-utils/fixtures/pointCloud';

--- a/react-components/src/components/RevealToolbar/LayersButton/hooks/useModelHandlers.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/hooks/useModelHandlers.test.tsx
@@ -8,14 +8,14 @@ import {
   viewerImage360CollectionsMock,
   viewerMock,
   viewerModelsMock
-} from '../../../../../tests/tests-utilities/fixtures/viewer';
+} from '#test-utils/fixtures/viewer';
 import { type CogniteModel } from '@cognite/reveal';
-import { cadMock, createCadMock } from '../../../../../tests/tests-utilities/fixtures/cadModel';
-import { createImage360ClassicMock } from '../../../../../tests/tests-utilities/fixtures/image360';
-import { wrapper } from '../../../../../tests/tests-utilities/fixtures/wrapper';
+import { cadMock, createCadMock } from '#test-utils/fixtures/cadModel';
+import { createImage360ClassicMock } from '#test-utils/fixtures/image360';
+import { wrapper } from '#test-utils/fixtures/wrapper';
 import { type LayersUrlStateParam } from '../types';
 import { type Dispatch, type SetStateAction } from 'react';
-import { createPointCloudMock } from '../../../../../tests/tests-utilities/fixtures/pointCloud';
+import { createPointCloudMock } from '#test-utils/fixtures/pointCloud';
 import { type use3DModelName } from '../../../../query';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { Mock } from 'moq.ts';

--- a/react-components/src/components/RevealToolbar/LayersButton/hooks/useSyncExternalLayersState.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/hooks/useSyncExternalLayersState.test.tsx
@@ -9,7 +9,7 @@ import {
   createPointCloudHandlerMock,
   createImage360HandlerMock
 } from '#test-utils/fixtures/modelHandler';
-import { wrapper } from '#test-utils/fixtures/wrapper';
+import { wrapper } from '#test-components/fixtures/wrapper';
 
 describe(useSyncExternalLayersState.name, () => {
   const mockCadHandler = createCadHandlerMock();

--- a/react-components/src/components/RevealToolbar/LayersButton/hooks/useSyncExternalLayersState.test.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/hooks/useSyncExternalLayersState.test.tsx
@@ -8,8 +8,8 @@ import {
   createCadHandlerMock,
   createPointCloudHandlerMock,
   createImage360HandlerMock
-} from '../../../../../tests/tests-utilities/fixtures/modelHandler';
-import { wrapper } from '../../../../../tests/tests-utilities/fixtures/wrapper';
+} from '#test-utils/fixtures/modelHandler';
+import { wrapper } from '#test-utils/fixtures/wrapper';
 
 describe(useSyncExternalLayersState.name, () => {
   const mockCadHandler = createCadHandlerMock();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->


## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Use the new test-utils import alias in some places that were missed in #5044 

In addition, I had to introduce a second alias, as the first one only covers `.ts`-files, but there is a `.tsx`-files in the utils that we also want to export. If there's a better way to support this than adding a second import, I'd be interested to know.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

By running the tests

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
- [x] I have noted down and am currently tracking any technical debt introduced in this PR.
