### PR TITLE
fix(react-components): set the initial state of the lastSetExternalState as undefined to force the camera being updated even when comparing with the incoming externalState at the beginning

### DIFF
--- a/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
+++ b/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, test, vi, beforeEach, beforeAll, afterAll } from 'vit
 import { renderHook } from '@testing-library/react';
 
 import { Quaternion, Vector3 } from 'three';
-import { ARBITRARY_CALLBACK_DELAY, cameraManagerGlobalCameraEvents } from '#test-utils/fixtures/cameraManager';
+import {
+  ARBITRARY_CALLBACK_DELAY,
+  cameraManagerGlobalCameraEvents
+} from '#test-utils/fixtures/cameraManager';
 import { viewerMock } from '#test-utils/fixtures/viewer';
 import { useCameraStateControl, type CameraStateParameters } from './useCameraStateControl';
 
@@ -15,7 +18,6 @@ vi.mock('../ViewerContext', () => ({
 }));
 
 describe(useCameraStateControl.name, () => {
-
   // to be triggered after the camera stop event is called in the camera manager mock:
   // ARBITRARY_CALLBACK_DELAY of the camera manager mock setCameraState callback + 10ms for the setTimeout
   const ARBITRARY_RERENDER_DELAY = ARBITRARY_CALLBACK_DELAY + 10;

--- a/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
+++ b/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
@@ -105,6 +105,7 @@ describe(useCameraStateControl.name, () => {
     // The setter should be called twice: once for the initial state and once for the updated state
     expect(setter).toHaveBeenCalledTimes(2);
   });
+  
   test('provided setter is called after updating camera state target', () => {
     const setter = vi.fn<(cameraState?: CameraStateParameters) => void>();
     renderHook(() => {

--- a/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
+++ b/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
@@ -129,6 +129,7 @@ describe(useCameraStateControl.name, () => {
     // The setter should be called twice: once for the initial state and once for the updated state
     expect(setter).toHaveBeenCalledTimes(2);
   });
+  
   test('provided setter is called after updating camera state rotation', () => {
     const setter = vi.fn<(cameraState?: CameraStateParameters) => void>();
     renderHook(() => {

--- a/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
+++ b/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test, vi, beforeEach, beforeAll, afterAll } from 'vit
 import { renderHook } from '@testing-library/react';
 
 import { Quaternion, Vector3 } from 'three';
-import { cameraManagerGlobalCameraEvents } from '#test-utils/fixtures/cameraManager';
+import { ARBITRARY_CALLBACK_DELAY, cameraManagerGlobalCameraEvents } from '#test-utils/fixtures/cameraManager';
 import { viewerMock } from '#test-utils/fixtures/viewer';
 import { useCameraStateControl, type CameraStateParameters } from './useCameraStateControl';
 
@@ -15,6 +15,11 @@ vi.mock('../ViewerContext', () => ({
 }));
 
 describe(useCameraStateControl.name, () => {
+
+  // to be triggered after the camera stop event is called in the camera manager mock:
+  // ARBITRARY_CALLBACK_DELAY of the camera manager mock setCameraState callback + 10ms for the setTimeout
+  const ARBITRARY_RERENDER_DELAY = ARBITRARY_CALLBACK_DELAY + 10;
+
   beforeEach(() => {
     vi.resetAllMocks();
   });
@@ -105,7 +110,10 @@ describe(useCameraStateControl.name, () => {
       rotation: new Quaternion(0, 0, 0, 1)
     });
 
-    rerender();
+    // Wait for the camera stop callback to be triggered in the camera manager mock - setCameraState
+    setTimeout(() => {
+      rerender();
+    }, ARBITRARY_RERENDER_DELAY);
 
     // target
     viewerMock.cameraManager.setCameraState({
@@ -114,7 +122,10 @@ describe(useCameraStateControl.name, () => {
       rotation: new Quaternion(0, 0, 0, 1)
     });
 
-    rerender();
+    // Wait for the camera stop callback to be triggered in the camera manager mock - setCameraState
+    setTimeout(() => {
+      rerender();
+    }, ARBITRARY_RERENDER_DELAY);
 
     // rotation
     viewerMock.cameraManager.setCameraState({
@@ -123,7 +134,11 @@ describe(useCameraStateControl.name, () => {
       rotation: new Quaternion(0.1, 0.01, 0, 0.995)
     });
 
-    rerender();
+    // Wait for the camera stop callback to be triggered in the camera manager mock - setCameraState
+    setTimeout(() => {
+      rerender();
+    }, ARBITRARY_RERENDER_DELAY);
+
     vi.runAllTimers();
 
     expect(setter).toHaveBeenCalledTimes(3);

--- a/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
+++ b/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.test.ts
@@ -105,7 +105,7 @@ describe(useCameraStateControl.name, () => {
     // The setter should be called twice: once for the initial state and once for the updated state
     expect(setter).toHaveBeenCalledTimes(2);
   });
-  
+
   test('provided setter is called after updating camera state target', () => {
     const setter = vi.fn<(cameraState?: CameraStateParameters) => void>();
     renderHook(() => {
@@ -129,7 +129,7 @@ describe(useCameraStateControl.name, () => {
     // The setter should be called twice: once for the initial state and once for the updated state
     expect(setter).toHaveBeenCalledTimes(2);
   });
-  
+
   test('provided setter is called after updating camera state rotation', () => {
     const setter = vi.fn<(cameraState?: CameraStateParameters) => void>();
     renderHook(() => {

--- a/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.ts
+++ b/react-components/src/components/RevealCanvas/hooks/useCameraStateControl.ts
@@ -15,15 +15,7 @@ export const useCameraStateControl = (
   externalCameraState?: CameraStateParameters,
   setCameraState?: (cameraState?: CameraStateParameters) => void
 ): void => {
-  const lastSetExternalState = useRef<CameraStateParameters | undefined>(
-    externalCameraState === undefined
-      ? undefined
-      : {
-          position: externalCameraState.position.clone(),
-          target: externalCameraState.target.clone(),
-          rotation: externalCameraState.rotation?.clone()
-        }
-  );
+  const lastSetExternalState = useRef<CameraStateParameters | undefined>(undefined);
 
   useSetInternalCameraStateOnExternalUpdate(externalCameraState, lastSetExternalState);
 

--- a/react-components/tests/tests-utilities/fixtures/cameraManager.ts
+++ b/react-components/tests/tests-utilities/fixtures/cameraManager.ts
@@ -5,8 +5,6 @@ import { PerspectiveCamera } from 'three';
 
 import { vi, type Mock as viMock } from 'vitest';
 
-export const ARBITRARY_CALLBACK_DELAY = 50; // ms
-
 export const cameraManagerGlobalCameraEvents: Record<CameraManagerEventType, viMock[]> = {
   cameraChange: [],
   cameraStop: []
@@ -36,7 +34,7 @@ export const cameraManagerMock = new Mock<CameraManager>()
       cameraManagerGlobalCameraEvents.cameraStop.forEach((callback) => {
         callback(position!, target!);
       });
-    }, ARBITRARY_CALLBACK_DELAY);
+    }, 50);
   })
   .setup((p) => p.getCameraState())
   .returns(cameraManagerGlobalCurrentCameraState as Required<CameraState>)

--- a/react-components/tests/tests-utilities/fixtures/cameraManager.ts
+++ b/react-components/tests/tests-utilities/fixtures/cameraManager.ts
@@ -5,6 +5,8 @@ import { PerspectiveCamera } from 'three';
 
 import { vi, type Mock as viMock } from 'vitest';
 
+export const ARBITRARY_CALLBACK_DELAY = 50; // ms
+
 export const cameraManagerGlobalCameraEvents: Record<CameraManagerEventType, viMock[]> = {
   cameraChange: [],
   cameraStop: []
@@ -34,7 +36,7 @@ export const cameraManagerMock = new Mock<CameraManager>()
       cameraManagerGlobalCameraEvents.cameraStop.forEach((callback) => {
         callback(position!, target!);
       });
-    }, 50);
+    }, ARBITRARY_CALLBACK_DELAY);
   })
   .setup((p) => p.getCameraState())
   .returns(cameraManagerGlobalCurrentCameraState as Required<CameraState>)


### PR DESCRIPTION
### Type of change
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
This fix an issue when navigating from application to unified-3d and the `externalCameraState` is set externally and no `lastSetExternalState` is defined yet and so the camera has to start in a custom set.
What was happening is if no `lastSetExternalState` is yet defined, it clones the current `externalCameraState` but in order to update the camera, it has to pass off the `isCameraStateEqual` in order to update the camera. If it's the same values, then the camera is not updated and it goes to the camera initial value, which is 0,0,0. So having the `lastSetExternalState` with the initial value as undefined, then force the camera update it with the `externalCameraState` value instead of 0.

This fix is coming along with the feature: 
https://cognitedata.atlassian.net/browse/BND3D-5650
In this PR:
https://github.com/cognitedata/fusion/pull/13315


## How has this been tested? :mag:

1. Switching between unified-3d and search ui by changing the URL app with a custom `externalCameraState` URL Parameter and using the new feature of switching between 3d widget to the 3d full view in here: https://github.com/cognitedata/fusion/pull/13315

## Test instructions :information_source:

1. In Search UI 3d view, move the camera in order to update the url parameter.
2. Change the url app entry point: from search to unified-3d. For example:
 From this: https://cog-demo.dev.fusion.cogniteapp.com/lervik-industries/search?...
 To this: https://cog-demo.dev.fusion.cogniteapp.com/lervik-industries/unified-3d?....

Or test it under the feature to navigate between 3d widget to 3d full view here: https://cognitedata.atlassian.net/browse/BND3D-5650

It should reset the cameraStateControl, including the `lastSetExternalState` which forces to has it as undefined and letting the camera use the `externalCameraState` to be updated.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [X] I am happy with this implementation.
- [X] I have performed a self-review of my own code.
- [X] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [X] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
