### PR TITLE
fix: unmounting CadModelContainer does not properly remove cad model

### DIFF
--- a/react-components/src/components/CadModelContainer/CadModelContainer.context.ts
+++ b/react-components/src/components/CadModelContainer/CadModelContainer.context.ts
@@ -1,0 +1,29 @@
+import { createContext } from 'react';
+import { useRevealKeepAlive } from '../RevealKeepAlive/RevealKeepAliveContext';
+import { useRenderTarget } from '../RevealCanvas';
+import {
+  useReveal3DResourceLoadFailCount,
+  useReveal3DResourcesCount
+} from '../Reveal3DResources/Reveal3DResourcesInfoContext';
+import { useApplyCadModelStyling } from './useApplyCadModelStyling';
+import { RevealModelsUtils } from '../../architecture/concrete/reveal/RevealModelsUtils';
+
+export type CadModelContextDependencies = {
+  useRevealKeepAlive: typeof useRevealKeepAlive;
+  useRenderTarget: typeof useRenderTarget;
+  useReveal3DResourcesCount: typeof useReveal3DResourcesCount;
+  useReveal3DResourceLoadFailCount: typeof useReveal3DResourceLoadFailCount;
+  useApplyCadModelStyling: typeof useApplyCadModelStyling;
+  createCadDomainObject: typeof RevealModelsUtils.addModel;
+  removeCadDomainObject: typeof RevealModelsUtils.remove;
+};
+
+export const CadModelContext = createContext<CadModelContextDependencies>({
+  useRevealKeepAlive,
+  useRenderTarget,
+  useReveal3DResourcesCount,
+  useReveal3DResourceLoadFailCount,
+  useApplyCadModelStyling,
+  createCadDomainObject: RevealModelsUtils.addModel.bind(this),
+  removeCadDomainObject: RevealModelsUtils.remove.bind(this)
+});

--- a/react-components/src/components/CadModelContainer/CadModelContainer.spec.tsx
+++ b/react-components/src/components/CadModelContainer/CadModelContainer.spec.tsx
@@ -1,0 +1,72 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CadModelContainer } from './CadModelContainer';
+import { CadModelContext, type CadModelContextDependencies } from './CadModelContainer.context';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { Mock } from 'moq.ts';
+import type { RevealRenderTarget } from '../../architecture';
+import { type CogniteCadModel, type Cognite3DViewer, type CogniteModel } from '@cognite/reveal';
+
+describe('CadModelContainer', () => {
+  const deps: CadModelContextDependencies = {
+    useRevealKeepAlive: vi.fn(),
+    useRenderTarget: vi.fn(),
+    useReveal3DResourcesCount: vi.fn(),
+    useReveal3DResourceLoadFailCount: vi.fn(),
+    useApplyCadModelStyling: vi.fn(),
+    createCadDomainObject: vi.fn(),
+    removeCadDomainObject: vi.fn()
+  };
+
+  const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+    <CadModelContext.Provider value={deps}>{children}</CadModelContext.Provider>
+  );
+
+  it('should properly add and remove Cad Model when mounting and unmounting CadModelContainer', async () => {
+    const models = vi.fn<() => CogniteModel[]>();
+    const renderTargetMock = new Mock<RevealRenderTarget>()
+      .setup((x) => x.viewer)
+      .returns(
+        new Mock<Cognite3DViewer>()
+          .setup((x) => x.models)
+          .callback(models)
+          .setup((x) => x.get360ImageCollections)
+          .returns(() => [])
+          .object()
+      );
+    vi.mocked(deps.useRenderTarget).mockReturnValue(renderTargetMock.object());
+
+    vi.mocked(deps.useReveal3DResourcesCount).mockReturnValue({
+      reveal3DResourcesCount: 0,
+      setRevealResourcesCount: vi.fn()
+    });
+
+    vi.mocked(deps.useReveal3DResourceLoadFailCount).mockReturnValue({
+      reveal3DResourceLoadFailCount: 0,
+      setReveal3DResourceLoadFailCount: vi.fn()
+    });
+
+    const cadModel = new Mock<CogniteCadModel>().object();
+    vi.mocked(deps.createCadDomainObject).mockResolvedValue(cadModel);
+    models.mockReturnValue([]);
+
+    const addModelOptions1 = { modelId: 1, revisionId: 1 };
+
+    const { unmount } = render(
+      <CadModelContainer addModelOptions={addModelOptions1} onLoad={vi.fn()} />,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(deps.createCadDomainObject).toHaveBeenCalled();
+    });
+
+    models.mockReturnValue([cadModel]);
+
+    unmount();
+
+    await waitFor(() => {
+      expect(deps.removeCadDomainObject).toHaveBeenCalled();
+    });
+  });
+});

--- a/react-components/stories/CadModelContainer.stories.tsx
+++ b/react-components/stories/CadModelContainer.stories.tsx
@@ -4,7 +4,7 @@ import { Color, Matrix4 } from 'three';
 import { type AddModelOptions } from '@cognite/reveal';
 import { RevealStoryContainer } from './utilities/RevealStoryContainer';
 import { getAddModelOptionsFromUrl } from './utilities/getAddModelOptionsFromUrl';
-import { useRef, type ReactElement } from 'react';
+import { useRef, useState, type ReactElement } from 'react';
 import { signalStoryReadyForScreenshot } from './utilities/signalStoryReadyForScreenshot';
 
 const meta = {
@@ -43,14 +43,24 @@ export const Main: Story = {
     transform?: Matrix4;
     styling?: CadModelStyling;
   }) => {
+    const [enabled, setEnabled] = useState<boolean>(true);
     return (
-      <RevealStoryContainer color={new Color(0x4a4a4a)}>
-        <CadModelContainerStoryContent
-          addModelOptions={addModelOptions}
-          styling={styling}
-          transform={transform}
-        />
-      </RevealStoryContainer>
+      <>
+        <button
+          onClick={() => {
+            setEnabled((prev) => !prev);
+          }}>
+          {enabled ? 'Disable Models' : 'Enable Models'}
+        </button>
+        <RevealStoryContainer color={new Color(0x4a4a4a)}>
+          <CadModelContainerStoryContent
+            addModelOptions={addModelOptions}
+            styling={styling}
+            transform={transform}
+            enabled={enabled}
+          />
+        </RevealStoryContainer>
+      </>
     );
   }
 };
@@ -59,12 +69,14 @@ type CadModelContainerStoryContentProps = {
   addModelOptions: AddModelOptions;
   transform?: Matrix4;
   styling?: CadModelStyling;
+  enabled: boolean;
 };
 
 const CadModelContainerStoryContent = ({
   addModelOptions,
   transform,
-  styling
+  styling,
+  enabled
 }: CadModelContainerStoryContentProps): ReactElement => {
   const modelsLoadedRef = useRef(0);
   const cameraNavigationActions = useCameraNavigation();
@@ -77,8 +89,16 @@ const CadModelContainerStoryContent = ({
   };
   return (
     <>
-      <CadModelContainer addModelOptions={addModelOptions} styling={styling} onLoad={onLoad} />
-      <CadModelContainer addModelOptions={addModelOptions} transform={transform} onLoad={onLoad} />
+      {enabled ? (
+        <div>
+          <CadModelContainer addModelOptions={addModelOptions} styling={styling} onLoad={onLoad} />
+          <CadModelContainer
+            addModelOptions={addModelOptions}
+            transform={transform}
+            onLoad={onLoad}
+          />
+        </div>
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes a very ugly bug in the CadModelContainer due to closure not properly capturing the correct instance of the model in the remove model closure. I discovered this while creating a mount / unmount button in the storybook to provoke the race conditions that @pramod-cog 's workaround circumvents:
![image](https://github.com/user-attachments/assets/4776e4b5-804c-46bd-8b17-ea58a021f395)

The fix is simply lines 63-65 in the diff, where we pass the actual instance. The rest is simply making this bug testable. We likely have the same issue in PointClouds and maybe 360s as well which needs to be investigated.
