### PR TITLE
fix(react-component): Fix various issues with the DropdownButton not used in settings (standalone in a toolbar) [BND3D-5561]

### DIFF
--- a/react-components/src/components/Architecture/DropdownButton.test.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.test.tsx
@@ -5,8 +5,9 @@ import { type PropsWithChildren, type ReactElement } from 'react';
 import { viewerMock } from '#test-utils/fixtures/viewer';
 import { sdkMock } from '#test-utils/fixtures/sdk';
 import { ViewerContextProvider } from '../RevealCanvas/ViewerContext';
-import { DROPDOWN_BUTTON_ID, DROPDOWN_MENU_ITEM_ID, DropdownButton } from './DropdownButton';
+import { DropdownButton } from './DropdownButton';
 import { MockEnumOptionCommand } from '../../../tests/tests-utilities/architecture/mock-commands/MockEnumOptionCommand';
+import { Translator } from '../i18n/Translator';
 
 // Help page here:  https://bogr.dev/blog/react-testing-intro/
 
@@ -31,7 +32,8 @@ describe(DropdownButton.name + ' (not used in settings)', () => {
   });
 
   test('should render with correct default value and no dropdown', async () => {
-    const button = screen.getByTestId(DROPDOWN_BUTTON_ID);
+    const label = testCommand.getLabel(Translator.instance.translate);
+    const button = screen.getByLabelText(label);
 
     // Check that the selected value is updated by the default value
     const expectedValue = 'Red';
@@ -39,15 +41,17 @@ describe(DropdownButton.name + ' (not used in settings)', () => {
     expect(button.textContent).toBe(expectedValue);
 
     // Check that the the option menu is closed
-    const menuItems = screen.queryAllByTestId(DROPDOWN_MENU_ITEM_ID); // this doesn't crash when nothing found
+
+    const menuItems = screen.queryAllByRole('menuitem'); // this doesn't crash when nothing found
     expect(menuItems).toHaveLength(0);
   });
 
   test('should click and open dropdown menu', async () => {
-    fireEvent.click(screen.getByTestId(DROPDOWN_BUTTON_ID));
+    const label = testCommand.getLabel(Translator.instance.translate);
+    fireEvent.click(screen.getByLabelText(label));
 
     // Check that the menu is open and selected is checked
-    const menuItems = await screen.findAllByTestId(DROPDOWN_MENU_ITEM_ID);
+    const menuItems = await screen.findAllByRole('menuitem');
     expect(menuItems).toHaveLength(3);
     for (let i = 0; i < menuItems.length; i++) {
       const menuItem = menuItems[i];
@@ -56,18 +60,19 @@ describe(DropdownButton.name + ' (not used in settings)', () => {
   });
 
   test('should select by dropdown menu and close', async () => {
-    fireEvent.click(screen.getByTestId(DROPDOWN_BUTTON_ID));
+    const label = testCommand.getLabel(Translator.instance.translate);
+    fireEvent.click(screen.getByLabelText(label));
 
-    const menuItemsBeforeClick = await screen.findAllByTestId(DROPDOWN_MENU_ITEM_ID);
+    const menuItemsBeforeClick = await screen.findAllByRole('menuitem');
     fireEvent.click(menuItemsBeforeClick[2]); // Select the third option
 
     // Check that the menu is closed after selection
-    const menuItemsAfterClick = screen.queryAllByTestId(DROPDOWN_MENU_ITEM_ID);
+    const menuItemsAfterClick = screen.queryAllByRole('menuitem');
     expect(menuItemsAfterClick).toHaveLength(0);
 
     // Check that the selected value is updated
     const expectedValue = 'Blue';
     expect(testCommand.value).toBe(expectedValue);
-    expect(screen.getByTestId(DROPDOWN_BUTTON_ID).textContent).toBe(expectedValue);
+    expect(screen.getByLabelText(label).textContent).toBe(expectedValue);
   });
 });

--- a/react-components/src/components/Architecture/DropdownButton.test.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.test.tsx
@@ -1,0 +1,72 @@
+import { beforeEach, afterEach, describe, expect, test } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { RevealRenderTarget } from '../../architecture';
+import { type PropsWithChildren, type ReactElement } from 'react';
+import { viewerMock } from '#test-utils/fixtures/viewer';
+import { sdkMock } from '#test-utils/fixtures/sdk';
+import { ViewerContextProvider } from '../RevealCanvas/ViewerContext';
+import { DROPDOWN_BUTTON_ID, DROPDOWN_MENU_ITEM_ID, DropdownButton } from './DropdownButton';
+import { MockEnumOptionCommand } from '../../../tests/tests-utilities/architecture/mock-commands/MockEnumOptionCommand';
+
+// Help page here:  https://bogr.dev/blog/react-testing-intro/
+
+describe(DropdownButton.name + ' used in settings', () => {
+  let renderTargetMock: RevealRenderTarget;
+  let testCommand: MockEnumOptionCommand;
+
+  beforeEach(() => {
+    renderTargetMock = new RevealRenderTarget(viewerMock, sdkMock);
+
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <ViewerContextProvider value={renderTargetMock}>{children}</ViewerContextProvider>
+    );
+    testCommand = new MockEnumOptionCommand();
+    render(<DropdownButton inputCommand={testCommand} placement={'top'} usedInSettings={false} />, {
+      wrapper
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should render with correct default value and no dropdown', async () => {
+    const button = screen.getByTestId(DROPDOWN_BUTTON_ID);
+
+    // Check that the selected value is updated
+    const expectedValue = 'Red';
+    expect(testCommand.value).toBe(expectedValue);
+    expect(button.textContent).toBe(expectedValue);
+
+    const menuItems = screen.queryAllByTestId(DROPDOWN_MENU_ITEM_ID); // this doesn't crash when nothing found
+    expect(menuItems).toHaveLength(0);
+  });
+
+  test('should click and open dropdown menu', async () => {
+    fireEvent.click(screen.getByTestId(DROPDOWN_BUTTON_ID));
+
+    // Check that the menu is open and selected is checked
+    const menuItems = await screen.findAllByTestId(DROPDOWN_MENU_ITEM_ID);
+    expect(menuItems).toHaveLength(3);
+    for (let i = 0; i < menuItems.length; i++) {
+      const menuItem = menuItems[i];
+      expect(menuItem.getAttribute('aria-checked')).toBe(i === 0 ? 'true' : 'false');
+    }
+  });
+
+  test('should select by dropdown menu and close', async () => {
+    fireEvent.click(screen.getByTestId(DROPDOWN_BUTTON_ID));
+
+    const menuItemsBeforeClick = await screen.findAllByTestId(DROPDOWN_MENU_ITEM_ID);
+    fireEvent.click(menuItemsBeforeClick[2]); // Select the third option
+
+    // Check that the menu is closed after selection
+    const menuItemsAfterClick = screen.queryAllByTestId(DROPDOWN_MENU_ITEM_ID);
+    expect(menuItemsAfterClick).toHaveLength(0);
+
+    // Check that the selected value is updated
+    const expectedValue = 'Blue';
+    expect(testCommand.value).toBe(expectedValue);
+    expect(screen.getByTestId(DROPDOWN_BUTTON_ID).textContent).toBe(expectedValue);
+  });
+});

--- a/react-components/src/components/Architecture/DropdownButton.test.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.test.tsx
@@ -10,7 +10,7 @@ import { MockEnumOptionCommand } from '../../../tests/tests-utilities/architectu
 
 // Help page here:  https://bogr.dev/blog/react-testing-intro/
 
-describe(DropdownButton.name + ' used in settings', () => {
+describe(DropdownButton.name + ' (not used in settings)', () => {
   let renderTargetMock: RevealRenderTarget;
   let testCommand: MockEnumOptionCommand;
 

--- a/react-components/src/components/Architecture/DropdownButton.test.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.test.tsx
@@ -33,11 +33,12 @@ describe(DropdownButton.name + ' (not used in settings)', () => {
   test('should render with correct default value and no dropdown', async () => {
     const button = screen.getByTestId(DROPDOWN_BUTTON_ID);
 
-    // Check that the selected value is updated
+    // Check that the selected value is updated by the default value
     const expectedValue = 'Red';
     expect(testCommand.value).toBe(expectedValue);
     expect(button.textContent).toBe(expectedValue);
 
+    // Check that the the option menu is closed
     const menuItems = screen.queryAllByTestId(DROPDOWN_MENU_ITEM_ID); // this doesn't crash when nothing found
     expect(menuItems).toHaveLength(0);
   });

--- a/react-components/src/components/Architecture/DropdownButton.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.tsx
@@ -78,6 +78,7 @@ const DropdownElement = ({
 
   const label = command.getLabel(t);
   const selectedLabel = command.selectedChild?.getLabel(t);
+  const isDisabled = label === undefined || isOpen;
   const OpenButtonIcon = isOpen ? ChevronUpIcon : ChevronDownIcon;
   return (
     <Menu
@@ -90,7 +91,7 @@ const DropdownElement = ({
       renderTrigger={(props: any) => (
         <CogsTooltip
           content={<LabelWithShortcut label={label} command={command} />}
-          disabled={label === undefined || isOpen}
+          disabled={isDisabled}
           enterDelay={TOOLTIP_DELAY}
           placement={getTooltipPlacement(placement)}>
           <Button

--- a/react-components/src/components/Architecture/DropdownButton.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.tsx
@@ -161,20 +161,15 @@ function createMenuItem(
   // @update-ui-component-pattern
   const [isEnabled, setEnabled] = useState(true);
   const [isChecked, setChecked] = useState(true);
-  const [isVisible, setVisible] = useState(true);
   const [uniqueId, setUniqueId] = useState(0);
 
   useOnUpdate(command, () => {
     setEnabled(command.isEnabled);
-    setVisible(command.isVisible);
     setChecked(command.isChecked);
     setUniqueId(command.uniqueId);
   });
   // @end
 
-  if (!isVisible) {
-    return <></>;
-  }
   return (
     <Menu.ItemToggled
       data-testid={DROPDOWN_MENU_ITEM_ID}

--- a/react-components/src/components/Architecture/DropdownButton.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.tsx
@@ -19,10 +19,6 @@ import styled from 'styled-components';
 import { useOnUpdate } from './useOnUpdate';
 import { type PlacementType } from './types';
 
-export const DROPDOWN_BUTTON_ID = 'dropdown-button';
-export const DROPDOWN_MENU_ID = 'dropdown-menu';
-export const DROPDOWN_MENU_ITEM_ID = 'dropdown-menu-item';
-
 export const DropdownButton = ({
   inputCommand,
   placement,
@@ -89,7 +85,6 @@ const DropdownElement = ({
         setOpen(open);
       }}
       open={isOpen}
-      data-testid={'dropdown-menu'}
       placement={'bottom-start'}
       disableCloseOnClickInside
       renderTrigger={(props: any) => (
@@ -109,7 +104,6 @@ const DropdownElement = ({
             iconPlacement="left"
             aria-label={command.getLabel(t)}
             toggled={isOpen}
-            data-testid={DROPDOWN_BUTTON_ID}
             {...props}
             onClick={(event) => {
               event.stopPropagation();
@@ -172,7 +166,6 @@ function createMenuItem(
 
   return (
     <Menu.ItemToggled
-      data-testid={DROPDOWN_MENU_ITEM_ID}
       key={uniqueId}
       disabled={!isEnabled}
       toggled={isChecked}


### PR DESCRIPTION
#### Type of change

![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5561

## Description :pencil:

This bug was caused by some other refactoring. It is only in the user interface code, not in the business  layer.

I have refactor the `DropdownButton` component so it is clear by moving some code to inner component. IsVisible is used in the `DropdownButton`, and removed from the inner components.

Now the option closes when selected, as it normally should do for option menus of this sort.

Since it wasn't under unit test, I also added unit test for this part. I have used some time to understand making test for react-components, and I think the test should cover the feature in this component. The test is for usage when **usedInSettings = false**, the opposite is already make a unit test for.

![image](https://github.com/user-attachments/assets/f7d35068-1329-49f5-90f3-f043b7d2d154)

## How has this been tested? :mag:

1. `yarn storybook`
2. Open **Architecture/Main**
3. Check the top toolbar as image above shows
4. The bug was that that the option was not close after selection

