### PR TITLE
fix(react-component): cad mapping stopped by DM pointcloud

### DIFF
--- a/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.test.ts
+++ b/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.test.ts
@@ -1,13 +1,22 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, test, vi } from 'vitest';
 import { CoreDm3dFdm3dDataProvider } from './CoreDm3dDataProvider';
 import { Mock, It, type IMock } from 'moq.ts';
-import { type FdmSDK } from '../FdmSDK';
+import { NodeItem, type FdmSDK } from '../FdmSDK';
 import { restrictToDmsId } from '../../utilities/restrictToDmsId';
 import { type AddImage360CollectionDatamodelsOptions } from '../../components';
 import {
   modelInstanceFixture0,
   revisionInstanceFixture0
 } from '#test-utils/fixtures/dm/model3dData';
+import { isEqual } from 'lodash';
+import {
+  COGNITE_3D_MODEL_SOURCE,
+  COGNITE_3D_REVISION_SOURCE,
+  CORE_DM_3D_CONTAINER_SPACE
+} from './dataModels';
+import { QueryRequest, QueryResponse } from '@cognite/sdk';
+import { QueryResult, SelectSourceWithParams } from '../utils/queryNodesAndEdges';
+import { createDmsNodeItem } from '#test-utils/dms/createDmsNodeItem';
 
 const image360CollectionId: AddImage360CollectionDatamodelsOptions = {
   externalId: 'image360Collection0',
@@ -22,33 +31,172 @@ describe(CoreDm3dFdm3dDataProvider.name, () => {
   let fdmSdkMock: IMock<FdmSDK>;
 
   beforeEach(() => {
+    vi.resetAllMocks();
     fdmSdkMock = createFdmSdkMock();
   });
 
-  it('should fetch model ref for classic input model options', async () => {
-    const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
+  describe('getDMSModels', () => {
+    it('should fetch model ref for classic input model options', async () => {
+      const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
 
-    const result = await coreDmProvider.getDMSModels(modelId0);
+      const result = await coreDmProvider.getDMSModels(modelId0);
 
-    expect(result).toEqual([restrictToDmsId(modelInstanceFixture0)]);
+      expect(result).toEqual([restrictToDmsId(modelInstanceFixture0)]);
+    });
   });
 
-  it('should fetch revision ref for classic input model options', async () => {
-    const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
+  describe('getRevisionRefs', () => {
+    it('should fetch revision ref for classic input model options', async () => {
+      const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
 
-    const result = await coreDmProvider.getRevisionRefs([
-      { modelId: modelId0, revisionId: revisionId0 }
-    ]);
+      const result = await coreDmProvider.getRevisionRefs([
+        { modelId: modelId0, revisionId: revisionId0 }
+      ]);
 
-    expect(result).toEqual([restrictToDmsId(revisionInstanceFixture0)]);
+      expect(result).toEqual([restrictToDmsId(revisionInstanceFixture0)]);
+    });
+
+    it('should return the input ID when input is CoreDM image360 options', async () => {
+      const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
+
+      const result = await coreDmProvider.getRevisionRefs([image360CollectionId]);
+
+      expect(result).toEqual([restrictToDmsId(image360CollectionId)]);
+    });
   });
 
-  it('should return the input ID when input is CoreDM image360 options', async () => {
-    const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
+  describe('getCadConnectionsForRevisions', () => {
+    const mockQueryNodesAndEdges =
+      vi.fn<(request: QueryRequest) => Promise<QueryResult<any, any>>>();
+    const mockQueryAllNodesAndEdges =
+      vi.fn<(request: QueryRequest, cursors: string[]) => Promise<QueryResult<any, any>>>();
 
-    const result = await coreDmProvider.getRevisionRefs([image360CollectionId]);
+    const TEST_MODEL_ID = 123;
+    const TEST_REVISION_ID = 234;
+    const TEST_TREE_INDEX = 987;
 
-    expect(result).toEqual([restrictToDmsId(image360CollectionId)]);
+    const TEST_MODEL_INSTANCE = {
+      externalId: `cog_3d_model_${TEST_MODEL_ID}`,
+      space: 'model-space'
+    };
+    const TEST_REVISION_INSTANCE = {
+      externalId: `cog_3d_revision_${TEST_REVISION_ID}`,
+      space: 'revision-space'
+    };
+    const TEST_ASSET_INSTANCE = {
+      externalId: 'asset-id',
+      space: 'asset-space'
+    };
+
+    const TEST_OBJECT_3D_ID = { externalId: 'object3d-id', space: 'object3d-space' };
+
+    beforeEach(() => {
+      fdmSdkMock
+        .setup((p) => p.queryNodesAndEdges)
+        .returns(mockQueryNodesAndEdges)
+        .setup((p) => p.queryAllNodesAndEdges)
+        .returns(mockQueryAllNodesAndEdges);
+
+      mockQueryNodesAndEdges
+        // getDMSModels
+        .mockResolvedValueOnce({
+          items: {
+            models: [
+              createDmsNodeItem({
+                id: TEST_MODEL_INSTANCE
+              })
+            ]
+          }
+        })
+        // getDMSRevision
+        .mockResolvedValueOnce({
+          items: {
+            revision: [
+              createDmsNodeItem({
+                id: TEST_REVISION_INSTANCE
+              })
+            ]
+          }
+        });
+
+      mockQueryAllNodesAndEdges
+        // getCadConnectionsForRevisiions
+        .mockResolvedValueOnce({
+          items: {
+            assets: [
+              createDmsNodeItem({
+                id: TEST_ASSET_INSTANCE,
+                properties: { cdf_cdm: { 'CogniteAsset/v1': { object3D: TEST_OBJECT_3D_ID } } }
+              })
+            ],
+            cad_nodes: [
+              createDmsNodeItem({
+                id: {
+                  externalId: 'cad-node-id',
+                  space: 'cad-node-space'
+                },
+                properties: {
+                  cdf_cdm: {
+                    'CogniteCADNode/v1': {
+                      object3D: TEST_OBJECT_3D_ID,
+                      model3D: TEST_MODEL_INSTANCE,
+                      revisions: [TEST_REVISION_INSTANCE],
+                      treeIndexes: [TEST_TREE_INDEX]
+                    }
+                  }
+                }
+              })
+            ]
+          }
+        });
+    });
+
+    test('returns empty array for empty input', async () => {
+      const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
+      const result = await coreDmProvider.getCadConnectionsForRevisions([]);
+
+      expect(result).toEqual([]);
+    });
+
+    test('returns correct result for single CAD model', async () => {
+      const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
+      const result = await coreDmProvider.getCadConnectionsForRevisions([
+        { modelId: TEST_MODEL_ID, revisionId: TEST_REVISION_ID }
+      ]);
+
+      expect(mockQueryNodesAndEdges).toHaveBeenCalledTimes(2);
+      expect(mockQueryAllNodesAndEdges).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([
+        {
+          instance: TEST_ASSET_INSTANCE,
+          modelId: TEST_MODEL_ID,
+          revisionId: TEST_REVISION_ID,
+          treeIndex: TEST_TREE_INDEX
+        }
+      ]);
+    });
+
+    test('should ignore models with modelIdentifier+revisionIdentifier equal to zero (like DM pointclouds)', async () => {
+      const coreDmProvider = new CoreDm3dFdm3dDataProvider(fdmSdkMock.object());
+      const result = await coreDmProvider.getCadConnectionsForRevisions([
+        { modelId: TEST_MODEL_ID, revisionId: TEST_REVISION_ID },
+        {
+          modelId: 0,
+          revisionId: 0
+        }
+      ]);
+
+      expect(mockQueryNodesAndEdges).toHaveBeenCalledTimes(2);
+      expect(mockQueryAllNodesAndEdges).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([
+        {
+          instance: TEST_ASSET_INSTANCE,
+          modelId: TEST_MODEL_ID,
+          revisionId: TEST_REVISION_ID,
+          treeIndex: TEST_TREE_INDEX
+        }
+      ]);
+    });
   });
 });
 

--- a/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.test.ts
+++ b/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.test.ts
@@ -1,21 +1,15 @@
 import { describe, expect, it, beforeEach, test, vi } from 'vitest';
 import { CoreDm3dFdm3dDataProvider } from './CoreDm3dDataProvider';
 import { Mock, It, type IMock } from 'moq.ts';
-import { NodeItem, type FdmSDK } from '../FdmSDK';
+import { type FdmSDK } from '../FdmSDK';
 import { restrictToDmsId } from '../../utilities/restrictToDmsId';
 import { type AddImage360CollectionDatamodelsOptions } from '../../components';
 import {
   modelInstanceFixture0,
   revisionInstanceFixture0
 } from '#test-utils/fixtures/dm/model3dData';
-import { isEqual } from 'lodash';
-import {
-  COGNITE_3D_MODEL_SOURCE,
-  COGNITE_3D_REVISION_SOURCE,
-  CORE_DM_3D_CONTAINER_SPACE
-} from './dataModels';
-import { QueryRequest, QueryResponse } from '@cognite/sdk';
-import { QueryResult, SelectSourceWithParams } from '../utils/queryNodesAndEdges';
+import { type QueryRequest } from '@cognite/sdk';
+import { type QueryResult } from '../utils/queryNodesAndEdges';
 import { createDmsNodeItem } from '#test-utils/dms/createDmsNodeItem';
 
 const image360CollectionId: AddImage360CollectionDatamodelsOptions = {

--- a/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.ts
+++ b/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.ts
@@ -192,7 +192,7 @@ export class CoreDm3dFdm3dDataProvider implements Fdm3dDataProvider {
   async getCadConnectionsForRevisions(
     modelOptions: Array<AddModelOptions<DataSourceType>>
   ): Promise<FdmCadConnection[]> {
-    const classicModels = modelOptions.filter((model) => isClassicIdentifier(model));
+    const classicModels = modelOptions.filter(isClassicIdentifier);
     if (classicModels.length === 0) {
       return EMPTY_ARRAY;
     }

--- a/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.ts
+++ b/react-components/src/data-providers/core-dm-provider/CoreDm3dDataProvider.ts
@@ -192,15 +192,15 @@ export class CoreDm3dFdm3dDataProvider implements Fdm3dDataProvider {
   async getCadConnectionsForRevisions(
     modelOptions: Array<AddModelOptions<DataSourceType>>
   ): Promise<FdmCadConnection[]> {
-    const isClassicModels = modelOptions.every((model) => isClassicIdentifier(model));
-    if (!isClassicModels) {
+    const classicModels = modelOptions.filter((model) => isClassicIdentifier(model));
+    if (classicModels.length === 0) {
       return EMPTY_ARRAY;
     }
-    const modelRefs = await this.getDMSModelsForIds(modelOptions.map((model) => model.modelId));
+    const modelRefs = await this.getDMSModelsForIds(classicModels.map((model) => model.modelId));
 
     const revisionRefs = await this.getDMSRevisionsForRevisionIdsAndModelRefs(
       modelRefs,
-      modelOptions.map((model) => model.revisionId)
+      classicModels.map((model) => model.revisionId)
     );
 
     const modelRevisions = zip(modelRefs, revisionRefs).filter(

--- a/react-components/tests/tests-utilities/dms/createDmsNodeItem.ts
+++ b/react-components/tests/tests-utilities/dms/createDmsNodeItem.ts
@@ -1,0 +1,16 @@
+import type { DmsUniqueIdentifier, NodeItem } from '../../../src';
+
+export function createDmsNodeItem<T extends Record<string, any>>(params?: {
+  id?: DmsUniqueIdentifier;
+  properties?: Record<string, Record<string, T>>;
+}): NodeItem<T> {
+  return {
+    externalId: params?.id?.externalId ?? 'some-external-id',
+    space: params?.id?.space ?? 'some-space',
+    createdTime: 0,
+    lastUpdatedTime: 0,
+    version: 1,
+    instanceType: 'node',
+    properties: params?.properties ?? {}
+  };
+}


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fix bug where CAD mappings would not be downloaded at all in cases where the scene includes at least one DM point cloud. 

This was visible when clicking a contextualized CAD node in the scene to highlight it, and then reload the page. The CAD node would in most cases no longer be highlighted. 

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Through Fusion


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Go to DM project in Unified 3D
- Click 3D DM Cad-node
- Refresh
- CAD node should remain highlighted

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
