### PR TITLE
test(react-components): Make unit test for the color code

### DIFF
--- a/react-components/src/architecture/base/domainObjects/DomainObject.test.ts
+++ b/react-components/src/architecture/base/domainObjects/DomainObject.test.ts
@@ -6,14 +6,14 @@ import { type TranslationInput } from '../utilities/TranslateInput';
 
 import { describe, test, expect, beforeAll, vi } from 'vitest';
 import { DomainObject } from './DomainObject';
-import { Color } from 'three/src/math/Color.js';
+import { Color } from 'three';
 import { DomainObjectChange } from '../domainObjectsHelpers/DomainObjectChange';
 import { Changes } from '../domainObjectsHelpers/Changes';
 import { PopupStyle } from '../domainObjectsHelpers/PopupStyle';
 import { RenderStyle } from '../renderStyles/RenderStyle';
 import { cloneDeep } from 'lodash';
 import { ColorType } from '../domainObjectsHelpers/ColorType';
-import { BLACK_COLOR, WHITE_COLOR } from '../utilities/colors/colorExtensions';
+import { BLACK_COLOR, isGreyScale, WHITE_COLOR } from '../utilities/colors/colorExtensions';
 import { ChangedDescription } from '../domainObjectsHelpers/ChangedDescription';
 import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
 import { CommandsUpdater } from '../reactUpdaters/CommandsUpdater';
@@ -76,11 +76,7 @@ describe('DomainObject', () => {
   test('should have color', () => {
     const domainObject = new ChildDomainObject();
     const color = domainObject.color;
-    const isGreyScale = color.r === color.g && color.r === color.b;
-    const rgbSum = color.r + color.g + color.b;
-    expect(isGreyScale).toBe(false);
-    expect(rgbSum).greaterThan(0);
-    expect(rgbSum).lessThan(3);
+    expect(isGreyScale(color)).toBe(false);
   });
 
   test('should set color', () => {

--- a/react-components/src/architecture/base/utilities/colors/colorExtensions.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/colorExtensions.test.ts
@@ -1,0 +1,116 @@
+import { Color } from 'three';
+import { describe, expect, test } from 'vitest';
+import {
+  BLACK_COLOR,
+  WHITE_COLOR,
+  GREY_COLOR,
+  convertToComplementary,
+  fractionToByte,
+  getColorFromBytes,
+  getComplementary,
+  getGammaCorrectedColor,
+  getHslMixedColor,
+  getMixedColor,
+  isGreyScale
+} from './colorExtensions';
+import { expectEqualColor } from '../../../../../tests/tests-utilities/primitives/primitiveTestUtil';
+
+const RED_COLOR = new Color(1, 0, 0);
+const BLUE_COLOR = new Color(0, 0, 1);
+const CYAN_COLOR = new Color(0, 1, 1);
+
+describe('colorExtensions', () => {
+  describe(isGreyScale.name, () => {
+    test('should be grayscale', () => {
+      expect(isGreyScale(WHITE_COLOR)).toBe(true);
+      expect(isGreyScale(BLACK_COLOR)).toBe(true);
+      expect(isGreyScale(GREY_COLOR)).toBe(true);
+    });
+
+    test('should not be grayscale', () => {
+      expect(isGreyScale(RED_COLOR)).toBe(false);
+      expect(isGreyScale(BLUE_COLOR)).toBe(false);
+      expect(isGreyScale(CYAN_COLOR)).toBe(false);
+    });
+  });
+
+  describe(getMixedColor.name, () => {
+    test('should mix colors equally', () => {
+      const actual = getMixedColor(RED_COLOR, BLUE_COLOR);
+      expectEqualColor(actual, new Color(0.5, 0, 0.5));
+    });
+
+    test('should mix colors by fraction', () => {
+      const actual = getMixedColor(RED_COLOR, BLUE_COLOR, 0.1);
+      expectEqualColor(actual, new Color(0.1, 0, 0.9));
+    });
+  });
+
+  describe(getHslMixedColor.name, () => {
+    test('should mix colors equally (long way around color wheel)', () => {
+      const actual = getHslMixedColor(RED_COLOR, BLUE_COLOR, 0.5, true);
+      expectEqualColor(actual, new Color(0, 1, 0));
+    });
+
+    test('should mix colors equally (short way around color wheel)', () => {
+      const actual = getHslMixedColor(RED_COLOR, BLUE_COLOR, 0.5, false);
+      expectEqualColor(actual, new Color(1, 0, 1));
+    });
+
+    test('should mix colors by fraction', () => {
+      const actual = getHslMixedColor(RED_COLOR, BLUE_COLOR, 0.1, false);
+      expectEqualColor(actual, new Color(0.2, 0, 1));
+    });
+  });
+
+  describe(getGammaCorrectedColor.name, () => {
+    test('should not change color when saturated', () => {
+      const actual = getGammaCorrectedColor(WHITE_COLOR);
+      expectEqualColor(actual, WHITE_COLOR);
+    });
+
+    test('should change color', () => {
+      const rgb0 = 0.5;
+      const rgb1 = 0.217637640824031;
+      const actual = getGammaCorrectedColor(new Color(rgb0, rgb0, rgb0));
+      expectEqualColor(actual, new Color(rgb1, rgb1, rgb1));
+    });
+  });
+  describe(convertToComplementary.name, () => {
+    test('should not change color from white to black', () => {
+      const color = WHITE_COLOR.clone();
+      convertToComplementary(color);
+      expectEqualColor(color, BLACK_COLOR);
+    });
+
+    test('should not change color from red to cyan', () => {
+      const color = RED_COLOR.clone();
+      convertToComplementary(color);
+      expectEqualColor(color, CYAN_COLOR);
+    });
+  });
+  describe(getComplementary.name, () => {
+    test('should not change color from white to black', () => {
+      const color = getComplementary(WHITE_COLOR);
+      expectEqualColor(color, BLACK_COLOR);
+    });
+
+    test('should not change color from red to cyan', () => {
+      const color = getComplementary(RED_COLOR);
+      expectEqualColor(color, CYAN_COLOR);
+    });
+  });
+
+  describe(fractionToByte.name + ' and ' + getColorFromBytes.name, () => {
+    test('should convert color to bytes and back again', () => {
+      for (let red = 0; red <= 1; red += 0.1) {
+        const expected = new Color(red, red / 2, red / 3); // Just made them different
+        const r = fractionToByte(expected.r);
+        const g = fractionToByte(expected.g);
+        const b = fractionToByte(expected.b);
+        const actual = getColorFromBytes(r, g, b);
+        expectEqualColor(actual, expected);
+      }
+    });
+  });
+});

--- a/react-components/src/architecture/base/utilities/colors/colorExtensions.ts
+++ b/react-components/src/architecture/base/utilities/colors/colorExtensions.ts
@@ -9,6 +9,10 @@ export const BLACK_COLOR = new Color(0, 0, 0);
 export const GREY_COLOR = new Color(0.67, 0.67, 0.67);
 export const MAX_BYTE = 255;
 
+export function isGreyScale(color: Color): boolean {
+  return color.r === color.g && color.g === color.b;
+}
+
 export function getMixedColor(color: Color, other: Color, fraction = 0.5): Color {
   const otherFraction = 1 - fraction;
   const r = color.r * fraction + other.r * otherFraction;
@@ -17,7 +21,12 @@ export function getMixedColor(color: Color, other: Color, fraction = 0.5): Color
   return new Color(r, g, b);
 }
 
-export function getHslMixedColor(color: Color, other: Color, fraction = 0.5, long: boolean): Color {
+export function getHslMixedColor(
+  color: Color,
+  other: Color,
+  fraction = 0.5,
+  long: boolean = true
+): Color {
   let hsl1: HSL = { h: 0, s: 0, l: 0 };
   let hsl2: HSL = { h: 0, s: 0, l: 0 };
   hsl1 = color.getHSL(hsl1);

--- a/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+import { getColorMap } from './colorMaps';
+import { ColorMapType } from './ColorMapType';
+import assert from 'assert';
+import { getColorFromBytes, WHITE_COLOR } from './colorExtensions';
+import { BYTE_PR_COLOR, ColorMap, TEXTURE_1D_WIDTH } from './ColorMap';
+import { Range1 } from '../geometry/Range1';
+
+describe(ColorMap.name, () => {
+  test('should have all colors different', () => {
+    const colorMap = getColorMap(ColorMapType.Terrain);
+    expect(colorMap).toBeDefined();
+    assert(colorMap !== undefined);
+
+    let prevColor = colorMap.getColor(0);
+    const inc = 0.1;
+    for (let fraction = inc; fraction <= 1; fraction += inc) {
+      const color = colorMap.getColor(fraction);
+      expect(color).toBeDefined();
+      expect(prevColor.equals(color)).toBe(false);
+      prevColor = color;
+    }
+  });
+
+  test('should test createColors', () => {
+    const colorMap = getColorMap(ColorMapType.Terrain);
+    expect(colorMap).toBeDefined();
+    assert(colorMap !== undefined);
+
+    const colorCount = 100;
+    const colors = colorMap.createColors(colorCount);
+    expect(colors.length).toBe(colorCount * TEXTURE_1D_WIDTH * BYTE_PR_COLOR);
+
+    let i = 0;
+    let prevColor = getColorFromBytes(colors[i++], colors[i++], colors[i++]);
+    i++; // skip alpha
+    for (let colorIndex = 1; colorIndex < colorCount; colorIndex++) {
+      const color = getColorFromBytes(colors[i++], colors[i++], colors[i++]);
+      expect(prevColor.equals(color)).toBe(false);
+      prevColor = color;
+      i++; // skip alpha
+    }
+  });
+
+  test('should test createColorsWithContours', () => {
+    const colorMap = getColorMap(ColorMapType.Terrain);
+    expect(colorMap).toBeDefined();
+    assert(colorMap !== undefined);
+
+    const colorCount = 100;
+    const colors = colorMap.createColorsWithContours(
+      new Range1(100, 200),
+      25,
+      0.5,
+      undefined,
+      colorCount
+    );
+    expect(colors.length).toBe(colorCount * TEXTURE_1D_WIDTH * BYTE_PR_COLOR);
+
+    let i = 0;
+    let prevColor = getColorFromBytes(colors[i++], colors[i++], colors[i++]);
+    i++; // skip alpha
+    for (let colorIndex = 1; colorIndex < colorCount; colorIndex++) {
+      const color = getColorFromBytes(colors[i++], colors[i++], colors[i++]);
+      expect(prevColor.equals(color)).toBe(false);
+      prevColor = color;
+      i++; // skip alpha
+    }
+  });
+});

--- a/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { getColorMap } from './colorMaps';
 import { ColorMapType } from './ColorMapType';
 import assert from 'assert';
-import { getColorFromBytes, WHITE_COLOR } from './colorExtensions';
+import { getColorFromBytes } from './colorExtensions';
 import { BYTE_PR_COLOR, ColorMap, TEXTURE_1D_WIDTH } from './ColorMap';
 import { Range1 } from '../geometry/Range1';
 
@@ -22,7 +22,7 @@ describe(ColorMap.name, () => {
     }
   });
 
-  test('should test createColors', () => {
+  test('should check that createColors returns different colors', () => {
     const colorMap = getColorMap(ColorMapType.Terrain);
     expect(colorMap).toBeDefined();
     assert(colorMap !== undefined);
@@ -42,7 +42,7 @@ describe(ColorMap.name, () => {
     }
   });
 
-  test('should test createColorsWithContours', () => {
+  test('should test createColorsWithContours returns different colors', () => {
     const colorMap = getColorMap(ColorMapType.Terrain);
     expect(colorMap).toBeDefined();
     assert(colorMap !== undefined);

--- a/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
@@ -5,6 +5,7 @@ import assert from 'assert';
 import { getColorFromBytes } from './colorExtensions';
 import { BYTE_PR_COLOR, ColorMap, TEXTURE_1D_WIDTH } from './ColorMap';
 import { Range1 } from '../geometry/Range1';
+import { type Color } from 'three';
 
 describe(ColorMap.name, () => {
   test('should have all colors different', () => {
@@ -12,13 +13,12 @@ describe(ColorMap.name, () => {
     expect(colorMap).toBeDefined();
     assert(colorMap !== undefined);
 
-    let prevColor = colorMap.getColor(0);
+    const uniqueColors = new Set<number>();
     const inc = 0.1;
     for (let fraction = inc; fraction <= 1; fraction += inc) {
-      const color = colorMap.getColor(fraction);
-      expect(color).toBeDefined();
-      expect(prevColor.equals(color)).toBe(false);
-      prevColor = color;
+      const colorHex = colorMap.getColor(fraction).getHex();
+      expect(uniqueColors.has(colorHex)).toBe(false);
+      uniqueColors.add(colorHex);
     }
   });
 
@@ -31,15 +31,16 @@ describe(ColorMap.name, () => {
     const colors = colorMap.createColors(colorCount);
     expect(colors.length).toBe(colorCount * TEXTURE_1D_WIDTH * BYTE_PR_COLOR);
 
+    const uniqueColors = new Set<number>();
     let i = 0;
-    let prevColor = getColorFromBytes(colors[i++], colors[i++], colors[i++]);
-    i++; // skip alpha
-    for (let colorIndex = 1; colorIndex < colorCount; colorIndex++) {
+    for (let colorIndex = 0; colorIndex < colorCount; colorIndex++) {
       const color = getColorFromBytes(colors[i++], colors[i++], colors[i++]);
-      expect(prevColor.equals(color)).toBe(false);
-      prevColor = color;
       i++; // skip alpha
+      const colorHex = color.getHex();
+      expect(uniqueColors.has(colorHex)).toBe(false);
+      uniqueColors.add(colorHex);
     }
+    expect(uniqueColors.size).toBe(colorCount);
   });
 
   test('should test createColorsWithContours returns different colors', () => {
@@ -57,6 +58,8 @@ describe(ColorMap.name, () => {
     );
     expect(colors.length).toBe(colorCount * TEXTURE_1D_WIDTH * BYTE_PR_COLOR);
 
+    // This can have the same color, so we can't check whether the all colors are different
+    // Therefore, only check with the previous color
     let i = 0;
     let prevColor = getColorFromBytes(colors[i++], colors[i++], colors[i++]);
     i++; // skip alpha

--- a/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/colorMap.test.ts
@@ -5,7 +5,6 @@ import assert from 'assert';
 import { getColorFromBytes } from './colorExtensions';
 import { BYTE_PR_COLOR, ColorMap, TEXTURE_1D_WIDTH } from './ColorMap';
 import { Range1 } from '../geometry/Range1';
-import { type Color } from 'three';
 
 describe(ColorMap.name, () => {
   test('should have all colors different', () => {

--- a/react-components/src/architecture/base/utilities/colors/colorMaps.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/colorMaps.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { getColorMap, getOptions } from './colorMaps';
+import { ColorMapType } from './ColorMapType';
+
+const colorMapTypes = [
+  ColorMapType.Terrain,
+  ColorMapType.Rainbow,
+  ColorMapType.RainbowReverse,
+  ColorMapType.Seismic,
+  ColorMapType.SeismicReverse,
+  ColorMapType.GreyScale,
+  ColorMapType.GreyScaleReverse
+];
+
+describe('colorMaps', () => {
+  test('should have all color maps defined', () => {
+    for (const colorMapType of colorMapTypes) {
+      const colorMap = getColorMap(colorMapType);
+      expect(colorMap).toBeDefined();
+    }
+  });
+  test('should have all color maps as options', () => {
+    const options = getOptions();
+    expect(options).toStrictEqual(colorMapTypes);
+  });
+});

--- a/react-components/src/architecture/base/utilities/colors/getNextColor.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/getNextColor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+import { getNextColor, getNextColorByIndex } from './getNextColor';
+
+describe('colorExtensions', () => {
+  describe(getNextColor.name, () => {
+    test('should different', () => {
+      let prevColor = getNextColor();
+      for (let i = 0; i < 20; i++) {
+        const color = getNextColor();
+        expect(prevColor.equals(color)).toBe(false);
+        prevColor = color;
+      }
+    });
+  });
+  describe(getNextColorByIndex.name, () => {
+    test('should different', () => {
+      let prevColor = getNextColorByIndex(0);
+      for (let i = 0; i < 20; i++) {
+        const color = getNextColorByIndex(i + 1);
+        expect(prevColor.equals(color)).toBe(false);
+        prevColor = color;
+      }
+    });
+  });
+});

--- a/react-components/src/architecture/base/utilities/colors/getNextColor.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/getNextColor.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, test } from 'vitest';
-import { getNextColor, getNextColorByIndex } from './getNextColor';
+import { getNextColor, getNextColorByIndex, NUMBER_OF_UNIQUE_COLORS } from './getNextColor';
 import { type Color } from 'three';
 
 describe('colorExtensions', () => {
   describe(getNextColor.name, () => {
     test('should different', () => {
-      let prevColor = getNextColor();
-      for (let i = 0; i < 20; i++) {
-        const color = getNextColor();
-        expect(prevColor.equals(color)).toBe(false);
-        prevColor = color;
+      const uniqueColors = new Set<number>();
+      for (let i = 0; i < NUMBER_OF_UNIQUE_COLORS; i++) {
+        const colorHex = getNextColor().getHex();
+        expect(uniqueColors.has(colorHex)).toBe(false);
+        uniqueColors.add(colorHex);
       }
+      expect(uniqueColors.size).toBe(NUMBER_OF_UNIQUE_COLORS);
     });
     test('should have legal colors', () => {
       for (let i = 0; i < 20; i++) {
@@ -20,15 +21,16 @@ describe('colorExtensions', () => {
   });
   describe(getNextColorByIndex.name, () => {
     test('should different', () => {
-      let prevColor = getNextColorByIndex(0);
-      for (let i = 0; i < 20; i++) {
-        const color = getNextColorByIndex(i + 1);
-        expect(prevColor.equals(color)).toBe(false);
-        prevColor = color;
+      const uniqueColors = new Set<number>();
+      for (let i = 0; i < NUMBER_OF_UNIQUE_COLORS; i++) {
+        const colorHex = getNextColorByIndex(i + 1).getHex();
+        expect(uniqueColors.has(colorHex)).toBe(false);
+        uniqueColors.add(colorHex);
       }
+      expect(uniqueColors.size).toBe(NUMBER_OF_UNIQUE_COLORS);
     });
     test('should have legal colors', () => {
-      for (let i = 0; i < 20; i++) {
+      for (let i = 0; i < NUMBER_OF_UNIQUE_COLORS; i++) {
         checkIfLegal(getNextColorByIndex(i));
       }
     });

--- a/react-components/src/architecture/base/utilities/colors/getNextColor.test.ts
+++ b/react-components/src/architecture/base/utilities/colors/getNextColor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { getNextColor, getNextColorByIndex } from './getNextColor';
+import { type Color } from 'three';
 
 describe('colorExtensions', () => {
   describe(getNextColor.name, () => {
@@ -9,6 +10,11 @@ describe('colorExtensions', () => {
         const color = getNextColor();
         expect(prevColor.equals(color)).toBe(false);
         prevColor = color;
+      }
+    });
+    test('should have legal colors', () => {
+      for (let i = 0; i < 20; i++) {
+        checkIfLegal(getNextColor());
       }
     });
   });
@@ -21,5 +27,19 @@ describe('colorExtensions', () => {
         prevColor = color;
       }
     });
+    test('should have legal colors', () => {
+      for (let i = 0; i < 20; i++) {
+        checkIfLegal(getNextColorByIndex(i));
+      }
+    });
   });
 });
+
+function checkIfLegal(color: Color): void {
+  expect(color.r).lessThanOrEqual(1);
+  expect(color.r).greaterThanOrEqual(0);
+  expect(color.g).lessThanOrEqual(1);
+  expect(color.g).greaterThanOrEqual(0);
+  expect(color.b).lessThanOrEqual(1);
+  expect(color.b).greaterThanOrEqual(0);
+}

--- a/react-components/src/architecture/base/utilities/colors/getNextColor.ts
+++ b/react-components/src/architecture/base/utilities/colors/getNextColor.ts
@@ -8,7 +8,7 @@ import { isEven } from '../extensions/mathExtensions';
 let currentIndex = 0;
 let uniqueColors: Color[] | undefined;
 
-const NUMBER_OF_UNIQUE_COLORS = 50;
+export const NUMBER_OF_UNIQUE_COLORS = 50;
 
 // ==================================================
 // PUBLIC FUNCTIONS:

--- a/react-components/tests/tests-utilities/primitives/primitiveTestUtil.ts
+++ b/react-components/tests/tests-utilities/primitives/primitiveTestUtil.ts
@@ -3,7 +3,7 @@
  */
 
 import { expect } from 'vitest';
-import { type Box3, type Euler, type Matrix4, type Vector3 } from 'three';
+import { type Color, type Box3, type Euler, type Matrix4, type Vector3 } from 'three';
 
 const EPSILON = 0.0001;
 
@@ -11,7 +11,7 @@ export function expectEqualVector3(
   actual: Vector3 | undefined,
   expected: Vector3 | undefined
 ): void {
-  const equals = equalsVector3(actual, expected);
+  const equals = equalsVector3(actual, expected); // Just to see the difference
   if (!equals) {
     expect(actual).toStrictEqual(expected);
   } else {
@@ -19,10 +19,18 @@ export function expectEqualVector3(
   }
 }
 
+export function expectEqualColor(actual: Color | undefined, expected: Color | undefined): void {
+  const equals = equalsColor(actual, expected);
+  if (!equals) {
+    expect(actual).toStrictEqual(expected); // Just to see the difference
+  } else {
+    expect(equals).toBe(true);
+  }
+}
 export function expectEqualEuler(actual: Euler, expected: Euler): void {
   const equals = equalsEuler(actual, expected);
   if (!equals) {
-    expect(actual).toStrictEqual(expected);
+    expect(actual).toStrictEqual(expected); // Just to see the difference
   } else {
     expect(equals).toBe(true);
   }
@@ -52,6 +60,29 @@ export function equalsVector3(
     if (!almostEquals(a.getComponent(i), b.getComponent(i), epsilon)) {
       return false;
     }
+  }
+  return true;
+}
+
+export function equalsColor(
+  a: Color | undefined,
+  b: Color | undefined,
+  epsilon = EPSILON
+): boolean {
+  if (a === undefined && b === undefined) {
+    return true;
+  }
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+  if (!almostEquals(a.r, b.r, epsilon)) {
+    return false;
+  }
+  if (!almostEquals(a.g, b.g, epsilon)) {
+    return false;
+  }
+  if (!almostEquals(a.b, b.b, epsilon)) {
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Test](https://img.shields.io/badge/Type-Test-blueviolet) 

## Description :pencil:

- This s mostly unit tests
- Added `isGreyScale `to `ColorsExtensions` since this is a nice utility functions and used it in some test.
- Use  `isGreyScale ` in the color test for `DomainObject`. Removed the sum part of the test because it doesn't catch any bugs anywhy.