### PR TITLE
chore: preserve modules and outdir

### DIFF
--- a/react-components/vite.config.ts
+++ b/react-components/vite.config.ts
@@ -1,85 +1,59 @@
 import { resolve } from 'path';
-import { type PluginOption, defineConfig } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { externalizeDeps } from 'vite-plugin-externalize-deps';
-import { exec } from 'node:child_process';
 import { coverageConfigDefaults } from 'vitest/config';
 
-export default defineConfig(({ command }) => {
-  return {
-    plugins: [
-      react(),
-      dts({ tsconfigPath: './tsconfig.build.json' }),
-      externalizeDeps({
-        devDeps: true
-      }),
-      yalcPush()
-    ],
-    build: {
-      lib: {
-        // Could also be a dictionary or array of multiple entry points
-        entry: resolve(__dirname, 'src/index.ts'),
-        name: 'Reveal react components',
-        // the proper extensions will be added
-        fileName: 'index',
-        formats: ['es']
-      },
-      sourcemap: command === 'build'
+export default defineConfig({
+  plugins: [
+    react(),
+    dts({ tsconfigPath: './tsconfig.build.json' }),
+    externalizeDeps({
+      devDeps: true
+    })
+  ],
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      fileName: '[name]',
+      formats: ['es']
     },
-    test: {
-      include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-      environment: 'happy-dom',
-      globals: true,
-      reporters: ['default'],
-      coverage: {
-        reportsDirectory: '../coverage/reveal-react-components',
-        exclude: [
-          ...coverageConfigDefaults.exclude,
-          'src/**/*.spec.ts',
-          'src/**/*.spec.tsx',
-          'src/**/*.test.ts',
-          'src/**/*.test.tsx',
-          'stories/**'
-        ]
-      },
-      // Need to add E5 modules as inlined dependencies to be able to import them in tests.
-      server: {
-        deps: {
-          inline: [
-            '@cognite/cogs-lab',
-            '@cognite/cogs.js',
-            '@cognite/cogs-core',
-            '@mui',
-            '@cognite/cogs-utils',
-            'lodash'
-          ]
-        }
+    rollupOptions: {
+      output: {
+        preserveModules: true
       }
     }
-  };
-});
-
-function yalcPush(): PluginOption {
-  if (process.env.YALC !== 'true') {
-    return false;
-  }
-  return {
-    name: 'yalc-push',
-    closeBundle: async () => {
-      await new Promise<void>((resolve, reject) => {
-        const process = exec('yalc push');
-        process.stdout
-          ?.on('data', (data) => {
-            console.log(data);
-          })
-          .on('error', (err) => {
-            reject(err);
-          })
-          .on('close', () => {
-            resolve();
-          });
-      });
+  },
+  test: {
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    environment: 'happy-dom',
+    globals: true,
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../coverage/reveal-react-components',
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        'src/**/*.spec.ts',
+        'src/**/*.spec.tsx',
+        'src/**/*.test.ts',
+        'src/**/*.test.tsx',
+        'stories/**'
+      ]
+    },
+    // Need to add E5 modules as inlined dependencies to be able to import them in tests.
+    server: {
+      deps: {
+        inline: [
+          '@cognite/cogs-lab',
+          '@cognite/cogs.js',
+          '@cognite/cogs-core',
+          '@mui',
+          '@cognite/cogs-utils',
+          'lodash'
+        ]
+      }
     }
-  };
-}
+  }
+});


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Preserve modules in the lib output. This makes it easier to reason about the output of the lib and apps will bundle anyway, so likely no reason for us to do it. 

Also do not clear the out dir, as this will break the links (using the `file:` protocol).

Process for linking to fusion:
![image](https://github.com/user-attachments/assets/2517a8f2-a158-48ef-9f23-083467cecee4)


Search for all package.json files including the regex (remember to enable if in VSCode) `"@cognite/reveal-react-components":.*,` and replace with the absolute path to the react components lib. For me that is: `"@cognite/reveal-react-components": "file:///Users/ChristopherTannum/reveal/react-components",` this may or may not be different depending on OS etc. Then click replace all. 

When building react components, then output in node_modules in fusion should be automatically updated:


https://github.com/user-attachments/assets/98907ed5-284b-4a12-8907-f129de43152d


## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
