### PR TITLE
chore(react-components): implement hybrid functionality in classic asset cache

### DIFF
--- a/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.test.ts
+++ b/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.test.ts
@@ -12,7 +12,7 @@ describe(createCadInstanceMappingsCache.name, () => {
   const mockClassicGetAssetMappingsForLowestAncestor =
     vi.fn<ClassicCadAssetMappingCache['getAssetMappingsForLowestAncestor']>();
   const mockClassicGetNodesForAssetIds =
-    vi.fn<ClassicCadAssetMappingCache['getNodesForAssetIds']>();
+    vi.fn<ClassicCadAssetMappingCache['getNodesForInstanceIds']>();
   const mockClassicGenerateNode3DCachePerItem =
     vi.fn<ClassicCadAssetMappingCache['generateNode3DCachePerItem']>();
   const mockClassicGenerateAssetMappingsCachePerItemFromModelCache =
@@ -22,7 +22,7 @@ describe(createCadInstanceMappingsCache.name, () => {
 
   const mockClassicCadAssetMappingCache: ClassicCadAssetMappingCache = {
     getAssetMappingsForLowestAncestor: mockClassicGetAssetMappingsForLowestAncestor,
-    getNodesForAssetIds: mockClassicGetNodesForAssetIds,
+    getNodesForInstanceIds: mockClassicGetNodesForAssetIds,
     generateNode3DCachePerItem: mockClassicGenerateNode3DCachePerItem,
     generateAssetMappingsCachePerItemFromModelCache:
       mockClassicGenerateAssetMappingsCachePerItemFromModelCache,

--- a/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.ts
@@ -1,9 +1,8 @@
 import { type Node3D } from '@cognite/sdk';
-import { type InstanceKey, isDmsInstance } from '../../../utilities/instanceIds';
+import { type InstanceId, type InstanceKey, isDmsInstance } from '../../../utilities/instanceIds';
 import { type ThreeDModelFdmMappings } from '../../../hooks';
 import {
   type CadNodeTreeData,
-  type AssetId,
   type FdmKey,
   type ModelRevisionId,
   type ModelRevisionKey
@@ -15,7 +14,6 @@ import { isDefined } from '../../../utilities/isDefined';
 import { mergeMapMapValues } from '../../../utilities/map/mergeMapMapValues';
 import { type ClassicCadAssetMappingCache } from './ClassicCadAssetMappingCache';
 import { type FdmCadNodeCache } from './FdmCadNodeCache';
-import { type DmsUniqueIdentifier } from '../../../data-providers';
 import type {
   CadInstanceMappingsCache,
   CadModelMappingsWithNodes,
@@ -48,7 +46,7 @@ class CadInstanceMappingsCacheImpl implements CadInstanceMappingsCache {
   }
 
   public async getMappingsForModelsAndInstances(
-    instances: Array<AssetId | DmsUniqueIdentifier>,
+    instances: InstanceId[],
     models: ModelRevisionId[]
   ): Promise<CadModelMappingsWithNodes> {
     if (models.length === 0 || instances.length === 0) {
@@ -83,7 +81,7 @@ class CadInstanceMappingsCacheImpl implements CadInstanceMappingsCache {
     );
     const modelsToClassicMappingsMap = new Map(classicResultTuples.filter(isDefined));
 
-    const mergedCadMappings = mergeMapMapValues<ModelRevisionKey, FdmKey | AssetId, Node3D>([
+    const mergedCadMappings = mergeMapMapValues<ModelRevisionKey, InstanceKey, Node3D>([
       ...modelsToClassicMappingsMap.entries(),
       ...(dmResultMap?.entries() ?? [])
     ]);
@@ -146,7 +144,7 @@ class CadInstanceMappingsCacheImpl implements CadInstanceMappingsCache {
       })
     );
 
-    return mergeMapMapValues<ModelRevisionKey, AssetId | FdmKey, CadNodeTreeData>([
+    return mergeMapMapValues<ModelRevisionKey, InstanceKey, CadNodeTreeData>([
       ...classicResultsMap.entries(),
       ...dmModelToInstanceToNodeMap.entries()
     ]);

--- a/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.ts
@@ -63,7 +63,7 @@ class CadInstanceMappingsCacheImpl implements CadInstanceMappingsCache {
 
     const classicResultsPromiseCallbacks = models
       .map((model) => async () => {
-        const nodeResult = await this._classicCache?.getNodesForAssetIds(
+        const nodeResult = await this._classicCache?.getNodesForInstanceIds(
           model.modelId,
           model.revisionId,
           internalIds

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCache.ts
@@ -1,8 +1,8 @@
 import type { Node3D } from '@cognite/sdk';
 import type { ModelWithAssetMappings } from '../../../hooks/cad/modelWithAssetMappings';
-import type { AssetId, FdmKey, ModelId, RevisionId } from '../types';
+import type { ModelId, RevisionId } from '../types';
 import type { HybridCadAssetMapping, HybridCadAssetTreeIndexMapping } from './assetMappingTypes';
-import type { InstanceId } from '../../../utilities/instanceIds';
+import type { InstanceId, InstanceKey } from '../../../utilities/instanceIds';
 
 export type HybridCadNodeAssetMappingResult = {
   node?: Node3D;
@@ -19,7 +19,7 @@ export type ClassicCadAssetMappingCache = {
     modelId: ModelId,
     revisionId: RevisionId,
     instanceIds: InstanceId[]
-  ) => Promise<Map<FdmKey | AssetId, Node3D[]>>;
+  ) => Promise<Map<InstanceKey, Node3D[]>>;
   generateNode3DCachePerItem: (
     modelId: ModelId,
     revisionId: RevisionId,

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCache.ts
@@ -15,7 +15,7 @@ export type ClassicCadAssetMappingCache = {
     revisionId: RevisionId,
     ancestors: Node3D[]
   ) => Promise<HybridCadNodeAssetMappingResult>;
-  getNodesForAssetIds: (
+  getNodesForInstanceIds: (
     modelId: ModelId,
     revisionId: RevisionId,
     instanceIds: InstanceId[]

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
@@ -8,9 +8,9 @@ import {
 } from '#test-utils/fixtures/sdk';
 import { createCadNodeMock } from '#test-utils/fixtures/cadNode';
 import { createCursorAndAsyncIteratorMock } from '#test-utils/fixtures/cursorAndIterator';
-import { InstanceId, isClassicInstanceId } from '../../../utilities/instanceIds';
-import { RawCdfHybridCadAssetMapping } from './rawAssetMappingTypes';
-import { AssetMapping3D, Node3D } from '@cognite/sdk';
+import { type InstanceId, isClassicInstanceId } from '../../../utilities/instanceIds';
+import { type RawCdfHybridCadAssetMapping } from './rawAssetMappingTypes';
+import { type AssetMapping3D, type Node3D } from '@cognite/sdk';
 
 describe(createClassicCadAssetMappingCache.name, () => {
   const MODEL_ID = 123;

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
@@ -147,7 +147,7 @@ describe(createClassicCadAssetMappingCache.name, () => {
         createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], ASSET_ID),
         createRawAssetMappingFromNodeAndInstance(CAD_NODES[2], 43)
       ];
-      assetMappings3DListMock.mockReturnValue(
+      assetMappings3DListMock.mockReturnValueOnce(
         createCursorAndAsyncIteratorMock({
           items: mappings as AssetMapping3D[]
         })
@@ -168,10 +168,14 @@ describe(createClassicCadAssetMappingCache.name, () => {
       const cache = createClassicCadAssetMappingCache(sdkMock);
 
       const result = await cache.getAssetMappingsForModel(MODEL_ID, REVISION_ID);
+
+      // The list endpoint is called twice, once for classic assets and once for DM
+      expect(assetMappings3DListMock).toHaveBeenCalledTimes(2);
+
       const result1 = await cache.getAssetMappingsForModel(MODEL_ID, REVISION_ID);
 
       expect(result).toEqual(result1);
-      expect(assetMappings3DListMock).toHaveBeenCalledTimes(1);
+      expect(assetMappings3DListMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'vitest';
+import { createClassicCadAssetMappingCache } from './ClassicCadAssetMappingCacheImpl';
+import {
+  assetMappings3DFilterMock,
+  assetMappings3DListMock,
+  nodes3dRetrieveMock,
+  sdkMock
+} from '#test-utils/fixtures/sdk';
+import { createCadNodeMock } from '#test-utils/fixtures/cadNode';
+import { createCursorAndAsyncIteratorMock } from '#test-utils/fixtures/cursorAndIterator';
+import { InstanceId, isClassicInstanceId } from '../../../utilities/instanceIds';
+import { RawCdfHybridCadAssetMapping } from './rawAssetMappingTypes';
+import { AssetMapping3D, Node3D } from '@cognite/sdk';
+
+describe(createClassicCadAssetMappingCache.name, () => {
+  const MODEL_ID = 123;
+  const REVISION_ID = 234;
+
+  const CAD_NODES = [
+    createCadNodeMock({ id: 123, treeIndex: 234 }),
+    createCadNodeMock({ id: 987, treeIndex: 345 }),
+    createCadNodeMock({ id: 678, treeIndex: 456 })
+  ];
+
+  const ASSET_ID = 42;
+
+  describe('getAssetMappingsForLowestAncestor', () => {
+    test('returns no mappings when no nodes were supplied', async () => {
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+
+      const result = await cache.getAssetMappingsForLowestAncestor(MODEL_ID, REVISION_ID, []);
+      expect(result).toEqual({ mappings: [] });
+    });
+
+    test('returns nothing if no relevant mappings exist', async () => {
+      assetMappings3DFilterMock.mockReturnValue(createCursorAndAsyncIteratorMock({ items: [] }));
+
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+
+      const result = await cache.getAssetMappingsForLowestAncestor(
+        MODEL_ID,
+        REVISION_ID,
+        CAD_NODES
+      );
+
+      expect(result).toEqual({ mappings: [] });
+    });
+
+    test('returns relevant mappings if exist', async () => {
+      const mapping = createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], ASSET_ID);
+
+      assetMappings3DFilterMock.mockReturnValue(
+        createCursorAndAsyncIteratorMock({
+          // SDK method uses `AssetMapping3D', but its `assetId` may not always
+          // be defined in real usage
+          items: [mapping] as AssetMapping3D[]
+        })
+      );
+
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+      const result = await cache.getAssetMappingsForLowestAncestor(
+        MODEL_ID,
+        REVISION_ID,
+        CAD_NODES
+      );
+
+      expect(result).toEqual({ node: CAD_NODES[0], mappings: [mapping] });
+    });
+
+    test('only returns results for the ancestor with the highest tree index', async () => {
+      const mappings = [
+        createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], 1),
+        createRawAssetMappingFromNodeAndInstance(CAD_NODES[1], 2),
+        createRawAssetMappingFromNodeAndInstance(CAD_NODES[2], 3)
+      ];
+
+      assetMappings3DFilterMock.mockReturnValue(
+        createCursorAndAsyncIteratorMock({
+          // SDK method uses `AssetMapping3D', but its `assetId` may not always
+          // be defined in real usage
+          items: mappings as AssetMapping3D[]
+        })
+      );
+
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+      const result = await cache.getAssetMappingsForLowestAncestor(
+        MODEL_ID,
+        REVISION_ID,
+        CAD_NODES
+      );
+
+      expect(result).toEqual({ node: CAD_NODES[2], mappings: [mappings[2]] });
+    });
+  });
+
+  describe('getNodesForInstanceIds', () => {
+    test('returns empty map if no associated mapping exists', async () => {
+      assetMappings3DFilterMock.mockReturnValue(
+        createCursorAndAsyncIteratorMock({
+          items: [
+            createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], ASSET_ID)
+          ] as AssetMapping3D[]
+        })
+      );
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+      const result = await cache.getNodesForInstanceIds(MODEL_ID, REVISION_ID, [ASSET_ID]);
+
+      expect(result).toEqual(new Map());
+    });
+
+    test('returns map with relevant mappings for input instance', async () => {
+      assetMappings3DFilterMock.mockReturnValue(
+        createCursorAndAsyncIteratorMock({
+          items: [
+            createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], ASSET_ID)
+          ] as AssetMapping3D[]
+        })
+      );
+
+      nodes3dRetrieveMock.mockResolvedValue([CAD_NODES[0]]);
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+      const result = await cache.getNodesForInstanceIds(MODEL_ID, REVISION_ID, [ASSET_ID]);
+
+      expect(result).toEqual(new Map([[ASSET_ID, [CAD_NODES[0]]]]));
+    });
+
+    test('calls asset mappings mock with model and asset IDs', async () => {
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+      await cache.getNodesForInstanceIds(MODEL_ID, REVISION_ID, [ASSET_ID]);
+      expect(assetMappings3DFilterMock).toHaveBeenCalledWith(MODEL_ID, REVISION_ID, {
+        limit: 1000,
+        filter: { assetIds: [ASSET_ID] }
+      });
+    });
+  });
+
+  describe('getAssetMappingsForModel', () => {
+    test('returns nothing if no relevant asset mappings exist', async () => {
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+
+      const result = await cache.getAssetMappingsForModel(MODEL_ID, REVISION_ID);
+      expect(result).toEqual([]);
+    });
+
+    test('uses SDK to fetch asset mappings for model', async () => {
+      const mappings = [
+        createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], ASSET_ID),
+        createRawAssetMappingFromNodeAndInstance(CAD_NODES[2], 43)
+      ];
+      assetMappings3DListMock.mockReturnValue(
+        createCursorAndAsyncIteratorMock({
+          items: mappings as AssetMapping3D[]
+        })
+      );
+
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+
+      const result = await cache.getAssetMappingsForModel(MODEL_ID, REVISION_ID);
+
+      expect(result).toEqual(mappings);
+      expect(assetMappings3DListMock).toHaveBeenCalledWith(MODEL_ID, REVISION_ID, {
+        limit: 1000,
+        getDmsInstances: true
+      });
+    });
+
+    test('caches result from SDK', async () => {
+      const cache = createClassicCadAssetMappingCache(sdkMock);
+
+      const result = await cache.getAssetMappingsForModel(MODEL_ID, REVISION_ID);
+      const result1 = await cache.getAssetMappingsForModel(MODEL_ID, REVISION_ID);
+
+      expect(result).toEqual(result1);
+      expect(assetMappings3DListMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+function createRawAssetMappingFromNodeAndInstance(
+  node: Node3D,
+  instanceId: InstanceId
+): RawCdfHybridCadAssetMapping {
+  const assetMappingBase = {
+    nodeId: node.id,
+    treeIndex: node.treeIndex,
+    subtreeSize: node.subtreeSize
+  };
+
+  if (isClassicInstanceId(instanceId)) {
+    return { ...assetMappingBase, assetId: instanceId };
+  }
+
+  return { ...assetMappingBase, assetInstanceId: instanceId };
+}

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
@@ -51,8 +51,8 @@ describe(createClassicCadAssetMappingCache.name, () => {
 
       assetMappings3DFilterMock.mockReturnValue(
         createCursorAndAsyncIteratorMock({
-          // SDK method uses `AssetMapping3D', but its `assetId` may not always
-          // be defined in real usage
+          // SDK method uses `AssetMapping3D', but it is out of
+          // date with the API definition, so we need to cast
           items: [mapping] as AssetMapping3D[]
         })
       );
@@ -76,8 +76,6 @@ describe(createClassicCadAssetMappingCache.name, () => {
 
       assetMappings3DFilterMock.mockReturnValue(
         createCursorAndAsyncIteratorMock({
-          // SDK method uses `AssetMapping3D', but its `assetId` may not always
-          // be defined in real usage
           items: mappings as AssetMapping3D[]
         })
       );

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.test.ts
@@ -76,6 +76,8 @@ describe(createClassicCadAssetMappingCache.name, () => {
 
       assetMappings3DFilterMock.mockReturnValue(
         createCursorAndAsyncIteratorMock({
+          // SDK method uses `AssetMapping3D', but it is out of
+          // date with the API definition, so we need to cast
           items: mappings as AssetMapping3D[]
         })
       );
@@ -95,6 +97,8 @@ describe(createClassicCadAssetMappingCache.name, () => {
     test('returns empty map if no associated mapping exists', async () => {
       assetMappings3DFilterMock.mockReturnValue(
         createCursorAndAsyncIteratorMock({
+          // SDK method uses `AssetMapping3D', but it is out of
+          // date with the API definition, so we need to cast
           items: [
             createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], ASSET_ID)
           ] as AssetMapping3D[]
@@ -108,6 +112,8 @@ describe(createClassicCadAssetMappingCache.name, () => {
 
     test('returns map with relevant mappings for input instance', async () => {
       assetMappings3DFilterMock.mockReturnValue(
+        // SDK method uses `AssetMapping3D', but it is out of
+        // date with the API definition, so we need to cast
         createCursorAndAsyncIteratorMock({
           items: [
             createRawAssetMappingFromNodeAndInstance(CAD_NODES[0], ASSET_ID)
@@ -147,6 +153,8 @@ describe(createClassicCadAssetMappingCache.name, () => {
       ];
       assetMappings3DListMock.mockReturnValueOnce(
         createCursorAndAsyncIteratorMock({
+          // SDK method uses `AssetMapping3D', but it is out of
+          // date with the API definition, so we need to cast
           items: mappings as AssetMapping3D[]
         })
       );

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
@@ -91,13 +91,13 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
     return { node: nearestMappedAncestor, mappings: mappingsOfNearestAncestor };
   }
 
-  public async getNodesForAssetIds(
+  public async getNodesForInstanceIds(
     modelId: ModelId,
     revisionId: RevisionId,
     instanceIds: InstanceId[]
-  ): Promise<Map<FdmKey | AssetId, Node3D[]>> {
     const [assetIds, _dmIds] = partition(instanceIds, isClassicInstanceId);
     const relevantAssetIds = new Set(assetIds);
+  ): Promise<Map<InstanceKey, Node3D[]>> {
 
     const assetIdsList = Array.from(relevantAssetIds);
     const chunkSize = Math.round(assetIdsList.length / this._amountOfAssetIdsChunks);

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
@@ -159,7 +159,7 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
     if (assetMappingsPerModel === undefined) {
       return;
     }
-    const promises = assetMappingsPerModel.flatMap((modelMapping) =>
+    const cachingPromises = assetMappingsPerModel.flatMap((modelMapping) =>
       modelMapping.assetMappings.map(async (item) => {
         const key = createModelInstanceIdKey(
           modelId,
@@ -170,7 +170,7 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
       })
     );
 
-    await Promise.all(promises);
+    await Promise.all(cachingPromises);
   }
 
   public async getAssetMappingsForModel(

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
@@ -315,7 +315,7 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
     modelId: ModelId,
     revisionId: RevisionId,
     ids: InstanceKey[],
-    filterType: 'nodeIds' | 'assetIds'
+    filterType: HybridCadCacheIndexType
   ): Promise<HybridCadAssetMapping[]> {
     if (ids.length === 0) {
       return [];

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
@@ -31,7 +31,8 @@ import {
   type HybridCadAssetTreeIndexMapping
 } from './assetMappingTypes';
 import { type HybridCadCacheIndexType } from './types';
-import { extractHybridAssetMappings } from './rawAssetMappingTypes';
+import { convertToHybridAssetMapping } from './rawAssetMappingTypes';
+import { isDefined } from '../../../utilities/isDefined';
 
 export function createClassicCadAssetMappingCache(sdk: CogniteClient): ClassicCadAssetMappingCache {
   return new ClassicCadAssetMappingCacheImpl(sdk);
@@ -253,7 +254,9 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
           filter
         })
         .autoPagingToArray({ limit: Infinity })
-    ).flatMap(extractHybridAssetMappings);
+    )
+      .map(convertToHybridAssetMapping)
+      .filter(isDefined);
 
     await Promise.all(
       assetMapping3D.map(async (assetMapping) => {

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
@@ -153,7 +153,11 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
     }
     assetMappingsPerModel.forEach(async (modelMapping) => {
       modelMapping.assetMappings.forEach(async (item) => {
-        const key = modelRevisionNodesAssetToKey(modelId, revisionId, item.assetId);
+        const key = createModelInstanceIdKey(
+          modelId,
+          revisionId,
+          createInstanceKey(getMappingInstanceId(item))
+        );
         await this.assetIdsToAssetMappingCache.setAssetMappingsCacheItem(key, item);
       });
     });
@@ -184,7 +188,7 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
 
     await Promise.all(
       currentChunk.map(async (id) => {
-        const key = modelRevisionNodesAssetToKey(modelId, revisionId, id);
+        const key = createModelInstanceIdKey(modelId, revisionId, id);
         const cachedResult = await this.getItemCacheResult(type, key);
         if (cachedResult !== undefined) {
           chunkInCache.push(...cachedResult);
@@ -240,7 +244,7 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
 
     await Promise.all(
       assetMapping3D.map(async (item) => {
-        const keyAssetId: ModelAssetIdKey = modelRevisionNodesAssetToKey(
+        const keyAssetId: ModelInstanceIdKey = createModelInstanceIdKey(
           modelId,
           revisionId,
           item.assetId
@@ -252,7 +256,7 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
     );
 
     currentChunk.forEach(async (id) => {
-      const key = modelRevisionNodesAssetToKey(modelId, revisionId, id);
+      const key = createModelInstanceIdKey(modelId, revisionId, id);
       const cachedResult = await this.getItemCacheResult(filterType, key);
 
       if (cachedResult === undefined) {

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
@@ -159,16 +159,18 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
     if (assetMappingsPerModel === undefined) {
       return;
     }
-    assetMappingsPerModel.forEach(async (modelMapping) => {
-      modelMapping.assetMappings.forEach(async (item) => {
+    const promises = assetMappingsPerModel.flatMap((modelMapping) =>
+      modelMapping.assetMappings.map(async (item) => {
         const key = createModelInstanceIdKey(
           modelId,
           revisionId,
           createInstanceKey(getMappingInstanceId(item))
         );
         await this.assetIdsToAssetMappingCache.setAssetMappingsCacheItem(key, item);
-      });
-    });
+      })
+    );
+
+    await Promise.all(promises);
   }
 
   public async getAssetMappingsForModel(

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerAssetIdCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerAssetIdCache.ts
@@ -1,28 +1,28 @@
-import { type ModelAssetIdKey } from '../types';
-import { type ClassicCadAssetMapping } from './assetMappingTypes';
+import { type ModelInstanceIdKey } from '../types';
+import { type HybridCadAssetMapping } from './assetMappingTypes';
 
 export class ClassicCadAssetMappingPerAssetIdCache {
   private readonly _assetIdsToAssetMappings = new Map<
-    ModelAssetIdKey,
-    Promise<ClassicCadAssetMapping[]>
+    ModelInstanceIdKey,
+    Promise<HybridCadAssetMapping[]>
   >();
 
   public setAssetIdsToAssetMappingCacheItem(
-    key: ModelAssetIdKey,
-    item: Promise<ClassicCadAssetMapping[]>
+    key: ModelInstanceIdKey,
+    item: Promise<HybridCadAssetMapping[]>
   ): void {
     this._assetIdsToAssetMappings.set(key, Promise.resolve(item));
   }
 
   public async getAssetIdsToAssetMappingCacheItem(
-    key: ModelAssetIdKey
-  ): Promise<ClassicCadAssetMapping[] | undefined> {
+    key: ModelInstanceIdKey
+  ): Promise<HybridCadAssetMapping[] | undefined> {
     return await this._assetIdsToAssetMappings.get(key);
   }
 
   public async setAssetMappingsCacheItem(
-    key: ModelAssetIdKey,
-    item: ClassicCadAssetMapping
+    key: ModelInstanceIdKey,
+    item: HybridCadAssetMapping
   ): Promise<void> {
     const currentAssetMappings = this.getAssetIdsToAssetMappingCacheItem(key);
     this.setAssetIdsToAssetMappingCacheItem(

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { ClassicCadAssetMappingPerModelCache } from './ClassicCadAssetMappingPerModelCache';
+import { assetMappings3DListMock, sdkMock } from '#test-utils/fixtures/sdk';
+import { createModelRevisionKey } from '../idAndKeyTranslation';
+import { type RawCdfHybridCadAssetMapping } from './rawAssetMappingTypes';
+import { type AssetMapping3D } from '@cognite/sdk';
+import { createCursorAndAsyncIteratorMock } from '#test-utils/fixtures/cursorAndIterator';
+
+describe(ClassicCadAssetMappingPerModelCache.name, () => {
+  const MODEL_ID = 123;
+  const REVISION_ID = 234;
+
+  const modelRevisionKey = createModelRevisionKey(MODEL_ID, REVISION_ID);
+
+  const ASSET_MAPPINGS: RawCdfHybridCadAssetMapping[] = [
+    { nodeId: 1, treeIndex: 2, subtreeSize: 3, assetId: 4 },
+    {
+      nodeId: 5,
+      treeIndex: 6,
+      subtreeSize: 7,
+      assetInstanceId: { externalId: 'externalId0', space: 'space0' }
+    },
+    {
+      nodeId: 8,
+      treeIndex: 9,
+      subtreeSize: 10,
+      assetId: 11,
+      assetInstanceId: { externalId: 'externalId1', space: 'space1' }
+    }
+  ];
+
+  beforeEach(() => {
+    // We need to do an explicit casting because the `AssetMapping3D` SDK type requires
+    // `assetId` to be defined, but this may not be true in real life
+    assetMappings3DListMock.mockReturnValue(
+      createCursorAndAsyncIteratorMock({ items: ASSET_MAPPINGS as AssetMapping3D[] })
+    );
+  });
+
+  test('returns undefined if nothing is cached yet', async () => {
+    const cache = new ClassicCadAssetMappingPerModelCache(sdkMock);
+
+    const result = await cache.getModelToAssetMappingCacheItems(modelRevisionKey);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns promise with separated mappings from `fetchAndCacheMappingsForModel`', async () => {
+    const cache = new ClassicCadAssetMappingPerModelCache(sdkMock);
+
+    const result = await cache.fetchAndCacheMappingsForModel(MODEL_ID, REVISION_ID);
+
+    const { assetInstanceId: instanceId0, ...assetMappingBase1 } = ASSET_MAPPINGS[1];
+    const {
+      assetId: assetId1,
+      assetInstanceId: instanceId1,
+      ...assetMappingBase2
+    } = ASSET_MAPPINGS[2];
+
+    expect(result).toEqual([
+      ASSET_MAPPINGS[0],
+      { ...assetMappingBase1, instanceId: instanceId0 },
+      { ...assetMappingBase2, assetId: assetId1 },
+      { ...assetMappingBase2, instanceId: instanceId1 }
+    ]);
+  });
+
+  test('calling getter returns cached result', async () => {
+    const cache = new ClassicCadAssetMappingPerModelCache(sdkMock);
+
+    const result = await cache.fetchAndCacheMappingsForModel(MODEL_ID, REVISION_ID);
+
+    const gotResult = await cache.getModelToAssetMappingCacheItems(modelRevisionKey);
+    expect(gotResult).toEqual(result);
+
+    expect(assetMappings3DListMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('results for different models are cached separately', async () => {
+    const cache = new ClassicCadAssetMappingPerModelCache(sdkMock);
+
+    const modelId1 = 987;
+    const revisionId1 = 876;
+
+    const result = await cache.fetchAndCacheMappingsForModel(MODEL_ID, REVISION_ID);
+
+    assetMappings3DListMock.mockReturnValue(
+      createCursorAndAsyncIteratorMock({ items: [ASSET_MAPPINGS[1]] as AssetMapping3D[] })
+    );
+
+    const result1 = await cache.fetchAndCacheMappingsForModel(modelId1, revisionId1);
+
+    expect(result1).not.toEqual(result);
+  });
+
+  test('calls asset mapping endpoint with getDmsInstances: true', async () => {
+    const cache = new ClassicCadAssetMappingPerModelCache(sdkMock);
+
+    await cache.fetchAndCacheMappingsForModel(MODEL_ID, REVISION_ID);
+
+    expect(assetMappings3DListMock).toHaveBeenCalledWith(
+      MODEL_ID,
+      REVISION_ID,
+      expect.objectContaining({ getDmsInstances: true })
+    );
+  });
+});

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.test.ts
@@ -30,8 +30,8 @@ describe(ClassicCadAssetMappingPerModelCache.name, () => {
   ];
 
   beforeEach(() => {
-    // We need to do an explicit casting because the `AssetMapping3D` SDK type requires
-    // `assetId` to be defined, but this may not be true in real life
+    // SDK method uses `AssetMapping3D', but it is out of
+    // date with the API definition, so we need to cast
     assetMappings3DListMock.mockReturnValueOnce(
       createCursorAndAsyncIteratorMock({ items: ASSET_MAPPINGS as AssetMapping3D[] })
     );

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.test.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.test.ts
@@ -32,7 +32,7 @@ describe(ClassicCadAssetMappingPerModelCache.name, () => {
   beforeEach(() => {
     // We need to do an explicit casting because the `AssetMapping3D` SDK type requires
     // `assetId` to be defined, but this may not be true in real life
-    assetMappings3DListMock.mockReturnValue(
+    assetMappings3DListMock.mockReturnValueOnce(
       createCursorAndAsyncIteratorMock({ items: ASSET_MAPPINGS as AssetMapping3D[] })
     );
   });
@@ -70,10 +70,13 @@ describe(ClassicCadAssetMappingPerModelCache.name, () => {
 
     const result = await cache.fetchAndCacheMappingsForModel(MODEL_ID, REVISION_ID);
 
+    // List endpoint gets called twice, once for classic and once for DM
+    expect(assetMappings3DListMock).toHaveBeenCalledTimes(2);
+
     const gotResult = await cache.getModelToAssetMappingCacheItems(modelRevisionKey);
     expect(gotResult).toEqual(result);
 
-    expect(assetMappings3DListMock).toHaveBeenCalledTimes(1);
+    expect(assetMappings3DListMock).toHaveBeenCalledTimes(2);
   });
 
   test('results for different models are cached separately', async () => {

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
@@ -46,11 +46,11 @@ export class ClassicCadAssetMappingPerModelCache {
   private async fetchAssetMappingsForModel(
     modelId: ModelId,
     revisionId: RevisionId
-  ): Promise<ClassicCadAssetMapping[]> {
-    const assetMapping3D = await this._sdk.assetMappings3D
-      .list(modelId, revisionId, { limit: 1000 })
+  ): Promise<HybridCadAssetMapping[]> {
+    const assetMapping3D: RawCdfHybridCadAssetMapping[] = await this._sdk.assetMappings3D
+      .list(modelId, revisionId, { limit: 1000, getDmsInstances: true })
       .autoPagingToArray({ limit: Infinity });
 
-    return assetMapping3D.filter(isValidClassicCadAssetMapping);
+    return assetMapping3D.flatMap(extractHybridAssetMappings);
   }
 }

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
@@ -19,7 +19,7 @@ export class ClassicCadAssetMappingPerModelCache {
     this._sdk = sdk;
   }
 
-  public setModelToAssetMappingCacheItems(
+  private setModelToAssetMappingCacheItems(
     key: ModelRevisionKey,
     assetMappings: Promise<HybridCadAssetMapping[]>
   ): void {

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
@@ -1,14 +1,18 @@
 import { type CogniteClient } from '@cognite/sdk';
 import { type ModelId, type RevisionId, type ModelRevisionKey } from '../types';
 import { createModelRevisionKey } from '../idAndKeyTranslation';
-import { type ClassicCadAssetMapping, isValidClassicCadAssetMapping } from './assetMappingTypes';
+import { type HybridCadAssetMapping } from './assetMappingTypes';
+import {
+  extractHybridAssetMappings,
+  type RawCdfHybridCadAssetMapping
+} from './rawAssetMappingTypes';
 
 export class ClassicCadAssetMappingPerModelCache {
   private readonly _sdk: CogniteClient;
 
   private readonly _modelToAssetMappings = new Map<
     ModelRevisionKey,
-    Promise<ClassicCadAssetMapping[]>
+    Promise<HybridCadAssetMapping[]>
   >();
 
   constructor(sdk: CogniteClient) {
@@ -17,21 +21,21 @@ export class ClassicCadAssetMappingPerModelCache {
 
   public setModelToAssetMappingCacheItems(
     key: ModelRevisionKey,
-    assetMappings: Promise<ClassicCadAssetMapping[]>
+    assetMappings: Promise<HybridCadAssetMapping[]>
   ): void {
     this._modelToAssetMappings.set(key, assetMappings);
   }
 
   public async getModelToAssetMappingCacheItems(
     key: ModelRevisionKey
-  ): Promise<ClassicCadAssetMapping[] | undefined> {
+  ): Promise<HybridCadAssetMapping[] | undefined> {
     return await this._modelToAssetMappings.get(key);
   }
 
   public async fetchAndCacheMappingsForModel(
     modelId: ModelId,
     revisionId: RevisionId
-  ): Promise<ClassicCadAssetMapping[]> {
+  ): Promise<HybridCadAssetMapping[]> {
     const key = createModelRevisionKey(modelId, revisionId);
     const assetMappings = this.fetchAssetMappingsForModel(modelId, revisionId);
 

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
@@ -3,9 +3,10 @@ import { type ModelId, type RevisionId, type ModelRevisionKey } from '../types';
 import { createModelRevisionKey } from '../idAndKeyTranslation';
 import { type HybridCadAssetMapping } from './assetMappingTypes';
 import {
-  extractHybridAssetMappings,
+  convertToHybridAssetMapping,
   type RawCdfHybridCadAssetMapping
 } from './rawAssetMappingTypes';
+import { isDefined } from '../../../utilities/isDefined';
 
 export class ClassicCadAssetMappingPerModelCache {
   private readonly _sdk: CogniteClient;
@@ -54,6 +55,8 @@ export class ClassicCadAssetMappingPerModelCache {
       .list(modelId, revisionId, { limit: 1000, getDmsInstances: true })
       .autoPagingToArray({ limit: Infinity });
 
-    return [...classicAssetMappings, ...dmAssetMappings].flatMap(extractHybridAssetMappings);
+    return [...classicAssetMappings, ...dmAssetMappings]
+      .map(convertToHybridAssetMapping)
+      .filter(isDefined);
   }
 }

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerModelCache.ts
@@ -47,10 +47,13 @@ export class ClassicCadAssetMappingPerModelCache {
     modelId: ModelId,
     revisionId: RevisionId
   ): Promise<HybridCadAssetMapping[]> {
-    const assetMapping3D: RawCdfHybridCadAssetMapping[] = await this._sdk.assetMappings3D
+    const classicAssetMappings: RawCdfHybridCadAssetMapping[] = await this._sdk.assetMappings3D
+      .list(modelId, revisionId, { limit: 1000 })
+      .autoPagingToArray({ limit: Infinity });
+    const dmAssetMappings: RawCdfHybridCadAssetMapping[] = await this._sdk.assetMappings3D
       .list(modelId, revisionId, { limit: 1000, getDmsInstances: true })
       .autoPagingToArray({ limit: Infinity });
 
-    return assetMapping3D.flatMap(extractHybridAssetMappings);
+    return [...classicAssetMappings, ...dmAssetMappings].flatMap(extractHybridAssetMappings);
   }
 }

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerNodeIdCache.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingPerNodeIdCache.ts
@@ -1,28 +1,28 @@
-import { type ModelTreeIndexKey } from '../types';
-import { type ClassicCadAssetMapping } from './assetMappingTypes';
+import { type ModelInstanceIdKey, type ModelNodeIdKey } from '../types';
+import { type HybridCadAssetMapping } from './assetMappingTypes';
 
 export class ClassicCadAssetMappingPerNodeIdCache {
   private readonly _nodeIdsToAssetMappings = new Map<
-    ModelTreeIndexKey,
-    Promise<ClassicCadAssetMapping[]>
+    ModelNodeIdKey | ModelInstanceIdKey,
+    Promise<HybridCadAssetMapping[]>
   >();
 
   public setNodeIdsToAssetMappingCacheItem(
-    key: ModelTreeIndexKey,
-    item: Promise<ClassicCadAssetMapping[]>
+    key: ModelNodeIdKey | ModelInstanceIdKey,
+    item: Promise<HybridCadAssetMapping[]>
   ): void {
     this._nodeIdsToAssetMappings.set(key, Promise.resolve(item));
   }
 
   public async getNodeIdsToAssetMappingCacheItem(
-    key: ModelTreeIndexKey
-  ): Promise<ClassicCadAssetMapping[] | undefined> {
+    key: ModelNodeIdKey | ModelInstanceIdKey
+  ): Promise<HybridCadAssetMapping[] | undefined> {
     return await this._nodeIdsToAssetMappings.get(key);
   }
 
   public async setAssetMappingsCacheItem(
-    key: ModelTreeIndexKey,
-    item: ClassicCadAssetMapping
+    key: ModelNodeIdKey | ModelInstanceIdKey,
+    item: HybridCadAssetMapping
   ): Promise<void> {
     const currentAssetMappings = this.getNodeIdsToAssetMappingCacheItem(key);
     this.setNodeIdsToAssetMappingCacheItem(

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
@@ -9,8 +9,7 @@ import {
   isClassicCadAssetMapping,
   isClassicCadAssetTreeIndexMapping,
   isDmCadAssetMapping,
-  isDmCadAssetTreeIndexMapping,
-  isValidCdfHybridCadAssetMapping
+  isDmCadAssetTreeIndexMapping
 } from './assetMappingTypes';
 import assert from 'assert';
 import { type AssetMapping3D } from '@cognite/sdk';
@@ -87,16 +86,25 @@ describe('assetMappingTypes', () => {
       expect(
         isValidCdfHybridCadAssetMapping({ nodeId: 1, assetId: 12, subtreeSize: 3 })
       ).toBeFalsy();
+  describe(isDmCadAssetTreeIndexMapping.name, () => {
+    test('recognizes DM tree index mapping', () => {
+      expect(isDmCadAssetTreeIndexMapping(dmAssetTreeIndexMapping)).toBeTruthy();
     });
 
     test('recognizes asset mappings with all fields, and asserts type', () => {
       expect(isValidCdfHybridCadAssetMapping(classicAssetMapping)).toBeTruthy();
+    test('rejects classic tree index mapping', () => {
+      expect(isDmCadAssetTreeIndexMapping(classicAssetTreeIndexMapping)).toBeFalsy();
     });
 
     test('asserts asset mapping to be ClassicCadAssetMapping', () => {
       const mapping = classicAssetMapping as AssetMapping3D;
       assert(isValidCdfHybridCadAssetMapping(mapping));
       expectTypeOf<ClassicCadAssetMapping>(mapping);
+    test('asserts tree index mapping to be DmCadAssetTreeIndexMapping', () => {
+      const mapping = dmAssetTreeIndexMapping as HybridCadAssetTreeIndexMapping;
+      assert(isDmCadAssetTreeIndexMapping(mapping));
+      expectTypeOf<DmCadAssetTreeIndexMapping>(mapping);
     });
   });
 
@@ -113,22 +121,6 @@ describe('assetMappingTypes', () => {
       const mapping = classicAssetTreeIndexMapping as HybridCadAssetTreeIndexMapping;
       assert(isClassicCadAssetTreeIndexMapping(mapping));
       expectTypeOf<ClassicCadAssetTreeIndexMapping>(mapping);
-    });
-  });
-
-  describe(isDmCadAssetTreeIndexMapping.name, () => {
-    test('recognizes DM tree index mapping', () => {
-      expect(isDmCadAssetTreeIndexMapping(dmAssetTreeIndexMapping)).toBeTruthy();
-    });
-
-    test('rejects classic tree index mapping', () => {
-      expect(isDmCadAssetTreeIndexMapping(classicAssetTreeIndexMapping)).toBeFalsy();
-    });
-
-    test('asserts tree index mapping to be DmCadAssetTreeIndexMapping', () => {
-      const mapping = dmAssetTreeIndexMapping as HybridCadAssetTreeIndexMapping;
-      assert(isDmCadAssetTreeIndexMapping(mapping));
-      expectTypeOf<DmCadAssetTreeIndexMapping>(mapping);
     });
   });
 });

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
@@ -10,7 +10,7 @@ import {
   isClassicCadAssetTreeIndexMapping,
   isDmCadAssetMapping,
   isDmCadAssetTreeIndexMapping,
-  isValidClassicCadAssetMapping
+  isValidCdfHybridCadAssetMapping
 } from './assetMappingTypes';
 import assert from 'assert';
 import { type AssetMapping3D } from '@cognite/sdk';
@@ -78,20 +78,24 @@ describe('assetMappingTypes', () => {
     });
   });
 
-  describe(isValidClassicCadAssetMapping.name, () => {
+  describe(isValidCdfHybridCadAssetMapping.name, () => {
     test('rejects asset mappings without treeIndex and subtreeSize', () => {
-      expect(isValidClassicCadAssetMapping({ nodeId: 1, assetId: 12 })).toBeFalsy();
-      expect(isValidClassicCadAssetMapping({ nodeId: 1, assetId: 12, treeIndex: 23 })).toBeFalsy();
-      expect(isValidClassicCadAssetMapping({ nodeId: 1, assetId: 12, subtreeSize: 3 })).toBeFalsy();
+      expect(isValidCdfHybridCadAssetMapping({ nodeId: 1, assetId: 12 })).toBeFalsy();
+      expect(
+        isValidCdfHybridCadAssetMapping({ nodeId: 1, assetId: 12, treeIndex: 23 })
+      ).toBeFalsy();
+      expect(
+        isValidCdfHybridCadAssetMapping({ nodeId: 1, assetId: 12, subtreeSize: 3 })
+      ).toBeFalsy();
     });
 
     test('recognizes asset mappings with all fields, and asserts type', () => {
-      expect(isValidClassicCadAssetMapping(classicAssetMapping)).toBeTruthy();
+      expect(isValidCdfHybridCadAssetMapping(classicAssetMapping)).toBeTruthy();
     });
 
     test('asserts asset mapping to be ClassicCadAssetMapping', () => {
       const mapping = classicAssetMapping as AssetMapping3D;
-      assert(isValidClassicCadAssetMapping(mapping));
+      assert(isValidCdfHybridCadAssetMapping(mapping));
       expectTypeOf<ClassicCadAssetMapping>(mapping);
     });
   });

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
@@ -77,30 +77,15 @@ describe('assetMappingTypes', () => {
     });
   });
 
-  describe(isValidCdfHybridCadAssetMapping.name, () => {
-    test('rejects asset mappings without treeIndex and subtreeSize', () => {
-      expect(isValidCdfHybridCadAssetMapping({ nodeId: 1, assetId: 12 })).toBeFalsy();
-      expect(
-        isValidCdfHybridCadAssetMapping({ nodeId: 1, assetId: 12, treeIndex: 23 })
-      ).toBeFalsy();
-      expect(
-        isValidCdfHybridCadAssetMapping({ nodeId: 1, assetId: 12, subtreeSize: 3 })
-      ).toBeFalsy();
   describe(isDmCadAssetTreeIndexMapping.name, () => {
     test('recognizes DM tree index mapping', () => {
       expect(isDmCadAssetTreeIndexMapping(dmAssetTreeIndexMapping)).toBeTruthy();
     });
 
-    test('recognizes asset mappings with all fields, and asserts type', () => {
-      expect(isValidCdfHybridCadAssetMapping(classicAssetMapping)).toBeTruthy();
     test('rejects classic tree index mapping', () => {
       expect(isDmCadAssetTreeIndexMapping(classicAssetTreeIndexMapping)).toBeFalsy();
     });
 
-    test('asserts asset mapping to be ClassicCadAssetMapping', () => {
-      const mapping = classicAssetMapping as AssetMapping3D;
-      assert(isValidCdfHybridCadAssetMapping(mapping));
-      expectTypeOf<ClassicCadAssetMapping>(mapping);
     test('asserts tree index mapping to be DmCadAssetTreeIndexMapping', () => {
       const mapping = dmAssetTreeIndexMapping as HybridCadAssetTreeIndexMapping;
       assert(isDmCadAssetTreeIndexMapping(mapping));

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, expectTypeOf, test } from 'vitest';
 import {
   type ClassicCadAssetMapping,
-  ClassicCadAssetMappingInstance,
+  type ClassicCadAssetMappingInstance,
   type ClassicCadAssetTreeIndexMapping,
   type DmCadAssetMapping,
-  DmCadAssetMappingInstance,
+  type DmCadAssetMappingInstance,
   type DmCadAssetTreeIndexMapping,
   type HybridCadAssetMapping,
-  HybridCadAssetMappingInstance,
+  type HybridCadAssetMappingInstance,
   type HybridCadAssetTreeIndexMapping,
   isClassicCadAssetMapping,
   isClassicCadAssetMappingInstance,

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
@@ -75,7 +75,7 @@ describe('assetMappingTypes', () => {
     });
 
     test('asserts asset mapping to be ClassicCadAssetMapping', () => {
-      const mapping = classicAssetMapping as HybridCadAssetMappingInstance;
+      const mapping = dmAssetMapping as HybridCadAssetMappingInstance;
       assert(isDmCadAssetMappingInstance(mapping));
       expectTypeOf<DmCadAssetMappingInstance>(mapping);
     });

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.test.ts
@@ -1,18 +1,22 @@
 import { describe, expect, expectTypeOf, test } from 'vitest';
 import {
   type ClassicCadAssetMapping,
+  ClassicCadAssetMappingInstance,
   type ClassicCadAssetTreeIndexMapping,
   type DmCadAssetMapping,
+  DmCadAssetMappingInstance,
   type DmCadAssetTreeIndexMapping,
   type HybridCadAssetMapping,
+  HybridCadAssetMappingInstance,
   type HybridCadAssetTreeIndexMapping,
   isClassicCadAssetMapping,
+  isClassicCadAssetMappingInstance,
   isClassicCadAssetTreeIndexMapping,
   isDmCadAssetMapping,
+  isDmCadAssetMappingInstance,
   isDmCadAssetTreeIndexMapping
 } from './assetMappingTypes';
 import assert from 'assert';
-import { type AssetMapping3D } from '@cognite/sdk';
 
 describe('assetMappingTypes', () => {
   const DM_INSTANCE_ID = { externalId: 'externalId', space: 'space' };
@@ -44,6 +48,38 @@ describe('assetMappingTypes', () => {
     treeIndex: TREE_INDEX,
     subtreeSize: SUBTREE_SIZE
   };
+
+  describe(isClassicCadAssetMappingInstance.name, () => {
+    test('recognizes classic asset mapping', () => {
+      expect(isClassicCadAssetMappingInstance({ assetId: ASSET_ID })).toBeTruthy();
+    });
+
+    test('does not accept DM asset mapping', () => {
+      expect(isClassicCadAssetMappingInstance({ instanceId: DM_INSTANCE_ID })).toBeFalsy();
+    });
+
+    test('asserts asset mapping to be ClassicCadAssetMapping', () => {
+      const mapping = classicAssetMapping as HybridCadAssetMappingInstance;
+      assert(isClassicCadAssetMappingInstance(mapping));
+      expectTypeOf<ClassicCadAssetMappingInstance>(mapping);
+    });
+  });
+
+  describe(isDmCadAssetMappingInstance.name, () => {
+    test('recognizes DM asset mapping', () => {
+      expect(isDmCadAssetMappingInstance({ instanceId: DM_INSTANCE_ID })).toBeTruthy();
+    });
+
+    test('rejects classic asset mapping', () => {
+      expect(isDmCadAssetMappingInstance({ assetId: ASSET_ID })).toBeFalsy();
+    });
+
+    test('asserts asset mapping to be ClassicCadAssetMapping', () => {
+      const mapping = classicAssetMapping as HybridCadAssetMappingInstance;
+      assert(isDmCadAssetMappingInstance(mapping));
+      expectTypeOf<DmCadAssetMappingInstance>(mapping);
+    });
+  });
 
   describe(isClassicCadAssetMapping.name, () => {
     test('recognizes classic asset mapping', () => {

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.ts
@@ -1,4 +1,3 @@
-import { type AssetMapping3D, type CogniteInternalId } from '@cognite/sdk';
 import { type AssetId, type CadNodeIdData, type CadNodeTreeData } from '../types';
 import { type DmsUniqueIdentifier } from '../../../data-providers';
 import { type InstanceId } from '../../../utilities/instanceIds';
@@ -20,6 +19,13 @@ export type HybridCadAssetMappingInstance =
   | ClassicCadAssetMappingInstance
   | DmCadAssetMappingInstance;
 
+/**
+ * These are reusable type guards that operate on any type that has an instance reference akin
+ * to the ones in the asset mappings (assetId or instanceId). Ideally, we could have used
+ * only these in place of the more specific ones defined further down in this file (e.g.
+ * `isClassicCadAssetMapping`), but the type checker was e.g. not able to infer the result type to be
+ * `ClassicCadAssetMapping[]` when using this inside a `.filter` on an array of `HybridCadAssetMapping`
+ */
 export function isClassicCadAssetMappingInstance(
   mapping: HybridCadAssetMappingInstance
 ): mapping is ClassicCadAssetMappingInstance {

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.ts
@@ -1,60 +1,62 @@
 import { type AssetMapping3D, type CogniteInternalId } from '@cognite/sdk';
-import { type CadNodeIdData, type CadNodeTreeData } from '../types';
+import { type AssetId, type CadNodeIdData, type CadNodeTreeData } from '../types';
 import { type DmsUniqueIdentifier } from '../../../data-providers';
+import { type InstanceId } from '../../../utilities/instanceIds';
+import { assertNever } from '../../../utilities/assertNever';
+
+/**
+ * Raw CAD instance mapping instance identifier constituents
+ */
+
+export type ClassicCadAssetMappingInstance = {
+  assetId: AssetId;
+};
+
+export type DmCadAssetMappingInstance = {
+  instanceId: DmsUniqueIdentifier;
+};
+
+export type HybridCadAssetMappingInstance =
+  | ClassicCadAssetMappingInstance
+  | DmCadAssetMappingInstance;
+
+export function isClassicCadAssetMappingInstance(
+  mapping: HybridCadAssetMappingInstance
+): mapping is ClassicCadAssetMappingInstance {
+  return 'assetId' in mapping && mapping.assetId !== undefined && !('instanceId' in mapping);
+}
+
+export function isDmCadAssetMappingInstance(
+  mapping: HybridCadAssetMappingInstance
+): mapping is DmCadAssetMappingInstance {
+  return 'instanceId' in mapping && mapping.instanceId !== undefined && !('assetId' in mapping);
+}
 
 /**
  * asset mapping with treeIndex, subtreeSize and nodeId
  */
-export type ClassicCadAssetMapping = CadNodeIdData & {
-  assetId: CogniteInternalId;
-};
-
-export type DmCadAssetMapping = CadNodeIdData & {
-  instanceId: DmsUniqueIdentifier;
-};
+export type ClassicCadAssetMapping = CadNodeIdData & ClassicCadAssetMappingInstance;
+export type DmCadAssetMapping = CadNodeIdData & DmCadAssetMappingInstance;
 
 export type HybridCadAssetMapping = ClassicCadAssetMapping | DmCadAssetMapping;
 
 export function isClassicCadAssetMapping(
-  assetMapping: HybridCadAssetMapping
-): assetMapping is ClassicCadAssetMapping {
-  return (
-    'assetId' in assetMapping &&
-    assetMapping.assetId !== undefined &&
-    !('instanceId' in assetMapping)
-  );
+  mapping: HybridCadAssetMapping
+): mapping is ClassicCadAssetMapping {
+  return isClassicCadAssetMappingInstance(mapping);
 }
 
-export function isDmCadAssetMapping(
-  assetMapping: HybridCadAssetMapping
-): assetMapping is DmCadAssetMapping {
-  return (
-    'instanceId' in assetMapping &&
-    assetMapping.instanceId !== undefined &&
-    !('assetId' in assetMapping)
-  );
-}
-
-/**
- * older asset mappings in the Asset Mappings API may not have treeIndex and subtreeSize.
- * This type guard is used to catch these cases in runtime
- */
-export function isValidClassicCadAssetMapping(
-  assetMapping: AssetMapping3D
-): assetMapping is ClassicCadAssetMapping {
-  return assetMapping.treeIndex !== undefined && assetMapping.subtreeSize !== undefined;
+export function isDmCadAssetAssetMapping(
+  mapping: HybridCadAssetMapping
+): mapping is DmCadAssetMapping {
+  return isDmCadAssetMappingInstance(mapping);
 }
 
 /**
  * asset mapping with treeIndex and subtreeSize only
  */
-export type ClassicCadAssetTreeIndexMapping = CadNodeTreeData & {
-  assetId: CogniteInternalId;
-};
-
-export type DmCadAssetTreeIndexMapping = CadNodeTreeData & {
-  instanceId: DmsUniqueIdentifier;
-};
+export type ClassicCadAssetTreeIndexMapping = CadNodeTreeData & ClassicCadAssetMappingInstance;
+export type DmCadAssetTreeIndexMapping = CadNodeTreeData & DmCadAssetMappingInstance;
 
 export type HybridCadAssetTreeIndexMapping =
   | ClassicCadAssetTreeIndexMapping
@@ -63,11 +65,28 @@ export type HybridCadAssetTreeIndexMapping =
 export function isClassicCadAssetTreeIndexMapping(
   mapping: HybridCadAssetTreeIndexMapping
 ): mapping is ClassicCadAssetTreeIndexMapping {
-  return 'assetId' in mapping && mapping.assetId !== undefined && !('instanceId' in mapping);
+  return isClassicCadAssetMappingInstance(mapping);
 }
 
-export function isDmCadAssetTreeIndexMapping(
+export function isDmCadAssetAssetTreeIndexMapping(
   mapping: HybridCadAssetTreeIndexMapping
 ): mapping is DmCadAssetTreeIndexMapping {
-  return 'instanceId' in mapping && mapping.instanceId !== undefined && !('assetId' in mapping);
+  return isDmCadAssetMappingInstance(mapping);
+}
+
+/**
+ * asset instance key from mapping
+ */
+export function getMappingInstanceId(
+  mappingInstance: ClassicCadAssetMappingInstance | DmCadAssetMappingInstance
+): InstanceId {
+  if (isClassicCadAssetMappingInstance(mappingInstance)) {
+    return mappingInstance.assetId;
+  }
+
+  if (isDmCadAssetMappingInstance(mappingInstance)) {
+    return mappingInstance.instanceId;
+  }
+
+  assertNever(mappingInstance);
 }

--- a/react-components/src/components/CacheProvider/cad/assetMappingTypes.ts
+++ b/react-components/src/components/CacheProvider/cad/assetMappingTypes.ts
@@ -46,9 +46,7 @@ export function isClassicCadAssetMapping(
   return isClassicCadAssetMappingInstance(mapping);
 }
 
-export function isDmCadAssetAssetMapping(
-  mapping: HybridCadAssetMapping
-): mapping is DmCadAssetMapping {
+export function isDmCadAssetMapping(mapping: HybridCadAssetMapping): mapping is DmCadAssetMapping {
   return isDmCadAssetMappingInstance(mapping);
 }
 
@@ -68,7 +66,7 @@ export function isClassicCadAssetTreeIndexMapping(
   return isClassicCadAssetMappingInstance(mapping);
 }
 
-export function isDmCadAssetAssetTreeIndexMapping(
+export function isDmCadAssetTreeIndexMapping(
   mapping: HybridCadAssetTreeIndexMapping
 ): mapping is DmCadAssetTreeIndexMapping {
   return isDmCadAssetMappingInstance(mapping);

--- a/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.test.ts
@@ -7,33 +7,27 @@ describe('raw asset mapping types', () => {
   const INSTANCE_ID = { externalId: 'external-id', space: 'space' };
 
   describe(convertToHybridAssetMapping.name, () => {
-    test('extracts nothing if mapping contains no asset reference', () => {
-      expect(convertToHybridAssetMapping(BASE_ASSET_MAPPING)).toEqual([]);
+    test('extracts nothing if mapping contains no treeIndex/subtreeSize', () => {
+      expect(convertToHybridAssetMapping({ nodeId: 123, assetId: ASSET_ID })).toEqual(undefined);
+      expect(
+        convertToHybridAssetMapping({ nodeId: 123, assetId: ASSET_ID, treeIndex: 234 })
+      ).toEqual(undefined);
+      expect(
+        convertToHybridAssetMapping({ nodeId: 123, assetId: ASSET_ID, subtreeSize: 345 })
+      ).toEqual(undefined);
     });
 
     test('extracts assetId if present', () => {
-      expect(convertToHybridAssetMapping({ ...BASE_ASSET_MAPPING, assetId: ASSET_ID })).toEqual([
-        { ...BASE_ASSET_MAPPING, assetId: ASSET_ID }
-      ]);
+      expect(convertToHybridAssetMapping({ ...BASE_ASSET_MAPPING, assetId: ASSET_ID })).toEqual({
+        ...BASE_ASSET_MAPPING,
+        assetId: ASSET_ID
+      });
     });
 
     test('extracts instanceId if present', () => {
       expect(
         convertToHybridAssetMapping({ ...BASE_ASSET_MAPPING, assetInstanceId: INSTANCE_ID })
-      ).toEqual([{ ...BASE_ASSET_MAPPING, instanceId: INSTANCE_ID }]);
-    });
-
-    test('extracts both assetId and instanceId if both present', () => {
-      expect(
-        convertToHybridAssetMapping({
-          ...BASE_ASSET_MAPPING,
-          assetId: ASSET_ID,
-          assetInstanceId: INSTANCE_ID
-        })
-      ).toEqual([
-        { ...BASE_ASSET_MAPPING, assetId: ASSET_ID },
-        { ...BASE_ASSET_MAPPING, instanceId: INSTANCE_ID }
-      ]);
+      ).toEqual({ ...BASE_ASSET_MAPPING, instanceId: INSTANCE_ID });
     });
   });
 });

--- a/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { extractHybridAssetMappings } from './rawAssetMappingTypes';
+
+describe('raw asset mapping types', () => {
+  const BASE_ASSET_MAPPING = { nodeId: 123, treeIndex: 234, subtreeSize: 345 };
+  const ASSET_ID = 987;
+  const INSTANCE_ID = { externalId: 'external-id', space: 'space' };
+
+  describe(extractHybridAssetMappings.name, () => {
+    test('extracts nothing if mapping contains no asset reference', () => {
+      expect(extractHybridAssetMappings(BASE_ASSET_MAPPING)).toEqual([]);
+    });
+
+    test('extracts assetId if present', () => {
+      expect(extractHybridAssetMappings({ ...BASE_ASSET_MAPPING, assetId: ASSET_ID })).toEqual([
+        { ...BASE_ASSET_MAPPING, assetId: ASSET_ID }
+      ]);
+    });
+
+    test('extracts instanceId if present', () => {
+      expect(
+        extractHybridAssetMappings({ ...BASE_ASSET_MAPPING, assetInstanceId: INSTANCE_ID })
+      ).toEqual([{ ...BASE_ASSET_MAPPING, instanceId: INSTANCE_ID }]);
+    });
+
+    test('extracts both assetId and instanceId if both present', () => {
+      expect(
+        extractHybridAssetMappings({
+          ...BASE_ASSET_MAPPING,
+          assetId: ASSET_ID,
+          assetInstanceId: INSTANCE_ID
+        })
+      ).toEqual([
+        { ...BASE_ASSET_MAPPING, assetId: ASSET_ID },
+        { ...BASE_ASSET_MAPPING, instanceId: INSTANCE_ID }
+      ]);
+    });
+  });
+});

--- a/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.test.ts
+++ b/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.test.ts
@@ -1,31 +1,31 @@
 import { describe, expect, test } from 'vitest';
-import { extractHybridAssetMappings } from './rawAssetMappingTypes';
+import { convertToHybridAssetMapping } from './rawAssetMappingTypes';
 
 describe('raw asset mapping types', () => {
   const BASE_ASSET_MAPPING = { nodeId: 123, treeIndex: 234, subtreeSize: 345 };
   const ASSET_ID = 987;
   const INSTANCE_ID = { externalId: 'external-id', space: 'space' };
 
-  describe(extractHybridAssetMappings.name, () => {
+  describe(convertToHybridAssetMapping.name, () => {
     test('extracts nothing if mapping contains no asset reference', () => {
-      expect(extractHybridAssetMappings(BASE_ASSET_MAPPING)).toEqual([]);
+      expect(convertToHybridAssetMapping(BASE_ASSET_MAPPING)).toEqual([]);
     });
 
     test('extracts assetId if present', () => {
-      expect(extractHybridAssetMappings({ ...BASE_ASSET_MAPPING, assetId: ASSET_ID })).toEqual([
+      expect(convertToHybridAssetMapping({ ...BASE_ASSET_MAPPING, assetId: ASSET_ID })).toEqual([
         { ...BASE_ASSET_MAPPING, assetId: ASSET_ID }
       ]);
     });
 
     test('extracts instanceId if present', () => {
       expect(
-        extractHybridAssetMappings({ ...BASE_ASSET_MAPPING, assetInstanceId: INSTANCE_ID })
+        convertToHybridAssetMapping({ ...BASE_ASSET_MAPPING, assetInstanceId: INSTANCE_ID })
       ).toEqual([{ ...BASE_ASSET_MAPPING, instanceId: INSTANCE_ID }]);
     });
 
     test('extracts both assetId and instanceId if both present', () => {
       expect(
-        extractHybridAssetMappings({
+        convertToHybridAssetMapping({
           ...BASE_ASSET_MAPPING,
           assetId: ASSET_ID,
           assetInstanceId: INSTANCE_ID

--- a/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.ts
+++ b/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.ts
@@ -1,0 +1,82 @@
+import type { DmsUniqueIdentifier } from '../../../data-providers';
+import { isDefined } from '../../../utilities/isDefined';
+import type {
+  ClassicCadAssetMapping,
+  DmCadAssetMapping,
+  HybridCadAssetMapping
+} from './assetMappingTypes';
+
+export type RawCdfHybridCadAssetMappingBase = {
+  nodeId: number;
+  assetId?: number;
+  assetInstanceId?: DmsUniqueIdentifier;
+};
+
+/**
+ * The raw CDF asset mapping type, including DM instance IDs
+ * The AssetMapping3D type defined in the SDK does not cover all variations,
+ * in particular it always requires `assetId` to be defined, but it may be undefined
+ * if `assetInstanceId` is defined
+ */
+
+export type RawCdfHybridCadAssetMapping = RawCdfHybridCadAssetMappingBase & {
+  treeIndex?: number;
+  subtreeSize?: number;
+};
+
+type ValidCdfHybridCadAssetMapping = RawCdfHybridCadAssetMappingBase & {
+  treeIndex: number;
+  subtreeSize: number;
+};
+
+/**
+ * older asset mappings in the Asset Mappings API may not have treeIndex and subtreeSize.
+ * This type guard is used to catch these cases in runtime
+ */
+function isValidCdfHybridCadAssetMapping(
+  assetMapping: RawCdfHybridCadAssetMapping
+): assetMapping is ValidCdfHybridCadAssetMapping {
+  return assetMapping.treeIndex !== undefined && assetMapping.subtreeSize !== undefined;
+}
+
+export function extractHybridAssetMappings(
+  rawAssetMapping: RawCdfHybridCadAssetMapping
+): HybridCadAssetMapping[] {
+  if (!isValidCdfHybridCadAssetMapping(rawAssetMapping)) {
+    return [];
+  }
+
+  return [
+    extractClassicAssetMapping(rawAssetMapping),
+    extractDmAssetMapping(rawAssetMapping)
+  ].filter(isDefined);
+}
+
+function extractClassicAssetMapping(
+  validAssetMapping: ValidCdfHybridCadAssetMapping
+): ClassicCadAssetMapping | undefined {
+  if (validAssetMapping.assetId === undefined) {
+    return undefined;
+  }
+  return {
+    nodeId: validAssetMapping.nodeId,
+    treeIndex: validAssetMapping.treeIndex,
+    subtreeSize: validAssetMapping.subtreeSize,
+    assetId: validAssetMapping.assetId
+  };
+}
+
+function extractDmAssetMapping(
+  validAssetMapping: ValidCdfHybridCadAssetMapping
+): DmCadAssetMapping | undefined {
+  if (validAssetMapping.assetInstanceId === undefined) {
+    return undefined;
+  }
+
+  return {
+    nodeId: validAssetMapping.nodeId,
+    treeIndex: validAssetMapping.treeIndex,
+    subtreeSize: validAssetMapping.subtreeSize,
+    instanceId: validAssetMapping.assetInstanceId
+  };
+}

--- a/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.ts
+++ b/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.ts
@@ -1,11 +1,6 @@
 import type { DmsUniqueIdentifier } from '../../../data-providers';
-import { isDefined } from '../../../utilities/isDefined';
-import { AssetId, NodeId, TreeIndex } from '../types';
-import type {
-  ClassicCadAssetMapping,
-  DmCadAssetMapping,
-  HybridCadAssetMapping
-} from './assetMappingTypes';
+import { type AssetId, type NodeId, type TreeIndex } from '../types';
+import type { HybridCadAssetMapping } from './assetMappingTypes';
 
 /**
  * The raw CDF asset mapping type, including DM instance IDs

--- a/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.ts
+++ b/react-components/src/components/CacheProvider/cad/rawAssetMappingTypes.ts
@@ -64,45 +64,28 @@ function isRawDmAssetMappingInstance(
   );
 }
 
-export function extractHybridAssetMappings(
+export function convertToHybridAssetMapping(
   rawAssetMapping: RawCdfHybridCadAssetMapping
-): HybridCadAssetMapping[] {
+): HybridCadAssetMapping | undefined {
   if (!isValidCdfHybridCadAssetMapping(rawAssetMapping)) {
-    return [];
-  }
-
-  return [
-    extractClassicAssetMapping(rawAssetMapping),
-    extractDmAssetMapping(rawAssetMapping)
-  ].filter(isDefined);
-}
-
-function extractClassicAssetMapping(
-  validAssetMapping: ValidCdfHybridCadAssetMapping
-): ClassicCadAssetMapping | undefined {
-  if (!isRawClassicAssetMappingInstance(validAssetMapping)) {
     return undefined;
   }
 
-  return {
-    nodeId: validAssetMapping.nodeId,
-    treeIndex: validAssetMapping.treeIndex,
-    subtreeSize: validAssetMapping.subtreeSize,
-    assetId: validAssetMapping.assetId
-  };
-}
-
-function extractDmAssetMapping(
-  validAssetMapping: ValidCdfHybridCadAssetMapping
-): DmCadAssetMapping | undefined {
-  if (!isRawDmAssetMappingInstance(validAssetMapping)) {
-    return undefined;
+  if (isRawClassicAssetMappingInstance(rawAssetMapping)) {
+    return {
+      nodeId: rawAssetMapping.nodeId,
+      treeIndex: rawAssetMapping.treeIndex,
+      subtreeSize: rawAssetMapping.subtreeSize,
+      assetId: rawAssetMapping.assetId
+    };
   }
 
-  return {
-    nodeId: validAssetMapping.nodeId,
-    treeIndex: validAssetMapping.treeIndex,
-    subtreeSize: validAssetMapping.subtreeSize,
-    instanceId: validAssetMapping.assetInstanceId
-  };
+  if (isRawDmAssetMappingInstance(rawAssetMapping)) {
+    return {
+      nodeId: rawAssetMapping.nodeId,
+      treeIndex: rawAssetMapping.treeIndex,
+      subtreeSize: rawAssetMapping.subtreeSize,
+      instanceId: rawAssetMapping.assetInstanceId
+    };
+  }
 }

--- a/react-components/src/components/CacheProvider/cad/types.ts
+++ b/react-components/src/components/CacheProvider/cad/types.ts
@@ -1,0 +1,1 @@
+export type HybridCadCacheIndexType = 'nodeIds' | 'assetIds';

--- a/react-components/src/components/CacheProvider/idAndKeyTranslation.test.ts
+++ b/react-components/src/components/CacheProvider/idAndKeyTranslation.test.ts
@@ -4,8 +4,9 @@ import {
   createInstanceKey,
   createModelRevisionKey,
   createModelTreeIndexKey,
-  modelRevisionNodesAssetToKey,
-  revisionKeyToIds
+  createModelInstanceIdKey,
+  revisionKeyToIds,
+  createModelNodeIdKey
 } from './idAndKeyTranslation';
 
 describe('idAndKeyTranslation', () => {
@@ -13,6 +14,7 @@ describe('idAndKeyTranslation', () => {
   const REVISION_ID = 456;
   const INSTANCE = { externalId: 'externalId', space: 'space' };
   const ASSET_ID = 765;
+  const NODE_ID = 654;
 
   describe(createModelRevisionKey.name, () => {
     test('concatenates model and revision into key', () => {
@@ -60,10 +62,18 @@ describe('idAndKeyTranslation', () => {
     });
   });
 
-  describe(modelRevisionNodesAssetToKey.name, () => {
+  describe(createModelInstanceIdKey.name, () => {
     test('concatenates model ID, revision ID and asset ID into key', () => {
-      expect(modelRevisionNodesAssetToKey(MODEL_ID, REVISION_ID, ASSET_ID)).toBe(
+      expect(createModelInstanceIdKey(MODEL_ID, REVISION_ID, ASSET_ID)).toBe(
         `${MODEL_ID}/${REVISION_ID}/${ASSET_ID}`
+      );
+    });
+  });
+
+  describe(createModelNodeIdKey.name, () => {
+    test('concatenates model ID, revision ID and node ID into key', () => {
+      expect(createModelNodeIdKey(MODEL_ID, REVISION_ID, NODE_ID)).toBe(
+        `${MODEL_ID}/${REVISION_ID}/${NODE_ID}`
       );
     });
   });

--- a/react-components/src/components/CacheProvider/idAndKeyTranslation.ts
+++ b/react-components/src/components/CacheProvider/idAndKeyTranslation.ts
@@ -8,8 +8,9 @@ import {
   type TreeIndex,
   type RevisionId,
   type ModelId,
-  type ModelAssetIdKey,
-  type AssetId
+  type ModelInstanceIdKey,
+  type NodeId,
+  type ModelNodeIdKey
 } from './types';
 
 import { split } from 'lodash';
@@ -21,14 +22,6 @@ export function createModelRevisionKey(modelId: ModelId, revisionId: RevisionId)
 export function revisionKeyToIds(revisionKey: ModelRevisionKey): [ModelId, RevisionId] {
   const components = split(revisionKey, '/');
   return [Number(components[0]), Number(components[1])];
-}
-
-export function createModelTreeIndexKey(
-  modelId: ModelId,
-  revisionId: RevisionId,
-  treeIndex: TreeIndex
-): ModelTreeIndexKey {
-  return `${modelId}/${revisionId}/${treeIndex}`;
 }
 
 export function createFdmKey(id: DmsUniqueIdentifier): FdmKey {
@@ -43,10 +36,26 @@ export function createInstanceKey(id: InstanceId): InstanceKey {
   }
 }
 
-export function modelRevisionNodesAssetToKey(
+export function createModelTreeIndexKey(
   modelId: ModelId,
   revisionId: RevisionId,
-  id: AssetId
-): ModelAssetIdKey {
+  treeIndex: TreeIndex
+): ModelTreeIndexKey {
+  return `${modelId}/${revisionId}/${treeIndex}`;
+}
+
+export function createModelInstanceIdKey(
+  modelId: ModelId,
+  revisionId: RevisionId,
+  id: InstanceKey
+): ModelInstanceIdKey {
+  return `${modelId}/${revisionId}/${id}`;
+}
+
+export function createModelNodeIdKey(
+  modelId: ModelId,
+  revisionId: RevisionId,
+  id: NodeId
+): ModelNodeIdKey {
   return `${modelId}/${revisionId}/${id}`;
 }

--- a/react-components/src/components/CacheProvider/types.ts
+++ b/react-components/src/components/CacheProvider/types.ts
@@ -8,6 +8,7 @@ import { type Source, type DmsUniqueIdentifier } from '../../data-providers/FdmS
 import { type AssetAnnotationImage360Info, type DataSourceType } from '@cognite/reveal';
 import { type Vector3 } from 'three';
 import { type AssetInstance } from '../../utilities/instances';
+import { type InstanceKey } from '../../utilities/instanceIds';
 
 export type FdmCadConnection = {
   instance: DmsUniqueIdentifier;
@@ -59,8 +60,13 @@ export type ModelRevisionId = { modelId: number; revisionId: number };
 
 export type ModelRevisionKey = `${ModelId}/${RevisionId}`;
 export type FdmKey = `${string}/${string}`;
+
 export type ModelTreeIndexKey = `${ModelId}/${RevisionId}/${TreeIndex}`;
+export type ModelNodeIdKey = `${ModelId}/${RevisionId}/${NodeId}`;
 export type ModelAssetIdKey = `${ModelId}/${RevisionId}/${AssetId}`;
+export type ModelFdmIdKey = `${ModelId}/${RevisionId}/${FdmKey}`;
+
+export type ModelInstanceIdKey = ModelAssetIdKey | ModelFdmIdKey;
 
 export type ModelRevisionToConnectionMap = Map<ModelRevisionKey, FdmConnectionWithNode[]>;
 
@@ -78,9 +84,9 @@ export type Image360AnnotationAssetInfo = {
 
 export type AnnotationId = number;
 
-export type ChunkInCacheTypes<ObjectType> = {
+export type ChunkInCacheTypes<ObjectType, KeyType extends InstanceKey> = {
   chunkInCache: ObjectType[];
-  chunkNotInCache: number[];
+  chunkNotInCache: KeyType[];
 };
 
 type PointCloudVolume = {

--- a/react-components/src/components/CacheProvider/types.ts
+++ b/react-components/src/components/CacheProvider/types.ts
@@ -84,7 +84,7 @@ export type Image360AnnotationAssetInfo = {
 
 export type AnnotationId = number;
 
-export type ChunkInCacheTypes<ObjectType, KeyType extends InstanceKey> = {
+export type ChunkInCacheTypes<ObjectType, KeyType extends InstanceKey | NodeId> = {
   chunkInCache: ObjectType[];
   chunkNotInCache: KeyType[];
 };

--- a/react-components/src/components/RuleBasedOutputs/RuleBasedOutputsSelector.tsx
+++ b/react-components/src/components/RuleBasedOutputs/RuleBasedOutputsSelector.tsx
@@ -20,7 +20,10 @@ import { useExtractTimeseriesIdsFromRuleSet } from './hooks/useExtractTimeseries
 import { useAll3dDirectConnectionsWithProperties } from '../../query/useAll3dDirectConnectionsWithProperties';
 import { useAssetMappedNodesForRevisions, useMappedEdgesForRevisions } from '../../hooks/cad';
 import { generateRuleBasedOutputs } from './core/generateRuleBasedOutputs';
-import { type ClassicCadAssetMapping } from '../CacheProvider/cad/assetMappingTypes';
+import {
+  isClassicCadAssetMapping,
+  type ClassicCadAssetMapping
+} from '../CacheProvider/cad/assetMappingTypes';
 
 const ruleSetStylingCache = new Map<string, AllMappingStylingGroupAndStyleIndex[]>();
 
@@ -116,7 +119,7 @@ export function RuleBasedOutputsSelector({
           if (flatAssetsMappingsList.length === 0 && fdmMappings?.length === 0) return [];
 
           const mappingsStylings = await initializeRuleBasedOutputs({
-            assetMappings: flatAssetsMappingsList,
+            assetMappings: flatAssetsMappingsList.filter(isClassicCadAssetMapping),
             fdmMappings: fdmMappings ?? [],
             contextualizedAssetNodes,
             ruleSet,

--- a/react-components/src/components/RuleBasedOutputs/RuleBasedOutputsSelector.tsx
+++ b/react-components/src/components/RuleBasedOutputs/RuleBasedOutputsSelector.tsx
@@ -14,7 +14,7 @@ import { useAssetsAndTimeseriesLinkageDataQuery } from '../../query/useAssetsAnd
 import { type CadModelOptions } from '../Reveal3DResources/types';
 import { useAssetsByIdsQuery } from '../../query/useAssetsByIdsQuery';
 import { useCreateAssetMappingsMapPerModel } from '../../hooks/useCreateAssetMappingsMapPerModel';
-import { useExtractUniqueAssetIdsFromMapped } from './hooks/useExtractUniqueAssetIdsFromMapped';
+import { useExtractUniqueClassicAssetIdsFromMapped } from './hooks/useExtractUniqueClassicAssetIdsFromMapped';
 import { useConvertAssetMetadatasToLowerCase } from './hooks/useConvertAssetMetadatasToLowerCase';
 import { useExtractTimeseriesIdsFromRuleSet } from './hooks/useExtractTimeseriesIdsFromRuleSet';
 import { useAll3dDirectConnectionsWithProperties } from '../../query/useAll3dDirectConnectionsWithProperties';
@@ -53,7 +53,7 @@ export function RuleBasedOutputsSelector({
   const { data: assetMappings, isLoading: isAssetMappingsLoading } =
     useAssetMappedNodesForRevisions(cadModels);
 
-  const assetIdsFromMapped = useExtractUniqueAssetIdsFromMapped(assetMappings);
+  const assetIdsFromMapped = useExtractUniqueClassicAssetIdsFromMapped(assetMappings);
 
   const {
     data: mappedAssets,

--- a/react-components/src/components/RuleBasedOutputs/hooks/useExtractUniqueAssetIdsFromMapped.tsx
+++ b/react-components/src/components/RuleBasedOutputs/hooks/useExtractUniqueAssetIdsFromMapped.tsx
@@ -3,6 +3,7 @@ import { type ModelWithAssetMappings } from '../../../hooks/cad/modelWithAssetMa
 import { useMemo } from 'react';
 import { uniqBy } from 'lodash';
 import { isDefined } from '../../../utilities/isDefined';
+import { isClassicCadAssetMapping } from '../../CacheProvider/cad/assetMappingTypes';
 
 export const useExtractUniqueAssetIdsFromMapped = (
   assetMappings: ModelWithAssetMappings[] | undefined
@@ -10,6 +11,7 @@ export const useExtractUniqueAssetIdsFromMapped = (
   return useMemo(() => {
     const mappings = assetMappings?.map((item) => item.assetMappings).flat() ?? [];
     const assetIds: InternalId[] = mappings
+      .filter(isClassicCadAssetMapping)
       .flatMap((item) => {
         return {
           id: item.assetId

--- a/react-components/src/components/RuleBasedOutputs/hooks/useExtractUniqueClassicAssetIdsFromMapped.tsx
+++ b/react-components/src/components/RuleBasedOutputs/hooks/useExtractUniqueClassicAssetIdsFromMapped.tsx
@@ -5,7 +5,7 @@ import { uniqBy } from 'lodash';
 import { isDefined } from '../../../utilities/isDefined';
 import { isClassicCadAssetMapping } from '../../CacheProvider/cad/assetMappingTypes';
 
-export const useExtractUniqueAssetIdsFromMapped = (
+export const useExtractUniqueClassicAssetIdsFromMapped = (
   assetMappings: ModelWithAssetMappings[] | undefined
 ): InternalId[] => {
   return useMemo(() => {

--- a/react-components/src/hooks/cad/modelWithAssetMappings.ts
+++ b/react-components/src/hooks/cad/modelWithAssetMappings.ts
@@ -1,15 +1,15 @@
 import { type CadModelOptions } from '../../components/Reveal3DResources/types';
 import {
-  type ClassicCadAssetTreeIndexMapping,
-  type ClassicCadAssetMapping
+  type HybridCadAssetMapping,
+  type HybridCadAssetTreeIndexMapping
 } from '../../components/CacheProvider/cad/assetMappingTypes';
 
 export type ModelWithAssetMappings = {
   model: CadModelOptions;
-  assetMappings: ClassicCadAssetMapping[];
+  assetMappings: HybridCadAssetMapping[];
 };
 
 export type ModelWithAssetTreeIndexMappings = {
   model: CadModelOptions;
-  assetMappings: ClassicCadAssetTreeIndexMapping[];
+  assetMappings: HybridCadAssetTreeIndexMapping[];
 };

--- a/react-components/src/hooks/useCreateAssetMappingsMapPerModel.tsx
+++ b/react-components/src/hooks/useCreateAssetMappingsMapPerModel.tsx
@@ -2,14 +2,14 @@ import { CogniteCadModel, type CogniteModel, type DataSourceType } from '@cognit
 import { useMemo } from 'react';
 import { type ModelWithAssetMappings } from './cad/modelWithAssetMappings';
 import { isDefined } from '../utilities/isDefined';
-import { type ClassicCadAssetMapping } from '../components/CacheProvider/cad/assetMappingTypes';
+import { type HybridCadAssetMapping } from '../components/CacheProvider/cad/assetMappingTypes';
 
 export const useCreateAssetMappingsMapPerModel = (
   models: Array<CogniteModel<DataSourceType>>,
   assetMappings: ModelWithAssetMappings[] | undefined
-): Map<CogniteCadModel, ClassicCadAssetMapping[] | undefined> => {
+): Map<CogniteCadModel, HybridCadAssetMapping[] | undefined> => {
   return useMemo(() => {
-    const mappingsPerModel = new Map<CogniteCadModel, ClassicCadAssetMapping[] | undefined>();
+    const mappingsPerModel = new Map<CogniteCadModel, HybridCadAssetMapping[] | undefined>();
     models.forEach((model) => {
       if (!(model instanceof CogniteCadModel)) {
         return;

--- a/react-components/src/query/network/searchClassicCadAssetsWithFilters.ts
+++ b/react-components/src/query/network/searchClassicCadAssetsWithFilters.ts
@@ -31,7 +31,9 @@ export async function searchClassicCadAssetsWithFilters(
 
   const mapped3dAssetIds = new Set(
     assetMappingList.flatMap((mapping) =>
-      mapping.assetMappings.map((assetMapping) => assetMapping.assetId)
+      mapping.assetMappings
+        .filter(isClassicCadAssetTreeIndexMapping)
+        .map((assetMapping) => assetMapping.assetId)
     )
   );
 

--- a/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
+++ b/react-components/src/query/useSearchMappedEquipmentAssetMappings.tsx
@@ -17,6 +17,7 @@ import { useAssetMappedNodesForRevisions } from '../hooks/cad';
 import { useMemo } from 'react';
 import { getAssetsFromAssetMappings } from './network/getAssetsFromAssetMappings';
 import { buildClassicAssetQueryFilter } from './network/buildClassicAssetFilter';
+import { isClassicCadAssetMapping } from '../components/CacheProvider/cad/assetMappingTypes';
 
 export type ModelMappings = {
   model: AddModelOptions;
@@ -51,7 +52,9 @@ export const useSearchMappedEquipmentAssetMappings = (
     if (assetMappingList === undefined) return new Set<number>();
     return new Set(
       assetMappingList.flatMap((mapping) =>
-        mapping.assetMappings.map((assetMapping) => assetMapping.assetId)
+        mapping.assetMappings
+          .filter(isClassicCadAssetMapping)
+          .map((assetMapping) => assetMapping.assetId)
       )
     );
   }, [assetMappingList]);

--- a/react-components/tests/tests-utilities/fixtures/sdk.ts
+++ b/react-components/tests/tests-utilities/fixtures/sdk.ts
@@ -6,7 +6,9 @@ import {
   type HttpRequestOptions,
   type AssetMappings3DAPI,
   type Nodes3DAPI,
-  type Revisions3DAPI
+  type Revisions3DAPI,
+  type CursorAndAsyncIterator,
+  type AssetMapping3D
 } from '@cognite/sdk';
 import { vi } from 'vitest';
 import { type AssetProperties } from '../../../src/data-providers/core-dm-provider/utils/filters';
@@ -29,12 +31,12 @@ export const retrieveMock = vi.fn<AssetsAPI['retrieve']>(async (assetIds) => {
   );
 });
 
-export const assetMappings3DListMock = vi.fn<AssetMappings3DAPI['list']>(() =>
-  createCursorAndAsyncIteratorMock({ items: [] })
+export const assetMappings3DListMock = vi.fn<AssetMappings3DAPI['list']>(
+  (): CursorAndAsyncIterator<AssetMapping3D> => createCursorAndAsyncIteratorMock({ items: [] })
 );
 
-export const assetMappings3DFilterMock = vi.fn<AssetMappings3DAPI['filter']>(() =>
-  createCursorAndAsyncIteratorMock({ items: [] })
+export const assetMappings3DFilterMock = vi.fn<AssetMappings3DAPI['filter']>(
+  (): CursorAndAsyncIterator<AssetMapping3D> => createCursorAndAsyncIteratorMock({ items: [] })
 );
 
 export const nodes3dRetrieveMock = vi.fn<Nodes3DAPI['retrieve']>(

--- a/react-components/tests/tests-utilities/fixtures/sdk.ts
+++ b/react-components/tests/tests-utilities/fixtures/sdk.ts
@@ -4,7 +4,11 @@ import {
   type CogniteClient,
   type HttpResponse,
   type HttpRequestOptions,
-  type AssetMappings3DAPI
+  type AssetMappings3DAPI,
+  AssetMappings3DListFilter,
+  Revision3D,
+  Nodes3DAPI,
+  Revisions3DAPI
 } from '@cognite/sdk';
 import { vi } from 'vitest';
 import { type AssetProperties } from '../../../src/data-providers/core-dm-provider/utils/filters';
@@ -27,9 +31,15 @@ export const retrieveMock = vi.fn<AssetsAPI['retrieve']>(async (assetIds) => {
   );
 });
 
-export const assetMappings3DListMock = vi.fn<AssetMappings3DAPI['list']>(
-  async () => await createCursorAndAsyncIteratorMock({ items: [] })
+export const assetMappings3DListMock = vi.fn<AssetMappings3DAPI['list']>(() =>
+  createCursorAndAsyncIteratorMock({ items: [] })
 );
+
+export const assetMappings3DFilterMock = vi.fn<AssetMappings3DAPI['filter']>(() =>
+  createCursorAndAsyncIteratorMock({ items: [] })
+);
+
+export const nodes3dRetrieveMock = vi.fn<Nodes3DAPI['retrieve']>(() => Promise.resolve([]));
 
 export const postMock = vi.fn<
   (
@@ -84,6 +94,13 @@ export const assetRetrieveMock = new Mock<AssetsAPI>()
 export const assetMappingsMock = new Mock<AssetMappings3DAPI>()
   .setup((p) => p.list)
   .returns(assetMappings3DListMock)
+  .setup((p) => p.filter)
+  .returns(assetMappings3DFilterMock)
+  .object();
+
+export const revisions3dMock = new Mock<Revisions3DAPI>()
+  .setup((p) => p.retrieve3DNodes)
+  .returns(nodes3dRetrieveMock)
   .object();
 
 export const sdkMock = new Mock<CogniteClient>()
@@ -95,6 +112,8 @@ export const sdkMock = new Mock<CogniteClient>()
   .returns(assetRetrieveMock)
   .setup((p) => p.assetMappings3D)
   .returns(assetMappingsMock)
+  .setup((p) => p.revisions3D)
+  .returns(revisions3dMock)
   .setup((p) => p.post)
   .returns(postMock as <T>(path: string, options?: HttpRequestOptions) => Promise<HttpResponse<T>>)
   .setup((p) => p.models3D.retrieve)

--- a/react-components/tests/tests-utilities/fixtures/sdk.ts
+++ b/react-components/tests/tests-utilities/fixtures/sdk.ts
@@ -3,7 +3,8 @@ import {
   type AssetsAPI,
   type CogniteClient,
   type HttpResponse,
-  type HttpRequestOptions
+  type HttpRequestOptions,
+  type AssetMappings3DAPI
 } from '@cognite/sdk';
 import { vi } from 'vitest';
 import { type AssetProperties } from '../../../src/data-providers/core-dm-provider/utils/filters';
@@ -12,6 +13,7 @@ import {
   type ExternalIdsResultList,
   type NodeItem
 } from '../../../src/data-providers/FdmSDK';
+import { createCursorAndAsyncIteratorMock } from './cursorAndIterator';
 
 export const retrieveMock = vi.fn<AssetsAPI['retrieve']>(async (assetIds) => {
   return await Promise.resolve(
@@ -24,6 +26,10 @@ export const retrieveMock = vi.fn<AssetsAPI['retrieve']>(async (assetIds) => {
     }))
   );
 });
+
+export const assetMappings3DListMock = vi.fn<AssetMappings3DAPI['list']>(
+  async () => await createCursorAndAsyncIteratorMock({ items: [] })
+);
 
 export const postMock = vi.fn<
   (
@@ -75,6 +81,11 @@ export const assetRetrieveMock = new Mock<AssetsAPI>()
   .returns(retrieveMock)
   .object();
 
+export const assetMappingsMock = new Mock<AssetMappings3DAPI>()
+  .setup((p) => p.list)
+  .returns(assetMappings3DListMock)
+  .object();
+
 export const sdkMock = new Mock<CogniteClient>()
   .setup((p) => p.getBaseUrl())
   .returns('https://api.cognitedata.com')
@@ -82,6 +93,8 @@ export const sdkMock = new Mock<CogniteClient>()
   .returns('test-project')
   .setup((p) => p.assets)
   .returns(assetRetrieveMock)
+  .setup((p) => p.assetMappings3D)
+  .returns(assetMappingsMock)
   .setup((p) => p.post)
   .returns(postMock as <T>(path: string, options?: HttpRequestOptions) => Promise<HttpResponse<T>>)
   .setup((p) => p.models3D.retrieve)

--- a/react-components/tests/tests-utilities/fixtures/sdk.ts
+++ b/react-components/tests/tests-utilities/fixtures/sdk.ts
@@ -5,10 +5,8 @@ import {
   type HttpResponse,
   type HttpRequestOptions,
   type AssetMappings3DAPI,
-  AssetMappings3DListFilter,
-  Revision3D,
-  Nodes3DAPI,
-  Revisions3DAPI
+  type Nodes3DAPI,
+  type Revisions3DAPI
 } from '@cognite/sdk';
 import { vi } from 'vitest';
 import { type AssetProperties } from '../../../src/data-providers/core-dm-provider/utils/filters';
@@ -39,7 +37,9 @@ export const assetMappings3DFilterMock = vi.fn<AssetMappings3DAPI['filter']>(() 
   createCursorAndAsyncIteratorMock({ items: [] })
 );
 
-export const nodes3dRetrieveMock = vi.fn<Nodes3DAPI['retrieve']>(() => Promise.resolve([]));
+export const nodes3dRetrieveMock = vi.fn<Nodes3DAPI['retrieve']>(
+  async () => await Promise.resolve([])
+);
 
 export const postMock = vi.fn<
   (


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

Closes https://cognitedata.atlassian.net/browse/BND3D-4989

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Changes the classic CAD cache to also handle hybrid asset mappings; asset mappings that may contain DMS IDs in addition to / instead of classic asset IDs.

All changes:
- Introduced `rawAssetMappingTypes.ts` which defines the bridging between asset mappings from the CDF API and our internal types. It provides a more accurate CDF asset mapping type (where `assetId` is optional) and translation functions
- Refactored `assetMappingTypes` with reusable typeguards operating on wider types, used by the other type guards in the file. Also added a utility for getting the instance from an asset mapping.
- Renamed and added another model-key utility in `idAndKeyTranslation`
- Renamed `getNodesForAssetIds` on the `CadInstanceMappingsCache` to `getNodesForInstanceIds`
- Replaced `FdmKey | AssetId` with `InstanceKey` and `AssetId | DmsUniqueIdentifier` with `InstanceId` a few places (they are equivalent)
-  Added a type `HybridCadCacheIndexType = 'nodeIds' | 'assetIds'`, which is used some places for internal caches
- Changed types inside the `ClassicCadAssetMappingCacheImpl` class and related classes to accomodate hybrid instances. This involves replacing `AssetId` by `InstanceKey` a few places, with relevant transformations. 
- Actually ensure that we fetch hybrid asset mappings, by passing `getDmsInstances: true` to the asset mappings list endpoint
- Filtered away non-classic mappings a couple of places where we use the cache directly (and kept notes on these places)

Note that we don't have full feature parity with the classic asset mappings, since the backend does not (yet) support lookups of asset mappings with model/revision ID + DM instance ID, as it does with model/revision ID + classic asset ID. The upcoming front-end work to accomodate this is tracked here: https://cognitedata.atlassian.net/browse/BND3D-5837

I have also added a few more points to the issue https://cognitedata.atlassian.net/browse/BND3D-5836, noting places where we intentionally filter out hybrid mappings in order to appease the type checker. These will be fixed when the corresponding end-features are implemented.

There are no expected functional change from this PR. The functional changes will be introduced when each feature depending on this cache is addressed individually.

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
