### PR TITLE
fix(react-components): Poi share panel hidden behind Poi Info panel

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.79.1",
+  "version": "0.79.2",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/components/Architecture/pointsOfInterest/PoiHeader.tsx
+++ b/react-components/src/components/Architecture/pointsOfInterest/PoiHeader.tsx
@@ -37,7 +37,9 @@ export const PoiHeader = (): ReactNode => {
         </Flex>
         <Divider direction="vertical" weight="2px" />
         <Flex direction="row" justifyContent="flex-start">
-          <Dropdown placement="bottom-end" content={<PoiSharePanel />}>
+          {/* zIndex is set to 10000 to ensure the dropdown appears above other elements
+              This is temporary fix until we have styleScope configured */}
+          <Dropdown placement="bottom-end" content={<PoiSharePanel />} zIndex={10000}>
             <Tooltip placement="top-end" content={t({ key: 'SHARE' })}>
               <Button icon={<ShareIcon />} type="ghost" />
             </Tooltip>


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
This PR fixes POI share panel hidden behind POI Info panel. Have tested all other UI for any regression

**Note**: Previous `cogs.js` package upgrade did seems to fix this issue, but after clearing cache, this bug re-appeared.

Fixed Ref:
<img width="1497" alt="Screenshot 2025-06-10 at 19 07 46" src="https://github.com/user-attachments/assets/cfde8a9c-3212-444a-b389-75a34721ab04" />
Issue Ref:
<img width="1039" alt="Screenshot 2025-06-10 at 19 08 22" src="https://github.com/user-attachments/assets/50e75545-67b9-4524-ba31-7e0c44f7c348" />

## How has this been tested? :mag:

In Search & unified-3d


## Test instructions :information_source:

- Link the local `react-component` build to `fusion`


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
