### PR TITLE
chore(react-components): rename asset mapping types

### DIFF
--- a/react-components/src/architecture/base/renderTarget/CdfCaches.ts
+++ b/react-components/src/architecture/base/renderTarget/CdfCaches.ts
@@ -1,6 +1,6 @@
 import { type CogniteClient } from '@cognite/sdk';
-import { AssetMappingAndNode3DCache } from '../../../components/CacheProvider/AssetMappingAndNode3DCache';
-import { FdmNodeCache } from '../../../components/CacheProvider/FdmNodeCache';
+import { ClassicCadAssetMappingCache } from '../../../components/CacheProvider/cad/ClassicAssetMappingCache';
+import { FdmCadNodeCache } from '../../../components/CacheProvider/FdmCadNodeCache';
 import { FdmSDK } from '../../../data-providers/FdmSDK';
 import { PointCloudAnnotationCache } from '../../../components/CacheProvider/PointCloudAnnotationCache';
 import { Image360AnnotationCache } from '../../../components/CacheProvider/Image360AnnotationCache';
@@ -14,8 +14,8 @@ export type CdfCachesOptions = {
 };
 
 export class CdfCaches {
-  private readonly _assetMappingAndNode3dCache: AssetMappingAndNode3DCache;
-  private readonly _fdmNodeCache: FdmNodeCache;
+  private readonly _assetMappingAndNode3dCache: ClassicCadAssetMappingCache;
+  private readonly _fdmCadNodeCache: FdmCadNodeCache;
   private readonly _pointCloudAnnotationCache: PointCloudAnnotationCache;
   private readonly _image360AnnotationCache: Image360AnnotationCache;
 
@@ -35,8 +35,8 @@ export class CdfCaches {
       ? new CoreDm3dFdm3dDataProvider(fdmClient)
       : new LegacyFdm3dDataProvider(fdmClient, cdfClient);
 
-    this._assetMappingAndNode3dCache = new AssetMappingAndNode3DCache(cdfClient);
-    this._fdmNodeCache = new FdmNodeCache(cdfClient, fdmClient, fdm3dDataProvider);
+    this._assetMappingAndNode3dCache = new ClassicCadAssetMappingCache(cdfClient);
+    this._fdmCadNodeCache = new FdmCadNodeCache(cdfClient, fdm3dDataProvider);
     this._pointCloudAnnotationCache = new PointCloudAnnotationCache(cdfClient);
     this._image360AnnotationCache = new Image360AnnotationCache(cdfClient, viewer);
 
@@ -45,12 +45,12 @@ export class CdfCaches {
     this._coreDmOnly = coreDmOnly;
   }
 
-  public get assetMappingAndNode3dCache(): AssetMappingAndNode3DCache {
+  public get classicCadAssetMappingCache(): ClassicCadAssetMappingCache {
     return this._assetMappingAndNode3dCache;
   }
 
-  public get fdmNodeCache(): FdmNodeCache {
-    return this._fdmNodeCache;
+  public get fdmCadNodeCache(): FdmCadNodeCache {
+    return this._fdmCadNodeCache;
   }
 
   public get pointCloudAnnotationCache(): PointCloudAnnotationCache {

--- a/react-components/src/components/CacheProvider/CacheProvider.ts
+++ b/react-components/src/components/CacheProvider/CacheProvider.ts
@@ -1,7 +1,7 @@
 import { type CdfCaches } from '../../architecture/base/renderTarget/CdfCaches';
 import { useRenderTarget } from '../RevealCanvas';
-import { type AssetMappingAndNode3DCache } from './AssetMappingAndNode3DCache';
-import { type FdmNodeCache } from './FdmNodeCache';
+import { type ClassicCadAssetMappingCache } from './cad/ClassicAssetMappingCache';
+import { type FdmCadNodeCache } from './FdmCadNodeCache';
 import { type PointCloudAnnotationCache } from './PointCloudAnnotationCache';
 import { type Image360AnnotationCache } from './Image360AnnotationCache';
 import { type Fdm3dDataProvider } from '../../data-providers/Fdm3dDataProvider';
@@ -11,12 +11,12 @@ const useCacheObject = (): CdfCaches => {
   return revealRenderTarget.cdfCaches;
 };
 
-export const useFdmNodeCache = (): FdmNodeCache => {
-  return useCacheObject().fdmNodeCache;
+export const useFdmCadNodeCache = (): FdmCadNodeCache => {
+  return useCacheObject().fdmCadNodeCache;
 };
 
-export const useAssetMappingAndNode3DCache = (): AssetMappingAndNode3DCache => {
-  return useCacheObject().assetMappingAndNode3dCache;
+export const useClassicCadAssetMappingCache = (): ClassicCadAssetMappingCache => {
+  return useCacheObject().classicCadAssetMappingCache;
 };
 
 export const usePointCloudAnnotationCache = (): PointCloudAnnotationCache => {

--- a/react-components/src/components/CacheProvider/FdmCadNodeCache.ts
+++ b/react-components/src/components/CacheProvider/FdmCadNodeCache.ts
@@ -1,5 +1,5 @@
 import { type Node3D, type CogniteClient, type CogniteExternalId } from '@cognite/sdk';
-import { type Source, type FdmSDK, type DmsUniqueIdentifier } from '../../data-providers/FdmSDK';
+import { type Source, FdmSDK, type DmsUniqueIdentifier } from '../../data-providers/FdmSDK';
 import { RevisionFdmNodeCache } from './RevisionFdmNodeCache';
 import {
   type FdmConnectionWithNode,
@@ -28,7 +28,7 @@ import { fetchNodesForNodeIds, inspectNodes, treeIndexesToNodeIds } from './requ
 import { type ThreeDModelFdmMappings } from '../../hooks/types';
 import { type Fdm3dDataProvider } from '../../data-providers/Fdm3dDataProvider';
 
-export class FdmNodeCache {
+export class FdmCadNodeCache {
   private readonly _revisionNodeCaches = new Map<ModelRevisionKey, RevisionFdmNodeCache>();
 
   private readonly _cdfClient: CogniteClient;
@@ -37,13 +37,9 @@ export class FdmNodeCache {
 
   private readonly _completeRevisions = new Set<ModelRevisionKey>();
 
-  public constructor(
-    cdfClient: CogniteClient,
-    fdmClient: FdmSDK,
-    fdm3dDataProvider: Fdm3dDataProvider
-  ) {
+  public constructor(cdfClient: CogniteClient, fdm3dDataProvider: Fdm3dDataProvider) {
     this._cdfClient = cdfClient;
-    this._fdmClient = fdmClient;
+    this._fdmClient = new FdmSDK(cdfClient);
     this._fdm3dDataProvider = fdm3dDataProvider;
   }
 

--- a/react-components/src/components/CacheProvider/cad/AssetMappingPerAssetIdCache.ts
+++ b/react-components/src/components/CacheProvider/cad/AssetMappingPerAssetIdCache.ts
@@ -1,27 +1,28 @@
-import { type CdfAssetMapping, type ModelAssetIdKey } from './types';
+import { type ModelAssetIdKey } from '../types';
+import { type ClassicCadAssetMapping } from './ClassicAssetMapping';
 
 export class AssetMappingPerAssetIdCache {
   private readonly _assetIdsToAssetMappings = new Map<
     ModelAssetIdKey,
-    Promise<CdfAssetMapping[]>
+    Promise<ClassicCadAssetMapping[]>
   >();
 
   public setAssetIdsToAssetMappingCacheItem(
     key: ModelAssetIdKey,
-    item: Promise<CdfAssetMapping[]>
+    item: Promise<ClassicCadAssetMapping[]>
   ): void {
     this._assetIdsToAssetMappings.set(key, Promise.resolve(item));
   }
 
   public async getAssetIdsToAssetMappingCacheItem(
     key: ModelAssetIdKey
-  ): Promise<CdfAssetMapping[] | undefined> {
+  ): Promise<ClassicCadAssetMapping[] | undefined> {
     return await this._assetIdsToAssetMappings.get(key);
   }
 
   public async setAssetMappingsCacheItem(
     key: ModelAssetIdKey,
-    item: CdfAssetMapping
+    item: ClassicCadAssetMapping
   ): Promise<void> {
     const currentAssetMappings = this.getAssetIdsToAssetMappingCacheItem(key);
     this.setAssetIdsToAssetMappingCacheItem(

--- a/react-components/src/components/CacheProvider/cad/AssetMappingPerModelCache.ts
+++ b/react-components/src/components/CacheProvider/cad/AssetMappingPerModelCache.ts
@@ -1,17 +1,15 @@
 import { type CogniteClient } from '@cognite/sdk';
-import {
-  type ModelId,
-  type RevisionId,
-  type ModelRevisionKey,
-  type CdfAssetMapping
-} from './types';
-import { isValidAssetMapping } from './utils';
-import { createModelRevisionKey } from './idAndKeyTranslation';
+import { type ModelId, type RevisionId, type ModelRevisionKey } from '../types';
+import { createModelRevisionKey } from '../idAndKeyTranslation';
+import { type ClassicCadAssetMapping, isValidClassicCadAssetMapping } from './ClassicAssetMapping';
 
 export class AssetMappingPerModelCache {
   private readonly _sdk: CogniteClient;
 
-  private readonly _modelToAssetMappings = new Map<ModelRevisionKey, Promise<CdfAssetMapping[]>>();
+  private readonly _modelToAssetMappings = new Map<
+    ModelRevisionKey,
+    Promise<ClassicCadAssetMapping[]>
+  >();
 
   constructor(sdk: CogniteClient) {
     this._sdk = sdk;
@@ -19,21 +17,21 @@ export class AssetMappingPerModelCache {
 
   public setModelToAssetMappingCacheItems(
     key: ModelRevisionKey,
-    assetMappings: Promise<CdfAssetMapping[]>
+    assetMappings: Promise<ClassicCadAssetMapping[]>
   ): void {
     this._modelToAssetMappings.set(key, assetMappings);
   }
 
   public async getModelToAssetMappingCacheItems(
     key: ModelRevisionKey
-  ): Promise<CdfAssetMapping[] | undefined> {
+  ): Promise<ClassicCadAssetMapping[] | undefined> {
     return await this._modelToAssetMappings.get(key);
   }
 
   public async fetchAndCacheMappingsForModel(
     modelId: ModelId,
     revisionId: RevisionId
-  ): Promise<CdfAssetMapping[]> {
+  ): Promise<ClassicCadAssetMapping[]> {
     const key = createModelRevisionKey(modelId, revisionId);
     const assetMappings = this.fetchAssetMappingsForModel(modelId, revisionId);
 
@@ -44,11 +42,11 @@ export class AssetMappingPerModelCache {
   private async fetchAssetMappingsForModel(
     modelId: ModelId,
     revisionId: RevisionId
-  ): Promise<CdfAssetMapping[]> {
+  ): Promise<ClassicCadAssetMapping[]> {
     const assetMapping3D = await this._sdk.assetMappings3D
       .list(modelId, revisionId, { limit: 1000 })
       .autoPagingToArray({ limit: Infinity });
 
-    return assetMapping3D.filter(isValidAssetMapping);
+    return assetMapping3D.filter(isValidClassicCadAssetMapping);
   }
 }

--- a/react-components/src/components/CacheProvider/cad/AssetMappingPerNodeIdCache.ts
+++ b/react-components/src/components/CacheProvider/cad/AssetMappingPerNodeIdCache.ts
@@ -1,27 +1,28 @@
-import { type ModelTreeIndexKey, type CdfAssetMapping } from './types';
+import { type ModelTreeIndexKey } from '../types';
+import { ClassicCadAssetMapping } from './ClassicAssetMapping';
 
 export class AssetMappingPerNodeIdCache {
   private readonly _nodeIdsToAssetMappings = new Map<
     ModelTreeIndexKey,
-    Promise<CdfAssetMapping[]>
+    Promise<ClassicCadAssetMapping[]>
   >();
 
   public setNodeIdsToAssetMappingCacheItem(
     key: ModelTreeIndexKey,
-    item: Promise<CdfAssetMapping[]>
+    item: Promise<ClassicCadAssetMapping[]>
   ): void {
     this._nodeIdsToAssetMappings.set(key, Promise.resolve(item));
   }
 
   public async getNodeIdsToAssetMappingCacheItem(
     key: ModelTreeIndexKey
-  ): Promise<CdfAssetMapping[] | undefined> {
+  ): Promise<ClassicCadAssetMapping[] | undefined> {
     return await this._nodeIdsToAssetMappings.get(key);
   }
 
   public async setAssetMappingsCacheItem(
     key: ModelTreeIndexKey,
-    item: CdfAssetMapping
+    item: ClassicCadAssetMapping
   ): Promise<void> {
     const currentAssetMappings = this.getNodeIdsToAssetMappingCacheItem(key);
     this.setNodeIdsToAssetMappingCacheItem(

--- a/react-components/src/components/CacheProvider/cad/ClassicAssetMapping.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicAssetMapping.ts
@@ -1,0 +1,17 @@
+import { type AssetMapping3D } from '@cognite/sdk';
+
+import { CogniteInternalId } from '@cognite/sdk';
+import { DmsUniqueIdentifier } from '../../../data-providers';
+
+export type ClassicCadAssetMapping = {
+  treeIndex: number;
+  subtreeSize: number;
+  nodeId: CogniteInternalId;
+  assetId: CogniteInternalId;
+};
+
+export function isValidClassicCadAssetMapping(
+  assetMapping: AssetMapping3D
+): assetMapping is ClassicCadAssetMapping {
+  return assetMapping.treeIndex !== undefined && assetMapping.subtreeSize !== undefined;
+}

--- a/react-components/src/components/CacheProvider/cad/ClassicAssetMappingCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicAssetMappingCache.ts
@@ -11,10 +11,10 @@ import { chunk, maxBy } from 'lodash';
 import assert from 'assert';
 import { modelRevisionNodesAssetToKey, createModelRevisionKey } from '../idAndKeyTranslation';
 import { type ModelWithAssetMappings } from '../../../hooks/cad/ModelWithAssetMappings';
-import { AssetMappingPerAssetIdCache } from './AssetMappingPerAssetIdCache';
-import { AssetMappingPerNodeIdCache } from './AssetMappingPerNodeIdCache';
+import { ClassicCadAssetMappingPerAssetIdCache } from './ClassicCadAssetMappingPerAssetIdCache';
+import { ClassicCadAssetMappingPerNodeIdCache } from './ClassicCadAssetMappingPerNodeIdCache';
 import { Node3DPerNodeIdCache } from './Node3DPerNodeIdCache';
-import { AssetMappingPerModelCache } from './AssetMappingPerModelCache';
+import { ClassicCadAssetMappingPerModelCache } from './ClassicCadAssetMappingPerModelCache';
 import { isValidClassicCadAssetMapping, type ClassicCadAssetMapping } from './ClassicAssetMapping';
 
 export type NodeAssetMappingResult = { node?: Node3D; mappings: ClassicCadAssetMapping[] };
@@ -22,11 +22,11 @@ export type NodeAssetMappingResult = { node?: Node3D; mappings: ClassicCadAssetM
 export class ClassicCadAssetMappingCache {
   private readonly _sdk: CogniteClient;
 
-  private readonly modelToAssetMappingsCache: AssetMappingPerModelCache;
+  private readonly modelToAssetMappingsCache: ClassicCadAssetMappingPerModelCache;
 
-  private readonly assetIdsToAssetMappingCache: AssetMappingPerAssetIdCache;
+  private readonly assetIdsToAssetMappingCache: ClassicCadAssetMappingPerAssetIdCache;
 
-  private readonly nodeIdsToAssetMappingCache: AssetMappingPerNodeIdCache;
+  private readonly nodeIdsToAssetMappingCache: ClassicCadAssetMappingPerNodeIdCache;
 
   private readonly nodeIdsToNode3DCache: Node3DPerNodeIdCache;
 
@@ -34,9 +34,9 @@ export class ClassicCadAssetMappingCache {
 
   constructor(sdk: CogniteClient) {
     this._sdk = sdk;
-    this.assetIdsToAssetMappingCache = new AssetMappingPerAssetIdCache();
-    this.nodeIdsToAssetMappingCache = new AssetMappingPerNodeIdCache();
-    this.modelToAssetMappingsCache = new AssetMappingPerModelCache(this._sdk);
+    this.assetIdsToAssetMappingCache = new ClassicCadAssetMappingPerAssetIdCache();
+    this.nodeIdsToAssetMappingCache = new ClassicCadAssetMappingPerNodeIdCache();
+    this.modelToAssetMappingsCache = new ClassicCadAssetMappingPerModelCache(this._sdk);
     this.nodeIdsToNode3DCache = new Node3DPerNodeIdCache(this._sdk);
   }
 

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerAssetIdCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerAssetIdCache.ts
@@ -1,7 +1,7 @@
 import { type ModelAssetIdKey } from '../types';
 import { type ClassicCadAssetMapping } from './ClassicAssetMapping';
 
-export class AssetMappingPerAssetIdCache {
+export class ClassicCadAssetMappingPerAssetIdCache {
   private readonly _assetIdsToAssetMappings = new Map<
     ModelAssetIdKey,
     Promise<ClassicCadAssetMapping[]>

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
@@ -3,7 +3,7 @@ import { type ModelId, type RevisionId, type ModelRevisionKey } from '../types';
 import { createModelRevisionKey } from '../idAndKeyTranslation';
 import { type ClassicCadAssetMapping, isValidClassicCadAssetMapping } from './ClassicAssetMapping';
 
-export class AssetMappingPerModelCache {
+export class ClassicCadAssetMappingPerModelCache {
   private readonly _sdk: CogniteClient;
 
   private readonly _modelToAssetMappings = new Map<

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerNodeIdCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerNodeIdCache.ts
@@ -1,7 +1,7 @@
 import { type ModelTreeIndexKey } from '../types';
-import { ClassicCadAssetMapping } from './ClassicAssetMapping';
+import { type ClassicCadAssetMapping } from './ClassicAssetMapping';
 
-export class AssetMappingPerNodeIdCache {
+export class ClassicCadAssetMappingPerNodeIdCache {
   private readonly _nodeIdsToAssetMappings = new Map<
     ModelTreeIndexKey,
     Promise<ClassicCadAssetMapping[]>

--- a/react-components/src/components/CacheProvider/cad/Node3DPerNodeIdCache.ts
+++ b/react-components/src/components/CacheProvider/cad/Node3DPerNodeIdCache.ts
@@ -4,9 +4,9 @@ import {
   type ModelId,
   type RevisionId,
   type ModelTreeIndexKey
-} from './types';
-import { modelRevisionNodesAssetToKey } from './idAndKeyTranslation';
-import { fetchNodesForNodeIds } from './requests';
+} from '../types';
+import { modelRevisionNodesAssetToKey } from '../idAndKeyTranslation';
+import { fetchNodesForNodeIds } from '../requests';
 
 export class Node3DPerNodeIdCache {
   private readonly _sdk: CogniteClient;

--- a/react-components/src/components/CacheProvider/types.ts
+++ b/react-components/src/components/CacheProvider/types.ts
@@ -46,7 +46,6 @@ export type RevisionId = number;
 export type NodeId = number;
 export type TreeIndex = number;
 export type AssetId = number;
-export type FdmId = DmsUniqueIdentifier;
 
 export type ModelRevisionId = { modelId: number; revisionId: number };
 
@@ -61,14 +60,6 @@ export type PointCloudAnnotationModel = AnnotationModel & { data: AnnotationsBou
 
 export type Image360AnnotationModel = AnnotationModel & {
   data: AnnotationsTypesImagesAssetLink;
-};
-
-export type CdfAssetMapping = {
-  treeIndex: number;
-  subtreeSize: number;
-  nodeId: CogniteInternalId;
-  assetId: CogniteInternalId;
-  assetInstanceId?: DmsUniqueIdentifier;
 };
 
 export type Image360AnnotationAssetInfo = {

--- a/react-components/src/components/CacheProvider/utils.ts
+++ b/react-components/src/components/CacheProvider/utils.ts
@@ -2,7 +2,6 @@ import {
   type AnnotationsTypesImagesAssetLink,
   type AnnotationModel,
   type AnnotationsBoundingVolume,
-  type AssetMapping3D,
   type IdEither
 } from '@cognite/sdk';
 import { type CoreDmImage360Annotation, type DataSourceType } from '@cognite/reveal';
@@ -12,7 +11,6 @@ import {
   type InstanceReferenceKey
 } from '../../utilities/instanceIds/toKey';
 import { createFdmKey } from './idAndKeyTranslation';
-import { type CdfAssetMapping } from './types';
 
 export function getInstanceReferenceFromPointCloudAnnotation(
   annotation: AnnotationModel
@@ -61,8 +59,4 @@ function isCoreDmImage360Annotation(
   annotation: DataSourceType['image360AnnotationType']
 ): annotation is CoreDmImage360Annotation {
   return (annotation as CoreDmImage360Annotation).annotationIdentifier?.externalId !== undefined;
-}
-
-export function isValidAssetMapping(assetMapping: AssetMapping3D): assetMapping is CdfAssetMapping {
-  return assetMapping.treeIndex !== undefined && assetMapping.subtreeSize !== undefined;
 }

--- a/react-components/src/components/Reveal3DResources/Reveal3DResources.context.tsx
+++ b/react-components/src/components/Reveal3DResources/Reveal3DResources.context.tsx
@@ -7,7 +7,7 @@ import { useCalculateCadStyling } from './hooks/useCalculateCadStyling';
 import { useReveal3DResourcesStylingLoadingSetter } from './Reveal3DResourcesInfoContext';
 import { useTypedModels } from './hooks/useTypedModels';
 import {
-  useAssetMappedNodesForRevisions,
+  useClassicAssetMappedNodesForRevisions,
   useGenerateAssetMappingCachePerItemFromModelCache,
   useGenerateNode3DCache
 } from '../../hooks/cad';
@@ -26,7 +26,7 @@ export type Reveal3DResourcesDependencies = {
   useTypedModels: typeof useTypedModels;
   useSetExpectedLoadCount: typeof useSetExpectedLoadCount;
   useCallCallbackOnFinishedLoading: typeof useCallCallbackOnFinishedLoading;
-  useAssetMappedNodesForRevisions: typeof useAssetMappedNodesForRevisions;
+  useClassicAssetMappedNodesForRevisions: typeof useClassicAssetMappedNodesForRevisions;
   useGenerateAssetMappingCachePerItemFromModelCache: typeof useGenerateAssetMappingCachePerItemFromModelCache;
   useGenerateNode3DCache: typeof useGenerateNode3DCache;
   useCalculateCadStyling: typeof useCalculateCadStyling;
@@ -48,7 +48,7 @@ export const defaultReveal3DResourcesDependencies: Reveal3DResourcesDependencies
   useTypedModels,
   useSetExpectedLoadCount,
   useCallCallbackOnFinishedLoading,
-  useAssetMappedNodesForRevisions,
+  useClassicAssetMappedNodesForRevisions,
   useGenerateAssetMappingCachePerItemFromModelCache,
   useGenerateNode3DCache,
   useCalculateCadStyling,

--- a/react-components/src/components/Reveal3DResources/Reveal3DResources.test.tsx
+++ b/react-components/src/components/Reveal3DResources/Reveal3DResources.test.tsx
@@ -20,7 +20,7 @@ describe(Reveal3DResources.name, () => {
 
   beforeEach(() => {
     defaultDependencies.useTypedModels.mockReturnValue({ data: [], loading: false } as any);
-    defaultDependencies.useAssetMappedNodesForRevisions.mockReturnValue({ data: [] } as any);
+    defaultDependencies.useClassicAssetMappedNodesForRevisions.mockReturnValue({ data: [] } as any);
     defaultDependencies.useCalculateCadStyling.mockReturnValue({
       styledModels: [],
       isModelMappingsLoading: false

--- a/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
+++ b/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
@@ -43,7 +43,7 @@ export const Reveal3DResources = ({
     return reveal3DModels.filter((model): model is CadModelOptions => model.type === 'cad');
   }, [reveal3DModels]);
 
-  const { data: assetMappings } = hooks.useAssetMappedNodesForRevisions(cadModelOptions);
+  const { data: assetMappings } = hooks.useClassicAssetMappedNodesForRevisions(cadModelOptions);
 
   hooks.useGenerateAssetMappingCachePerItemFromModelCache(cadModelOptions, assetMappings);
   hooks.useGenerateNode3DCache(cadModelOptions, assetMappings);

--- a/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.tsx
@@ -12,8 +12,7 @@ import {
   type NodeId,
   type FdmConnectionWithNode,
   type AssetId,
-  type ModelRevisionAssetNodesResult,
-  type CdfAssetMapping
+  type ModelRevisionAssetNodesResult
 } from '../../CacheProvider/types';
 import {
   type CadStylingGroup,
@@ -27,10 +26,11 @@ import {
 import { type ThreeDModelFdmMappings } from '../../../hooks/types';
 import { isSameModel } from '../../../utilities/isSameModel';
 import {
-  useAssetMappedNodesForRevisions,
+  useClassicAssetMappedNodesForRevisions,
   useMappedEdgesForRevisions,
   useNodesForAssets
 } from '../../../hooks/cad';
+import { ClassicCadAssetMapping } from '../../CacheProvider/cad/ClassicAssetMapping';
 
 type ModelStyleGroup = {
   model: CadModelOptions;
@@ -100,7 +100,7 @@ function useCalculateMappedStyling(
     isLoading: isAssetMappingsLoading,
     isFetched: isAssetMappingsFetched,
     isError: isAssetMappingsError
-  } = useAssetMappedNodesForRevisions(modelsRevisionsWithMappedEquipment);
+  } = useClassicAssetMappedNodesForRevisions(modelsRevisionsWithMappedEquipment);
 
   const modelsMappedFdmStyleGroups = useMemo(() => {
     const isFdmMappingUnavailableOrLoading =
@@ -343,7 +343,7 @@ function getMappedStyleGroupFromFdm(
 }
 
 function getMappedStyleGroupFromAssetMappings(
-  assetMappings: CdfAssetMapping[],
+  assetMappings: ClassicCadAssetMapping[],
   nodeAppearance: NodeAppearance
 ): TreeIndexStylingGroup {
   const indexSet = new IndexSet();

--- a/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
+++ b/react-components/src/components/RevealToolbar/AssetContextualizedButton.tsx
@@ -4,7 +4,7 @@ import { AssetsIcon, Button, Tooltip as CogsTooltip } from '@cognite/cogs.js';
 import { useTranslation } from '../i18n/I18n';
 import { use3dModels } from '../../hooks/use3dModels';
 import { type CadModelOptions } from '../Reveal3DResources/types';
-import { useAssetMappedNodesForRevisions } from '../../hooks/cad';
+import { useClassicAssetMappedNodesForRevisions } from '../../hooks/cad';
 
 type AssetContextualizedButtonProps = {
   setEnableMappedStyling: (enabled: boolean) => void;
@@ -26,7 +26,7 @@ export const AssetContextualizedButton = ({
   const models = use3dModels();
   const cadModels = models.filter((model) => model.type === 'cad') as CadModelOptions[];
   const [enableContextualizedStyling, setEnableContextualizedStyling] = useState<boolean>(false);
-  const { isLoading, isFetched } = useAssetMappedNodesForRevisions(cadModels);
+  const { isLoading, isFetched } = useClassicAssetMappedNodesForRevisions(cadModels);
   const disabled = isLoading && !isFetched;
 
   const tooltip = disabled ? tooltipMapping.true : tooltipMapping.false;

--- a/react-components/src/components/RevealToolbar/LayersButton/LayersButton.tsx
+++ b/react-components/src/components/RevealToolbar/LayersButton/LayersButton.tsx
@@ -19,6 +19,7 @@ export const LayersButton = ({
   defaultLayerConfiguration
 }: LayersButtonProps): ReactElement => {
   const { t } = useTranslation();
+
   const { modelLayerHandlers, updateCallback, ModelLayerSelection } = useLayersButtonViewModel(
     setExternalLayersState,
     defaultLayerConfiguration,

--- a/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
+++ b/react-components/src/components/RevealToolbar/RuleBasedOutputsButton.tsx
@@ -18,7 +18,7 @@ import { RuleBasedSelectionItem } from '../RuleBasedOutputs/components/RuleBased
 import { useReveal3DResourcesStylingLoading } from '../Reveal3DResources/Reveal3DResourcesInfoContext';
 import { offset } from '@floating-ui/dom';
 import { TOOLBAR_HORIZONTAL_PANEL_OFFSET } from '../constants';
-import { useAssetMappedNodesForRevisions } from '../../hooks/cad';
+import { useClassicAssetMappedNodesForRevisions } from '../../hooks/cad';
 import { generateEmptyRuleForSelection } from '../RuleBasedOutputs/core/generateEmptyRuleForSelection';
 import { getRuleBasedById } from '../RuleBasedOutputs/core/getRuleBasedById';
 
@@ -44,7 +44,7 @@ export const RuleBasedOutputsButton = ({
   const [isRuleLoading, setIsRuleLoading] = useState(false);
 
   const { isLoading: isAssetMappingsLoading, isFetched: isAssetMappingsFetched } =
-    useAssetMappedNodesForRevisions(cadModels);
+    useClassicAssetMappedNodesForRevisions(cadModels);
 
   const [newRuleSetEnabled, setNewRuleSetEnabled] = useState<RuleAndEnabled>();
   const isRuleLoadingFromContext = useReveal3DResourcesStylingLoading();

--- a/react-components/src/components/RuleBasedOutputs/RuleBasedOutputsSelector.tsx
+++ b/react-components/src/components/RuleBasedOutputs/RuleBasedOutputsSelector.tsx
@@ -18,9 +18,12 @@ import { useExtractUniqueAssetIdsFromMapped } from './hooks/useExtractUniqueAsse
 import { useConvertAssetMetadatasToLowerCase } from './hooks/useConvertAssetMetadatasToLowerCase';
 import { useExtractTimeseriesIdsFromRuleSet } from './hooks/useExtractTimeseriesIdsFromRuleSet';
 import { useAll3dDirectConnectionsWithProperties } from '../../query/useAll3dDirectConnectionsWithProperties';
-import { useAssetMappedNodesForRevisions, useMappedEdgesForRevisions } from '../../hooks/cad';
+import {
+  useClassicAssetMappedNodesForRevisions,
+  useMappedEdgesForRevisions
+} from '../../hooks/cad';
 import { generateRuleBasedOutputs } from './core/generateRuleBasedOutputs';
-import { type CdfAssetMapping } from '../CacheProvider/types';
+import { type ClassicCadAssetMapping } from '../CacheProvider/cad/ClassicAssetMapping';
 
 const ruleSetStylingCache = new Map<string, AllMappingStylingGroupAndStyleIndex[]>();
 
@@ -48,7 +51,7 @@ export function RuleBasedOutputsSelector({
     });
 
   const { data: assetMappings, isLoading: isAssetMappingsLoading } =
-    useAssetMappedNodesForRevisions(cadModels);
+    useClassicAssetMappedNodesForRevisions(cadModels);
 
   const assetIdsFromMapped = useExtractUniqueAssetIdsFromMapped(assetMappings);
 
@@ -160,7 +163,7 @@ async function initializeRuleBasedOutputs({
   assetIdsAndTimeseries,
   timeseriesDatapoints
 }: {
-  assetMappings: CdfAssetMapping[];
+  assetMappings: ClassicCadAssetMapping[];
   fdmMappings: FdmInstanceNodeWithConnectionAndProperties[];
   contextualizedAssetNodes: Asset[];
   ruleSet: RuleOutputSet;

--- a/react-components/src/components/RuleBasedOutputs/core/analyzeAssetMappingsAgainstExpression.ts
+++ b/react-components/src/components/RuleBasedOutputs/core/analyzeAssetMappingsAgainstExpression.ts
@@ -9,7 +9,7 @@ import {
 import { generateTimeseriesAndDatapointsFromTheAsset } from './generateTimeseriesAndDatapointsFromTheAsset';
 import { traverseExpression } from './traverseExpression';
 import { applyAssetMappingsNodeStyles } from './applyAssetMappingsNodeStyles';
-import { type CdfAssetMapping } from '../../CacheProvider/types';
+import { type ClassicCadAssetMapping } from '../../CacheProvider/cad/ClassicAssetMapping';
 
 export const analyzeAssetMappingsAgainstExpression = async ({
   contextualizedAssetNodes,
@@ -22,11 +22,11 @@ export const analyzeAssetMappingsAgainstExpression = async ({
   contextualizedAssetNodes: Asset[];
   assetIdsAndTimeseries: AssetIdsAndTimeseries[];
   timeseriesDatapoints: Datapoints[] | undefined;
-  assetMappings: CdfAssetMapping[];
+  assetMappings: ClassicCadAssetMapping[];
   expression: Expression;
   outputSelected: ColorRuleOutput;
 }): Promise<AssetStylingGroupAndStyleIndex> => {
-  const allAssetMappingsTreeNodes: CdfAssetMapping[][] = [];
+  const allAssetMappingsTreeNodes: ClassicCadAssetMapping[][] = [];
 
   for (const contextualizedAssetNode of contextualizedAssetNodes) {
     const triggerData: TriggerTypeData[] = [];

--- a/react-components/src/components/RuleBasedOutputs/core/applyAssetMappingsNodeStyles.ts
+++ b/react-components/src/components/RuleBasedOutputs/core/applyAssetMappingsNodeStyles.ts
@@ -7,10 +7,10 @@ import { NumericRange, TreeIndexNodeCollection } from '@cognite/reveal';
 import { type AssetStylingGroup } from '../../Reveal3DResources';
 import { Color } from 'three';
 import { createRuleStyling } from './createRuleStyling';
-import { type CdfAssetMapping } from '../../CacheProvider/types';
+import { type ClassicCadAssetMapping } from '../../CacheProvider/cad/ClassicAssetMapping';
 
 export const applyAssetMappingsNodeStyles = (
-  treeNodes: CdfAssetMapping[],
+  treeNodes: ClassicCadAssetMapping[],
   outputSelected: ColorRuleOutput
 ): AssetStylingGroupAndStyleIndex => {
   const ruleOutputAndStyleIndex: RuleAndStyleIndex = {

--- a/react-components/src/components/RuleBasedOutputs/core/generateRuleBasedOutputs.ts
+++ b/react-components/src/components/RuleBasedOutputs/core/generateRuleBasedOutputs.ts
@@ -14,7 +14,7 @@ import { analyzeFdmMappingsAgainstExpression } from './analyzeFdmMappingsAgainst
 import { getRuleOutputFromTypeSelected } from './getRuleOutputFromTypeSelected';
 import { forEachExpression } from './forEachExpression';
 import { convertExpressionStringMetadataKeyToLowerCase } from './convertExpressionStringMetadataKeyToLowerCase';
-import { type CdfAssetMapping } from '../../CacheProvider/types';
+import { type ClassicCadAssetMapping } from '../../CacheProvider/cad/ClassicAssetMapping';
 
 export const generateRuleBasedOutputs = async ({
   contextualizedAssetNodes,
@@ -25,7 +25,7 @@ export const generateRuleBasedOutputs = async ({
   timeseriesDatapoints
 }: {
   contextualizedAssetNodes: Asset[];
-  assetMappings: CdfAssetMapping[];
+  assetMappings: ClassicCadAssetMapping[];
   fdmMappings: FdmInstanceNodeWithConnectionAndProperties[];
   ruleSet: RuleOutputSet;
   assetIdsAndTimeseries: AssetIdsAndTimeseries[];

--- a/react-components/src/hooks/cad/ModelWithAssetMappings.ts
+++ b/react-components/src/hooks/cad/ModelWithAssetMappings.ts
@@ -1,7 +1,7 @@
 import { type CadModelOptions } from '../../components/Reveal3DResources/types';
-import { type CdfAssetMapping } from '../../components/CacheProvider/types';
+import { type ClassicCadAssetMapping } from '../../components/CacheProvider/cad/ClassicAssetMapping';
 
 export type ModelWithAssetMappings = {
   model: CadModelOptions;
-  assetMappings: CdfAssetMapping[];
+  assetMappings: ClassicCadAssetMapping[];
 };

--- a/react-components/src/hooks/cad/index.ts
+++ b/react-components/src/hooks/cad/index.ts
@@ -1,4 +1,4 @@
-export { useAssetMappedNodesForRevisions } from './useAssetMappedNodesForRevisions';
+export { useClassicAssetMappedNodesForRevisions } from './useClassicAssetMappedNodesForRevisions';
 export { useAssetMappingForTreeIndex } from './useAssetMappingForTreeIndex';
 export { useFdm3dNodeDataPromises } from './useFdm3dNodeDataPromises';
 export { useFdmAssetMappings } from './useFdmAssetMappings';

--- a/react-components/src/hooks/cad/useAssetMappingForTreeIndex.ts
+++ b/react-components/src/hooks/cad/useAssetMappingForTreeIndex.ts
@@ -1,14 +1,14 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { fetchAncestorNodesForTreeIndex } from '../../components/CacheProvider/requests';
 import { type AnyIntersection } from '@cognite/reveal';
-import { type NodeAssetMappingResult } from '../../components/CacheProvider/AssetMappingAndNode3DCache';
+import { type NodeAssetMappingResult } from '../../components/CacheProvider/cad/ClassicAssetMappingCache';
 import { useSDK } from '../../components/RevealCanvas/SDKProvider';
-import { useAssetMappingAndNode3DCache } from '../../components/CacheProvider/CacheProvider';
+import { useClassicCadAssetMappingCache } from '../../components/CacheProvider/CacheProvider';
 
 export const useAssetMappingForTreeIndex = (
   intersection: AnyIntersection | undefined
 ): UseQueryResult<NodeAssetMappingResult> => {
-  const assetMappingAndNode3DCache = useAssetMappingAndNode3DCache();
+  const assetMappingAndNode3DCache = useClassicCadAssetMappingCache();
   const cdfClient = useSDK();
 
   const isCadModel = intersection?.type === 'cad';

--- a/react-components/src/hooks/cad/useClassicAssetMappedNodesForRevisions.ts
+++ b/react-components/src/hooks/cad/useClassicAssetMappedNodesForRevisions.ts
@@ -1,13 +1,13 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { type CadModelOptions } from '../../components';
 import { type ModelWithAssetMappings } from './ModelWithAssetMappings';
-import { useAssetMappingAndNode3DCache } from '../../components/CacheProvider/CacheProvider';
+import { useClassicCadAssetMappingCache } from '../../components/CacheProvider/CacheProvider';
 import { useIsCoreDmOnly } from '../useIsCoreDmOnly';
 
-export const useAssetMappedNodesForRevisions = (
+export const useClassicAssetMappedNodesForRevisions = (
   cadModels: CadModelOptions[]
 ): UseQueryResult<ModelWithAssetMappings[]> => {
-  const assetMappingAndNode3DCache = useAssetMappingAndNode3DCache();
+  const assetMappingCache = useClassicCadAssetMappingCache();
 
   const isCoreDmOnly = useIsCoreDmOnly();
 
@@ -21,7 +21,7 @@ export const useAssetMappedNodesForRevisions = (
     queryFn: async () => {
       const fetchPromises = cadModels.map(
         async (model) =>
-          await assetMappingAndNode3DCache
+          await assetMappingCache
             .getAssetMappingsForModel(model.modelId, model.revisionId)
             .then((assetMappings) => ({ model, assetMappings }))
       );

--- a/react-components/src/hooks/cad/useFdm3dNodeDataPromises.ts
+++ b/react-components/src/hooks/cad/useFdm3dNodeDataPromises.ts
@@ -1,13 +1,13 @@
 import { type AnyIntersection } from '@cognite/reveal';
 import { type FdmNodeDataPromises } from '../../components/CacheProvider/types';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
-import { useFdmNodeCache } from '../../components/CacheProvider/CacheProvider';
+import { useFdmCadNodeCache } from '../../components/CacheProvider/CacheProvider';
 import assert from 'assert';
 
 export const useFdm3dNodeDataPromises = (
   intersection: AnyIntersection | undefined
 ): UseQueryResult<FdmNodeDataPromises> => {
-  const content = useFdmNodeCache();
+  const content = useFdmCadNodeCache();
 
   const isCadModel = intersection?.type === 'cad';
 

--- a/react-components/src/hooks/cad/useFdmAssetMappings.ts
+++ b/react-components/src/hooks/cad/useFdmAssetMappings.ts
@@ -3,13 +3,13 @@ import { type DmsUniqueIdentifier } from '../../data-providers/FdmSDK';
 import { type CadModelOptions } from '../../components/Reveal3DResources/types';
 import { type ThreeDModelFdmMappings } from '../types';
 import { DEFAULT_QUERY_STALE_TIME } from '../../utilities/constants';
-import { useFdmNodeCache } from '../../components/CacheProvider/CacheProvider';
+import { useFdmCadNodeCache } from '../../components/CacheProvider/CacheProvider';
 
 export const useFdmAssetMappings = (
   fdmAssetExternalIds: DmsUniqueIdentifier[],
   models: CadModelOptions[]
 ): UseQueryResult<ThreeDModelFdmMappings[]> => {
-  const nodeCacheContent = useFdmNodeCache();
+  const nodeCacheContent = useFdmCadNodeCache();
 
   return useQuery({
     queryKey: [

--- a/react-components/src/hooks/cad/useGenerateAssetMappingCachePerItemFromModelCache.ts
+++ b/react-components/src/hooks/cad/useGenerateAssetMappingCachePerItemFromModelCache.ts
@@ -1,13 +1,13 @@
 import { useMemo } from 'react';
 import { type CadModelOptions } from '../../components';
 import { type ModelWithAssetMappings } from './ModelWithAssetMappings';
-import { useAssetMappingAndNode3DCache } from '../../components/CacheProvider/CacheProvider';
+import { useClassicCadAssetMappingCache } from '../../components/CacheProvider/CacheProvider';
 
 export const useGenerateAssetMappingCachePerItemFromModelCache = (
   cadModelOptions: CadModelOptions[],
   assetMappings: ModelWithAssetMappings[] | undefined
 ): void => {
-  const assetMappingAndNode3DCache = useAssetMappingAndNode3DCache();
+  const assetMappingAndNode3DCache = useClassicCadAssetMappingCache();
   useMemo(() => {
     cadModelOptions.forEach(async ({ modelId, revisionId }) => {
       const assetMapping = assetMappings?.filter(

--- a/react-components/src/hooks/cad/useGenerateNode3DCache.ts
+++ b/react-components/src/hooks/cad/useGenerateNode3DCache.ts
@@ -1,13 +1,13 @@
 import { type CadModelOptions } from '../../components';
 import { type ModelWithAssetMappings } from './ModelWithAssetMappings';
-import { useAssetMappingAndNode3DCache } from '../../components/CacheProvider/CacheProvider';
+import { useClassicCadAssetMappingCache } from '../../components/CacheProvider/CacheProvider';
 import { useMemo } from 'react';
 
 export const useGenerateNode3DCache = (
   cadModelOptions: CadModelOptions[],
   assetMappings: ModelWithAssetMappings[] | undefined
 ): void => {
-  const assetMappingAndNode3DCache = useAssetMappingAndNode3DCache();
+  const assetMappingAndNode3DCache = useClassicCadAssetMappingCache();
 
   useMemo(() => {
     cadModelOptions.forEach(async ({ modelId, revisionId }) => {

--- a/react-components/src/hooks/cad/useMappedEdgesForRevisions.ts
+++ b/react-components/src/hooks/cad/useMappedEdgesForRevisions.ts
@@ -1,13 +1,13 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { type ModelRevisionToConnectionMap } from '../../components/CacheProvider/types';
-import { useFdmNodeCache } from '../../components/CacheProvider/CacheProvider';
+import { useFdmCadNodeCache } from '../../components/CacheProvider/CacheProvider';
 
 export const useMappedEdgesForRevisions = (
   modelRevisionIds: Array<{ modelId: number; revisionId: number }>,
   fetchViews = false,
   enabled = true
 ): UseQueryResult<ModelRevisionToConnectionMap> => {
-  const content = useFdmNodeCache();
+  const content = useFdmCadNodeCache();
 
   return useQuery({
     queryKey: [

--- a/react-components/src/hooks/cad/useNodesForAssets.ts
+++ b/react-components/src/hooks/cad/useNodesForAssets.ts
@@ -4,13 +4,13 @@ import {
   type ModelRevisionId
 } from '../../components/CacheProvider/types';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
-import { useAssetMappingAndNode3DCache } from '../../components/CacheProvider/CacheProvider';
+import { useClassicCadAssetMappingCache } from '../../components/CacheProvider/CacheProvider';
 
 export const useNodesForAssets = (
   models: ModelRevisionId[],
   assetIds: CogniteInternalId[]
 ): UseQueryResult<ModelRevisionAssetNodesResult[]> => {
-  const assetMappingAndNode3DCache = useAssetMappingAndNode3DCache();
+  const assetMappingAndNode3DCache = useClassicCadAssetMappingCache();
 
   return useQuery({
     queryKey: [

--- a/react-components/src/hooks/useCameraNavigation.tsx
+++ b/react-components/src/hooks/useCameraNavigation.tsx
@@ -1,7 +1,7 @@
 import { type CameraState, type CogniteCadModel } from '@cognite/reveal';
 import { useReveal } from '../components/RevealCanvas/ViewerContext';
 import { Box3 } from 'three';
-import { useFdmNodeCache } from '../components/CacheProvider/CacheProvider';
+import { useFdmCadNodeCache } from '../components/CacheProvider/CacheProvider';
 
 export type CameraNavigationActions = {
   fitCameraToVisualSceneBoundingBox: (duration?: number) => void;
@@ -14,7 +14,7 @@ export type CameraNavigationActions = {
 };
 
 export const useCameraNavigation = (): CameraNavigationActions => {
-  const fdmNodeCache = useFdmNodeCache();
+  const fdmNodeCache = useFdmCadNodeCache();
   const viewer = useReveal();
 
   const fitCameraToVisualSceneBoundingBox = (duration?: number): void => {

--- a/react-components/src/hooks/useClickedNode.tsx
+++ b/react-components/src/hooks/useClickedNode.tsx
@@ -7,7 +7,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { type CogniteInternalId, type Node3D } from '@cognite/sdk';
 import { type FdmNodeDataPromises } from '../components/CacheProvider/types';
-import { type NodeAssetMappingResult } from '../components/CacheProvider/AssetMappingAndNode3DCache';
+import { type NodeAssetMappingResult } from '../components/CacheProvider/cad/ClassicAssetMappingCache';
 import { usePointCloudAnnotationMappingForIntersection } from './pointClouds/usePointCloudAnnotationMappingForIntersection';
 import { type PointCloudAnnotationMappedAssetData } from './types';
 import { MOUSE, Vector2, type Vector3 } from 'three';

--- a/react-components/src/hooks/useCreateAssetMappingsMapPerModel.tsx
+++ b/react-components/src/hooks/useCreateAssetMappingsMapPerModel.tsx
@@ -2,14 +2,14 @@ import { CogniteCadModel, type CogniteModel, type DataSourceType } from '@cognit
 import { useMemo } from 'react';
 import { type ModelWithAssetMappings } from './cad/ModelWithAssetMappings';
 import { isDefined } from '../utilities/isDefined';
-import { type CdfAssetMapping } from '../components/CacheProvider/types';
+import { type ClassicCadAssetMapping } from '../components/CacheProvider/cad/ClassicAssetMapping';
 
 export const useCreateAssetMappingsMapPerModel = (
   models: Array<CogniteModel<DataSourceType>>,
   assetMappings: ModelWithAssetMappings[] | undefined
-): Map<CogniteCadModel, CdfAssetMapping[] | undefined> => {
+): Map<CogniteCadModel, ClassicCadAssetMapping[] | undefined> => {
   return useMemo(() => {
-    const mappingsPerModel = new Map<CogniteCadModel, CdfAssetMapping[] | undefined>();
+    const mappingsPerModel = new Map<CogniteCadModel, ClassicCadAssetMapping[] | undefined>();
     models.forEach((model) => {
       if (!(model instanceof CogniteCadModel)) {
         return;

--- a/react-components/src/query/network/searchClassicAssetsForCadModels.ts
+++ b/react-components/src/query/network/searchClassicAssetsForCadModels.ts
@@ -1,5 +1,5 @@
 import { type AddModelOptions, type ClassicDataSourceType } from '@cognite/reveal';
-import { type AssetMappingAndNode3DCache } from '../../components/CacheProvider/AssetMappingAndNode3DCache';
+import { type ClassicCadAssetMappingCache } from '../../components/CacheProvider/cad/ClassicAssetMappingCache';
 import { type AllAssetFilterProps, hasFilters } from './filters';
 import { type SearchClassicCadAssetsResponse } from './types';
 import { type CursorForModel, fetchAllAssetsForCadModels } from './fetchAllAssetsForCadModels';
@@ -12,7 +12,7 @@ export async function searchClassicAssetsForCadModels(
   cursor: string | undefined,
   filters: AllAssetFilterProps | undefined,
   sdk: CogniteClient,
-  assetMappingAndNode3dCache: AssetMappingAndNode3DCache
+  assetMappingAndNode3dCache: ClassicCadAssetMappingCache
 ): Promise<SearchClassicCadAssetsResponse> {
   if (!hasFilters(filters)) {
     const cursorsForModels =

--- a/react-components/src/query/network/searchClassicAssetsForModels.test.ts
+++ b/react-components/src/query/network/searchClassicAssetsForModels.test.ts
@@ -14,7 +14,7 @@ import {
 import { createAssetMock } from '#test-utils/fixtures/assets';
 import assert from 'assert';
 import { isInternalId } from '../../utilities/instanceIds';
-import { type AssetMappingAndNode3DCache } from '../../components/CacheProvider/AssetMappingAndNode3DCache';
+import { type ClassicCadAssetMappingCache } from '../../components/CacheProvider/cad/ClassicAssetMappingCache';
 import { type RevealRenderTarget } from '../../architecture';
 import { drop, take } from 'lodash';
 import { taggedPointCloudModelOptions } from '#test-utils/fixtures/pointCloud';
@@ -80,12 +80,12 @@ const mockSdk = new Mock<CogniteClient>()
   .object();
 
 const mockGetAssetMappingsForModel =
-  vi.fn<AssetMappingAndNode3DCache['getAssetMappingsForModel']>();
+  vi.fn<ClassicCadAssetMappingCache['getAssetMappingsForModel']>();
 
 const mockRenderTarget = new Mock<RevealRenderTarget>()
-  .setup((p) => p.cdfCaches.assetMappingAndNode3dCache)
+  .setup((p) => p.cdfCaches.classicCadAssetMappingCache)
   .returns(
-    new Mock<AssetMappingAndNode3DCache>()
+    new Mock<ClassicCadAssetMappingCache>()
       .setup((p) => p.getAssetMappingsForModel)
       .returns(mockGetAssetMappingsForModel)
       .object()

--- a/react-components/src/query/network/searchClassicAssetsForModels.ts
+++ b/react-components/src/query/network/searchClassicAssetsForModels.ts
@@ -35,7 +35,7 @@ export async function searchClassicAssetsForModels(
 ): Promise<SearchClassicAssetsResponse> {
   const isFirstPage = cadAssetsCursor === undefined;
 
-  const assetMappingAndNode3DCache = renderTarget.cdfCaches.assetMappingAndNode3dCache;
+  const assetMappingAndNode3DCache = renderTarget.cdfCaches.classicCadAssetMappingCache;
 
   const cadModels = resources
     .filter((resource) => resource.type === 'cad')

--- a/react-components/src/query/network/searchClassicCadAssetsWithFilters.ts
+++ b/react-components/src/query/network/searchClassicCadAssetsWithFilters.ts
@@ -1,6 +1,6 @@
 import { type AddModelOptions, type ClassicDataSourceType } from '@cognite/reveal';
 import { type CadModelOptions } from '../../components';
-import { type AssetMappingAndNode3DCache } from '../../components/CacheProvider/AssetMappingAndNode3DCache';
+import { type ClassicCadAssetMappingCache } from '../../components/CacheProvider/cad/ClassicAssetMappingCache';
 import { type ModelWithAssetMappings } from '../../hooks/cad/ModelWithAssetMappings';
 import type { Asset, CogniteClient } from '@cognite/sdk';
 import { type AllAssetFilterProps } from './filters';
@@ -14,7 +14,7 @@ export async function searchClassicCadAssetsWithFilters(
   cursor: string | undefined,
   filters: AllAssetFilterProps | undefined,
   sdk: CogniteClient,
-  assetMappingAndNode3dCache: AssetMappingAndNode3DCache
+  assetMappingAndNode3dCache: ClassicCadAssetMappingCache
 ): Promise<SearchClassicCadAssetsResponse> {
   if (models.length === 0) {
     return { data: [], nextCursor: undefined };
@@ -76,7 +76,7 @@ export async function searchClassicCadAssetsWithFilters(
 
 async function fetchAssetMappedNodesForRevisions(
   cadModels: CadModelOptions[],
-  assetMappingAndNode3dCache: AssetMappingAndNode3DCache
+  assetMappingAndNode3dCache: ClassicCadAssetMappingCache
 ): Promise<ModelWithAssetMappings[]> {
   const fetchPromises = cadModels.map(async (model) => {
     const assetMappings = await assetMappingAndNode3dCache.getAssetMappingsForModel(

--- a/react-components/src/query/use3dNodeByExternalId.tsx
+++ b/react-components/src/query/use3dNodeByExternalId.tsx
@@ -2,14 +2,14 @@ import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import { type Node3D } from '@cognite/sdk';
 import { type DmsUniqueIdentifier } from '../data-providers/FdmSDK';
 import { useReveal } from '../components/RevealCanvas/ViewerContext';
-import { useFdmNodeCache } from '../components/CacheProvider/CacheProvider';
+import { useFdmCadNodeCache } from '../components/CacheProvider/CacheProvider';
 
 export const use3dNodeByExternalId = ({
   externalId,
   space
 }: Partial<DmsUniqueIdentifier>): UseQueryResult<Node3D> => {
   const viewer = useReveal();
-  const fdmNodeCache = useFdmNodeCache();
+  const fdmNodeCache = useFdmCadNodeCache();
 
   return useQuery({
     queryKey: ['reveal', 'react-components', '3dNodeByExternalId', externalId, space],

--- a/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
@@ -13,7 +13,7 @@ import {
 import { useSDK } from '../components/RevealCanvas/SDKProvider';
 import { getAssetsList } from '../hooks/network/getAssetsList';
 import { isDefined } from '../utilities/isDefined';
-import { useAssetMappedNodesForRevisions } from '../hooks/cad';
+import { useClassicAssetMappedNodesForRevisions } from '../hooks/cad';
 import { useMemo } from 'react';
 import { getAssetsFromAssetMappings } from './network/getAssetsFromAssetMappings';
 import { buildClassicAssetQueryFilter } from './network/buildClassicAssetFilter';
@@ -45,7 +45,7 @@ export const useSearchMappedEquipmentAssetMappings = (
 ): UseInfiniteQueryResult<InfiniteData<AssetPage>, Error> => {
   const sdk = useSDK(userSdk);
   const { data: assetMappingList, isFetched: isAssetMappingNodesFetched } =
-    useAssetMappedNodesForRevisions(models.map((model) => ({ ...model, type: 'cad' })));
+    useClassicAssetMappedNodesForRevisions(models.map((model) => ({ ...model, type: 'cad' })));
 
   const mapped3dAssetIds = useMemo(() => {
     if (assetMappingList === undefined) return new Set<number>();

--- a/react-components/src/utilities/getInstancesFromClick.ts
+++ b/react-components/src/utilities/getInstancesFromClick.ts
@@ -123,7 +123,7 @@ async function getCadFdmDataPromise(
   intersection: CadIntersection,
   caches: CdfCaches
 ): Promise<InstanceReference[]> {
-  const fdmNodeDataPromises = caches.fdmNodeCache.getClosestParentDataPromises(
+  const fdmNodeDataPromises = caches.fdmCadNodeCache.getClosestParentDataPromises(
     intersection.model.modelId,
     intersection.model.revisionId,
     intersection.treeIndex
@@ -147,11 +147,12 @@ async function getAssetMappingPromise(
     caches.cogniteClient
   );
 
-  const nodeAssetResult = await caches.assetMappingAndNode3dCache.getAssetMappingsForLowestAncestor(
-    intersection.model.modelId,
-    intersection.model.revisionId,
-    ancestors
-  );
+  const nodeAssetResult =
+    await caches.classicCadAssetMappingCache.getAssetMappingsForLowestAncestor(
+      intersection.model.modelId,
+      intersection.model.revisionId,
+      ancestors
+    );
 
   return nodeAssetResult.mappings.map((mapping) => ({ id: mapping.assetId }));
 }

--- a/react-components/tests/tests-utilities/fixtures/fdmNodeCache.ts
+++ b/react-components/tests/tests-utilities/fixtures/fdmNodeCache.ts
@@ -1,5 +1,5 @@
 import { Mock } from 'moq.ts';
-import { type FdmNodeCache } from '../../../src/components/CacheProvider/FdmNodeCache';
+import { type FdmCadNodeCache } from '../../../src/components/CacheProvider/FdmCadNodeCache';
 import { type Node3D } from '@cognite/sdk';
 import {
   type ModelRevisionId,
@@ -8,7 +8,7 @@ import {
 } from '../../../src/components/CacheProvider/types';
 import { type DmsUniqueIdentifier } from '../../../src/data-providers';
 
-const fdmNodeCacheMock = new Mock<FdmNodeCache>()
+const fdmCadNodeCacheMock = new Mock<FdmCadNodeCache>()
   .setup((instance) => instance.getAllMappingExternalIds.bind(instance))
   .returns(
     async (
@@ -62,6 +62,6 @@ const fdmNodeCacheMock = new Mock<FdmNodeCache>()
     }
   );
 
-const fdmNodeCacheContentMock = fdmNodeCacheMock.object();
+const fdmNodeCacheContentMock = fdmCadNodeCacheMock.object();
 
 export { fdmNodeCacheContentMock };

--- a/react-components/tests/tests-utilities/fixtures/renderTarget.ts
+++ b/react-components/tests/tests-utilities/fixtures/renderTarget.ts
@@ -12,7 +12,7 @@ import { viewerMock } from './viewer';
 import { RevealSettingsController } from '../../../src/architecture/concrete/reveal/RevealSettingsController';
 
 const cdfCachesMock = new Mock<CdfCaches>()
-  .setup((p) => p.fdmNodeCache)
+  .setup((p) => p.fdmCadNodeCache)
   .returns(fdmNodeCacheContentMock)
   .object();
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Renames various CAD asset-mapping-related types, functions and classes

The list of renames is as follows:
- `CdfAssetMapping` -> `ClassicCadAssetMapping`
- `FdmNodeCache` -> `FdmCadNodeCache`
- `AssetMappingAndNode3DCache` -> `ClassicAssetMappingCache`
- `AssetMappingPerNodeIdCache` -> `ClassicCadAssetMappingPerNodeIdCache`
- `AssetMappingPerAssetIdCache` -> `ClassicCadAssetMappingPerAssetIdCache`
- `AssetMappingPerModelCache` -> `ClassicCadAssetMappingPerModelCache`

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

TBA

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
