### PR TITLE
refactor(react-components): Introduce Reveal settings controller (BND3D-5504 part 4)

### DIFF
--- a/react-components/src/architecture/base/concreteCommands/SetQualityCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/SetQualityCommand.ts
@@ -3,9 +3,9 @@
  */
 
 import { type TranslationInput } from '../utilities/TranslateInput';
-import { type QualitySettings } from '../../../components/RevealToolbar/SettingsContainer/types';
 import { type DataSourceType, type Cognite3DViewer } from '@cognite/reveal';
 import { RenderTargetCommand } from '../commands/RenderTargetCommand';
+import { QualitySettings } from '../utilities/quality/QualitySettings';
 
 export class SetQualityCommand extends RenderTargetCommand {
   // ==================================================

--- a/react-components/src/architecture/base/renderTarget/RevealRenderTarget.ts
+++ b/react-components/src/architecture/base/renderTarget/RevealRenderTarget.ts
@@ -42,6 +42,7 @@ import { type Class } from '../domainObjectsHelpers/Class';
 import { CdfCaches } from './CdfCaches';
 import { type DmsUniqueIdentifier } from '../../../data-providers';
 import { type Image360Model, type PointCloud } from '../../concrete/reveal/RevealTypes';
+import { RevealSettingsController } from '../../concrete/reveal/RevealSettingsController';
 
 const DIRECTIONAL_LIGHT_NAME = 'DirectionalLight';
 
@@ -60,6 +61,7 @@ export class RevealRenderTarget {
   private readonly _contextmenuController: ContextMenuController;
   private readonly _cdfCaches: CdfCaches;
   private readonly _instanceStylingController: InstanceStylingController;
+  private readonly _revealSettingsController: RevealSettingsController;
 
   private _ambientLight: AmbientLight | undefined;
   private _directionalLight: DirectionalLight | undefined;
@@ -88,6 +90,7 @@ export class RevealRenderTarget {
     this._commandsController.addEventListeners();
     this._contextmenuController = new ContextMenuController();
     this._instanceStylingController = new InstanceStylingController();
+    this._revealSettingsController = new RevealSettingsController(viewer);
     this._rootDomainObject = new RootDomainObject(this, sdk);
     this._rootDomainObject.isExpanded = true;
 
@@ -143,6 +146,10 @@ export class RevealRenderTarget {
 
   public get instanceStylingController(): InstanceStylingController {
     return this._instanceStylingController;
+  }
+
+  public get revealSettingsController(): RevealSettingsController {
+    return this._revealSettingsController;
   }
 
   public get cursor(): string {

--- a/react-components/src/architecture/base/utilities/quality/QualitySettings.ts
+++ b/react-components/src/architecture/base/utilities/quality/QualitySettings.ts
@@ -1,0 +1,7 @@
+import type { CadModelBudget, PointCloudBudget, ResolutionOptions } from '@cognite/reveal';
+
+export type QualitySettings = {
+  cadBudget: CadModelBudget;
+  pointCloudBudget: PointCloudBudget;
+  resolutionOptions: ResolutionOptions;
+};

--- a/react-components/src/architecture/concrete/reveal/RevealSettingsController.test.ts
+++ b/react-components/src/architecture/concrete/reveal/RevealSettingsController.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from 'vitest';
+import { RevealSettingsController } from './RevealSettingsController';
+import {
+  viewerMock,
+  viewerSetCadModelBudgetMock,
+  viewerSetPointCloudModelBudgetMock
+} from '#test-utils/fixtures/viewer';
+
+describe(RevealSettingsController.name, () => {
+  test("it updates reveal's quality settings when changed", () => {
+    const settingsController = new RevealSettingsController(viewerMock);
+
+    const testQualitySettings = {
+      cadBudget: { maximumRenderCost: 1231232, highDetailProximityThreshold: 0 },
+      pointCloudBudget: { numberOfPoints: 123121212 },
+      resolutionOptions: { maxRenderResolution: 1.3e4, movingCameraResolutionFactor: 0.3 }
+    };
+
+    settingsController.renderQuality(testQualitySettings);
+
+    expect(viewerSetCadModelBudgetMock).toHaveBeenCalledWith(testQualitySettings.cadBudget);
+    expect(viewerSetPointCloudModelBudgetMock).toHaveBeenCalledWith(
+      testQualitySettings.pointCloudBudget
+    );
+    expect(vi.mocked(viewerMock.setResolutionOptions)).toHaveBeenCalledWith(
+      testQualitySettings.resolutionOptions
+    );
+  });
+});

--- a/react-components/src/architecture/concrete/reveal/RevealSettingsController.ts
+++ b/react-components/src/architecture/concrete/reveal/RevealSettingsController.ts
@@ -1,0 +1,30 @@
+import { effect, Signal, signal } from '@cognite/signals';
+import { QualitySettings } from '../../base/utilities/quality/QualitySettings';
+import { DEFAULT_REVEAL_QUALITY_SETTINGS } from './constants';
+import { Cognite3DViewer, DataSourceType } from '@cognite/reveal';
+
+export class RevealSettingsController {
+  private _viewer: Cognite3DViewer<DataSourceType>;
+  private _renderQualitySignal = signal<QualitySettings>(DEFAULT_REVEAL_QUALITY_SETTINGS);
+
+  constructor(viewer: Cognite3DViewer<DataSourceType>) {
+    this._viewer = viewer;
+
+    effect(() => {
+      setQualityOnViewer(this._renderQualitySignal(), this._viewer);
+    });
+  }
+
+  public get renderQuality(): Signal<QualitySettings> {
+    return this._renderQualitySignal;
+  }
+}
+
+function setQualityOnViewer<T extends DataSourceType>(
+  quality: QualitySettings,
+  viewer: Cognite3DViewer<T>
+): void {
+  viewer.setResolutionOptions(quality.resolutionOptions);
+  viewer.cadBudget = quality.cadBudget;
+  viewer.pointCloudBudget = quality.pointCloudBudget;
+}

--- a/react-components/src/architecture/concrete/reveal/constants.ts
+++ b/react-components/src/architecture/concrete/reveal/constants.ts
@@ -1,0 +1,15 @@
+import { QualitySettings } from '../../base/utilities/quality/QualitySettings';
+
+export const DEFAULT_REVEAL_QUALITY_SETTINGS: QualitySettings = {
+  cadBudget: {
+    maximumRenderCost: 15_000_000,
+    highDetailProximityThreshold: 0
+  },
+  pointCloudBudget: {
+    numberOfPoints: 3_000_000
+  },
+  resolutionOptions: {
+    maxRenderResolution: 1.4e6,
+    movingCameraResolutionFactor: 0.5
+  }
+};

--- a/react-components/src/architecture/index.ts
+++ b/react-components/src/architecture/index.ts
@@ -87,6 +87,7 @@ export { getNextColorByIndex } from './base/utilities/colors/getNextColor';
 export { getResizeCursor } from './base/utilities/geometry/getResizeCursor';
 export type { TranslateDelegate } from './base/utilities/TranslateInput';
 export type { TranslationInput } from './base/utilities/TranslateInput';
+export type { QualitySettings } from './base/utilities/quality/QualitySettings';
 
 // New architecture: views
 export { BaseView } from './base/views/BaseView';

--- a/react-components/src/components/RevealToolbar/RevealToolbar.tsx
+++ b/react-components/src/components/RevealToolbar/RevealToolbar.tsx
@@ -11,7 +11,7 @@ import { withSuppressRevealEvents } from '../../higher-order-components/withSupp
 import { HelpButton } from './HelpButton';
 import { ShareButton } from './ShareButton';
 import { ResetCameraButton } from './ResetCameraButton';
-import { type QualitySettings } from './SettingsContainer/types';
+import { type QualitySettings } from '../../architecture/base/utilities/quality/QualitySettings';
 import styled from 'styled-components';
 import { SelectSceneButton } from './SelectSceneButton';
 import { RuleBasedOutputsButton } from './RuleBasedOutputsButton';

--- a/react-components/src/components/RevealToolbar/SettingsButton.tsx
+++ b/react-components/src/components/RevealToolbar/SettingsButton.tsx
@@ -5,7 +5,7 @@
 import { useState, type ReactElement } from 'react';
 import { Button, Tooltip as CogsTooltip, SettingsIcon } from '@cognite/cogs.js';
 import { Menu } from '@cognite/cogs-lab';
-import { type QualitySettings } from './SettingsContainer/types';
+import { type QualitySettings } from '../../architecture/base/utilities/quality/QualitySettings';
 import { HighFidelityContainer } from './SettingsContainer/HighFidelityContainer';
 import { useTranslation } from '../i18n/I18n';
 import { TOOLBAR_HORIZONTAL_PANEL_OFFSET } from '../constants';

--- a/react-components/src/components/RevealToolbar/SettingsContainer/HighFidelityContainer.tsx
+++ b/react-components/src/components/RevealToolbar/SettingsContainer/HighFidelityContainer.tsx
@@ -5,7 +5,8 @@
 import { type ReactElement, useState } from 'react';
 import { Menu } from '@cognite/cogs-lab';
 import { useReveal } from '../../RevealCanvas/ViewerContext';
-import { type QualitySettings, type QualityProps } from './types';
+import { type QualityProps } from './types';
+import { type QualitySettings } from '../../../architecture/base/utilities/quality/QualitySettings';
 import { type DataSourceType, type Cognite3DViewer } from '@cognite/reveal';
 import { useTranslation } from '../../i18n/I18n';
 

--- a/react-components/src/components/RevealToolbar/SettingsContainer/types.ts
+++ b/react-components/src/components/RevealToolbar/SettingsContainer/types.ts
@@ -2,12 +2,8 @@
  * Copyright 2023 Cognite AS
  */
 
-import {
-  type CadModelBudget,
-  type PointCloudBudget,
-  type ResolutionOptions
-} from '@cognite/reveal';
 import { type ReactElement } from 'react';
+import { QualitySettings } from '../../../architecture/base/utilities/quality/QualitySettings';
 
 export type QualityProps = {
   lowQualitySettings?: Partial<QualitySettings>;
@@ -16,10 +12,4 @@ export type QualityProps = {
 
 export type SettingsContainerProps = QualityProps & {
   customSettingsContent?: ReactElement;
-};
-
-export type QualitySettings = {
-  cadBudget: CadModelBudget;
-  pointCloudBudget: PointCloudBudget;
-  resolutionOptions: ResolutionOptions;
 };

--- a/react-components/src/components/RevealToolbar/index.ts
+++ b/react-components/src/components/RevealToolbar/index.ts
@@ -6,4 +6,3 @@ export { RevealToolbar } from './RevealToolbar';
 export type { RevealToolbarProps } from './RevealToolbar';
 export type { LayersButtonProps } from './LayersButton/LayersButton';
 export type { LayersUrlStateParam, DefaultLayersConfiguration } from './LayersButton/types';
-export type { QualitySettings } from './SettingsContainer/types';

--- a/react-components/stories/Toolbar.stories.tsx
+++ b/react-components/stories/Toolbar.stories.tsx
@@ -5,7 +5,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   CadModelContainer,
-  type QualitySettings,
   RevealToolbar,
   withSuppressRevealEvents,
   useCameraNavigation,
@@ -22,6 +21,7 @@ import { getAddModelOptionsFromUrl } from './utilities/getAddModelOptionsFromUrl
 import { useGetCameraStateFromUrlParam } from './utilities/useGetCameraStateFromUrlParam';
 import { type AddModelOptions } from '@cognite/reveal';
 import { LayersButtonStrip } from '../src/components/RevealToolbar/LayersButton/components/LayersButtonsStrip';
+import { type QualitySettings } from '../src/architecture';
 
 const meta = {
   title: 'Example/Toolbar',

--- a/react-components/tests/tests-utilities/fixtures/viewer.ts
+++ b/react-components/tests/tests-utilities/fixtures/viewer.ts
@@ -3,9 +3,8 @@ import { vi } from 'vitest';
 import {
   type DataSourceType,
   type Cognite3DViewer,
-  CadModelBudget,
-  PointCloudBudget,
-  ResolutionOptions
+  type CadModelBudget,
+  type PointCloudBudget
 } from '@cognite/reveal';
 import { Mock, It } from 'moq.ts';
 import { cameraManagerMock } from './cameraManager';
@@ -64,9 +63,13 @@ export const viewerMock = new Mock<Cognite3DViewer<DataSourceType>>()
   .setup((p) => p.removeCustomObject)
   .returns(vi.fn())
   .setup((p) => (p.cadBudget = It.IsAny<CadModelBudget>()))
-  .callback((p) => viewerSetCadModelBudgetMock(p.args[0]))
+  .callback((p) => {
+    viewerSetCadModelBudgetMock(p.args[0]);
+  })
   .setup((p) => (p.pointCloudBudget = It.IsAny<PointCloudBudget>()))
-  .callback((p) => viewerSetPointCloudModelBudgetMock(p.args[0]))
+  .callback((p) => {
+    viewerSetPointCloudModelBudgetMock(p.args[0]);
+  })
   .setup((p) => p.setResolutionOptions)
   .returns(vi.fn())
   .object();

--- a/react-components/tests/tests-utilities/fixtures/viewer.ts
+++ b/react-components/tests/tests-utilities/fixtures/viewer.ts
@@ -1,6 +1,12 @@
 import { vi } from 'vitest';
 
-import type { DataSourceType, Cognite3DViewer } from '@cognite/reveal';
+import {
+  type DataSourceType,
+  type Cognite3DViewer,
+  CadModelBudget,
+  PointCloudBudget,
+  ResolutionOptions
+} from '@cognite/reveal';
 import { Mock, It } from 'moq.ts';
 import { cameraManagerMock } from './cameraManager';
 
@@ -15,6 +21,8 @@ export const viewerImage360CollectionsMock = vi.fn<Cognite3DViewer['get360ImageC
 export const fitCameraToVisualSceneBoundingBoxMock =
   vi.fn<Cognite3DViewer['fitCameraToVisualSceneBoundingBox']>();
 export const fitCameraToModelsMock = vi.fn<Cognite3DViewer['fitCameraToModels']>();
+export const viewerSetCadModelBudgetMock = vi.fn<(budget: CadModelBudget) => void>();
+export const viewerSetPointCloudModelBudgetMock = vi.fn<(budget: PointCloudBudget) => void>();
 
 export const viewerMock = new Mock<Cognite3DViewer<DataSourceType>>()
   .setup((viewer) => {
@@ -54,5 +62,11 @@ export const viewerMock = new Mock<Cognite3DViewer<DataSourceType>>()
   .setup((p) => p.addCustomObject)
   .returns(vi.fn())
   .setup((p) => p.removeCustomObject)
+  .returns(vi.fn())
+  .setup((p) => (p.cadBudget = It.IsAny<CadModelBudget>()))
+  .callback((p) => viewerSetCadModelBudgetMock(p.args[0]))
+  .setup((p) => (p.pointCloudBudget = It.IsAny<PointCloudBudget>()))
+  .callback((p) => viewerSetPointCloudModelBudgetMock(p.args[0]))
+  .setup((p) => p.setResolutionOptions)
   .returns(vi.fn())
   .object();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) <!-- refactoring production code, eg. renaming a variable -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Introduce `RevealSettingsController`, which works as an interface between the RevealRenderTarget and Reveal's `Cognite3DViewer`. It's made to centralize global settings on Reveal, and its signal-based interface will be used to update components.

It currently only contains render quality settings to control.
It will be used for the upcoming render quality slider.

https://cognitedata.atlassian.net/browse/BND3D-5504

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
