### PR TITLE
fix(react-components): export Reveal domain objects and bump to 0.82.1

### DIFF
--- a/react-components/src/architecture/index.ts
+++ b/react-components/src/architecture/index.ts
@@ -46,6 +46,12 @@ export { DefaultRevealConfig } from './base/renderTarget/DefaultRevealConfig';
 export { RevealRenderTarget } from './base/renderTarget/RevealRenderTarget';
 export { UnitSystem } from './base/renderTarget/UnitSystem';
 
+// New architecture: Reveal domain objects
+export { RevealDomainObject } from './concrete/reveal/RevealDomainObject';
+export { CadDomainObject } from './concrete/reveal/cad/CadDomainObject';
+export { PointCloudDomainObject } from './concrete/reveal/pointCloud/PointCloudDomainObject';
+export { Image360CollectionDomainObject } from './concrete/reveal/Image360Collection/Image360CollectionDomainObject';
+
 // New architecture: renderStyles
 export { RenderStyle } from './base/renderStyles/RenderStyle';
 export { CommonRenderStyle } from './base/renderStyles/CommonRenderStyle';


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Export missing Reveal-related domain objects.
Bump react-components version to 0.82.1

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
