### PR TITLE
feat(react-components): render quality slider

### DIFF
--- a/react-components/src/architecture/base/commands/BaseBannerCommand.ts
+++ b/react-components/src/architecture/base/commands/BaseBannerCommand.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+
+import { IconName } from '../utilities/IconName';
+import { TranslationInput } from '../utilities/TranslateInput';
+import { RenderTargetCommand } from './RenderTargetCommand';
+
+export enum BannerStatus {
+  Critical = 'critical',
+  Neutral = 'neutral',
+  Success = 'success',
+  Warning = 'warning'
+}
+/**
+ * Base class for all option like commands. Override createOptions to add options
+ * or use add method to add them in.
+ */
+
+export abstract class BaseBannerCommand extends RenderTargetCommand {
+  // ==================================================
+  // INSTANCE FIELDS/PROPERTIES
+  // ==================================================
+
+  public abstract get content(): TranslationInput;
+
+  public get status(): BannerStatus {
+    return BannerStatus.Neutral;
+  }
+}

--- a/react-components/src/architecture/base/commands/BaseSliderCommand.ts
+++ b/react-components/src/architecture/base/commands/BaseSliderCommand.ts
@@ -28,6 +28,10 @@ export abstract class BaseSliderCommand extends RenderTargetCommand {
   // VIRTUAL METHODS (To be overridden)
   // =================================================
 
+  public get marks(): Record<number, { label: string }> | undefined {
+    return undefined;
+  }
+
   public abstract get value(): number;
 
   public abstract set value(value: number);

--- a/react-components/src/architecture/base/concreteCommands/SetQualityCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualityCommand.ts
@@ -3,9 +3,9 @@
  */
 
 import { type TranslationInput } from '../utilities/TranslateInput';
-import { type QualitySettings } from '../../../components/RevealToolbar/SettingsContainer/types';
 import { type DataSourceType, type Cognite3DViewer } from '@cognite/reveal';
 import { RenderTargetCommand } from '../commands/RenderTargetCommand';
+import { QualitySettings } from '../utilities/quality/QualitySettings';
 
 export class SetQualityCommand extends RenderTargetCommand {
   // ==================================================

--- a/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/QualityWarningBannerCommand.test.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/QualityWarningBannerCommand.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { QualityWarningBannerCommand } from './QualityWarningBannerCommand';
+import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
+import { type FidelityLevel, getQualityForFidelityLevel, MAX_FIDELITY } from './fidelityLevels';
+import { type RevealRenderTarget } from '../../renderTarget/RevealRenderTarget';
+import { BannerStatus } from '../../commands/BaseBannerCommand';
+import { isTranslatedString } from '../../utilities/TranslateInput';
+
+describe(QualityWarningBannerCommand.name, () => {
+  let renderTargetMock: RevealRenderTarget;
+  let command: QualityWarningBannerCommand;
+
+  beforeEach(() => {
+    renderTargetMock = createRenderTargetMock();
+    command = new QualityWarningBannerCommand();
+    command.attach(renderTargetMock);
+  });
+
+  test('should be visible with content and warning status on high fidelity level', () => {
+    renderTargetMock.revealSettingsController.renderQuality(
+      getQualityForFidelityLevel(MAX_FIDELITY)
+    );
+
+    expect(command.isVisible).toBeTruthy();
+    expect(isTranslatedString(command.content)).toBeTruthy();
+    expect(command.status).toBe(BannerStatus.Warning);
+  });
+
+  test('should be invisible on any lower fidelity level', () => {
+    renderTargetMock.revealSettingsController.renderQuality(
+      getQualityForFidelityLevel((MAX_FIDELITY - 1) as FidelityLevel)
+    );
+
+    expect(command.isVisible).toBeFalsy();
+  });
+});

--- a/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/QualityWarningBannerCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/QualityWarningBannerCommand.ts
@@ -1,0 +1,36 @@
+import { effect } from '@cognite/signals';
+import { BannerStatus, BaseBannerCommand } from '../../commands/BaseBannerCommand';
+import { TranslationInput } from '../../utilities/TranslateInput';
+import { getClosestFidelity, MAX_FIDELITY } from './fidelityLevels';
+import { RevealRenderTarget } from '../../renderTarget/RevealRenderTarget';
+
+export class QualityWarningBannerCommand extends BaseBannerCommand {
+  // ==================================================
+  // OVERRIDES
+  // ==================================================
+
+  public override get isVisible(): boolean {
+    const closestFidelity = getClosestFidelity(
+      this.renderTarget.revealSettingsController.renderQuality()
+    );
+    return closestFidelity === MAX_FIDELITY;
+  }
+
+  public override get content(): TranslationInput {
+    return { key: 'RENDER_QUALITY_SLIDER_PERFORMANCE_WARNING' };
+  }
+
+  public override get status(): BannerStatus {
+    return BannerStatus.Warning;
+  }
+
+  public override attach(renderTarget: RevealRenderTarget) {
+    super.attach(renderTarget);
+
+    // Until `isVisible` becomes a signal, we have to propagate setting updates like this
+    effect(() => {
+      this.renderTarget.revealSettingsController.renderQuality();
+      this.update();
+    });
+  }
+}

--- a/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/SetQualitySliderCommand.test.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/SetQualitySliderCommand.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { SetQualitySliderCommand } from './SetQualitySliderCommand';
+import { type RevealRenderTarget } from '../../renderTarget/RevealRenderTarget';
+import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
+import { FIDELITY_LEVELS, getQualityForFidelityLevel } from './fidelityLevels';
+
+describe(SetQualitySliderCommand.name, () => {
+  let renderTarget: RevealRenderTarget;
+  let command: SetQualitySliderCommand;
+
+  beforeEach(() => {
+    renderTarget = createRenderTargetMock();
+    command = new SetQualitySliderCommand();
+    command.attach(renderTarget);
+  });
+
+  test('contains the value set on the render settings', () => {
+    const testFidelityLevel = 3;
+    const testQualitySetting = getQualityForFidelityLevel(testFidelityLevel);
+
+    expect(command.value).not.toEqual(testQualitySetting);
+
+    renderTarget.revealSettingsController.renderQuality(testQualitySetting);
+
+    expect(command.value).toEqual(testFidelityLevel);
+  });
+
+  test('sets the value on render settings when updated', () => {
+    const testFidelityLevel = 3;
+    const testQualitySetting = getQualityForFidelityLevel(testFidelityLevel);
+
+    expect(renderTarget.revealSettingsController.renderQuality()).not.toEqual(testQualitySetting);
+
+    command.value = testFidelityLevel;
+
+    expect(renderTarget.revealSettingsController.renderQuality()).toEqual(testQualitySetting);
+  });
+
+  test('ignores invalid inputs', () => {
+    const originalQuality = renderTarget.revealSettingsController.renderQuality();
+
+    command.value = 100;
+
+    expect(renderTarget.revealSettingsController.renderQuality()).toEqual(originalQuality);
+  });
+
+  test('contains a mark for every fidelity level', () => {
+    FIDELITY_LEVELS.forEach((level) => {
+      expect(command.marks?.[level]).toBeDefined();
+    });
+  });
+});

--- a/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/SetQualitySliderCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/SetQualitySliderCommand.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+import {
+  FIDELITY_LEVELS,
+  FidelityLevel,
+  getClosestFidelity,
+  getQualityForFidelityLevel,
+  MAX_FIDELITY,
+  MIN_FIDELITY
+} from './fidelityLevels';
+import { BaseSliderCommand } from '../../commands/BaseSliderCommand';
+import { TranslateDelegate } from '../../utilities/TranslateInput';
+import { Changes } from '../../domainObjectsHelpers/Changes';
+
+export class SetQualitySliderCommand extends BaseSliderCommand {
+  // ==================================================
+  // CONSTRUCTOR
+  // ==================================================
+
+  public constructor() {
+    super(MIN_FIDELITY, MAX_FIDELITY, 1);
+  }
+
+  // ==================================================
+  // OVERRIDES
+  // =================================================
+
+  public override get value(): FidelityLevel {
+    const viewerQualitySettings = this.renderTarget.revealSettingsController.renderQuality();
+    return getClosestFidelity(viewerQualitySettings);
+  }
+
+  public override set value(value: number) {
+    this.update(Changes.renderStyle);
+    const rounded = Math.round(value);
+
+    if (!isValidFidelityLevel(rounded)) {
+      return;
+    }
+
+    const qualitySettings = getQualityForFidelityLevel(rounded);
+    this.renderTarget.revealSettingsController.renderQuality(qualitySettings);
+  }
+
+  public override getLabel(translate: TranslateDelegate): string {
+    return translate({ key: 'RENDER_QUALITY_SLIDER_HEADER' });
+  }
+
+  public override get marks(): Record<number, { label: string }> | undefined {
+    return FIDELITY_LEVELS.reduce(
+      (mapping, level) => {
+        mapping[level] = { label: `${level}` };
+
+        return mapping;
+      },
+      {} as Record<number, { label: string }>
+    );
+  }
+}
+
+function isValidFidelityLevel(value: number): value is FidelityLevel {
+  return (FIDELITY_LEVELS as readonly number[]).includes(value);
+}

--- a/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/fidelityLevels.test.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/fidelityLevels.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+import {
+  FIDELITY_LEVELS,
+  getClosestFidelity,
+  getQualityForFidelityLevel,
+  MAX_FIDELITY,
+  MIN_FIDELITY
+} from './fidelityLevels';
+import { type QualitySettings } from '../../utilities/quality/QualitySettings';
+
+describe('fidelityLevels', () => {
+  describe(getClosestFidelity.name, () => {
+    test('returns the same fidelity level for matching quality', () => {
+      FIDELITY_LEVELS.forEach((level) => {
+        expect(getClosestFidelity(getQualityForFidelityLevel(level))).toBe(level);
+      });
+    });
+
+    test('returns highest fidelity for enormously large quality setting', () => {
+      const highQualitySetting: QualitySettings = {
+        cadBudget: { highDetailProximityThreshold: Infinity, maximumRenderCost: Infinity },
+        pointCloudBudget: { numberOfPoints: Infinity },
+        resolutionOptions: { maxRenderResolution: Infinity, movingCameraResolutionFactor: Infinity }
+      };
+
+      expect(getClosestFidelity(highQualitySetting)).toBe(MAX_FIDELITY);
+    });
+
+    test('returns lowest fidelity for extremely small setting', () => {
+      const lowQualitySetting: QualitySettings = {
+        cadBudget: { highDetailProximityThreshold: 1, maximumRenderCost: 10 },
+        pointCloudBudget: { numberOfPoints: 10 },
+        resolutionOptions: { maxRenderResolution: 1, movingCameraResolutionFactor: 0.1 }
+      };
+
+      expect(getClosestFidelity(lowQualitySetting)).toBe(MIN_FIDELITY);
+    });
+
+    test('chooses closest budget when deviations are small', () => {
+      FIDELITY_LEVELS.forEach((level) => {
+        const quality = getQualityForFidelityLevel(level);
+        quality.cadBudget.maximumRenderCost -= 10_000;
+        quality.pointCloudBudget.numberOfPoints -= 200_000;
+        quality.resolutionOptions.maxRenderResolution -= 100_000;
+        quality.resolutionOptions.movingCameraResolutionFactor -= 0.1;
+
+        expect(getClosestFidelity(quality)).toBe(level);
+      });
+    });
+  });
+});

--- a/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/fidelityLevels.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualitySliderCommand/fidelityLevels.ts
@@ -1,0 +1,134 @@
+import { assertNever } from '../../../../utilities/assertNever';
+
+export const FIDELITY_LEVELS = [1, 2, 3, 4, 5] as const;
+
+export type FidelityLevel = (typeof FIDELITY_LEVELS)[number];
+
+export const MAX_FIDELITY: FidelityLevel = 5;
+export const MIN_FIDELITY: FidelityLevel = 1;
+
+import { maxBy } from 'lodash';
+import { QualitySettings } from '../../utilities/quality/QualitySettings';
+import assert from 'assert';
+
+export function getQualityForFidelityLevel(fidelityLevel: FidelityLevel) {
+  switch (fidelityLevel) {
+    case 1:
+      return {
+        cadBudget: {
+          maximumRenderCost: 8_000_000,
+          highDetailProximityThreshold: 0
+        },
+        pointCloudBudget: {
+          numberOfPoints: 1_500_000
+        },
+        resolutionOptions: {
+          maxRenderResolution: 0.7e6,
+          movingCameraResolutionFactor: 0.1
+        }
+      };
+
+    case 2:
+      return {
+        cadBudget: {
+          maximumRenderCost: 15_000_000,
+          highDetailProximityThreshold: 0
+        },
+        pointCloudBudget: {
+          numberOfPoints: 3_000_000
+        },
+        resolutionOptions: {
+          maxRenderResolution: 1.4e6,
+          movingCameraResolutionFactor: 0.5
+        }
+      };
+
+    case 3:
+      return {
+        cadBudget: {
+          maximumRenderCost: 35_000_000,
+          highDetailProximityThreshold: 0
+        },
+        pointCloudBudget: {
+          numberOfPoints: 7_000_000
+        },
+        resolutionOptions: {
+          maxRenderResolution: 6e6,
+          movingCameraResolutionFactor: 1
+        }
+      };
+    case 4:
+      return {
+        cadBudget: {
+          maximumRenderCost: 80_000_000,
+          highDetailProximityThreshold: 0
+        },
+        pointCloudBudget: {
+          numberOfPoints: 20_000_000
+        },
+        resolutionOptions: {
+          maxRenderResolution: Infinity,
+          movingCameraResolutionFactor: 1
+        }
+      };
+    case 5:
+      return {
+        cadBudget: {
+          maximumRenderCost: 130_000_000,
+          highDetailProximityThreshold: 0
+        },
+        pointCloudBudget: {
+          numberOfPoints: 35_000_000
+        },
+        resolutionOptions: {
+          maxRenderResolution: Infinity,
+          movingCameraResolutionFactor: 1
+        }
+      };
+    default:
+      assertNever(fidelityLevel);
+  }
+}
+
+export function getClosestFidelity(quality: QualitySettings): FidelityLevel {
+  let similaritiesWithLevel = FIDELITY_LEVELS.map((level) => ({
+    level,
+    similarity: getQualitySimilarityHeuristic(quality, getQualityForFidelityLevel(level))
+  }));
+  const closestMatch = maxBy(similaritiesWithLevel, ({ similarity }) => similarity)?.level;
+
+  assert(closestMatch !== undefined);
+
+  return closestMatch;
+}
+
+function getQualitySimilarityHeuristic(q0: QualitySettings, q1: QualitySettings) {
+  const cadRenderCostRatio = getSmallestRatio(
+    q0.cadBudget.maximumRenderCost,
+    q1.cadBudget.maximumRenderCost
+  );
+  const pointCloudPointRatio = getSmallestRatio(
+    q0.pointCloudBudget.numberOfPoints,
+    q1.pointCloudBudget.numberOfPoints
+  );
+  const maxResolutionRatio = getSmallestRatio(
+    q0.resolutionOptions.maxRenderResolution,
+    q1.resolutionOptions.maxRenderResolution
+  );
+  const cameraMovementRatio = getSmallestRatio(
+    q0.resolutionOptions.movingCameraResolutionFactor,
+    q1.resolutionOptions.movingCameraResolutionFactor
+  );
+
+  return cadRenderCostRatio + pointCloudPointRatio + maxResolutionRatio + cameraMovementRatio;
+}
+
+function getSmallestRatio(f0: number | undefined, f1: number | undefined) {
+  if (f0 === undefined || f1 === undefined) {
+    return 0;
+  }
+
+  const clampedF0 = Math.max(0.001, Math.min(f0, 1e9));
+  const clampedF1 = Math.max(0.001, Math.min(f1, 1e9));
+  return Math.min(clampedF0 / clampedF1, clampedF1 / clampedF0);
+}

--- a/react-components/src/architecture/base/concreteCommands/SettingsCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/SettingsCommand.ts
@@ -6,7 +6,6 @@ import { type TranslationInput } from '../utilities/TranslateInput';
 import { type IconName } from '../utilities/IconName';
 
 import { BaseSettingsCommand } from '../commands/BaseSettingsCommand';
-import { SetQualityCommand } from './SetQualityCommand';
 import { SetPointSizeCommand } from './pointCloud/SetPointSizeCommand';
 import { SetPointColorTypeCommand } from './pointCloud/SetPointColorTypeCommand';
 import { SetPointShapeCommand } from './pointCloud/SetPointShapeCommand';
@@ -23,6 +22,10 @@ import { SetPointsOfInterestVisibleCommand } from '../../concrete/pointsOfIntere
 import { PointsOfInterestDividerCommand } from '../../concrete/pointsOfInterest/PointsOfInterestDividerCommand';
 import { PointsOfInterestSectionCommand } from '../../concrete/pointsOfInterest/PointsOfInterestSectionCommand';
 import { SetGhostModeCommand } from './cad/SetGhostModeCommand';
+import { SetQualitySliderCommand } from './SetQualitySliderCommand/SetQualitySliderCommand';
+import { QualityWarningBannerCommand } from './SetQualitySliderCommand/QualityWarningBannerCommand';
+import { DividerCommand } from '../commands/DividerCommand';
+import { QualitySectionCommand } from './SetQualitySliderCommand/QualitySectionCommand';
 
 export class SettingsCommand extends BaseSettingsCommand {
   // ==================================================
@@ -32,7 +35,10 @@ export class SettingsCommand extends BaseSettingsCommand {
   public constructor(include360Images: boolean = true, includePois: boolean = false) {
     super();
 
-    this.add(new SetQualityCommand());
+    this.add(new SetQualitySliderCommand());
+    this.add(new QualityWarningBannerCommand());
+    this.add(new DividerCommand());
+
     this.add(new SetGhostModeCommand());
 
     if (includePois) {

--- a/react-components/src/architecture/base/renderTarget/RevealRenderTarget.ts
+++ b/react-components/src/architecture/base/renderTarget/RevealRenderTarget.ts
@@ -42,6 +42,7 @@ import { type Class } from '../domainObjectsHelpers/Class';
 import { CdfCaches } from './CdfCaches';
 import { type DmsUniqueIdentifier } from '../../../data-providers';
 import { type Image360Model, type PointCloud } from '../../concrete/reveal/RevealTypes';
+import { RevealSettingsController } from '../../concrete/reveal/RevealSettingsController';
 
 const DIRECTIONAL_LIGHT_NAME = 'DirectionalLight';
 
@@ -60,6 +61,7 @@ export class RevealRenderTarget {
   private readonly _contextmenuController: ContextMenuController;
   private readonly _cdfCaches: CdfCaches;
   private readonly _instanceStylingController: InstanceStylingController;
+  private readonly _revealSettingsController: RevealSettingsController;
 
   private _ambientLight: AmbientLight | undefined;
   private _directionalLight: DirectionalLight | undefined;
@@ -88,6 +90,7 @@ export class RevealRenderTarget {
     this._commandsController.addEventListeners();
     this._contextmenuController = new ContextMenuController();
     this._instanceStylingController = new InstanceStylingController();
+    this._revealSettingsController = new RevealSettingsController(viewer);
     this._rootDomainObject = new RootDomainObject(this, sdk);
     this._rootDomainObject.isExpanded = true;
 
@@ -143,6 +146,10 @@ export class RevealRenderTarget {
 
   public get instanceStylingController(): InstanceStylingController {
     return this._instanceStylingController;
+  }
+
+  public get revealSettingsController(): RevealSettingsController {
+    return this._revealSettingsController;
   }
 
   public get cursor(): string {

--- a/react-components/src/architecture/base/utilities/quality/QualitySettings.ts
+++ b/react-components/src/architecture/base/utilities/quality/QualitySettings.ts
@@ -1,0 +1,7 @@
+import type { CadModelBudget, PointCloudBudget, ResolutionOptions } from '@cognite/reveal';
+
+export type QualitySettings = {
+  cadBudget: CadModelBudget;
+  pointCloudBudget: PointCloudBudget;
+  resolutionOptions: ResolutionOptions;
+};

--- a/react-components/src/architecture/concrete/reveal/RevealSettingsController.test.ts
+++ b/react-components/src/architecture/concrete/reveal/RevealSettingsController.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from 'vitest';
+import { RevealSettingsController } from './RevealSettingsController';
+import {
+  viewerMock,
+  viewerSetCadModelBudgetMock,
+  viewerSetPointCloudModelBudgetMock
+} from '#test-utils/fixtures/viewer';
+
+describe(RevealSettingsController.name, () => {
+  test("it updates reveal's quality settings when changed", () => {
+    const settingsController = new RevealSettingsController(viewerMock);
+
+    const testQualitySettings = {
+      cadBudget: { maximumRenderCost: 1231232, highDetailProximityThreshold: 0 },
+      pointCloudBudget: { numberOfPoints: 123121212 },
+      resolutionOptions: { maxRenderResolution: 1.3e4, movingCameraResolutionFactor: 0.3 }
+    };
+
+    settingsController.renderQuality(testQualitySettings);
+
+    expect(viewerSetCadModelBudgetMock).toHaveBeenCalledWith(testQualitySettings.cadBudget);
+    expect(viewerSetPointCloudModelBudgetMock).toHaveBeenCalledWith(
+      testQualitySettings.pointCloudBudget
+    );
+    expect(vi.mocked(viewerMock.setResolutionOptions)).toHaveBeenCalledWith(
+      testQualitySettings.resolutionOptions
+    );
+  });
+});

--- a/react-components/src/architecture/concrete/reveal/RevealSettingsController.ts
+++ b/react-components/src/architecture/concrete/reveal/RevealSettingsController.ts
@@ -1,0 +1,30 @@
+import { effect, Signal, signal } from '@cognite/signals';
+import { QualitySettings } from '../../base/utilities/quality/QualitySettings';
+import { DEFAULT_REVEAL_QUALITY_SETTINGS } from './constants';
+import { Cognite3DViewer, DataSourceType } from '@cognite/reveal';
+
+export class RevealSettingsController {
+  private _viewer: Cognite3DViewer<DataSourceType>;
+  private _renderQualitySignal = signal<QualitySettings>(DEFAULT_REVEAL_QUALITY_SETTINGS);
+
+  constructor(viewer: Cognite3DViewer<DataSourceType>) {
+    this._viewer = viewer;
+
+    effect(() => {
+      setQualityOnViewer(this._renderQualitySignal(), this._viewer);
+    });
+  }
+
+  public get renderQuality(): Signal<QualitySettings> {
+    return this._renderQualitySignal;
+  }
+}
+
+function setQualityOnViewer<T extends DataSourceType>(
+  quality: QualitySettings,
+  viewer: Cognite3DViewer<T>
+): void {
+  viewer.setResolutionOptions(quality.resolutionOptions);
+  viewer.cadBudget = quality.cadBudget;
+  viewer.pointCloudBudget = quality.pointCloudBudget;
+}

--- a/react-components/src/architecture/concrete/reveal/constants.ts
+++ b/react-components/src/architecture/concrete/reveal/constants.ts
@@ -1,0 +1,15 @@
+import { QualitySettings } from '../../base/utilities/quality/QualitySettings';
+
+export const DEFAULT_REVEAL_QUALITY_SETTINGS: QualitySettings = {
+  cadBudget: {
+    maximumRenderCost: 15_000_000,
+    highDetailProximityThreshold: 0
+  },
+  pointCloudBudget: {
+    numberOfPoints: 3_000_000
+  },
+  resolutionOptions: {
+    maxRenderResolution: 1.4e6,
+    movingCameraResolutionFactor: 0.5
+  }
+};

--- a/react-components/src/architecture/index.ts
+++ b/react-components/src/architecture/index.ts
@@ -35,6 +35,7 @@ export { SetQualityCommand } from './base/concreteCommands/SetQualityCommand';
 export { SettingsCommand } from './base/concreteCommands/SettingsCommand';
 export { ToggleMetricUnitsCommand } from './base/concreteCommands/ToggleMetricUnitsCommand';
 export { UndoCommand } from './base/concreteCommands/UndoCommand';
+export { BaseBannerCommand } from './base/commands/BaseBannerCommand';
 
 // New architecture: domainObjects
 export { DomainObject } from './base/domainObjects/DomainObject';

--- a/react-components/src/architecture/index.ts
+++ b/react-components/src/architecture/index.ts
@@ -87,6 +87,7 @@ export { getNextColorByIndex } from './base/utilities/colors/getNextColor';
 export { getResizeCursor } from './base/utilities/geometry/getResizeCursor';
 export type { TranslateDelegate } from './base/utilities/TranslateInput';
 export type { TranslationInput } from './base/utilities/TranslateInput';
+export type { QualitySettings } from './base/utilities/quality/QualitySettings';
 
 // New architecture: views
 export { BaseView } from './base/views/BaseView';

--- a/react-components/src/common/i18n/en/reveal-react-components.json
+++ b/react-components/src/common/i18n/en/reveal-react-components.json
@@ -118,6 +118,7 @@
   "RADIUS": "Radius",
   "REDO": "Redo",
   "RENDER_QUALITY_SLIDER_HEADER": "Rendering detail level",
+  "RENDER_QUALITY_SLIDER_PERFORMANCE_WARNING": "High detail might overload CPU/GPU/RAM",
   "RESOURCES_3D": "3D resources",
   "RESET_CAMERA_TO_HOME": "Reset camera to home",
   "REVISIONS": "Revisions",

--- a/react-components/src/common/i18n/en/reveal-react-components.json
+++ b/react-components/src/common/i18n/en/reveal-react-components.json
@@ -117,6 +117,7 @@
   "POLYLINE": "Polyline",
   "RADIUS": "Radius",
   "REDO": "Redo",
+  "RENDER_QUALITY_SLIDER_HEADER": "Rendering detail level",
   "RESOURCES_3D": "3D resources",
   "RESET_CAMERA_TO_HOME": "Reset camera to home",
   "REVISIONS": "Revisions",

--- a/react-components/src/components/Architecture/BannerComponent.tsx
+++ b/react-components/src/components/Architecture/BannerComponent.tsx
@@ -1,0 +1,51 @@
+import { Banner } from '@cognite/cogs-lab';
+import { TranslateDelegate, TranslationInput } from '../../architecture';
+import {
+  BannerStatus,
+  BaseBannerCommand
+} from '../../architecture/base/commands/BaseBannerCommand';
+import { useOnUpdate } from './useOnUpdate';
+import { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Infobox } from '@cognite/cogs.js';
+import { getDefaultCommand } from './utilities';
+import { useRenderTarget } from '../RevealCanvas';
+
+export const BannerComponent = ({
+  command: inputCommand,
+  t
+}: {
+  command: BaseBannerCommand;
+  t: TranslateDelegate;
+}) => {
+  const renderTarget = useRenderTarget();
+  const command = useMemo<BaseBannerCommand>(
+    () => getDefaultCommand<BaseBannerCommand>(inputCommand, renderTarget),
+    []
+  );
+
+  const [visible, setVisible] = useState<boolean>(command.isVisible);
+  const [content, setContent] = useState<TranslationInput>(command.content);
+  const [status, setStatus] = useState<BannerStatus>(command.status);
+
+  useOnUpdate(command, () => {
+    setVisible(command.isVisible);
+    setContent(command.content);
+    setStatus(command.status);
+  });
+
+  if (!visible) {
+    return null;
+  }
+
+  return <StyledInfobox status={status}>{t(content)}</StyledInfobox>;
+};
+
+const StyledInfobox = styled(Infobox)`
+  display: flex;
+  min-width: 200px;
+  padding: var(--Container-padding-top, 8px) var(--Container-padding-left-right, 12px);
+  align-items: flex-start;
+  gap: var(--Container-horizontal-gap, 8px);
+  align-self: stretch;
+`;

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -34,6 +34,8 @@ import { DividerCommand } from '../../architecture/base/commands/DividerCommand'
 import { SectionCommand } from '../../architecture/base/commands/SectionCommand';
 import { useOnUpdate } from './useOnUpdate';
 import { FlexDirection, type PlacementType } from './types';
+import { BaseBannerCommand } from '../../architecture';
+import { BannerComponent } from './BannerComponent';
 
 export const SettingsButton = ({
   inputCommand,
@@ -117,6 +119,9 @@ function createMenuItem(command: BaseCommand, t: TranslateDelegate): ReactNode {
   }
   if (command instanceof SectionCommand) {
     return <SectionComponent key={command.uniqueId} command={command} t={t} />;
+  }
+  if (command instanceof BaseBannerCommand) {
+    return <BannerComponent key={command.uniqueId} command={command} t={t} />;
   }
 
   return <ButtonComponent key={command.uniqueId} command={command} t={t} />;

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -268,6 +268,7 @@ function SliderComponent({
         min={command.min}
         max={command.max}
         step={command.step}
+        marks={command.marks}
         onChange={(value: number) => {
           command.value = value;
           setValue(value);

--- a/react-components/src/components/RevealToolbar/RevealToolbar.tsx
+++ b/react-components/src/components/RevealToolbar/RevealToolbar.tsx
@@ -11,7 +11,7 @@ import { withSuppressRevealEvents } from '../../higher-order-components/withSupp
 import { HelpButton } from './HelpButton';
 import { ShareButton } from './ShareButton';
 import { ResetCameraButton } from './ResetCameraButton';
-import { type QualitySettings } from './SettingsContainer/types';
+import { type QualitySettings } from '../../architecture/base/utilities/quality/QualitySettings';
 import styled from 'styled-components';
 import { SelectSceneButton } from './SelectSceneButton';
 import { RuleBasedOutputsButton } from './RuleBasedOutputsButton';

--- a/react-components/src/components/RevealToolbar/SettingsButton.tsx
+++ b/react-components/src/components/RevealToolbar/SettingsButton.tsx
@@ -5,7 +5,7 @@
 import { useState, type ReactElement } from 'react';
 import { Button, Tooltip as CogsTooltip, SettingsIcon } from '@cognite/cogs.js';
 import { Menu } from '@cognite/cogs-lab';
-import { type QualitySettings } from './SettingsContainer/types';
+import { type QualitySettings } from '../../architecture/base/utilities/quality/QualitySettings';
 import { HighFidelityContainer } from './SettingsContainer/HighFidelityContainer';
 import { useTranslation } from '../i18n/I18n';
 import { TOOLBAR_HORIZONTAL_PANEL_OFFSET } from '../constants';

--- a/react-components/src/components/RevealToolbar/SettingsContainer/HighFidelityContainer.tsx
+++ b/react-components/src/components/RevealToolbar/SettingsContainer/HighFidelityContainer.tsx
@@ -5,7 +5,8 @@
 import { type ReactElement, useState } from 'react';
 import { Menu } from '@cognite/cogs-lab';
 import { useReveal } from '../../RevealCanvas/ViewerContext';
-import { type QualitySettings, type QualityProps } from './types';
+import { type QualityProps } from './types';
+import { type QualitySettings } from '../../../architecture/base/utilities/quality/QualitySettings';
 import { type DataSourceType, type Cognite3DViewer } from '@cognite/reveal';
 import { useTranslation } from '../../i18n/I18n';
 

--- a/react-components/src/components/RevealToolbar/SettingsContainer/types.ts
+++ b/react-components/src/components/RevealToolbar/SettingsContainer/types.ts
@@ -2,12 +2,8 @@
  * Copyright 2023 Cognite AS
  */
 
-import {
-  type CadModelBudget,
-  type PointCloudBudget,
-  type ResolutionOptions
-} from '@cognite/reveal';
 import { type ReactElement } from 'react';
+import { QualitySettings } from '../../../architecture/base/utilities/quality/QualitySettings';
 
 export type QualityProps = {
   lowQualitySettings?: Partial<QualitySettings>;
@@ -16,10 +12,4 @@ export type QualityProps = {
 
 export type SettingsContainerProps = QualityProps & {
   customSettingsContent?: ReactElement;
-};
-
-export type QualitySettings = {
-  cadBudget: CadModelBudget;
-  pointCloudBudget: PointCloudBudget;
-  resolutionOptions: ResolutionOptions;
 };

--- a/react-components/src/components/RevealToolbar/index.ts
+++ b/react-components/src/components/RevealToolbar/index.ts
@@ -6,4 +6,3 @@ export { RevealToolbar } from './RevealToolbar';
 export type { RevealToolbarProps } from './RevealToolbar';
 export type { LayersButtonProps } from './LayersButton/LayersButton';
 export type { LayersUrlStateParam, DefaultLayersConfiguration } from './LayersButton/types';
-export type { QualitySettings } from './SettingsContainer/types';

--- a/react-components/tests/tests-utilities/fixtures/renderTarget.ts
+++ b/react-components/tests/tests-utilities/fixtures/renderTarget.ts
@@ -9,6 +9,7 @@ import { fdmNodeCacheContentMock } from './fdmNodeCache';
 import { sdkMock } from './sdk';
 import { vi } from 'vitest';
 import { viewerMock } from './viewer';
+import { RevealSettingsController } from '../../../src/architecture/concrete/reveal/RevealSettingsController';
 
 const cdfCachesMock = new Mock<CdfCaches>()
   .setup((p) => p.fdmNodeCache)
@@ -35,7 +36,9 @@ export function createRenderTargetMock(): RevealRenderTarget {
     .setup((p) => p.commandsController)
     .returns(commandsControllerMock)
     .setup((p) => p.invalidate.bind(p))
-    .returns(vi.fn());
+    .returns(vi.fn())
+    .setup((p) => p.revealSettingsController)
+    .returns(new RevealSettingsController(viewerMock));
 
   const root = new RootDomainObject(mock.object(), sdkMock);
   mock.setup((p) => p.rootDomainObject).returns(root);

--- a/react-components/tests/tests-utilities/fixtures/viewer.ts
+++ b/react-components/tests/tests-utilities/fixtures/viewer.ts
@@ -3,9 +3,8 @@ import { vi } from 'vitest';
 import {
   type DataSourceType,
   type Cognite3DViewer,
-  CadModelBudget,
-  PointCloudBudget,
-  ResolutionOptions
+  type CadModelBudget,
+  type PointCloudBudget
 } from '@cognite/reveal';
 import { Mock, It } from 'moq.ts';
 import { cameraManagerMock } from './cameraManager';
@@ -64,9 +63,13 @@ export const viewerMock = new Mock<Cognite3DViewer<DataSourceType>>()
   .setup((p) => p.removeCustomObject)
   .returns(vi.fn())
   .setup((p) => (p.cadBudget = It.IsAny<CadModelBudget>()))
-  .callback((p) => viewerSetCadModelBudgetMock(p.args[0]))
+  .callback((p) => {
+    viewerSetCadModelBudgetMock(p.args[0]);
+  })
   .setup((p) => (p.pointCloudBudget = It.IsAny<PointCloudBudget>()))
-  .callback((p) => viewerSetPointCloudModelBudgetMock(p.args[0]))
+  .callback((p) => {
+    viewerSetPointCloudModelBudgetMock(p.args[0]);
+  })
   .setup((p) => p.setResolutionOptions)
   .returns(vi.fn())
   .object();

--- a/react-components/tests/tests-utilities/fixtures/viewer.ts
+++ b/react-components/tests/tests-utilities/fixtures/viewer.ts
@@ -1,6 +1,12 @@
 import { vi } from 'vitest';
 
-import type { DataSourceType, Cognite3DViewer } from '@cognite/reveal';
+import {
+  type DataSourceType,
+  type Cognite3DViewer,
+  CadModelBudget,
+  PointCloudBudget,
+  ResolutionOptions
+} from '@cognite/reveal';
 import { Mock, It } from 'moq.ts';
 import { cameraManagerMock } from './cameraManager';
 
@@ -15,6 +21,8 @@ export const viewerImage360CollectionsMock = vi.fn<Cognite3DViewer['get360ImageC
 export const fitCameraToVisualSceneBoundingBoxMock =
   vi.fn<Cognite3DViewer['fitCameraToVisualSceneBoundingBox']>();
 export const fitCameraToModelsMock = vi.fn<Cognite3DViewer['fitCameraToModels']>();
+export const viewerSetCadModelBudgetMock = vi.fn<(budget: CadModelBudget) => void>();
+export const viewerSetPointCloudModelBudgetMock = vi.fn<(budget: PointCloudBudget) => void>();
 
 export const viewerMock = new Mock<Cognite3DViewer<DataSourceType>>()
   .setup((viewer) => {
@@ -54,5 +62,11 @@ export const viewerMock = new Mock<Cognite3DViewer<DataSourceType>>()
   .setup((p) => p.addCustomObject)
   .returns(vi.fn())
   .setup((p) => p.removeCustomObject)
+  .returns(vi.fn())
+  .setup((p) => (p.cadBudget = It.IsAny<CadModelBudget>()))
+  .callback((p) => viewerSetCadModelBudgetMock(p.args[0]))
+  .setup((p) => (p.pointCloudBudget = It.IsAny<PointCloudBudget>()))
+  .callback((p) => viewerSetPointCloudModelBudgetMock(p.args[0]))
+  .setup((p) => p.setResolutionOptions)
   .returns(vi.fn())
   .object();


### PR DESCRIPTION
## Superceded by 5081 & co

#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

This PR introduces the `SetQualitySliderCommand` which is a class representing a slider UI element for controlling Reveal's render fidelity. In addition, related commands were added.

Here's the list of changes:
- Create a `RevealSettings` class which centralizes global settings on the Reveal viewer instance and exposes them as signals to the rest of the components library. It currently only holds the quality settings, but is planned to be extended in the future
- Add the slider command, including a new `marks` property in the base class to support marks on the slider. It uses the `RevealSettings` class to update the quality
- Add a banner that shows up and warns the user when using the highest quality level. This includes a new base class for such banners, the React-translation of that base class, and the concrete implementation of this quality-warning banner.
- Update the default Settings toolbar to use this quality controller instead of the old one 

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
