### PR TITLE
fix: throwing errors when trying to remove an already removed model

### DIFF
--- a/react-components/src/architecture/concrete/reveal/RevealModelsUtils.test.ts
+++ b/react-components/src/architecture/concrete/reveal/RevealModelsUtils.test.ts
@@ -94,6 +94,9 @@ describe(RevealModelsUtils.name, () => {
 
     // Add model
     await RevealModelsUtils.addModel(renderTargetMock, cadModelOptions);
+
+    viewerModelsMock.mockReturnValue([model]);
+
     let domainObject = RevealModelsUtils.getByRevealModel(root, model);
     expect(domainObject).toBeDefined();
 
@@ -121,7 +124,7 @@ describe(RevealModelsUtils.name, () => {
     }).not.toThrow();
   });
 
-  test.only('should not throw when removing a non-existing Point Cloud model', async () => {
+  test('should not throw when removing a non-existing Point Cloud model', async () => {
     const model = createPointCloudMock();
     const removeFn = vi.fn().mockImplementation(() => {
       throw new Error();
@@ -148,6 +151,9 @@ describe(RevealModelsUtils.name, () => {
 
     // Add model
     await RevealModelsUtils.addPointCloud(renderTargetMock, pointCloudModelOptions);
+
+    viewerModelsMock.mockReturnValue([model]);
+
     let domainObject = RevealModelsUtils.getByRevealModel(root, model);
     expect(domainObject).toBeDefined();
 

--- a/react-components/src/architecture/concrete/reveal/RevealModelsUtils.test.ts
+++ b/react-components/src/architecture/concrete/reveal/RevealModelsUtils.test.ts
@@ -3,7 +3,7 @@ import { cadModelOptions, createCadMock } from '#test-utils/fixtures/cadModel';
 import { createImage360ClassicMock, image360ClassicOptions } from '#test-utils/fixtures/image360';
 import { createPointCloudMock, pointCloudModelOptions } from '#test-utils/fixtures/pointCloud';
 import { createRenderTargetMock } from '#test-utils/fixtures/renderTarget';
-import { viewerMock } from '#test-utils/fixtures/viewer';
+import { viewerMock, viewerModelsMock } from '#test-utils/fixtures/viewer';
 import { CadDomainObject } from './cad/CadDomainObject';
 import { Image360CollectionDomainObject } from './Image360Collection/Image360CollectionDomainObject';
 import { PointCloudDomainObject } from './pointCloud/PointCloudDomainObject';
@@ -101,6 +101,42 @@ describe(RevealModelsUtils.name, () => {
     domainObject = RevealModelsUtils.getByRevealModel(root, model);
     expect(domainObject).toBeUndefined();
     expect(removeFn).toHaveBeenCalledWith(model);
+  });
+
+  test('should not throw when removing a non-existing CAD model', async () => {
+    const model = createCadMock();
+    const removeFn = vi.fn().mockImplementation(() => {
+      throw new Error();
+    });
+    viewerMock.removeModel = removeFn;
+    const addFn = vi.fn().mockResolvedValue(model);
+    viewerMock.addCadModel = addFn;
+
+    viewerModelsMock.mockReturnValue([]);
+
+    await RevealModelsUtils.addModel(renderTargetMock, cadModelOptions);
+
+    expect(() => {
+      RevealModelsUtils.remove(renderTargetMock, model);
+    }).not.toThrow();
+  });
+
+  test.only('should not throw when removing a non-existing Point Cloud model', async () => {
+    const model = createPointCloudMock();
+    const removeFn = vi.fn().mockImplementation(() => {
+      throw new Error();
+    });
+    viewerMock.removeModel = removeFn;
+    const addFn = vi.fn().mockResolvedValue(model);
+    viewerMock.addPointCloudModel = addFn;
+
+    viewerModelsMock.mockReturnValue([]);
+
+    await RevealModelsUtils.addPointCloud(renderTargetMock, pointCloudModelOptions);
+
+    expect(() => {
+      RevealModelsUtils.remove(renderTargetMock, model);
+    }).not.toThrow();
   });
 
   test('should remove the PointCloud model', async () => {

--- a/react-components/src/architecture/concrete/reveal/cad/CadDomainObject.test.ts
+++ b/react-components/src/architecture/concrete/reveal/cad/CadDomainObject.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import { createFullRenderTargetMock } from '../../../../../tests/tests-utilities/fixtures/createFullRenderTargetMock';
-import { CogniteCadModel } from '@cognite/reveal';
+import type { CogniteCadModel } from '@cognite/reveal';
 import { createCadMock } from '../../../../../tests/tests-utilities/fixtures/cadModel';
 import { CadRenderStyle } from './CadRenderStyle';
 import { CadDomainObject } from './CadDomainObject';
-import { type RevealRenderTarget } from '../../../base/renderTarget/RevealRenderTarget';
+import type { RevealRenderTarget } from '../../../base/renderTarget/RevealRenderTarget';
+import { viewerModelsMock } from '#test-utils/fixtures/viewer';
 
-describe(CogniteCadModel.name, () => {
+describe(CadDomainObject.name, () => {
   let model: CogniteCadModel;
   let domainObject: CadDomainObject;
   let renderTarget: RevealRenderTarget;
@@ -27,6 +28,7 @@ describe(CogniteCadModel.name, () => {
   });
 
   test('should be removed', async () => {
+    viewerModelsMock.mockReturnValue([model]);
     domainObject.removeInteractive();
     expect(renderTarget.viewer.removeModel).toHaveBeenCalledWith(model);
   });

--- a/react-components/src/architecture/concrete/reveal/cad/CadDomainObject.ts
+++ b/react-components/src/architecture/concrete/reveal/cad/CadDomainObject.ts
@@ -52,6 +52,9 @@ export class CadDomainObject extends VisualDomainObject {
 
   protected override removeCore(): void {
     super.removeCore();
-    getRenderTarget(this)?.viewer?.removeModel(this._model);
+    const viewer = getRenderTarget(this)?.viewer;
+    if (viewer?.models.includes(this._model) ?? false) {
+      viewer?.removeModel(this._model);
+    }
   }
 }

--- a/react-components/src/architecture/concrete/reveal/pointCloud/PointCloudDomainObject.test.ts
+++ b/react-components/src/architecture/concrete/reveal/pointCloud/PointCloudDomainObject.test.ts
@@ -5,6 +5,7 @@ import { PointCloudRenderStyle } from './PointCloudRenderStyle';
 import { createFullRenderTargetMock } from '../../../../../tests/tests-utilities/fixtures/createFullRenderTargetMock';
 import { type RevealRenderTarget } from '../../../base/renderTarget/RevealRenderTarget';
 import { type CognitePointCloudModel } from '@cognite/reveal';
+import { viewerModelsMock } from '#test-utils/fixtures/viewer';
 
 describe(PointCloudDomainObject.name, () => {
   let model: CognitePointCloudModel;
@@ -27,6 +28,7 @@ describe(PointCloudDomainObject.name, () => {
   });
 
   test('should be removed', async () => {
+    viewerModelsMock.mockReturnValue([model]);
     domainObject.removeInteractive();
     expect(renderTarget.viewer.removeModel).toHaveBeenCalledWith(model);
   });

--- a/react-components/src/architecture/concrete/reveal/pointCloud/PointCloudDomainObject.ts
+++ b/react-components/src/architecture/concrete/reveal/pointCloud/PointCloudDomainObject.ts
@@ -51,6 +51,9 @@ export class PointCloudDomainObject extends VisualDomainObject {
 
   protected override removeCore(): void {
     super.removeCore();
-    getRenderTarget(this)?.viewer?.removeModel(this._model);
+    const viewer = getRenderTarget(this)?.viewer;
+    if (viewer?.models.includes(this._model) ?? false) {
+      viewer?.removeModel(this._model);
+    }
   }
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5792

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an issue where if a model that has already been removed, is removed again, then we would throw an error.

Note that 360 images do not need this fix, as Reveal already handles this internally.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

Unit tests.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
