### PR TITLE
feat(react-components): create useRevealDomainObjects function

### DIFF
--- a/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.test.ts
+++ b/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { getRevealDomainUpdateSignal } from './getRevealDomainObjectsSignal';
 import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
-import { RevealRenderTarget } from '../../../base/renderTarget/RevealRenderTarget';
+import { type RevealRenderTarget } from '../../../base/renderTarget/RevealRenderTarget';
 import { CadDomainObject } from '../cad/CadDomainObject';
 import { createCadMock } from '#test-utils/fixtures/cadModel';
 import { createImage360ClassicMock } from '#test-utils/fixtures/image360';

--- a/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.test.ts
+++ b/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getRevealDomainUpdateSignal } from './getRevealDomainObjectsSignal';
+import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
+import { RevealRenderTarget } from '../../../base/renderTarget/RevealRenderTarget';
+import { CadDomainObject } from '../cad/CadDomainObject';
+import { createCadMock } from '#test-utils/fixtures/cadModel';
+import { createImage360ClassicMock } from '#test-utils/fixtures/image360';
+import { createPointCloudMock } from '#test-utils/fixtures/pointCloud';
+import { DomainObject } from '../../../base/domainObjects/DomainObject';
+import { Image360CollectionDomainObject } from '../Image360Collection/Image360CollectionDomainObject';
+import { PointCloudDomainObject } from '../pointCloud/PointCloudDomainObject';
+import { effect } from '@cognite/signals';
+import { Changes } from '../../../base/domainObjectsHelpers/Changes';
+
+describe(getRevealDomainUpdateSignal.name, () => {
+  let revealRenderTarget: RevealRenderTarget;
+
+  beforeEach(() => {
+    revealRenderTarget = createRenderTargetMock();
+  });
+
+  test('returns callback with added Reveal domain objects', () => {
+    const cadDomainObject = new CadDomainObject(createCadMock());
+    const pointCloudDomainObject = new PointCloudDomainObject(createPointCloudMock());
+    const image360DomainObject = new Image360CollectionDomainObject(createImage360ClassicMock());
+    const dummyDomainObject = new DummyDomainOject();
+
+    revealRenderTarget.rootDomainObject.addChild(cadDomainObject);
+    revealRenderTarget.rootDomainObject.addChild(pointCloudDomainObject);
+    revealRenderTarget.rootDomainObject.addChild(image360DomainObject);
+    revealRenderTarget.rootDomainObject.addChild(dummyDomainObject);
+
+    const signalResult = getRevealDomainUpdateSignal(revealRenderTarget);
+
+    const value = signalResult.signal()();
+    expect(value[0]).toBe(cadDomainObject);
+    expect(value[1]).toBe(pointCloudDomainObject);
+    expect(value[2]).toBe(image360DomainObject);
+  });
+
+  test('adds event listener, and calling dispose removes event listener', () => {
+    const addEventMock = vi.spyOn(revealRenderTarget.rootDomainObject.views, 'addEventListener');
+    const removeEventMock = vi.spyOn(
+      revealRenderTarget.rootDomainObject.views,
+      'removeEventListener'
+    );
+
+    const res = getRevealDomainUpdateSignal(revealRenderTarget);
+
+    expect(addEventMock).toHaveBeenCalledTimes(1);
+    expect(removeEventMock).toHaveBeenCalledTimes(0);
+
+    const eventCallback = addEventMock.mock.calls[0][0];
+
+    res.dispose();
+
+    expect(removeEventMock).toHaveBeenCalledTimes(1);
+    expect(removeEventMock).toHaveBeenCalledWith(eventCallback);
+  });
+
+  test('signal updates when object is added and removed', () => {
+    const cadDomainObject = new CadDomainObject(createCadMock());
+    const pointCloudDomainObject = new PointCloudDomainObject(createPointCloudMock());
+
+    let signalUpdates = 0;
+
+    revealRenderTarget.rootDomainObject.addChild(cadDomainObject);
+
+    const signalResult = getRevealDomainUpdateSignal(revealRenderTarget);
+
+    effect(() => {
+      signalResult.signal();
+      signalUpdates++;
+    });
+
+    const initialDomainObjects = signalResult.signal()();
+
+    expect(signalUpdates).toBe(1);
+    expect(initialDomainObjects).toHaveLength(1);
+    expect(initialDomainObjects[0]).toBe(cadDomainObject);
+
+    revealRenderTarget.rootDomainObject.addChildInteractive(pointCloudDomainObject);
+
+    const domainObjectsAfterAdd = signalResult.signal()();
+
+    expect(signalUpdates).toBe(2);
+    expect(domainObjectsAfterAdd).toHaveLength(2);
+    expect(domainObjectsAfterAdd[0]).toBe(cadDomainObject);
+    expect(domainObjectsAfterAdd[1]).toBe(pointCloudDomainObject);
+
+    cadDomainObject.removeInteractive();
+
+    const domainObjectsAfterRemove = signalResult.signal()();
+
+    expect(signalUpdates).toBe(3);
+    expect(domainObjectsAfterRemove).toHaveLength(1);
+    expect(domainObjectsAfterRemove[0]).toBe(pointCloudDomainObject);
+  });
+
+  test('returns domain objects based on predicate and provided change flag', () => {
+    const cadDomainObject = new CadDomainObject(createCadMock());
+    const pointCloudDomainObject = new PointCloudDomainObject(createPointCloudMock());
+
+    cadDomainObject.setVisibleInteractive(true, revealRenderTarget);
+    pointCloudDomainObject.setVisibleInteractive(true, revealRenderTarget);
+
+    revealRenderTarget.rootDomainObject.addChildInteractive(cadDomainObject);
+    revealRenderTarget.rootDomainObject.addChildInteractive(pointCloudDomainObject);
+
+    const signalResult = getRevealDomainUpdateSignal(
+      revealRenderTarget,
+      (domainObject) => domainObject.isVisible(revealRenderTarget),
+      [Changes.visibleState]
+    );
+
+    const resultBeforeHiding = signalResult.signal()();
+    expect(resultBeforeHiding).toHaveLength(2);
+    expect(resultBeforeHiding[0]).toBe(cadDomainObject);
+    expect(resultBeforeHiding[1]).toBe(pointCloudDomainObject);
+
+    cadDomainObject.setVisibleInteractive(false, revealRenderTarget);
+
+    const resultAfterHiding = signalResult.signal()();
+
+    expect(resultAfterHiding).toHaveLength(1);
+    expect(resultAfterHiding[0]).toBe(pointCloudDomainObject);
+  });
+});
+
+class DummyDomainOject extends DomainObject {
+  typeName = { untranslated: 'DummyDomainObject' };
+}

--- a/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.test.ts
+++ b/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.test.ts
@@ -33,6 +33,7 @@ describe(getRevealDomainUpdateSignal.name, () => {
     const signalResult = getRevealDomainUpdateSignal(revealRenderTarget);
 
     const value = signalResult.signal()();
+    expect(value).toHaveLength(3);
     expect(value[0]).toBe(cadDomainObject);
     expect(value[1]).toBe(pointCloudDomainObject);
     expect(value[2]).toBe(image360DomainObject);
@@ -45,14 +46,14 @@ describe(getRevealDomainUpdateSignal.name, () => {
       'removeEventListener'
     );
 
-    const res = getRevealDomainUpdateSignal(revealRenderTarget);
+    const result = getRevealDomainUpdateSignal(revealRenderTarget);
 
     expect(addEventMock).toHaveBeenCalledTimes(1);
     expect(removeEventMock).toHaveBeenCalledTimes(0);
 
     const eventCallback = addEventMock.mock.calls[0][0];
 
-    res.dispose();
+    result.dispose();
 
     expect(removeEventMock).toHaveBeenCalledTimes(1);
     expect(removeEventMock).toHaveBeenCalledWith(eventCallback);

--- a/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
+++ b/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
@@ -31,13 +31,15 @@ export function getRevealDomainUpdateSignal(
     domainObject: DomainObject,
     change: DomainObjectChange
   ): void {
-    const relevantChanges = [Changes.added, Changes.deleting, ...additionalChangeFlags];
-
     if (!(domainObject instanceof RevealDomainObject)) {
       return;
     }
 
-    const isRelevantChange = change.isChanged(...relevantChanges);
+    const isRelevantChange = change.isChanged(
+      Changes.added,
+      Changes.deleting,
+      ...additionalChangeFlags
+    );
 
     if (!isRelevantChange) {
       return;

--- a/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
+++ b/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
@@ -33,10 +33,13 @@ export function getRevealDomainUpdateSignal(
   ): void {
     const relevantChanges = [Changes.added, Changes.deleting, ...additionalChangeFlags];
 
+    if (!(domainObject instanceof RevealDomainObject)) {
+      return;
+    }
+
     const isRelevantChange = change.isChanged(...relevantChanges);
 
-    const isRelevantEvent = domainObject instanceof RevealDomainObject && isRelevantChange;
-    if (!isRelevantEvent) {
+    if (!isRelevantChange) {
       return;
     }
 

--- a/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
+++ b/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
@@ -1,0 +1,56 @@
+import { signal } from '@cognite/signals';
+import { type DisposableSignal } from '../../../../utilities/signal/DisposableSignal';
+import { type DomainObject } from '../../../base/domainObjects/DomainObject';
+import { type DomainObjectChange } from '../../../base/domainObjectsHelpers/DomainObjectChange';
+import { type RevealRenderTarget } from '../../../base/renderTarget/RevealRenderTarget';
+import { filter } from '../../../base/utilities/extensions/generatorUtils';
+import { RevealDomainObject } from '../RevealDomainObject';
+import { Changes } from '../../../base/domainObjectsHelpers/Changes';
+
+export function getRevealDomainUpdateSignal(
+  renderTarget: RevealRenderTarget,
+  predicate: (domainObject: RevealDomainObject) => boolean = () => true,
+  additionalChangeFlags: symbol[] = []
+): DisposableSignal<RevealDomainObject[]> {
+  const objectsSignal = signal<() => RevealDomainObject[]>(() =>
+    getRevealDomainObjects(renderTarget, predicate)
+  );
+
+  renderTarget.rootDomainObject.views.addEventListener(updateDomainObjectListOnRelevantEvent);
+
+  return {
+    signal: objectsSignal,
+    dispose: () => {
+      renderTarget.rootDomainObject.views.removeEventListener(
+        updateDomainObjectListOnRelevantEvent
+      );
+    }
+  };
+
+  function updateDomainObjectListOnRelevantEvent(
+    domainObject: DomainObject,
+    change: DomainObjectChange
+  ): void {
+    const relevantChanges = [Changes.added, Changes.deleting, ...additionalChangeFlags];
+
+    const isRelevantChange = change.isChanged(...relevantChanges);
+
+    console.log('Got event ', change, ' relevant: ', isRelevantChange);
+
+    const isRelevantEvent = domainObject instanceof RevealDomainObject && isRelevantChange;
+    if (!isRelevantEvent) {
+      return;
+    }
+
+    objectsSignal(() => getRevealDomainObjects(renderTarget, predicate));
+  }
+}
+
+function getRevealDomainObjects(
+  renderTarget: RevealRenderTarget,
+  predicate: (domainObject: RevealDomainObject) => boolean
+): RevealDomainObject[] {
+  return [
+    ...filter(renderTarget.rootDomainObject.getDescendantsByType(RevealDomainObject), predicate)
+  ];
+}

--- a/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
+++ b/react-components/src/architecture/concrete/reveal/signal/getRevealDomainObjectsSignal.ts
@@ -35,8 +35,6 @@ export function getRevealDomainUpdateSignal(
 
     const isRelevantChange = change.isChanged(...relevantChanges);
 
-    console.log('Got event ', change, ' relevant: ', isRelevantChange);
-
     const isRelevantEvent = domainObject instanceof RevealDomainObject && isRelevantChange;
     if (!isRelevantEvent) {
       return;

--- a/react-components/src/hooks/index.ts
+++ b/react-components/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { use3dModels } from './use3dModels';
+export { useRevealDomainObjects } from './useRevealDomainObjects';
 export { useCameraNavigation } from './useCameraNavigation';
 export { useClickedNodeData } from './useClickedNode';
 export { useCreateAssetMappingsMapPerModel } from './useCreateAssetMappingsMapPerModel';

--- a/react-components/src/hooks/useRevealDomainObjects.test.tsx
+++ b/react-components/src/hooks/useRevealDomainObjects.test.tsx
@@ -5,9 +5,7 @@ import {
   type UseRevealDomainObjectsDependencies
 } from './useRevealDomainObjects';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { type PropsWithChildren } from 'react';
-import { useRenderTarget } from '../components';
-import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
+import { type ReactElement, type PropsWithChildren } from 'react';
 import { createCadMock } from '#test-utils/fixtures/cadModel';
 import { createPointCloudMock } from '#test-utils/fixtures/pointCloud';
 import { createImage360ClassicMock } from '#test-utils/fixtures/image360';
@@ -15,13 +13,13 @@ import { Image360CollectionDomainObject } from '../architecture/concrete/reveal/
 import { PointCloudDomainObject } from '../architecture/concrete/reveal/pointCloud/PointCloudDomainObject';
 import { CadDomainObject } from '../architecture/concrete/reveal/cad/CadDomainObject';
 import { Changes, DomainObject, RevealRenderTarget } from '../architecture';
-import { createViewerMock, viewerMock } from '#test-utils/fixtures/viewer';
+import { createViewerMock } from '#test-utils/fixtures/viewer';
 import { sdkMock } from '#test-utils/fixtures/sdk';
 
 describe(useRevealDomainObjects.name, () => {
   const mockUseRenderTarget = vi.fn<UseRevealDomainObjectsDependencies['useRenderTarget']>();
 
-  const wrapper = ({ children }: PropsWithChildren) => (
+  const wrapper = ({ children }: PropsWithChildren): ReactElement => (
     <UseRevealDomainObjectsContext.Provider value={{ useRenderTarget: mockUseRenderTarget }}>
       {children}
     </UseRevealDomainObjectsContext.Provider>

--- a/react-components/src/hooks/useRevealDomainObjects.test.tsx
+++ b/react-components/src/hooks/useRevealDomainObjects.test.tsx
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  useRevealDomainObjects,
+  UseRevealDomainObjectsContext,
+  type UseRevealDomainObjectsDependencies
+} from './useRevealDomainObjects';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { useRenderTarget } from '../components';
+import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
+import { createCadMock } from '#test-utils/fixtures/cadModel';
+import { createPointCloudMock } from '#test-utils/fixtures/pointCloud';
+import { createImage360ClassicMock } from '#test-utils/fixtures/image360';
+import { Image360CollectionDomainObject } from '../architecture/concrete/reveal/Image360Collection/Image360CollectionDomainObject';
+import { PointCloudDomainObject } from '../architecture/concrete/reveal/pointCloud/PointCloudDomainObject';
+import { CadDomainObject } from '../architecture/concrete/reveal/cad/CadDomainObject';
+import { Changes, DomainObject, RevealRenderTarget } from '../architecture';
+import { createViewerMock, viewerMock } from '#test-utils/fixtures/viewer';
+import { sdkMock } from '#test-utils/fixtures/sdk';
+
+describe(useRevealDomainObjects.name, () => {
+  const mockUseRenderTarget = vi.fn<UseRevealDomainObjectsDependencies['useRenderTarget']>();
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <UseRevealDomainObjectsContext.Provider value={{ useRenderTarget: mockUseRenderTarget }}>
+      {children}
+    </UseRevealDomainObjectsContext.Provider>
+  );
+
+  let revealRenderTarget: RevealRenderTarget;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    revealRenderTarget = new RevealRenderTarget(createViewerMock(), sdkMock);
+    mockUseRenderTarget.mockReturnValue(revealRenderTarget);
+  });
+
+  test('returns nothing when no Reveal domain objects exist', () => {
+    const { result } = renderHook(() => useRevealDomainObjects(), { wrapper });
+
+    expect(result.current).toEqual([]);
+  });
+
+  test('returns all domain objects in render target', () => {
+    const dummyDomainObject = new DummyDomainObject();
+    const cadDomainObject = new CadDomainObject(createCadMock());
+    const pointCloudDomainObject = new PointCloudDomainObject(createPointCloudMock());
+    const image360DomainObject = new Image360CollectionDomainObject(createImage360ClassicMock());
+
+    revealRenderTarget.rootDomainObject.addChild(dummyDomainObject);
+    dummyDomainObject.addChild(cadDomainObject);
+    revealRenderTarget.rootDomainObject.addChild(pointCloudDomainObject);
+    revealRenderTarget.rootDomainObject.addChild(image360DomainObject);
+
+    const { result } = renderHook(() => useRevealDomainObjects(), { wrapper });
+
+    expect(result.current).toHaveLength(3);
+    expect(result.current[0]).toBe(cadDomainObject);
+    expect(result.current[1]).toBe(pointCloudDomainObject);
+    expect(result.current[2]).toBe(image360DomainObject);
+  });
+
+  test('holds stable reference over rerenders', () => {
+    const pointCloudDomainObject = new PointCloudDomainObject(createPointCloudMock());
+    revealRenderTarget.rootDomainObject.addChild(pointCloudDomainObject);
+    const { result, rerender } = renderHook(() => useRevealDomainObjects(), { wrapper });
+
+    const initialResult = result.current;
+    expect(initialResult).toHaveLength(1);
+    expect(initialResult[0]).toBe(pointCloudDomainObject);
+
+    rerender();
+
+    expect(result.current).toBe(initialResult);
+  });
+
+  test('updates returned reference when a Reveal object is added to render target', async () => {
+    const cadDomainObject = new CadDomainObject(createCadMock());
+    const pointCloudDomainObject = new PointCloudDomainObject(createPointCloudMock());
+
+    revealRenderTarget.rootDomainObject.addChild(cadDomainObject);
+
+    const { result } = renderHook(() => useRevealDomainObjects(), { wrapper });
+
+    const initialResult = result.current;
+
+    act(() => {
+      revealRenderTarget.rootDomainObject.addChildInteractive(pointCloudDomainObject);
+    });
+
+    const secondResult = result.current;
+
+    await waitFor(() => {
+      expect(result.current).not.toBe(initialResult);
+    });
+
+    expect(secondResult).toHaveLength(2);
+    expect(secondResult[0]).toBe(cadDomainObject);
+    expect(secondResult[1]).toBe(pointCloudDomainObject);
+  });
+
+  test('updates returned reference  when a Reveal object is removed from render target', () => {
+    const cadDomainObject = new CadDomainObject(createCadMock());
+    const pointCloudDomainObject = new PointCloudDomainObject(createPointCloudMock());
+
+    revealRenderTarget.rootDomainObject.addChild(cadDomainObject);
+    revealRenderTarget.rootDomainObject.addChild(pointCloudDomainObject);
+
+    const { result } = renderHook(() => useRevealDomainObjects(), { wrapper });
+
+    const initialResult = result.current;
+
+    expect(initialResult).toHaveLength(2);
+
+    act(() => {
+      cadDomainObject.removeInteractive();
+    });
+
+    const secondResult = result.current;
+
+    expect(secondResult).not.toBe(initialResult);
+
+    expect(secondResult).toHaveLength(1);
+    expect(secondResult[0]).toBe(pointCloudDomainObject);
+  });
+
+  test('updates returned objects filtered by predicate when a user-specified change happens', () => {
+    const cadDomainObject = new CadDomainObject(createCadMock());
+    const dummyDomainObject = new DummyDomainObject();
+    revealRenderTarget.rootDomainObject.addChild(cadDomainObject);
+    revealRenderTarget.rootDomainObject.addChild(dummyDomainObject);
+
+    cadDomainObject.setVisibleInteractive(true, revealRenderTarget);
+
+    const { result } = renderHook(
+      () =>
+        useRevealDomainObjects(
+          (domainObject) => domainObject.isVisible(revealRenderTarget),
+          [Changes.visibleState]
+        ),
+      {
+        wrapper
+      }
+    );
+
+    const initialResult = result.current;
+
+    expect(initialResult).toHaveLength(1);
+
+    act(() => {
+      cadDomainObject.setVisibleInteractive(false, revealRenderTarget);
+    });
+
+    const secondResult = result.current;
+
+    expect(secondResult).not.toBe(initialResult);
+    expect(secondResult).toEqual([]);
+  });
+});
+
+class DummyDomainObject extends DomainObject {
+  typeName = { untranslated: 'DummyDomainObject' };
+}

--- a/react-components/src/hooks/useRevealDomainObjects.ts
+++ b/react-components/src/hooks/useRevealDomainObjects.ts
@@ -22,7 +22,11 @@ export function useRevealDomainObjects(
 
   const disposableSignal = useMemo(
     () => getRevealDomainUpdateSignal(renderTarget, predicate, additionalChangeFlags),
-    [renderTarget, predicate, additionalChangeFlags]
+    [
+      renderTarget,
+      predicate,
+      additionalChangeFlags?.map((changeFlag) => changeFlag.toString()).join(',')
+    ]
   );
 
   return useDisposableSignal(disposableSignal);

--- a/react-components/src/hooks/useRevealDomainObjects.ts
+++ b/react-components/src/hooks/useRevealDomainObjects.ts
@@ -1,0 +1,29 @@
+import { createContext, useContext, useMemo } from 'react';
+import { useRenderTarget } from '../components/RevealCanvas/ViewerContext';
+import { useDisposableSignal } from '../utilities/signal/useDisposableSignal';
+import { getRevealDomainUpdateSignal } from '../architecture/concrete/reveal/signal/getRevealDomainObjectsSignal';
+import { type RevealDomainObject } from '../architecture/concrete/reveal/RevealDomainObject';
+
+export type UseRevealDomainObjectsDependencies = {
+  useRenderTarget: typeof useRenderTarget;
+};
+
+export const UseRevealDomainObjectsContext = createContext({
+  useRenderTarget
+});
+
+export function useRevealDomainObjects(
+  predicate?: (domainObject: RevealDomainObject) => boolean,
+  additionalChangeFlags?: symbol[]
+): RevealDomainObject[] {
+  const { useRenderTarget } = useContext(UseRevealDomainObjectsContext);
+
+  const renderTarget = useRenderTarget();
+
+  const disposableSignal = useMemo(
+    () => getRevealDomainUpdateSignal(renderTarget, predicate, additionalChangeFlags),
+    [renderTarget, predicate, additionalChangeFlags]
+  );
+
+  return useDisposableSignal(disposableSignal);
+}

--- a/react-components/src/utilities/signal/DisposableSignal.ts
+++ b/react-components/src/utilities/signal/DisposableSignal.ts
@@ -1,0 +1,6 @@
+import { type ReadonlySignal } from '@cognite/signals';
+
+export type DisposableSignal<T> = {
+  signal: ReadonlySignal<() => T>;
+  dispose: () => void;
+};

--- a/react-components/src/utilities/signal/useDisposableSignal.test.ts
+++ b/react-components/src/utilities/signal/useDisposableSignal.test.ts
@@ -59,7 +59,9 @@ describe(useDisposableSignal.name, () => {
 
     const newValue = 43;
 
-    act(() => testSignal(() => newValue));
+    act(() => {
+      testSignal(() => newValue);
+    });
 
     expect(result.current).toBe(newValue);
   });

--- a/react-components/src/utilities/signal/useDisposableSignal.test.ts
+++ b/react-components/src/utilities/signal/useDisposableSignal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import { useDisposableSignal } from './useDisposableSignal';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { signal } from '@cognite/signals';
 import { type DisposableSignal } from './DisposableSignal';
 
@@ -59,7 +59,7 @@ describe(useDisposableSignal.name, () => {
 
     const newValue = 43;
 
-    testSignal(() => newValue);
+    act(() => testSignal(() => newValue));
 
     expect(result.current).toBe(newValue);
   });

--- a/react-components/src/utilities/signal/useDisposableSignal.test.ts
+++ b/react-components/src/utilities/signal/useDisposableSignal.test.ts
@@ -57,8 +57,10 @@ describe(useDisposableSignal.name, () => {
 
     const { result } = renderHook(() => useDisposableSignal(disposableSignal));
 
-    testSignal(() => 43);
+    const newValue = 43;
 
-    expect(result.current).toBe(43);
+    testSignal(() => newValue);
+
+    expect(result.current).toBe(newValue);
   });
 });

--- a/react-components/src/utilities/signal/useDisposableSignal.test.ts
+++ b/react-components/src/utilities/signal/useDisposableSignal.test.ts
@@ -47,4 +47,18 @@ describe(useDisposableSignal.name, () => {
 
     expect(result.current).toBe(initialResult);
   });
+
+  test('returns new value when signal updates', () => {
+    const testSignal = signal<() => number>(() => 42);
+    const disposableSignal: DisposableSignal<number> = {
+      signal: testSignal,
+      dispose: () => {}
+    };
+
+    const { result } = renderHook(() => useDisposableSignal(disposableSignal));
+
+    testSignal(() => 43);
+
+    expect(result.current).toBe(43);
+  });
 });

--- a/react-components/src/utilities/signal/useDisposableSignal.test.ts
+++ b/react-components/src/utilities/signal/useDisposableSignal.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest';
+import { useDisposableSignal } from './useDisposableSignal';
+import { renderHook } from '@testing-library/react';
+import { signal } from '@cognite/signals';
+import { type DisposableSignal } from './DisposableSignal';
+
+describe(useDisposableSignal.name, () => {
+  test('returns signal value', () => {
+    const signalResult = 42;
+
+    const disposableSignal: DisposableSignal<number> = {
+      signal: signal(() => signalResult),
+      dispose: () => {}
+    };
+
+    const { result } = renderHook(() => useDisposableSignal(disposableSignal));
+
+    expect(result.current).toBe(signalResult);
+  });
+
+  test('calls dispose on unmount', () => {
+    const disposableSignal = {
+      signal: signal(() => 0),
+      dispose: vi.fn()
+    };
+
+    const { unmount } = renderHook(() => useDisposableSignal(disposableSignal));
+
+    expect(disposableSignal.dispose).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(disposableSignal.dispose).toHaveBeenCalledOnce();
+  });
+
+  test('returns stable reference across rerenders', () => {
+    const disposableSignal: DisposableSignal<number[]> = {
+      signal: signal(() => [42]),
+      dispose: () => {}
+    };
+
+    const { result, rerender } = renderHook(() => useDisposableSignal(disposableSignal));
+
+    const initialResult = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(initialResult);
+  });
+});

--- a/react-components/src/utilities/signal/useDisposableSignal.ts
+++ b/react-components/src/utilities/signal/useDisposableSignal.ts
@@ -1,0 +1,12 @@
+import { useSignalValue } from '@cognite/signals/react';
+import { type DisposableSignal } from './DisposableSignal';
+import { useEffect, useMemo } from 'react';
+
+export function useDisposableSignal<T>(effectSignal: DisposableSignal<T>): T {
+  useEffect(() => {
+    return effectSignal.dispose;
+  }, [effectSignal]);
+
+  const valueCallback = useSignalValue(effectSignal.signal);
+  return useMemo(() => valueCallback(), [valueCallback]);
+}

--- a/react-components/src/utilities/signal/useDisposableSignal.ts
+++ b/react-components/src/utilities/signal/useDisposableSignal.ts
@@ -2,11 +2,11 @@ import { useSignalValue } from '@cognite/signals/react';
 import { type DisposableSignal } from './DisposableSignal';
 import { useEffect, useMemo } from 'react';
 
-export function useDisposableSignal<T>(effectSignal: DisposableSignal<T>): T {
+export function useDisposableSignal<T>(disposableSignal: DisposableSignal<T>): T {
   useEffect(() => {
-    return effectSignal.dispose;
-  }, [effectSignal]);
+    return disposableSignal.dispose;
+  }, [disposableSignal]);
 
-  const valueCallback = useSignalValue(effectSignal.signal);
+  const valueCallback = useSignalValue(disposableSignal.signal);
   return useMemo(() => valueCallback(), [valueCallback]);
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

Part of the work for https://cognitedata.atlassian.net/browse/BND3D-5790

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Introduces the hook `useRevealDomainObjects` which is implemented with a signal, and updates whenever (relevant) changes to the DomainObject hierarchy occurs. I intend this to be a generally useful function with a few use cases in existing hooks coming up in a subsequent PR.

This also introduces a pattern involving `DisposableSignal`, a signal that contains a callback and that comes with an attached dispose-function, which is relevant if e.g. the signal is based on an event listener to properly unregister the listener when the signal is no longer needed. The `useDisposableSignal` hook streamlines this part.

The reason for requiring `DisposableSignal` to return a callback in the signal, is that it allows us to avoid double-buffering values that should only exist one place, e.g. Reveal domain objects in the domain object hierarchy. Having this engraved in the type also lets us more easily implement `useDisposableSignal` without having the user put a `useMemo` at the end manually to actually trigger the callback themselves.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Through unit tests and, with upcoming changes, in Fusion

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
