### PR TITLE
feat(react-components): support for hybrid cad asset mapping styling on selected asset

### DIFF
--- a/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
@@ -53,6 +53,9 @@ describe(useCalculateCadStyling.name, () => {
 
   const ASSET_ID = 987;
   const TREE_INDEX = 123;
+  const HYBRID_TREE_INDEX_1 = 456;
+  const HYBRID_TREE_INDEX_2 = 789;
+  const FDM_TREE_INDEX = 456;
   const INSTANCE_ID: DmsUniqueIdentifier = {
     externalId: 'default-external-id1',
     space: 'default-space'
@@ -166,7 +169,7 @@ describe(useCalculateCadStyling.name, () => {
     });
   });
 
-  test('returns objects with models and applicable style groups for DM instance', async () => {
+  test('returns objects with models and style groups for DM instance', async () => {
     mockGetMappingsForModelsAndInstances.mockResolvedValue(
       createModelToAssetMappingsMap(MODEL, ASSET_ID, TREE_INDEX)
     );
@@ -201,11 +204,9 @@ describe(useCalculateCadStyling.name, () => {
   });
 
   test('returns style groups for hybrid asset mappings when FDM mappings do not exist', async () => {
-    const hybridTreeIndex = 456;
-
     mockGetMappingsForModelsAndInstances.mockResolvedValue(new Map());
     mockGetNodesForInstanceIds.mockResolvedValue(
-      createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex)
+      createHybridAssetMappingsMap(INSTANCE_ID, HYBRID_TREE_INDEX_1)
     );
 
     const { result } = renderHook(
@@ -233,14 +234,11 @@ describe(useCalculateCadStyling.name, () => {
   });
 
   test('combines style groups from both FDM and hybrid mappings', async () => {
-    const hybridTreeIndex = 456;
-    const fdmTreeIndex = 789;
-
     mockGetMappingsForModelsAndInstances.mockResolvedValue(
-      createModelToAssetMappingsMap(MODEL, ASSET_ID, fdmTreeIndex)
+      createModelToAssetMappingsMap(MODEL, ASSET_ID, FDM_TREE_INDEX)
     );
     mockGetNodesForInstanceIds.mockResolvedValue(
-      createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex)
+      createHybridAssetMappingsMap(INSTANCE_ID, HYBRID_TREE_INDEX_1)
     );
 
     const { result } = renderHook(
@@ -294,17 +292,15 @@ describe(useCalculateCadStyling.name, () => {
 
   test('processes multiple models with separate FDM and hybrid mappings', async () => {
     const MODEL2 = { modelId: 456, revisionId: 567, type: 'cad' } as const;
-    const hybridTreeIndex1 = 456;
-    const hybridTreeIndex2 = 789;
 
     mockGetMappingsForModelsAndInstances.mockResolvedValue(
       createModelToAssetMappingsMap(MODEL, ASSET_ID, TREE_INDEX)
     );
     mockGetNodesForInstanceIds.mockImplementation(async (modelId, revisionId) => {
       if (modelId === MODEL.modelId && revisionId === MODEL.revisionId) {
-        return createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex1);
+        return createHybridAssetMappingsMap(INSTANCE_ID, HYBRID_TREE_INDEX_1);
       } else if (modelId === MODEL2.modelId && revisionId === MODEL2.revisionId) {
-        return createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex2);
+        return createHybridAssetMappingsMap(INSTANCE_ID, HYBRID_TREE_INDEX_2);
       }
       return new Map();
     });

--- a/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
@@ -169,7 +169,7 @@ describe(useCalculateCadStyling.name, () => {
     });
   });
 
-  test('returns objects with models and style groups for DM instance', async () => {
+  test('returns loading state for DM instance style group', async () => {
     mockGetMappingsForModelsAndInstances.mockResolvedValue(new Map());
     mockGetNodesForInstanceIds.mockResolvedValue(
       createHybridAssetMappingsMap(INSTANCE_ID, HYBRID_TREE_INDEX_1)
@@ -188,6 +188,22 @@ describe(useCalculateCadStyling.name, () => {
       styledModels: [{ model: MODEL, styleGroups: [] }],
       isModelMappingsLoading: true
     });
+  });
+
+  test('returns objects with models and style groups for DM instance after loading', async () => {
+    mockGetMappingsForModelsAndInstances.mockResolvedValue(new Map());
+    mockGetNodesForInstanceIds.mockResolvedValue(
+      createHybridAssetMappingsMap(INSTANCE_ID, HYBRID_TREE_INDEX_1)
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCalculateCadStyling(
+          [MODEL],
+          [{ fdmAssetExternalIds: [INSTANCE_ID], style: { cad: { renderGhosted: true } } }]
+        ),
+      { wrapper }
+    );
 
     await waitFor(() => {
       expect(result.current.isModelMappingsLoading).toBeFalsy();

--- a/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
@@ -11,7 +11,7 @@ import {
 } from './useCalculateCadStyling';
 
 import { getMocksByDefaultDependencies } from '#test-utils/vitest-extensions/getMocksByDefaultDependencies';
-import { createModelRevisionKey } from '../../CacheProvider/idAndKeyTranslation';
+import { createFdmKey, createModelRevisionKey } from '../../CacheProvider/idAndKeyTranslation';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createCadNodeMock } from '#test-utils/fixtures/cadNode';
 import { IndexSet } from '@cognite/reveal';
@@ -21,6 +21,11 @@ import {
   type CadInstanceMappingsCache,
   type CadModelMappingsWithNodes
 } from '../../CacheProvider/cad/CadInstanceMappingsCache';
+import { type ClassicCadAssetMappingCache } from '../../CacheProvider/cad/ClassicCadAssetMappingCache';
+import { type FdmKey } from '../../CacheProvider/types';
+import { type DmsUniqueIdentifier } from '../../../data-providers/FdmSDK';
+import { type Node3D } from '@cognite/sdk';
+import { type InstanceKey } from '../../../utilities/instanceIds';
 
 describe(useCalculateCadStyling.name, () => {
   const dependencies = getMocksByDefaultDependencies(defaultUseCalculateCadStylingDependencies);
@@ -28,6 +33,7 @@ describe(useCalculateCadStyling.name, () => {
   const mockGetMappingsForModelsAndInstances =
     vi.fn<CadInstanceMappingsCache['getMappingsForModelsAndInstances']>();
   const mockGetAllModelMappings = vi.fn<CadInstanceMappingsCache['getAllModelMappings']>();
+  const mockGetNodesForInstanceIds = vi.fn<ClassicCadAssetMappingCache['getNodesForInstanceIds']>();
 
   const queryClient = new QueryClient();
 
@@ -47,6 +53,7 @@ describe(useCalculateCadStyling.name, () => {
 
   const ASSET_ID = 987;
   const TREE_INDEX = 123;
+  const INSTANCE_ID: DmsUniqueIdentifier = { externalId: 'test-fdm-id', space: 'test-space' };
 
   beforeEach(() => {
     dependencies.useCadMappingsCache.mockReturnValue({
@@ -54,7 +61,16 @@ describe(useCalculateCadStyling.name, () => {
       getAllModelMappings: mockGetAllModelMappings
     });
 
+    dependencies.useClassicCadAssetMappingCache.mockReturnValue({
+      getNodesForInstanceIds: mockGetNodesForInstanceIds,
+      getAssetMappingsForLowestAncestor: vi.fn(),
+      generateNode3DCachePerItem: vi.fn(),
+      generateAssetMappingsCachePerItemFromModelCache: vi.fn(),
+      getAssetMappingsForModel: vi.fn()
+    });
+
     mockGetAllModelMappings.mockResolvedValue(new Map());
+    mockGetNodesForInstanceIds.mockResolvedValue(new Map());
   });
 
   test('indicates that loading is not finished when `isLoading` is true for request', async () => {
@@ -170,6 +186,166 @@ describe(useCalculateCadStyling.name, () => {
       isModelMappingsLoading: false
     });
   });
+
+  test('returns style groups for hybrid asset mappings when FDM mappings do not exist', async () => {
+    const hybridTreeIndex = 456;
+
+    // No FDM mappings
+    mockGetMappingsForModelsAndInstances.mockResolvedValue(new Map());
+
+    // But hybrid mappings exist
+    mockGetNodesForInstanceIds.mockResolvedValue(
+      createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex)
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCalculateCadStyling(
+          [MODEL],
+          [{ fdmAssetExternalIds: [INSTANCE_ID], style: { cad: { renderGhosted: true } } }]
+        ),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isModelMappingsLoading).toBeFalsy();
+    });
+
+    expect(result.current).toEqual({
+      styledModels: [
+        {
+          model: MODEL,
+          styleGroups: [{ style: { renderGhosted: true }, treeIndexSet: expect.any(IndexSet) }]
+        }
+      ],
+      isModelMappingsLoading: false
+    });
+  });
+
+  test('combines style groups from both FDM and hybrid mappings', async () => {
+    const hybridTreeIndex = 456;
+    const fdmTreeIndex = 789;
+
+    // Both FDM and hybrid mappings exist
+    mockGetMappingsForModelsAndInstances.mockResolvedValue(
+      createModelToAssetMappingsMap(MODEL, ASSET_ID, fdmTreeIndex)
+    );
+
+    mockGetNodesForInstanceIds.mockResolvedValue(
+      createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex)
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCalculateCadStyling(
+          [MODEL],
+          [
+            { assetIds: [ASSET_ID], style: { cad: { renderGhosted: true } } },
+            { fdmAssetExternalIds: [INSTANCE_ID], style: { cad: { renderInFront: true } } }
+          ]
+        ),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isModelMappingsLoading).toBeFalsy();
+    });
+
+    expect(result.current.styledModels).toHaveLength(1);
+    expect(result.current.styledModels[0].model).toEqual(MODEL);
+    expect(result.current.styledModels[0].styleGroups).toHaveLength(2);
+
+    // Should have both style groups
+    expect(result.current.styledModels[0].styleGroups).toEqual([
+      { style: { renderGhosted: true }, treeIndexSet: expect.any(IndexSet) },
+      { style: { renderInFront: true }, treeIndexSet: expect.any(IndexSet) }
+    ]);
+  });
+
+  test('returns empty style groups when neither FDM nor hybrid mappings exist', async () => {
+    // No mappings exist
+    mockGetMappingsForModelsAndInstances.mockResolvedValue(new Map());
+    mockGetNodesForInstanceIds.mockImplementation(async () => new Map());
+
+    // Create a fresh query client for this test to avoid caching issues
+    const freshQueryClient = new QueryClient();
+    const freshWrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={freshQueryClient}>
+        <UseCalculateCadStylingContext.Provider value={dependencies}>
+          {children}
+        </UseCalculateCadStylingContext.Provider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCalculateCadStyling(
+          [MODEL],
+          [{ fdmAssetExternalIds: [INSTANCE_ID], style: { cad: { renderGhosted: true } } }]
+        ),
+      { wrapper: freshWrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isModelMappingsLoading).toBeFalsy();
+    });
+
+    expect(result.current).toEqual({
+      styledModels: [{ model: MODEL, styleGroups: [] }],
+      isModelMappingsLoading: false
+    });
+  });
+
+  test('processes multiple models with separate FDM and hybrid mappings', async () => {
+    const MODEL2 = { modelId: 456, revisionId: 567, type: 'cad' } as const;
+    const hybridTreeIndex1 = 456;
+    const hybridTreeIndex2 = 789;
+
+    // FDM mappings for first model only
+    mockGetMappingsForModelsAndInstances.mockResolvedValue(
+      createModelToAssetMappingsMap(MODEL, ASSET_ID, TREE_INDEX)
+    );
+
+    // Hybrid mappings for both models
+    mockGetNodesForInstanceIds.mockImplementation(async (modelId, revisionId) => {
+      if (modelId === MODEL.modelId && revisionId === MODEL.revisionId) {
+        return createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex1);
+      } else if (modelId === MODEL2.modelId && revisionId === MODEL2.revisionId) {
+        return createHybridAssetMappingsMap(INSTANCE_ID, hybridTreeIndex2);
+      }
+      return new Map();
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCalculateCadStyling(
+          [MODEL, MODEL2],
+          [
+            { assetIds: [ASSET_ID], style: { cad: { renderGhosted: true } } },
+            { fdmAssetExternalIds: [INSTANCE_ID], style: { cad: { renderInFront: true } } }
+          ]
+        ),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isModelMappingsLoading).toBeFalsy();
+    });
+
+    expect(result.current.styledModels).toHaveLength(2);
+
+    // First model should have both FDM and hybrid style groups
+    expect(result.current.styledModels[0].model).toEqual(MODEL);
+    expect(result.current.styledModels[0].styleGroups).toHaveLength(2);
+
+    // Second model should have only hybrid style group
+    expect(result.current.styledModels[1].model).toEqual(MODEL2);
+    expect(result.current.styledModels[1].styleGroups).toHaveLength(1);
+    expect(result.current.styledModels[1].styleGroups[0]).toEqual({
+      style: { renderInFront: true },
+      treeIndexSet: expect.any(IndexSet)
+    });
+  });
 });
 
 function createModelToAssetMappingsMap(
@@ -183,4 +359,12 @@ function createModelToAssetMappingsMap(
       new Map([[assetId, [createCadNodeMock({ treeIndex })]]])
     ]
   ]);
+}
+
+function createHybridAssetMappingsMap(
+  fdmInstance: DmsUniqueIdentifier,
+  treeIndex: number
+): Map<InstanceKey, Node3D[]> {
+  const fdmKey: FdmKey = createFdmKey(fdmInstance);
+  return new Map([[fdmKey, [createCadNodeMock({ treeIndex })]]]);
 }

--- a/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.test.tsx
@@ -170,15 +170,16 @@ describe(useCalculateCadStyling.name, () => {
   });
 
   test('returns objects with models and style groups for DM instance', async () => {
-    mockGetMappingsForModelsAndInstances.mockResolvedValue(
-      createModelToAssetMappingsMap(MODEL, ASSET_ID, TREE_INDEX)
+    mockGetMappingsForModelsAndInstances.mockResolvedValue(new Map());
+    mockGetNodesForInstanceIds.mockResolvedValue(
+      createHybridAssetMappingsMap(INSTANCE_ID, HYBRID_TREE_INDEX_1)
     );
 
     const { result } = renderHook(
       () =>
         useCalculateCadStyling(
           [MODEL],
-          [{ assetIds: [ASSET_ID], style: { cad: { renderGhosted: true } } }]
+          [{ fdmAssetExternalIds: [INSTANCE_ID], style: { cad: { renderGhosted: true } } }]
         ),
       { wrapper }
     );

--- a/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.tsx
@@ -203,10 +203,7 @@ function useCalculateInstanceStyling(
           const modelMappings = mappings.get(modelKey);
           const hybridMappings = hybridAssetMappings[index];
 
-          if (
-            modelMappings === undefined &&
-            (hybridMappings === undefined || hybridMappings.size === 0)
-          ) {
+          if (modelMappings === undefined && hybridMappings.size === 0) {
             return undefined;
           }
 

--- a/react-components/stories/HighlightNode.stories.tsx
+++ b/react-components/stories/HighlightNode.stories.tsx
@@ -33,8 +33,8 @@ export const Main: Story = {
   args: {
     resources: [
       {
-        modelId: 2231774635735416,
-        revisionId: 912809199849811,
+        modelId: 6804308053946048,
+        revisionId: 6132207798738006,
         styling: {
           default: {
             color: new Color('#efefef')
@@ -60,7 +60,7 @@ export const Main: Story = {
   },
   render: ({ resources }: { resources: AddResourceOptions[] }) => {
     return (
-      <RevealContext sdk={sdk} color={new Color(0x4a4a4a)} useCoreDm={true}>
+      <RevealContext sdk={sdk} color={new Color(0x4a4a4a)}>
         <RevealCanvas>
           <StoryContent resources={resources} />
           <ReactQueryDevtools />


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-5825

## Description :pencil:
Added support for hybrid CAD asset mapping cad node highlighting on click

Feature video ref

https://github.com/user-attachments/assets/73d7d694-808c-457e-99a0-df21d06d268b


## How has this been tested? :mag:

In Storybook

## Test instructions :information_source:

- run `yarn && yarn build && yarn storybook`
- Load `HighlightNode` storybook example
- Click on highlighted `Tank` node which is hybrid asset.


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
