### PR TITLE
chore: add codecov token and set codecov project flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: viewer
 
   run-visual-tests:
     needs: [changes, populate-caches]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,8 @@ jobs:
 
       - name: Publish to codecov
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   run-visual-tests:
     needs: [changes, populate-caches]

--- a/.github/workflows/react-components-ci.yml
+++ b/.github/workflows/react-components-ci.yml
@@ -107,6 +107,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: react-components
 
       - name: Install playwright browsers
         working-directory: react-components


### PR DESCRIPTION
#### Type of change
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:

Added two distinct flags (viewer and react-components) to differentiate coverage reports in Codecov.
Fixed the missing token issue by ensuring CODECOV_TOKEN is correctly passed in the workflow.

## How has this been tested? :mag:

Tested during CI with the PR creation


## Test instructions :information_source:

Make sure https://app.codecov.io/gh/cognitedata/reveal shows both modules info


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
