### PR TITLE
fix(react-components): dont't append panel to 'parent'

### DIFF
--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.tsx
@@ -33,7 +33,6 @@ export const LayersButton = ({
     <>
       <SelectPanel
         placement="right"
-        appendTo={'parent'}
         hideOnOutsideClick
         offset={TOOLBAR_HORIZONTAL_PANEL_OFFSET}>
         <SelectPanel.Trigger>

--- a/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayerSelection.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/components/ModelLayerSelection.tsx
@@ -31,7 +31,6 @@ export const ModelLayerSelection = ({
   return (
     <SelectPanel
       placement="right"
-      appendTo={'parent'}
       hideOnOutsideClick={true}
       openOnHover={!isDisabled}>
       <SelectPanel.Trigger>


### PR DESCRIPTION
#### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Jira task
https://cognitedata.atlassian.net/browse/BND3D-5620

## Description :pencil:
Don't override the appendTo of the SelectPanel. Overriding the `appendTo` should instead be done in global style definition as we there know the correct overlay container to use

## How has this been tested? :mag:
Have verified that . This fix is dependent on the following PR: https://github.com/cognitedata/fusion/pull/12820

## Test instructions :information_source:
1. Build react components locally
2. Check out the following fusion branch `BND3D-5620`
3. Link the local react components build to fusion
4. Link react components to fusion
5. Open 3D Search
6. Verify that the placement of the `LayersButton` popup is correct


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
