### PR TITLE
fix(react-components): 360 image DM annotation on click selection

### DIFF
--- a/react-components/src/components/CacheProvider/Image360AnnotationCache.test.ts
+++ b/react-components/src/components/CacheProvider/Image360AnnotationCache.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Image360AnnotationCache } from './Image360AnnotationCache';
+import { type CogniteClient } from '@cognite/sdk';
+import { type InstanceReference } from '../../utilities/instanceIds';
+import { type Image360Collection } from '@cognite/reveal';
+
+function createMockViewer(collections: any[] = []) {
+  return {
+    get360ImageCollections: vi.fn(() => collections)
+  };
+}
+
+function createMockCollection(id: string, annotations: any[] = []) {
+  return {
+    id,
+    findImageAnnotations: vi.fn().mockResolvedValue(annotations)
+  };
+}
+
+const mockSdk = {} as CogniteClient;
+const mockAsset = { id: 'asset1' };
+const mockAssetInstance: InstanceReference = { id: 'asset1' };
+
+describe('Image360AnnotationCache', () => {
+  let cache: Image360AnnotationCache;
+  let mockViewer: any;
+  let mockCollection: any;
+
+  beforeEach(() => {
+    mockCollection = createMockCollection('site1', [
+      { annotation: { annotation: { id: 'ann1' }, getCenter: () => ({ applyMatrix4: vi.fn(() => ({})) }) }, image: { transform: {} } }
+    ]);
+    mockViewer = createMockViewer([mockCollection]);
+    cache = new Image360AnnotationCache(mockSdk, mockViewer);
+  });
+
+  it('returns empty array if viewer is undefined', async () => {
+    const cacheNoViewer = new Image360AnnotationCache(mockSdk, undefined);
+    const result = await cacheNoViewer.getReveal360AnnotationsForAssets(['site1'], [mockAssetInstance]);
+    expect(result).toEqual([]);
+  });
+
+  it('returns cached result if available', async () => {
+    const key = [mockAssetInstance].map(a => a.id).sort().join();
+    (cache as any)._annotationToAssetMappingsWithAssetInstance.set(key, ['cached']);
+    const result = await cache.getReveal360AnnotationsForAssets(['site1'], [mockAssetInstance]);
+    expect(result).toEqual(['cached']);
+  });
+
+  it('fetches and maps annotations', async () => {
+    // Mock fetchAssetsForAssetReferences to return the asset
+    vi.mock('./annotationModelUtils', () => ({
+      fetchAssetsForAssetReferences: vi.fn().mockResolvedValue([mockAsset])
+    }));
+
+    const result = await cache.getReveal360AnnotationsForAssets(['site1'], [mockAssetInstance]);
+    expect(Array.isArray(result)).toBe(true);
+    expect(mockCollection.findImageAnnotations).toHaveBeenCalled();
+  });
+});

--- a/react-components/src/components/CacheProvider/Image360AnnotationCache.ts
+++ b/react-components/src/components/CacheProvider/Image360AnnotationCache.ts
@@ -2,15 +2,13 @@ import { type CogniteClient } from '@cognite/sdk';
 import { type Image360AnnotationAssetInfo } from './types';
 import {
   getAssetIdKeyForImage360Annotation,
-  getInstanceReferenceFromImage360Annotation,
-  getIdKeyForImage360Annotation
+  getInstanceReferenceFromImage360Annotation
 } from './utils';
 import {
   type DataSourceType,
-  type AssetAnnotationImage360Info,
   type Cognite3DViewer,
   type Image360Collection,
-  type Image360Annotation
+  type Image360AnnotationAssetQueryResult
 } from '@cognite/reveal';
 import { fetchAssetsForAssetReferences } from './annotationModelUtils';
 import { isDefined } from '../../utilities/isDefined';
@@ -19,90 +17,116 @@ import { type InstanceReference } from '../../utilities/instanceIds';
 import { createInstanceReferenceKey } from '../../utilities/instanceIds/toKey';
 import { uniqBy } from 'lodash';
 import { type AssetInstance } from '../../utilities/instances';
-import { type Vector3 } from 'three';
 
 export class Image360AnnotationCache {
   private readonly _sdk: CogniteClient;
   private readonly _viewer: Cognite3DViewer<DataSourceType> | undefined;
-  private readonly _annotationToAssetMappings = new Map<string, Image360AnnotationAssetInfo[]>();
+  private readonly _annotationToAssetMappingsWithAssetInstance = new Map<
+    string,
+    Image360AnnotationAssetInfo[]
+  >();
 
   constructor(sdk: CogniteClient, viewer: Cognite3DViewer<DataSourceType> | undefined) {
     this._sdk = sdk;
     this._viewer = viewer;
   }
 
-  public async getReveal360Annotations(siteIds: string[]): Promise<Image360AnnotationAssetInfo[]> {
-    const key = siteIds.sort().join();
-    const cachedResult = this._annotationToAssetMappings.get(key);
-
-    if (cachedResult !== undefined) {
-      return cachedResult;
-    }
-
-    const annotationAssets = await this.getReveal360AnnotationInfo();
-    if (annotationAssets.length === 0) {
-      return [];
-    }
-    this._annotationToAssetMappings.set(key, annotationAssets);
-
-    return annotationAssets;
-  }
-
-  private async getReveal360AnnotationInfo(): Promise<Image360AnnotationAssetInfo[]> {
+  public async getReveal360AnnotationsForAssets(
+    siteIds: string[],
+    assetInstances: InstanceReference[]
+  ): Promise<Image360AnnotationAssetInfo[]> {
     if (this._viewer === undefined) {
       return [];
     }
     const image360Collections = this._viewer.get360ImageCollections();
 
-    const annotationsInfoPromise = await Promise.all(
-      image360Collections.map(async (image360Collection: Image360Collection<DataSourceType>) => {
-        return await image360Collection.getAnnotationsInfo('all');
-      })
-    );
-
-    const annotationsInfo = annotationsInfoPromise.flat();
-
-    const assetIds = new Array<InstanceReference>();
-    annotationsInfo.forEach((annotation) => {
-      const assetRef = getInstanceReferenceFromImage360Annotation(annotation.annotationInfo);
-      if (assetRef !== undefined) {
-        assetIds.push(assetRef);
-      }
+    const filteredImageCollections = image360Collections.filter((image360Collections) => {
+      return siteIds.includes(image360Collections.id);
     });
 
+    const key = assetInstances.map(createInstanceReferenceKey).sort().join();
+    const cachedResult = this._annotationToAssetMappingsWithAssetInstance.get(key);
+
+    if (cachedResult !== undefined) {
+      return cachedResult;
+    }
+
+    const annotationAssets = await this.getReveal360AnnotationInfoForAssets(
+      assetInstances,
+      filteredImageCollections
+    );
+    if (annotationAssets.length === 0) {
+      return [];
+    }
+    this._annotationToAssetMappingsWithAssetInstance.set(key, annotationAssets);
+
+    return annotationAssets;
+  }
+
+  private async getReveal360AnnotationInfoForAssets(
+    assetInstances: InstanceReference[],
+    image360Collections: Array<Image360Collection<DataSourceType>>
+  ): Promise<Image360AnnotationAssetInfo[]> {
+    const image360AnnotationAssetNested = await Promise.all(
+      assetInstances.map(async (assetInstance) => {
+        const results = await Promise.all(
+          image360Collections.map(
+            async (image360Collection) =>
+              await image360Collection.findImageAnnotations({ assetRef: assetInstance })
+          )
+        );
+        return results.flat();
+      })
+    );
+    const image360AnnotationAssets = image360AnnotationAssetNested.flat();
+
+    const assetIds = image360AnnotationAssets.reduce<InstanceReference[]>(
+      (acc, image360AnnotationAsset) => {
+        const assetRef = getInstanceReferenceFromImage360Annotation(
+          image360AnnotationAsset.annotation.annotation
+        );
+        if (assetRef !== undefined) {
+          acc.push(assetRef);
+        }
+        return acc;
+      },
+      []
+    );
     const uniqueAssetIds = uniqBy(assetIds, createInstanceReferenceKey);
 
     const assetsArray = await fetchAssetsForAssetReferences(uniqueAssetIds, this._sdk);
     const assets = new Map(assetsArray.map((asset) => [assetInstanceToKey(asset), asset]));
-    const assetsWithAnnotations = await this.getAssetWithAnnotationsMapped(annotationsInfo, assets);
 
-    return assetsWithAnnotations;
+    return await this.getAssetWithAnnotationsMapped(image360AnnotationAssets, assets);
   }
 
   private async getAssetWithAnnotationsMapped(
-    assetAnnotationImage360Infos: Array<AssetAnnotationImage360Info<DataSourceType>>,
+    image360AnnotationAssets: Array<Image360AnnotationAssetQueryResult<DataSourceType>>,
     assets: Map<string, AssetInstance>
   ): Promise<Image360AnnotationAssetInfo[]> {
-    const assetsWithAnnotationsPromises = assetAnnotationImage360Infos
-      .filter((assetAnnotationImageInfo) => {
-        const idRef = getAssetIdKeyForImage360Annotation(assetAnnotationImageInfo.annotationInfo);
-        return idRef !== undefined && assets.has(idRef);
-      })
-      .map(async (info) => await createAnnotationInfoWithAsset(info, assets));
-
-    const assetsWithAnnotations = (await Promise.all(assetsWithAnnotationsPromises)).filter(
-      isDefined
+    const image360AnnotationAssetInfo = await Promise.all(
+      image360AnnotationAssets
+        .filter((image360AnnotationAsset) => {
+          const idRef = getAssetIdKeyForImage360Annotation(
+            image360AnnotationAsset.annotation.annotation
+          );
+          return idRef !== undefined && assets.has(idRef);
+        })
+        .map(
+          async (image360AnnotationAsset) =>
+            await createAnnotationInfoWithAsset(image360AnnotationAsset, assets)
+        )
     );
 
-    return assetsWithAnnotations;
+    return image360AnnotationAssetInfo.filter(isDefined);
   }
 }
 
 async function createAnnotationInfoWithAsset(
-  assetAnnotationImageInfo: AssetAnnotationImage360Info<DataSourceType>,
+  image360AnnotationAsset: Image360AnnotationAssetQueryResult<DataSourceType>,
   assets: Map<string, AssetInstance>
 ): Promise<Image360AnnotationAssetInfo | undefined> {
-  const idRef = getAssetIdKeyForImage360Annotation(assetAnnotationImageInfo.annotationInfo);
+  const idRef = getAssetIdKeyForImage360Annotation(image360AnnotationAsset.annotation.annotation);
   if (idRef === undefined) {
     return undefined;
   }
@@ -110,33 +134,12 @@ async function createAnnotationInfoWithAsset(
   if (asset === undefined) {
     return undefined;
   }
-  const revisionAnnotations = await assetAnnotationImageInfo.imageRevision.getAnnotations();
-
-  const annotationIdKey = getIdKeyForImage360Annotation(assetAnnotationImageInfo.annotationInfo);
-  const correspondingRevisionAnnotation = revisionAnnotations.find((revisionAnnotation) => {
-    return getIdKeyForImage360Annotation(revisionAnnotation.annotation) === annotationIdKey;
-  });
-
-  if (correspondingRevisionAnnotation === undefined) {
-    return undefined;
-  }
-
-  const centerPosition = getAnnotationCenterPosition(
-    assetAnnotationImageInfo,
-    correspondingRevisionAnnotation
-  );
 
   return {
     asset,
-    assetAnnotationImage360Info: assetAnnotationImageInfo,
-    position: centerPosition
+    assetAnnotationImage360Info: image360AnnotationAsset,
+    position: image360AnnotationAsset.annotation
+      .getCenter()
+      .applyMatrix4(image360AnnotationAsset.image.transform)
   };
-}
-
-function getAnnotationCenterPosition(
-  assetAnnotationImageInfo: AssetAnnotationImage360Info<DataSourceType>,
-  revisionAnnotation: Image360Annotation<DataSourceType>
-): Vector3 {
-  const transform = assetAnnotationImageInfo.imageEntity.transform;
-  return revisionAnnotation.getCenter().applyMatrix4(transform);
 }

--- a/react-components/src/components/CacheProvider/types.ts
+++ b/react-components/src/components/CacheProvider/types.ts
@@ -5,7 +5,7 @@ import {
   type Node3D
 } from '@cognite/sdk';
 import { type Source, type DmsUniqueIdentifier } from '../../data-providers/FdmSDK';
-import { type AssetAnnotationImage360Info, type DataSourceType } from '@cognite/reveal';
+import { type Image360AnnotationAssetQueryResult, type DataSourceType } from '@cognite/reveal';
 import { type Vector3 } from 'three';
 import { type AssetInstance } from '../../utilities/instances';
 
@@ -72,7 +72,7 @@ export type Image360AnnotationModel = AnnotationModel & {
 
 export type Image360AnnotationAssetInfo = {
   asset: AssetInstance;
-  assetAnnotationImage360Info: AssetAnnotationImage360Info<DataSourceType>;
+  assetAnnotationImage360Info: Image360AnnotationAssetQueryResult<DataSourceType>;
   position: Vector3;
 };
 

--- a/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.context.ts
+++ b/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import { useImage360AnnotationCache } from '../components/CacheProvider/CacheProvider';
+
+export type Image360AnnotationMappingsDependencies = {
+  useImage360AnnotationCache: typeof useImage360AnnotationCache;
+};
+
+export const defaultImage360AnnotationMappingsDependencies: Image360AnnotationMappingsDependencies =
+  {
+    useImage360AnnotationCache
+  };
+
+export const Image360AnnotationMappingsContext =
+  createContext<Image360AnnotationMappingsDependencies>(
+    defaultImage360AnnotationMappingsDependencies
+  );

--- a/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.test.tsx
+++ b/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.test.tsx
@@ -1,44 +1,98 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { describe, expect, beforeEach, test, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useImage360AnnotationMappingsForInstanceReferences } from './useImage360AnnotationMappingsForInstanceReferences';
-import * as CacheProvider from '../components/CacheProvider/CacheProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { classic360AnnotationFixture } from '#test-utils/fixtures/image360Annotations';
+import { getMocksByDefaultDependencies } from '#test-utils/vitest-extensions/getMocksByDefaultDependencies';
+import {
+  defaultImage360AnnotationMappingsDependencies,
+  Image360AnnotationMappingsContext
+} from './useImage360AnnotationMappingsForInstanceReferences.context';
+import { type ReactElement, type ReactNode } from 'react';
+import { Image360AnnotationCache } from '../components/CacheProvider/Image360AnnotationCache';
+import { sdkMock } from '#test-utils/fixtures/sdk';
+import { viewerMock } from '#test-utils/fixtures/viewer';
 
-const mockAssetInfo = [
+const mockReveal360Annotations = [
   {
-    asset: { id: 'asset1' },
+    asset: { id: 3449 },
     assetAnnotationImage360Info: {
-      annotation: { annotation: { id: 'ann1' }, getCenter: () => ({ applyMatrix4: vi.fn(() => ({})) }) },
+      annotation: {
+        annotation: classic360AnnotationFixture,
+        getCenter: () => ({ applyMatrix4: () => ({}) })
+      },
       image: { transform: {} }
     },
     position: {}
   }
 ];
 
+const dependencies = getMocksByDefaultDependencies(defaultImage360AnnotationMappingsDependencies);
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+  <QueryClientProvider client={queryClient}>
+    <Image360AnnotationMappingsContext.Provider value={dependencies}>
+      {children}
+    </Image360AnnotationMappingsContext.Provider>
+  </QueryClientProvider>
+);
+
+const mockImage360AnnotationCache = new Image360AnnotationCache(sdkMock, viewerMock);
+
 describe(useImage360AnnotationMappingsForInstanceReferences.name, () => {
   beforeEach(() => {
-    vi.spyOn(CacheProvider, 'useImage360AnnotationCache').mockReturnValue({
-      getReveal360AnnotationsForAssets: vi.fn().mockResolvedValue(mockAssetInfo)
-    } as any);
+    dependencies.useImage360AnnotationCache.mockReturnValue(mockImage360AnnotationCache);
+    mockImage360AnnotationCache.getReveal360AnnotationsForAssets = vi
+      .fn()
+      .mockResolvedValue(mockReveal360Annotations);
   });
 
-  it('returns empty array if assetIds or siteIds are undefined', async () => {
-    const queryClient = new QueryClient();
+  test('returns empty array if assetIds or siteIds are undefined', async () => {
     const { result } = renderHook(
       () => useImage360AnnotationMappingsForInstanceReferences(undefined, undefined),
-      { wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider> }
+      { wrapper }
     );
-    expect(result.current.data).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
   });
 
-  it('returns filtered annotation asset info', async () => {
-    const queryClient = new QueryClient();
-    const { result, waitFor } = renderHook(
-      () => useImage360AnnotationMappingsForInstanceReferences([{ id: 'asset1' }], ['site1']),
-      { wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider> }
+  test('returns empty array if assetIds or siteIds are empty', async () => {
+    const { result } = renderHook(
+      () => useImage360AnnotationMappingsForInstanceReferences([], []),
+      { wrapper }
     );
-    await waitFor(() => result.current.isSuccess);
-    expect(result.current.data?.length).toBe(1);
-    expect(result.current.data?.[0].asset.id).toBe('asset1');
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
+  });
+
+  test('returns filtered annotation asset info', async () => {
+    const { result } = renderHook(
+      () => useImage360AnnotationMappingsForInstanceReferences([{ id: 3449 }], ['siteId1']),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.data?.length).toBe(1);
+    });
+
+    expect(result.current.data?.[0]).toMatchObject(mockReveal360Annotations[0]);
+  });
+
+  test('returns empty array if no matching asset', async () => {
+    const { result } = renderHook(
+      () => useImage360AnnotationMappingsForInstanceReferences([{ id: 654 }], ['siteId1']),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([]);
   });
 });

--- a/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.test.tsx
+++ b/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useImage360AnnotationMappingsForInstanceReferences } from './useImage360AnnotationMappingsForInstanceReferences';
+import * as CacheProvider from '../components/CacheProvider/CacheProvider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockAssetInfo = [
+  {
+    asset: { id: 'asset1' },
+    assetAnnotationImage360Info: {
+      annotation: { annotation: { id: 'ann1' }, getCenter: () => ({ applyMatrix4: vi.fn(() => ({})) }) },
+      image: { transform: {} }
+    },
+    position: {}
+  }
+];
+
+describe(useImage360AnnotationMappingsForInstanceReferences.name, () => {
+  beforeEach(() => {
+    vi.spyOn(CacheProvider, 'useImage360AnnotationCache').mockReturnValue({
+      getReveal360AnnotationsForAssets: vi.fn().mockResolvedValue(mockAssetInfo)
+    } as any);
+  });
+
+  it('returns empty array if assetIds or siteIds are undefined', async () => {
+    const queryClient = new QueryClient();
+    const { result } = renderHook(
+      () => useImage360AnnotationMappingsForInstanceReferences(undefined, undefined),
+      { wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider> }
+    );
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns filtered annotation asset info', async () => {
+    const queryClient = new QueryClient();
+    const { result, waitFor } = renderHook(
+      () => useImage360AnnotationMappingsForInstanceReferences([{ id: 'asset1' }], ['site1']),
+      { wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider> }
+    );
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data?.length).toBe(1);
+    expect(result.current.data?.[0].asset.id).toBe('asset1');
+  });
+});

--- a/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.ts
+++ b/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.ts
@@ -38,10 +38,14 @@ export const useImage360AnnotationMappingsForInstanceReferences = (
       }
       const assetIdSet = new Set(assetIds.map(createInstanceReferenceKey));
 
-      const annotationAssetInfo = await image360AnnotationCache.getReveal360Annotations(siteIds);
+      const annotationAssetInfo = await image360AnnotationCache.getReveal360AnnotationsForAssets(
+        siteIds,
+        assetIds
+      );
+
       const filteredAnnotationAssetInfo = annotationAssetInfo.filter((annotationInfo) => {
         const annotationAssetKey = getAssetIdKeyForImage360Annotation(
-          annotationInfo.assetAnnotationImage360Info.annotationInfo
+          annotationInfo.assetAnnotationImage360Info.annotation.annotation
         );
 
         return annotationAssetKey !== undefined && assetIdSet.has(annotationAssetKey);

--- a/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.ts
+++ b/react-components/src/hooks/useImage360AnnotationMappingsForInstanceReferences.ts
@@ -3,10 +3,11 @@ import {
   type Image360AnnotationAssetInfo,
   type Image360AnnotationModel
 } from '../components/CacheProvider/types';
-import { useImage360AnnotationCache } from '../components/CacheProvider/CacheProvider';
 import { getAssetIdKeyForImage360Annotation } from '../components/CacheProvider/utils';
 import { type InstanceReference } from '../utilities/instanceIds';
 import { createInstanceReferenceKey } from '../utilities/instanceIds/toKey';
+import { Image360AnnotationMappingsContext } from './useImage360AnnotationMappingsForInstanceReferences.context';
+import { useContext } from 'react';
 
 export type Image360AnnotationDataResult = {
   siteId: string;
@@ -17,6 +18,7 @@ export const useImage360AnnotationMappingsForInstanceReferences = (
   assetIds: InstanceReference[] | undefined,
   siteIds: string[] | undefined
 ): UseQueryResult<Image360AnnotationAssetInfo[]> => {
+  const { useImage360AnnotationCache } = useContext(Image360AnnotationMappingsContext);
   const image360AnnotationCache = useImage360AnnotationCache();
 
   return useQuery({
@@ -36,6 +38,7 @@ export const useImage360AnnotationMappingsForInstanceReferences = (
       ) {
         return [];
       }
+
       const assetIdSet = new Set(assetIds.map(createInstanceReferenceKey));
 
       const annotationAssetInfo = await image360AnnotationCache.getReveal360AnnotationsForAssets(
@@ -52,7 +55,6 @@ export const useImage360AnnotationMappingsForInstanceReferences = (
       });
       return filteredAnnotationAssetInfo;
     },
-    staleTime: Infinity,
-    enabled: assetIds !== undefined && siteIds !== undefined
+    staleTime: Infinity
   });
 };

--- a/react-components/tests/tests-utilities/fixtures/assets.ts
+++ b/react-components/tests/tests-utilities/fixtures/assets.ts
@@ -2,14 +2,16 @@ import { type Asset } from '@cognite/sdk';
 import { type AssetProperties } from '../../../src/data-providers/core-dm-provider/utils/filters';
 import { type ExternalIdsResultList, type NodeItem } from '../../../src/data-providers/FdmSDK';
 
+const fixedDate = new Date('2025-01-01T00:00:00.000Z');
+
 export function createAssetMock(id: number, name?: string, description?: string): Asset {
   return {
     id,
     name: name ?? `asset-${id}`,
     description: description ?? `asset-${id}`,
     parentId: 0,
-    createdTime: new Date(),
-    lastUpdatedTime: new Date(),
+    createdTime: fixedDate,
+    lastUpdatedTime: fixedDate,
     rootId: 0,
     externalId: 'external-id-123',
     metadata: { key: 'value' },

--- a/react-components/tests/tests-utilities/fixtures/image360.ts
+++ b/react-components/tests/tests-utilities/fixtures/image360.ts
@@ -32,6 +32,10 @@ export const taggedImage360DmOptions = {
   addOptions: image360DmOptions
 } as const satisfies TaggedAddImage360CollectionOptions;
 
+export const findImageAnnotationsMock = vi
+  .fn<Image360Collection<ClassicDataSourceType>['findImageAnnotations']>()
+  .mockResolvedValue([]);
+
 export function createImage360ClassicMock(parameters?: {
   visible?: boolean;
 }): Image360Collection<ClassicDataSourceType> {
@@ -61,6 +65,8 @@ export function createImage360ClassicMock(parameters?: {
     .returns(onEventMock)
     .setup((p) => p.off)
     .returns(offEventMock)
+    .setup((p) => p.findImageAnnotations)
+    .returns(findImageAnnotationsMock)
     .object();
 }
 

--- a/react-components/tests/tests-utilities/fixtures/image360AssetWithAnnotation.ts
+++ b/react-components/tests/tests-utilities/fixtures/image360AssetWithAnnotation.ts
@@ -1,0 +1,43 @@
+import {
+  type Image360AnnotationAssetQueryResult,
+  type ClassicDataSourceType,
+  type Image360Annotation,
+  type Image360
+} from '@cognite/reveal';
+import { type AnnotationsTypesImagesAssetLink, type AnnotationModel } from '@cognite/sdk';
+import { Mock } from 'moq.ts';
+import { Vector3, Matrix4 } from 'three';
+import { vi } from 'vitest';
+
+const mockAnnotationData = new Mock<AnnotationsTypesImagesAssetLink>()
+  .setup((p) => p.assetRef)
+  .returns({ id: 1 })
+  .object();
+
+const mockAnnotationModel = new Mock<AnnotationModel>()
+  .setup((p) => p.id)
+  .returns(987)
+  .setup((p) => p.data)
+  .returns(mockAnnotationData)
+  .object();
+
+export const mockImage360AnnotationAssetResult = new Mock<
+  Image360AnnotationAssetQueryResult<ClassicDataSourceType>
+>()
+  .setup((p) => p.annotation)
+  .returns(
+    new Mock<Image360Annotation<ClassicDataSourceType>>()
+      .setup((q) => q.annotation)
+      .returns(mockAnnotationModel)
+      .setup((q) => q.getCenter)
+      .returns(vi.fn(() => new Vector3(0, 0, 0)))
+      .object()
+  )
+  .setup((p) => p.image)
+  .returns(
+    new Mock<Image360<ClassicDataSourceType>>()
+      .setup((q) => q.transform)
+      .returns(new Matrix4())
+      .object()
+  )
+  .object();


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5683

## Description :pencil:
If 360 image dataset contain very large amount of `annotation` and user select a associated `Asset` from `FRS` panel, `annotation` was not selected. The issue was that we used to fetch all annotations in the `Image360Collection` from `Reveal` which will trigger large number network request in parallel causing `429` error in `Image360AnnotationCache. getReveal360Annotations()` call.
This PR changes the logic by fetching annotations for selected Asset by using `Reveal's` `Image360Collection.findImageAnnotations()` which will make a single network request.

## How has this been tested? :mag:

In `Unified-3D`

## Test instructions :information_source:
- link `react-component` to fusion branch `pramodcog/bump-reveal-react-component-v0.82.3`
- run `unified-3d` application with `jnc` project
- load `SP2` scene and select Asset `V3001` from `FRS` Panel

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
