### PR TITLE
fix(react-components): disable PoI-comment button on empty content

### DIFF
--- a/react-components/src/architecture/base/commands/BaseInputCommand.test.ts
+++ b/react-components/src/architecture/base/commands/BaseInputCommand.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from 'vitest';
+import { BaseInputCommand } from './BaseInputCommand';
+import { TestInputCommand } from '#test-utils/architecture/commands/TestInputCommand';
+
+describe(BaseInputCommand.name, () => {
+  test('getters/setters work as expected', () => {
+    const mockContent = 'mock-content';
+    const mockOnCancel = vi.fn();
+    const mockCommandUpdateListener = vi.fn();
+
+    const command = new TestInputCommand();
+
+    command.addEventListener(mockCommandUpdateListener);
+
+    expect(command.content).toBe('');
+    expect(command.onCancel).toBe(undefined);
+
+    command.content = mockContent;
+    expect(mockCommandUpdateListener).toHaveBeenCalled();
+    expect(command.content).toBe(mockContent);
+
+    command.onCancel = mockOnCancel;
+    expect(command.onCancel).toBe(mockOnCancel);
+  });
+
+  test('post button should always be enabled', () => {
+    const command = new TestInputCommand();
+
+    expect(command.isPostButtonEnabled).toBeTruthy();
+
+    command.content = 'some-content';
+
+    expect(command.isPostButtonEnabled).toBeTruthy();
+
+    command.content = '';
+
+    expect(command.isPostButtonEnabled).toBeTruthy();
+  });
+});

--- a/react-components/src/architecture/base/commands/BaseInputCommand.ts
+++ b/react-components/src/architecture/base/commands/BaseInputCommand.ts
@@ -5,11 +5,7 @@ import { type TranslationInput } from '../utilities/TranslateInput';
 import { RenderTargetCommand } from './RenderTargetCommand';
 
 export abstract class BaseInputCommand extends RenderTargetCommand {
-  protected _placeholder?: TranslationInput;
-  protected _content?: string;
-  protected _okButtonLabel?: TranslationInput;
-
-  protected _onFinish?: () => void;
+  protected _content: string = '';
   protected _onCancel?: () => void;
 
   public getCancelButtonLabel(): TranslationInput | undefined {
@@ -17,30 +13,26 @@ export abstract class BaseInputCommand extends RenderTargetCommand {
   }
 
   public abstract getPostButtonLabel(): TranslationInput | undefined;
-
   public abstract getPlaceholder(): TranslationInput | undefined;
 
-  public get onFinish(): (() => void) | undefined {
-    return this._onFinish;
-  }
-
-  public set onFinish(onFinish: () => void) {
-    this._onFinish = onFinish;
+  public get onCancel(): (() => void) | undefined {
+    return this._onCancel;
   }
 
   public set onCancel(onCancel: () => void) {
     this._onCancel = onCancel;
   }
 
-  public get onCancel(): (() => void) | undefined {
-    return this._onCancel;
+  public get content(): string {
+    return this._content;
   }
 
-  invokeWithContent(content: string): boolean {
+  public set content(content: string) {
     this._content = content;
+    this.update();
+  }
 
-    const invokeResult = this.invoke();
-    this._content = '';
-    return invokeResult;
+  public get isPostButtonEnabled(): boolean {
+    return true;
   }
 }

--- a/react-components/src/architecture/concrete/pointsOfInterest/CreatePoiCommentCommand.test.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/CreatePoiCommentCommand.test.ts
@@ -1,0 +1,93 @@
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+import { CreatePoiCommentCommand } from './CreatePoiCommentCommand';
+import { getTranslationKeyOrString } from '#test-utils/architecture/getTranslationKeyOrString';
+
+import { type PointOfInterest, PointsOfInterestStatus } from './types';
+import { PointsOfInterestDomainObject } from './PointsOfInterestDomainObject';
+import { Mock } from 'moq.ts';
+import { type RevealRenderTarget } from '../../base/renderTarget/RevealRenderTarget';
+import { type RootDomainObject } from '../../base/domainObjects/RootDomainObject';
+import { type CommandsController } from '../../base/renderTarget/CommandsController';
+
+const TEST_POINT_OF_INTEREST: PointOfInterest<string> = {
+  properties: {
+    name: 'poi_name',
+    positionX: 1,
+    positionY: 2,
+    positionZ: 3,
+    scene: {
+      externalId: 'scene_external_id',
+      space: 'scene_space'
+    },
+    sceneState: {}
+  },
+  id: 'poi_id',
+  status: PointsOfInterestStatus.Default
+} as const;
+
+describe(CreatePoiCommentCommand.name, () => {
+  beforeAll(() => {
+    vi.clearAllMocks();
+  });
+
+  test('has correct initial content', () => {
+    const poiCommentCommand = new CreatePoiCommentCommand(TEST_POINT_OF_INTEREST);
+
+    expect(getTranslationKeyOrString(poiCommentCommand.getCancelButtonLabel())).toBe('CANCEL');
+    expect(getTranslationKeyOrString(poiCommentCommand.getPostButtonLabel())).toBe('SEND');
+    expect(getTranslationKeyOrString(poiCommentCommand.getPlaceholder())).toBe(
+      'COMMENT_PLACEHOLDER'
+    );
+  });
+
+  test('post button is disabled when content is empty', () => {
+    const poiCommentCommand = new CreatePoiCommentCommand(TEST_POINT_OF_INTEREST);
+
+    expect(poiCommentCommand.content).toBe('');
+    expect(poiCommentCommand.isPostButtonEnabled).toBeFalsy();
+
+    poiCommentCommand.content = 'non-empty-content';
+
+    expect(poiCommentCommand.isPostButtonEnabled).toBeTruthy();
+  });
+
+  test('invoking command posts comment on Poi', () => {
+    const mockPostComment = vi.fn().mockReturnValue(Promise.resolve());
+    const mockDomainObjectNotify = vi.fn();
+
+    const mockPointsOfInterestDomainObject = new Mock<PointsOfInterestDomainObject<string>>()
+      .setup((p) => p.postCommentForPoi)
+      .returns(mockPostComment)
+      .setup((p) => p.notify)
+      .returns(mockDomainObjectNotify)
+      .object();
+
+    const mockRenderTarget = new Mock<RevealRenderTarget>()
+      .setup((p) => p.rootDomainObject)
+      .returns(
+        new Mock<RootDomainObject>()
+          .setup((p) => p.getDescendantByType(PointsOfInterestDomainObject))
+          .returns(mockPointsOfInterestDomainObject)
+          .object()
+      )
+      .setup((p) => p.commandsController)
+      .returns(
+        new Mock<CommandsController>()
+          .setup((p) => p.update)
+          .returns(vi.fn())
+          .object()
+      )
+      .object();
+
+    const commentContent = 'comment-content';
+
+    const poiCommentCommand = new CreatePoiCommentCommand(TEST_POINT_OF_INTEREST);
+
+    poiCommentCommand.attach(mockRenderTarget);
+
+    poiCommentCommand.content = commentContent;
+    poiCommentCommand.invoke();
+
+    expect(mockPostComment).toHaveBeenCalledWith(TEST_POINT_OF_INTEREST, commentContent);
+  });
+});

--- a/react-components/src/architecture/concrete/pointsOfInterest/CreatePoiCommentCommand.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/CreatePoiCommentCommand.ts
@@ -10,6 +10,8 @@ import { type PointOfInterest } from './types';
 export class CreatePoiCommentCommand extends BaseInputCommand {
   private readonly _poi: PointOfInterest<unknown>;
 
+  private _onFinish?: () => void;
+
   constructor(poi: PointOfInterest<unknown>) {
     super();
 
@@ -18,6 +20,14 @@ export class CreatePoiCommentCommand extends BaseInputCommand {
 
   public override get hasData(): true {
     return true;
+  }
+
+  public get onFinish(): (() => void) | undefined {
+    return this._onFinish;
+  }
+
+  public set onFinish(onFinish: () => void) {
+    this._onFinish = onFinish;
   }
 
   public override getPostButtonLabel(): TranslationInput {
@@ -30,6 +40,10 @@ export class CreatePoiCommentCommand extends BaseInputCommand {
 
   public override getPlaceholder(): TranslationInput {
     return { key: 'COMMENT_PLACEHOLDER' };
+  }
+
+  public override get isPostButtonEnabled(): boolean {
+    return this._content.length > 0;
   }
 
   public override invokeCore(): boolean {

--- a/react-components/src/components/Architecture/InputField.test.tsx
+++ b/react-components/src/components/Architecture/InputField.test.tsx
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { InputField } from './InputField';
+import { TestInputCommand } from '#test-utils/architecture/commands/TestInputCommand';
+import { act, render } from '@testing-library/react';
+import { RevealRenderTarget } from '../../architecture';
+import { type PropsWithChildren, type ReactElement } from 'react';
+import { viewerMock } from '#test-utils/fixtures/viewer';
+import { sdkMock } from '#test-utils/fixtures/sdk';
+import { ViewerContextProvider } from '../RevealCanvas/ViewerContext';
+
+import userEvent from '@testing-library/user-event';
+import assert from 'assert';
+
+const ARBITRARY_PLACEMENT = 'right';
+
+describe(InputField.name, () => {
+  let renderTargetMock: RevealRenderTarget;
+  let wrapper: (props: PropsWithChildren) => ReactElement;
+
+  beforeEach(() => {
+    renderTargetMock = new RevealRenderTarget(viewerMock, sdkMock);
+
+    wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <ViewerContextProvider value={renderTargetMock}>{children}</ViewerContextProvider>
+    );
+  });
+
+  test('should render an empty text field with a post-button by default ', () => {
+    const postButtonLabel = 'post-label-text';
+    const command = new TestInputCommand({ postButtonLabel });
+
+    const { container } = render(
+      <InputField inputCommand={command} placement={ARBITRARY_PLACEMENT} />,
+      { wrapper }
+    );
+
+    const inputFieldElement = container.querySelector('textarea');
+    const buttonElements = container.querySelectorAll('button');
+
+    expect(inputFieldElement).not.toBeNull();
+    expect(inputFieldElement?.value).toBe('');
+
+    expect(buttonElements).toHaveLength(1);
+    expect(buttonElements[0].textContent).toBe(postButtonLabel);
+  });
+
+  test('has the right placeholder text and post- and cancel-button labels', () => {
+    const postButtonLabel = 'post-button-label';
+    const cancelButtonLabel = 'cancel-button-label';
+    const placeholder = 'placeholder-text';
+
+    const command = new TestInputCommand({
+      postButtonLabel,
+      cancelButtonLabel,
+      placeholder
+    });
+
+    // In the Cogs Comment-component, the cancel-button won't appear unless an onCancel callback is supplied
+    command.onCancel = () => {};
+
+    const { container } = render(
+      <InputField inputCommand={command} placement={ARBITRARY_PLACEMENT} />,
+      { wrapper }
+    );
+
+    const textArea = container.querySelector('textarea');
+    const [cancelButton, postButton] = container.querySelectorAll('button');
+
+    expect(textArea?.placeholder).toBe(placeholder);
+    expect(postButton.textContent).toBe(postButtonLabel);
+    expect(cancelButton.textContent).toBe(cancelButtonLabel);
+  });
+
+  test('updates to text content propagates from command to view and the reverse', async () => {
+    const textContent = 'text-content';
+
+    const command = new TestInputCommand();
+    command.content = textContent;
+
+    const { container } = render(
+      <InputField inputCommand={command} placement={ARBITRARY_PLACEMENT} />,
+      { wrapper }
+    );
+
+    const textArea = container.querySelector('textarea');
+
+    assert(textArea !== null);
+
+    expect(textArea.value).toBe(textContent);
+
+    await act(() => (command.content = ''));
+
+    expect(textArea.value).toBe('');
+
+    await act(async () => {
+      await userEvent.type(textArea, textContent);
+    });
+
+    expect(textArea.value).toBe(textContent);
+  });
+
+  test('pressing post-button invokes command and resets content', async () => {
+    const onPost = vi.fn();
+    const command = new TestInputCommand({ onInvokeCallback: onPost });
+    command.content = 'arbitrary-content';
+
+    const { container } = render(
+      <InputField inputCommand={command} placement={ARBITRARY_PLACEMENT} />,
+      { wrapper }
+    );
+
+    const postButton = container.querySelector('button');
+
+    assert(postButton !== null);
+
+    await act(async () => {
+      await userEvent.click(postButton);
+    });
+
+    expect(onPost).toHaveBeenCalled();
+    expect(command.content).toBe('');
+  });
+
+  test('disables post button when enabled-flag is false', () => {
+    const command = new TestInputCommand();
+
+    const { container } = render(
+      <InputField inputCommand={command} placement={ARBITRARY_PLACEMENT} />,
+      { wrapper }
+    );
+
+    const postButton = container.querySelector('button');
+
+    assert(postButton !== null);
+
+    expect(postButton.getAttribute('aria-disabled')).toBe('false');
+
+    act(() => {
+      command.setPostButtonEnabled(false);
+    });
+
+    expect(postButton.getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/react-components/src/components/Architecture/InputField.tsx
+++ b/react-components/src/components/Architecture/InputField.tsx
@@ -26,6 +26,7 @@ export const InputField = ({
 
   const [content, setContent] = useState<string>('');
   const [enabled, setEnabled] = useState<boolean>(command.isEnabled);
+  const [postButtonEnabled, setPostButtonEnabled] = useState<boolean>(false);
   const [postLabel, setPostLabel] = useState<string | undefined>(
     translateIfExists(command.getPostButtonLabel())
   );
@@ -41,6 +42,8 @@ export const InputField = ({
     setCancelLabel(translateIfExists(command.getCancelButtonLabel()));
     setPlaceholder(translateIfExists(command.getPlaceholder()));
     setEnabled(command.isEnabled);
+    setPostButtonEnabled(command.isPostButtonEnabled);
+    setContent(command.content);
   });
 
   return (
@@ -48,13 +51,13 @@ export const InputField = ({
       key={command.uniqueId}
       placeholder={placeholder}
       message={content}
-      setMessage={setContent}
+      setMessage={(content) => (command.content = content)}
       onPostMessage={() => {
-        command.invokeWithContent(content);
-        setContent('');
+        command.invoke();
+        command.content = '';
       }}
       postButtonText={postLabel}
-      postButtonDisabled={!enabled}
+      postButtonDisabled={!(postButtonEnabled && enabled)}
       cancelButtonText={cancelLabel}
       cancelButtonDisabled={false}
       onCancel={command.onCancel}

--- a/react-components/tests/tests-utilities/architecture/commands/TestInputCommand.ts
+++ b/react-components/tests/tests-utilities/architecture/commands/TestInputCommand.ts
@@ -1,0 +1,65 @@
+import { type TranslationInput } from '../../../../src/architecture';
+import { BaseInputCommand } from '../../../../src/architecture/base/commands/BaseInputCommand';
+
+export type TestInputCommandOptions = {
+  postButtonLabel?: string;
+  cancelButtonLabel?: string;
+  placeholder?: string;
+  onInvokeCallback?: (() => void) | undefined;
+};
+
+export class TestInputCommand extends BaseInputCommand {
+  private readonly _postButtonLabel: string | undefined;
+  private readonly _cancelButtonLabel: string | undefined;
+  private readonly _placeholderText: string | undefined;
+  private readonly _onInvokeCallback: (() => void) | undefined;
+
+  private _isPostButtonEnabled: boolean = true;
+
+  constructor(options?: TestInputCommandOptions) {
+    super();
+    if (options === undefined) {
+      return;
+    }
+
+    const { postButtonLabel, cancelButtonLabel, placeholder, onInvokeCallback } = options;
+
+    this._postButtonLabel = postButtonLabel;
+    this._cancelButtonLabel = cancelButtonLabel;
+    this._placeholderText = placeholder;
+    this._onInvokeCallback = onInvokeCallback;
+  }
+
+  public override getPostButtonLabel(): TranslationInput | undefined {
+    return this._postButtonLabel === undefined
+      ? undefined
+      : { untranslated: this._postButtonLabel };
+  }
+
+  public override getCancelButtonLabel(): TranslationInput | undefined {
+    return this._cancelButtonLabel === undefined
+      ? undefined
+      : { untranslated: this._cancelButtonLabel };
+  }
+
+  public override getPlaceholder(): TranslationInput | undefined {
+    return this._placeholderText === undefined
+      ? undefined
+      : { untranslated: this._placeholderText };
+  }
+
+  public setPostButtonEnabled(enable: boolean): void {
+    this._isPostButtonEnabled = enable;
+    this.update();
+  }
+
+  public override get isPostButtonEnabled(): boolean {
+    return this._isPostButtonEnabled;
+  }
+
+  public override invokeCore(): boolean {
+    this._onInvokeCallback?.();
+
+    return true;
+  }
+}


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5422

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Disable the PoI comment post-button when the comment content is empty. 

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In Fusion, main 3D page in Search


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Build this and link it to Fusion
- Go to the main 3D page in Search
- Open any scene
- Create a new PoI (or select one already created)
- In the right side panel, notice that the comment text area is empty and the "Send"-button underneath is disabled
- Type in the comment text area
- Notice that the "Send"-button becomes enabled once the text area has text in it


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
