### PR TITLE
fix: ignore dereferencing when group is already disposed

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "4.25.2",
+  "version": "4.25.3",
   "description": "WebGL based 3D viewer for CAD and point clouds processed in Cognite Data Fusion.",
   "homepage": "https://github.com/cognitedata/reveal/tree/master/viewer",
   "repository": {

--- a/viewer/packages/cad-parsers/src/sector/SectorNode.test.ts
+++ b/viewer/packages/cad-parsers/src/sector/SectorNode.test.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright 2021 Cognite AS
+ */
+import { jest } from '@jest/globals';
+import { Box3 } from 'three';
+import { SectorNode } from './SectorNode';
+import { Mock } from 'moq.ts';
+import type { AutoDisposeGroup } from '@reveal/utilities';
+
+describe(SectorNode.name, () => {
+  test('dereferencing a disposed group should not crash', async () => {
+    const sectorNode = new SectorNode(1, 'testSector', new Box3());
+    const isDisposedMock = jest.fn<() => boolean>();
+    const group = new Mock<AutoDisposeGroup>()
+      .setup(p => p.reference())
+      .returns()
+      .setup(p => p.isDisposed())
+      .callback(isDisposedMock)
+      .object();
+
+    isDisposedMock.mockReturnValue(false);
+    sectorNode.updateGeometry(group, sectorNode.levelOfDetail);
+
+    isDisposedMock.mockReturnValue(true);
+    expect(() => sectorNode.dereference()).not.toThrow();
+  });
+});

--- a/viewer/packages/cad-parsers/src/sector/SectorNode.ts
+++ b/viewer/packages/cad-parsers/src/sector/SectorNode.ts
@@ -57,7 +57,7 @@ export class SectorNode extends THREE.Group {
   }
 
   dereference(): void {
-    if (this._group !== undefined) {
+    if (this._group !== undefined && !this._group.isDisposed()) {
       this._group.dereference();
     }
   }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

related to https://cognitedata.atlassian.net/browse/BND3D-5792

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an issue when CAD model is being disposed where a dereference of a geometry group is happening when it is already disposed.