### PR TITLE
fix: click depth on CAD models with newer ThreeJS versions

### DIFF
--- a/viewer/packages/cad-model/src/picking/PickingHandler.ts
+++ b/viewer/packages/cad-model/src/picking/PickingHandler.ts
@@ -49,11 +49,16 @@ export class PickingHandler {
   };
 
   private readonly _rgbaVector = new THREE.Vector4();
+
+  /**
+   * These factors are used for undoing the `packDepthToRGBA` GLSL operation defined by ThreeJS.
+   * They are taken from https://github.com/WestLangley/three.js/blob/bc58fecba18150103b95fbde5aaa3cc7cddf95a7/src/renderers/shaders/ShaderChunk/packing.glsl.js#L19
+   */
   private readonly _unpackFactors = new THREE.Vector4(
-    255 / 256 / (256 * 256 * 256),
-    255 / 256 / (256 * 256),
+    255 / 256,
     255 / 256 / 256,
-    255 / 256
+    255 / 256 / (256 * 256),
+    1 / (256 * 256 * 256)
   );
   private readonly _pipelineExecutor: BasicPipelineExecutor;
   private readonly _depthRenderPipeline: CadGeometryRenderModePipelineProvider;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5631

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Starting from ThreeJS r167, clicking on CAD nodes would set the camera pivot point at a wrong depth - usually much closer to the camera than the clicked surface. 

The error can be traced back to PR https://github.com/mrdoob/three.js/pull/28789 in ThreeJS, which reverses the significance of the components in the `vec4` when packing the depth as an RGBA vector in the shader. The unpacking function was changed accordingly, but we have our own implementation because we do this unpacking on the CPU-side. 

It's a little unconventional of us to actually pack the depth like this in the shader at all - it seems like we should be using a depth-only framebuffer / render target for this purpose. But I imagine getting it to work with the current render pipeline can be quite involved.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In `/examples`

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Build Reveal
- (Remove intersection handling code starting with `if (intersection !== undefined) {`... in `Viewer.tsx`, to avoid annoying errors when clicking
- Start examples and open the default Primitives model
- Click around and move the camera
- Note that the Pivot point appears at the exact point of click.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
