### PR TITLE
chore: update rustc compiler version

### DIFF
--- a/viewer/rust-toolchain.toml
+++ b/viewer/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.82.0"


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

related to https://cognitedata.atlassian.net/browse/BND3D-5792

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

publishing failed due to `package `wasm-bindgen-wasm-conventions v0.2.95` cannot be built because it requires rustc 1.76 or newer, while the currently active rustc version is 1.73.0`

So updating the current rustc version.
