### PR TITLE
feat(react-components): add hybrid cad mappings support (part 7)

### DIFF
--- a/react-components/src/index.ts
+++ b/react-components/src/index.ts
@@ -11,6 +11,8 @@ export * from './data-providers';
 
 export * from './utilities/externalIndex';
 
+export * from './utilities/hybrid/getCadHybridAssetMappings';
+
 // Higher order components
 export { withSuppressRevealEvents } from './higher-order-components/withSuppressRevealEvents';
 

--- a/react-components/src/utilities/hybrid/fetchMappedEquipmentAssetMappingsHybrid.ts
+++ b/react-components/src/utilities/hybrid/fetchMappedEquipmentAssetMappingsHybrid.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2025 Cognite AS
+ */
+import { type NodeDefinition, type CogniteClient } from '@cognite/sdk';
+import { type NodeDefinitionWithModelAndMappings, type ModelMappingsWithAssets } from '../../query';
+import { DmsUniqueIdentifier, type SimpleSource } from '../../data-providers';
+import { type ModelWithAssetMappings } from '../../hooks';
+
+export const fetchAllMappedEquipmentAssetMappingsHybrid = async ({
+  sdk,
+  viewToSearch,
+  assetMappingList,
+  hybridMappingsIdentifiers
+}: {
+  sdk: CogniteClient;
+  viewToSearch: SimpleSource;
+  assetMappingList: ModelWithAssetMappings[];
+  hybridMappingsIdentifiers: DmsUniqueIdentifier[];
+}): Promise<NodeDefinitionWithModelAndMappings[]> => {
+  const allEquipment = await sdk.instances.retrieve({
+    sources: [
+      {
+        source: {
+          externalId: viewToSearch.externalId,
+          space: viewToSearch.space,
+          type: 'view',
+          version: viewToSearch.version
+        }
+      }
+    ],
+    items: hybridMappingsIdentifiers.map((instance) => ({
+      instanceType: 'node',
+      space: instance.space,
+      externalId: instance.externalId
+    }))
+  });
+
+  const modelsWithCoreAssetsAndMappings: NodeDefinitionWithModelAndMappings[] = [];
+
+  assetMappingList.forEach((mapping) => {
+    allEquipment?.items.forEach((equipment) => {
+      if (equipment.instanceType !== 'node') return;
+
+      const mappingsFound = mapping.assetMappings.filter(
+        (item) =>
+          item.assetInstanceId?.externalId === equipment.externalId &&
+          item.assetInstanceId?.space === equipment.space
+      );
+
+      if (mappingsFound.length > 0) {
+        const assetNode: NodeDefinition = {
+          space: equipment.space,
+          externalId: equipment.externalId,
+          instanceType: 'node',
+          properties: equipment.properties ?? {},
+          version: equipment.version,
+          createdTime: equipment.createdTime,
+          lastUpdatedTime: equipment.lastUpdatedTime
+        };
+
+        modelsWithCoreAssetsAndMappings.push({
+          model: mapping.model,
+          asset: assetNode,
+          mappings: mappingsFound
+        });
+      }
+    });
+  });
+
+  return modelsWithCoreAssetsAndMappings;
+};

--- a/react-components/src/utilities/hybrid/getCadHybridAssetMappings.test.ts
+++ b/react-components/src/utilities/hybrid/getCadHybridAssetMappings.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCadHybridAssetMappings } from './getCadHybridAssetMappings';
+import { CadModelOptions } from '../../components';
+import { Source } from '../../data-providers';
+import { RevealRenderTarget } from '../../architecture';
+import { NodeDefinition } from '@cognite/sdk';
+import { CdfAssetMapping } from '../../components/CacheProvider/types';
+
+
+describe('getCadHybridAssetMappings', () => {
+  const mockCadModels: CadModelOptions[] = [
+    { modelId: 1, revisionId: 1, type: 'cad' },
+    { modelId: 2, revisionId: 2, type: 'cad' }
+  ];
+
+  const mockViewsToSearch: Source[] = [
+    { externalId: 'view1', space: 'space1', version: 'v1', type: 'view' },
+    { externalId: 'view2', space: 'space2', version: 'v1', type: 'view' },
+  ];
+  const mockAssetMappings: CdfAssetMapping[] = [
+    {
+      assetInstanceId: { externalId: 'asset1', space: 'space1' },
+      treeIndex: 0,
+      subtreeSize: 0,
+      nodeId: 0,
+      assetId: 0
+    },
+    {
+      assetInstanceId: { externalId: 'asset2', space: 'space2' },
+      treeIndex: 0,
+      subtreeSize: 0,
+      nodeId: 1,
+      assetId: 1
+    }
+  ];
+
+  const nodeDefinitions: NodeDefinition[] = [{
+    space: 'space1',
+    externalId: 'asset1',
+    instanceType: 'node',
+    properties: {
+      space1: { 'view1/v1': {} }
+    },
+    version: 1,
+    createdTime: 123456789,
+    lastUpdatedTime: 123456789
+  },
+  {
+    space: 'space2',
+    externalId: 'asset2',
+    instanceType: 'node',
+    properties: {
+      space2: { 'view2/v1': {} }
+    },
+    version: 1,
+    createdTime: 123456789,
+    lastUpdatedTime: 123456789
+  }];
+
+  let mockRenderTarget: RevealRenderTarget;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockRenderTarget = {
+      cdfCaches: {
+        assetMappingAndNode3dCache: {
+          getAssetMappingsForModel: vi.fn().mockResolvedValue([]),
+        }
+      },
+      rootDomainObject: {
+        sdk: {
+          instances: {
+            retrieve: vi.fn().mockResolvedValue([])
+          }
+        },
+        fdmSdk: {
+          searchInstances: vi.fn().mockResolvedValue([]),
+        }
+      }
+    } as unknown as RevealRenderTarget;
+  });
+
+  it('should return undefined mappings when no hybrid mappings are found', async () => {
+
+    const result = await getCadHybridAssetMappings(mockCadModels, mockViewsToSearch, 'query string', mockRenderTarget);
+
+    expect(result).toEqual({
+      allHybridAssetMappings: undefined,
+      searchedHybridAssetMappings: undefined
+    });
+  });
+
+  it('should fetch all hybrid mappings and filter them by views', async () => {
+
+    mockRenderTarget.cdfCaches.assetMappingAndNode3dCache.getAssetMappingsForModel = vi.fn().mockResolvedValue(mockAssetMappings);
+    mockRenderTarget.rootDomainObject.sdk.instances.retrieve = vi.fn().mockResolvedValue({
+      items: nodeDefinitions
+    });
+
+    const result = await getCadHybridAssetMappings(mockCadModels, mockViewsToSearch, '', mockRenderTarget);
+
+    expect(result.allHybridAssetMappings).toHaveLength(4);
+    expect(result.allHybridAssetMappings).toEqual(getExpectedAllHybridMappings());
+    expect(result.searchedHybridAssetMappings).toBeUndefined();
+  });
+
+  it('should fetch hybrid mappings and search instances when query is provided', async () => {
+
+    mockRenderTarget.cdfCaches.assetMappingAndNode3dCache.getAssetMappingsForModel = vi.fn().mockResolvedValue(mockAssetMappings);
+    mockRenderTarget.rootDomainObject.sdk.instances.retrieve = vi.fn().mockResolvedValue({
+      items: nodeDefinitions
+    });
+
+    mockRenderTarget.rootDomainObject.fdmSdk.searchInstances = vi.fn().mockResolvedValue({
+      instances: [{ externalId: 'asset1', space: 'space1' }]
+    });
+
+    const result = await getCadHybridAssetMappings(mockCadModels, mockViewsToSearch, 'asset1', mockRenderTarget);
+
+    expect(mockRenderTarget.rootDomainObject.fdmSdk.searchInstances).toHaveBeenCalledTimes(2);
+    expect(result.allHybridAssetMappings).toHaveLength(4);
+    expect(result.searchedHybridAssetMappings).toHaveLength(2);
+    expect(result.searchedHybridAssetMappings).toEqual(getExpectedSearchedHybridMappings());
+  });
+
+  it('should handle error gracefully with undefined when trying to get mappings from the caching system', async () => {
+    mockRenderTarget.cdfCaches.assetMappingAndNode3dCache.getAssetMappingsForModel = vi.fn().mockRejectedValueOnce(
+      new Error('Failed to fetch asset mappings')
+    );
+
+    const result = await getCadHybridAssetMappings(mockCadModels, mockViewsToSearch, '', mockRenderTarget);
+    expect(result).toEqual({
+      allHybridAssetMappings: undefined,
+      searchedHybridAssetMappings: undefined
+    });
+  });
+});
+
+function getExpectedSearchedHybridMappings() {
+  return [
+    {
+      view: {
+        externalId: "view1",
+        space: "space1",
+        version: "v1",
+        type: "view",
+      },
+      instances: [
+        {
+          externalId: "asset1",
+          space: "space1",
+        },
+      ],
+    },
+    {
+      view: {
+        externalId: "view2",
+        space: "space2",
+        version: "v1",
+        type: "view",
+      },
+      instances: [
+        {
+          externalId: "asset1",
+          space: "space1",
+        },
+      ],
+    },
+  ]
+}
+
+function getExpectedAllHybridMappings() {
+  return [
+    {
+      model: {
+        modelId: 1,
+        revisionId: 1,
+        type: "cad",
+      },
+      asset: {
+        space: "space1",
+        externalId: "asset1",
+        instanceType: "node",
+        properties: {
+          space1: {
+            "view1/v1": {
+            },
+          },
+        },
+        version: 1,
+        createdTime: 123456789,
+        lastUpdatedTime: 123456789,
+      },
+      mappings: [
+        {
+          assetInstanceId: {
+            externalId: "asset1",
+            space: "space1",
+          },
+          treeIndex: 0,
+          subtreeSize: 0,
+          nodeId: 0,
+          assetId: 0,
+        },
+      ],
+    },
+    {
+      model: {
+        modelId: 2,
+        revisionId: 2,
+        type: "cad",
+      },
+      asset: {
+        space: "space1",
+        externalId: "asset1",
+        instanceType: "node",
+        properties: {
+          space1: {
+            "view1/v1": {
+            },
+          },
+        },
+        version: 1,
+        createdTime: 123456789,
+        lastUpdatedTime: 123456789,
+      },
+      mappings: [
+        {
+          assetInstanceId: {
+            externalId: "asset1",
+            space: "space1",
+          },
+          treeIndex: 0,
+          subtreeSize: 0,
+          nodeId: 0,
+          assetId: 0,
+        },
+      ],
+    },
+    {
+      model: {
+        modelId: 1,
+        revisionId: 1,
+        type: "cad",
+      },
+      asset: {
+        space: "space2",
+        externalId: "asset2",
+        instanceType: "node",
+        properties: {
+          space2: {
+            "view2/v1": {
+            },
+          },
+        },
+        version: 1,
+        createdTime: 123456789,
+        lastUpdatedTime: 123456789,
+      },
+      mappings: [
+        {
+          assetInstanceId: {
+            externalId: "asset2",
+            space: "space2",
+          },
+          treeIndex: 0,
+          subtreeSize: 0,
+          nodeId: 1,
+          assetId: 1,
+        },
+      ],
+    },
+    {
+      model: {
+        modelId: 2,
+        revisionId: 2,
+        type: "cad",
+      },
+      asset: {
+        space: "space2",
+        externalId: "asset2",
+        instanceType: "node",
+        properties: {
+          space2: {
+            "view2/v1": {
+            },
+          },
+        },
+        version: 1,
+        createdTime: 123456789,
+        lastUpdatedTime: 123456789,
+      },
+      mappings: [
+        {
+          assetInstanceId: {
+            externalId: "asset2",
+            space: "space2",
+          },
+          treeIndex: 0,
+          subtreeSize: 0,
+          nodeId: 1,
+          assetId: 1,
+        },
+      ],
+    }
+  ];
+}

--- a/react-components/src/utilities/hybrid/getCadHybridAssetMappings.ts
+++ b/react-components/src/utilities/hybrid/getCadHybridAssetMappings.ts
@@ -1,0 +1,134 @@
+/*!
+ * Copyright 2024 Cognite AS
+ */
+import { UnitDMSUniqueIdentifier } from '@cognite/sdk';
+import { CadModelOptions } from '../../components';
+import { COGNITE_ASSET_SOURCE, Source } from '../../data-providers';
+import { RevealRenderTarget } from '../../architecture';
+import { AssetMappingAndNode3DCache } from '../../components/CacheProvider';
+import { InstancesWithView, NodeDefinitionWithModelAndMappings } from '../../query';
+import { fetchAllMappedEquipmentAssetMappingsHybrid } from './fetchMappedEquipmentAssetMappingsHybrid';
+import { type CdfAssetMapping } from '../../components/CacheProvider/types';
+import { isDefined } from './../isDefined';
+import { FdmSDK } from '../../data-providers/FdmSDK';
+
+type AllHybridMappingsAndSearchResult = {
+  allHybridAssetMappings: NodeDefinitionWithModelAndMappings[] | undefined;
+  searchedHybridAssetMappings: InstancesWithView[] | undefined;
+};
+
+export const getCadHybridAssetMappings = async (
+  cadModels: CadModelOptions[],
+  viewsToSearch: Source[],
+  query: string,
+  renderTarget: RevealRenderTarget,
+): Promise<AllHybridMappingsAndSearchResult> => {
+  const { cdfCaches, rootDomainObject } = renderTarget;
+  const { assetMappingAndNode3dCache } = cdfCaches;
+  const { sdk, fdmSdk } = rootDomainObject;
+
+  const assetMappingList = await getAllAssetMappingsFromCache(cadModels, assetMappingAndNode3dCache);
+
+  const hybridMappingsIdentifiers = assetMappingList.flatMap((item) =>
+    item.assetMappings.map((mapping) => mapping.assetInstanceId).filter(isDefined)
+  );
+
+  if (hybridMappingsIdentifiers.length === 0) return { allHybridAssetMappings: undefined, searchedHybridAssetMappings: undefined };
+
+  const allMappedHybridAssets = await fetchAllMappedEquipmentAssetMappingsHybrid({
+    sdk,
+    viewToSearch: COGNITE_ASSET_SOURCE,
+    assetMappingList,
+    hybridMappingsIdentifiers
+  });
+
+  const filterAllMappedHybridAssetsForViewsToSearch = filterMappingsPerViewsToSearch(viewsToSearch, allMappedHybridAssets);
+
+  if (query === '' || assetMappingList === undefined) {
+    return {
+      allHybridAssetMappings: filterAllMappedHybridAssetsForViewsToSearch,
+      searchedHybridAssetMappings: undefined
+    };
+  }
+
+  const instancesWithView = await getHybridAssetMappingsFromSearchQuery(
+    viewsToSearch,
+    query,
+    fdmSdk,
+    hybridMappingsIdentifiers
+  );
+
+  return {
+    allHybridAssetMappings: filterAllMappedHybridAssetsForViewsToSearch,
+    searchedHybridAssetMappings: instancesWithView
+  };
+};
+
+async function getAllAssetMappingsFromCache(cadModels: CadModelOptions[], assetMappingAndNode3dCache: AssetMappingAndNode3DCache): Promise<{
+  model: CadModelOptions;
+  assetMappings: CdfAssetMapping[];
+}[]> {
+  try {
+    const fetchPromises = cadModels.map(
+      async (model) =>
+        await assetMappingAndNode3dCache
+          .getAssetMappingsForModel(model.modelId, model.revisionId)
+          .then((assetMappings) => ({ model, assetMappings }))
+    );
+
+    return await Promise.all(fetchPromises);
+  } catch (error) {
+    console.error('Error fetching asset mappings:', error);
+    return [];
+  }
+}
+
+function filterMappingsPerViewsToSearch(viewsToSearch: Source[], allMappedHybridAssets: NodeDefinitionWithModelAndMappings[]): NodeDefinitionWithModelAndMappings[] {
+  const filterAllMappedHybridAssetsForViewsToSearch = viewsToSearch.flatMap(
+    (view) => {
+      const viewExternalIdWithVersion = `${view.externalId}/${view.version}`;
+      const viewSpace = view.space;
+      return allMappedHybridAssets.filter((item) => {
+        const properties = item.asset.properties as Record<string, Record<string, unknown>> | undefined;
+        return properties?.[viewSpace]?.[viewExternalIdWithVersion];
+      });
+    }
+  );
+  return filterAllMappedHybridAssetsForViewsToSearch;
+
+}
+
+async function getHybridAssetMappingsFromSearchQuery(viewsToSearch: Source[], query: string, fdmSdk: FdmSDK, hybridMappingsIdentifiers: UnitDMSUniqueIdentifier[]): Promise<InstancesWithView[]> {
+  const limit = 1000;
+  const searchResults: InstancesWithView[] = [];
+
+  for await (const view of viewsToSearch) {
+    const result = await fdmSdk.searchInstances(view, query, 'node', limit, undefined);
+
+    searchResults.push({
+      view,
+      instances: result.instances
+    });
+  }
+  return connectMappedInstancesWithSearchResult(searchResults, hybridMappingsIdentifiers);
+}
+
+function connectMappedInstancesWithSearchResult(
+  searchResults: InstancesWithView[],
+  mapped3dCDMAssetIdentifiers: UnitDMSUniqueIdentifier[]
+): InstancesWithView[] {
+  const filteredResults = searchResults.map((result) => {
+    const filteredInstances = result.instances.filter((instance) =>
+      mapped3dCDMAssetIdentifiers.find(
+        (mappedItem) =>
+          mappedItem.space === instance.space && mappedItem.externalId === instance.externalId
+      )
+    );
+    return {
+      view: result.view,
+      instances: filteredInstances
+    };
+  });
+
+  return filteredResults;
+}

--- a/react-components/src/utilities/hybrid/index.ts
+++ b/react-components/src/utilities/hybrid/index.ts
@@ -1,0 +1,3 @@
+
+export * from './fetchMappedEquipmentAssetMappingsHybrid';
+export * from './getCadHybridAssetMappings';


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->
https://cognitedata.atlassian.net/browse/BND3D-4989
https://cognitedata.atlassian.net/browse/BND3D-5576

https://cognitedata.atlassian.net/browse/

## Description :pencil:
Add get cad hybrid asset mapping function utility as the entry point of getting all hybrid mappings by views or query.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [X] I am happy with this implementation.
- [X] I have performed a self-review of my own code.
- [X] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [X] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [X] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
