### PR TITLE
feat(react-components): support for fetching asset mapping for hybrid instances

### DIFF
--- a/react-components/src/query/index.ts
+++ b/react-components/src/query/index.ts
@@ -18,6 +18,7 @@ export {
   useSearchMappedEquipmentAssetMappings,
   useMappingsForAssetIds
 } from './useSearchMappedEquipmentAssetMappings';
+export { useHybridMappingsForAssetInstances } from './useHybridMappingsForAssetInstances';
 export {
   useAllMappedEquipmentFDM,
   useSearchMappedEquipmentFDM,

--- a/react-components/src/query/useHybridMappingsForAssetInstances.context.ts
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import { useClassicCadAssetMappingCache } from '../components/CacheProvider/CacheProvider';
+
+export type UseHybridMappingsForAssetInstancesDependencies = {
+  useClassicCadAssetMappingCache: typeof useClassicCadAssetMappingCache;
+};
+
+export const defaultUseHybridMappingsForAssetInstancesDependencies: UseHybridMappingsForAssetInstancesDependencies =
+  {
+    useClassicCadAssetMappingCache
+  };
+
+export const UseHybridMappingsForAssetInstancesContext =
+  createContext<UseHybridMappingsForAssetInstancesDependencies>({
+    useClassicCadAssetMappingCache
+  });

--- a/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
@@ -3,8 +3,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { type AddModelOptions } from '@cognite/reveal';
 import { useHybridMappingsForAssetInstances } from './useHybridMappingsForAssetInstances';
 import {
-  UseHybridMappingsForAssetInstancesContext,
-  type UseHybridMappingsForAssetInstancesDependencies
+  defaultUseHybridMappingsForAssetInstancesDependencies,
+  UseHybridMappingsForAssetInstancesContext
 } from './useHybridMappingsForAssetInstances.context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { type DmsUniqueIdentifier } from '../data-providers';
@@ -14,84 +14,86 @@ import { Mock } from 'moq.ts';
 import type { FC, PropsWithChildren } from 'react';
 import { type FdmKey } from '../components/CacheProvider/types';
 import { type Node3D } from '@cognite/sdk';
-
-const queryClient = new QueryClient();
-
-const modelsMock: AddModelOptions[] = [
-  { modelId: 456, revisionId: 789 },
-  { modelId: 123, revisionId: 456 }
-];
-
-const assetInstanceIdsMock: DmsUniqueIdentifier[] = [
-  { space: 'test-space', externalId: 'instance-1' },
-  { space: 'test-space', externalId: 'instance-2' }
-];
-
-const firstNode3DMock: Node3D = {
-  id: 123,
-  name: 'Test Node',
-  treeIndex: 456,
-  boundingBox: { min: [0, 0, 0], max: [1, 1, 1] },
-  parentId: 0,
-  depth: 1,
-  subtreeSize: 1
-};
-
-const secondNode3DMock: Node3D = {
-  id: 987,
-  name: 'Test Node',
-  treeIndex: 789,
-  boundingBox: { min: [0, 0, 0], max: [1, 1, 1] },
-  parentId: 0,
-  depth: 1,
-  subtreeSize: 1
-};
-
-const firstMappingsMock = new Map<FdmKey, Node3D[]>([['test-space/instance-1', [firstNode3DMock]]]);
-
-const secondMappingsMock = new Map<FdmKey, Node3D[]>([
-  ['test-space/instance-2', [secondNode3DMock]]
-]);
-
-const emptyMappingsMock = new Map<FdmKey, Node3D[]>();
-
-const mockThreeDModelFdmMappings: ThreeDModelFdmMappings[] = [
-  {
-    modelId: modelsMock[0].modelId,
-    revisionId: modelsMock[0].revisionId,
-    mappings: firstMappingsMock
-  },
-  {
-    modelId: modelsMock[1].modelId,
-    revisionId: modelsMock[1].revisionId,
-    mappings: secondMappingsMock
-  }
-];
-
-const mockClassicCadAssetMappingCache = new Mock<ClassicCadAssetMappingCache>()
-  .setup((p) => p.getNodesForInstanceIds)
-  .returns(vi.fn<() => Promise<Map<FdmKey, Node3D[]>>>())
-  .object();
-
-const mockUseClassicCadAssetMappingCache = vi.fn<() => ClassicCadAssetMappingCache>();
-
-const mockDependencies: UseHybridMappingsForAssetInstancesDependencies = {
-  useClassicCadAssetMappingCache: mockUseClassicCadAssetMappingCache
-};
-
-const wrapper: FC<PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <UseHybridMappingsForAssetInstancesContext.Provider value={mockDependencies}>
-      {children}
-    </UseHybridMappingsForAssetInstancesContext.Provider>
-  </QueryClientProvider>
-);
+import { getMocksByDefaultDependencies } from '#test-utils/vitest-extensions/getMocksByDefaultDependencies';
 
 describe(useHybridMappingsForAssetInstances.name, () => {
+  const queryClient = new QueryClient();
+
+  const modelsMock: AddModelOptions[] = [
+    { modelId: 456, revisionId: 789 },
+    { modelId: 123, revisionId: 456 }
+  ];
+
+  const assetInstanceIdsMock: DmsUniqueIdentifier[] = [
+    { space: 'test-space', externalId: 'instance-1' },
+    { space: 'test-space', externalId: 'instance-2' }
+  ];
+
+  const firstNode3DMock: Node3D = {
+    id: 123,
+    name: 'Test Node',
+    treeIndex: 456,
+    boundingBox: { min: [0, 0, 0], max: [1, 1, 1] },
+    parentId: 0,
+    depth: 1,
+    subtreeSize: 1
+  };
+
+  const secondNode3DMock: Node3D = {
+    id: 987,
+    name: 'Test Node',
+    treeIndex: 789,
+    boundingBox: { min: [0, 0, 0], max: [1, 1, 1] },
+    parentId: 0,
+    depth: 1,
+    subtreeSize: 1
+  };
+
+  const firstMappingsMock = new Map<FdmKey, Node3D[]>([
+    ['test-space/instance-1', [firstNode3DMock]]
+  ]);
+
+  const secondMappingsMock = new Map<FdmKey, Node3D[]>([
+    ['test-space/instance-2', [secondNode3DMock]]
+  ]);
+
+  const emptyMappingsMock = new Map<FdmKey, Node3D[]>();
+
+  const mockThreeDModelFdmMappings: ThreeDModelFdmMappings[] = [
+    {
+      modelId: modelsMock[0].modelId,
+      revisionId: modelsMock[0].revisionId,
+      mappings: firstMappingsMock
+    },
+    {
+      modelId: modelsMock[1].modelId,
+      revisionId: modelsMock[1].revisionId,
+      mappings: secondMappingsMock
+    }
+  ];
+
+  const mockClassicCadAssetMappingCache = new Mock<ClassicCadAssetMappingCache>()
+    .setup((p) => p.getNodesForInstanceIds)
+    .returns(vi.fn<() => Promise<Map<FdmKey, Node3D[]>>>())
+    .object();
+
+  const mockDependencies = getMocksByDefaultDependencies(
+    defaultUseHybridMappingsForAssetInstancesDependencies
+  );
+
+  const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <UseHybridMappingsForAssetInstancesContext.Provider value={mockDependencies}>
+        {children}
+      </UseHybridMappingsForAssetInstancesContext.Provider>
+    </QueryClientProvider>
+  );
   beforeEach(() => {
     queryClient.clear();
 
-    mockUseClassicCadAssetMappingCache.mockReturnValue(mockClassicCadAssetMappingCache);
+    mockDependencies.useClassicCadAssetMappingCache.mockReturnValue(
+      mockClassicCadAssetMappingCache
+    );
     vi.mocked(mockClassicCadAssetMappingCache.getNodesForInstanceIds).mockResolvedValue(
       firstMappingsMock
     );
@@ -108,7 +110,17 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+    expect(result.current.data).toHaveLength(2);
+    result.current.data?.forEach((item, idx) => {
+      expect(item).toMatchObject({
+        modelId: modelsMock[idx].modelId,
+        revisionId: modelsMock[idx].revisionId,
+        mappings: idx === 0 ? firstMappingsMock : secondMappingsMock
+      });
     });
 
     modelsMock.forEach((model) => {
@@ -118,15 +130,6 @@ describe(useHybridMappingsForAssetInstances.name, () => {
         assetInstanceIdsMock
       );
     });
-
-    expect(result.current.data).toHaveLength(2);
-    result.current.data?.forEach((item, idx) => {
-      expect(item).toMatchObject({
-        modelId: modelsMock[idx].modelId,
-        revisionId: modelsMock[idx].revisionId,
-        mappings: idx === 0 ? firstMappingsMock : secondMappingsMock
-      });
-    });
   });
 
   it('should handle empty asset instance IDs', async () => {
@@ -135,10 +138,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     });
 
     await waitFor(() => {
-      expect(result.current.data).toBeUndefined();
+      expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
     expect(result.current.isError).toBe(false);
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).not.toHaveBeenCalled();
   });
@@ -150,8 +153,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
     });
+
+    expect(result.current.data).toEqual([]);
 
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).not.toHaveBeenCalled();
   });
@@ -166,8 +171,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual(expectedResult);
+      expect(result.current.isLoading).toBe(false);
     });
+
+    expect(result.current.data).toEqual(expectedResult);
 
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(1);
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
@@ -186,13 +193,15 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toHaveLength(2);
-      result.current.data?.forEach((item, idx) => {
-        expect(item).toMatchObject({
-          modelId: modelsMock[idx].modelId,
-          revisionId: modelsMock[idx].revisionId,
-          mappings: emptyMappingsMock
-        });
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toHaveLength(2);
+    result.current.data?.forEach((item, idx) => {
+      expect(item).toMatchObject({
+        modelId: modelsMock[idx].modelId,
+        revisionId: modelsMock[idx].revisionId,
+        mappings: emptyMappingsMock
       });
     });
 
@@ -212,14 +221,13 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toBeDefined();
+      expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockUseClassicCadAssetMappingCache).toHaveBeenCalled();
-
+    expect(result.current.data).toBeDefined();
     expect(result.current.data).toHaveLength(2);
-    expect(result.current.isLoading).toBe(false);
     expect(result.current.isError).toBe(false);
+    expect(mockDependencies.useClassicCadAssetMappingCache).toHaveBeenCalled();
   });
 
   it('should have infinite staleTime', async () => {
@@ -229,9 +237,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toBeDefined();
+      expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.data).toBeDefined();
     expect(result.current.isStale).toBe(false);
   });
 
@@ -251,9 +260,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+      expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
       modelsMock[0].modelId,
       modelsMock[0].revisionId,
@@ -272,9 +282,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toBeDefined();
+      expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.data).toBeDefined();
     expect(result.current.data).toHaveLength(2);
     result.current.data?.forEach((item, idx) => {
       expect(item).toMatchObject({
@@ -314,17 +325,20 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual([mockThreeDModelFdmMappings[0]]);
+      expect(result.current.isLoading).toBe(false);
     });
+
+    expect(result.current.data).toEqual([mockThreeDModelFdmMappings[0]]);
 
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(1);
 
     rerender({ models: modelsMock });
 
     await waitFor(() => {
-      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+      expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(3);
   });
 
@@ -345,9 +359,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+      expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
       modelsMock[0].modelId,
       modelsMock[0].revisionId,
@@ -357,9 +372,10 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     rerender({ instanceIds: assetInstanceIdsMock });
 
     await waitFor(() => {
-      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+      expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
       modelsMock[0].modelId,
       modelsMock[0].revisionId,

--- a/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type AddModelOptions } from '@cognite/reveal';
+import { useHybridMappingsForAssetInstances } from './useHybridMappingsForAssetInstances';
+import {
+  UseHybridMappingsForAssetInstancesContext,
+  type UseHybridMappingsForAssetInstancesDependencies
+} from './useHybridMappingsForAssetInstances.context';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type DmsUniqueIdentifier } from '../data-providers';
+import { type ThreeDModelFdmMappings } from '../hooks/types';
+import { type ClassicCadAssetMappingCache } from '../components/CacheProvider/cad/ClassicCadAssetMappingCache';
+import { Mock } from 'moq.ts';
+import type { FC, PropsWithChildren } from 'react';
+import { type FdmKey } from '../components/CacheProvider/types';
+import { type Node3D } from '@cognite/sdk';
+
+const queryClient = new QueryClient();
+
+const mockModels: AddModelOptions[] = [
+  { modelId: 456, revisionId: 789 },
+  { modelId: 123, revisionId: 456 }
+];
+
+const mockAssetInstanceIds: DmsUniqueIdentifier[] = [
+  { space: 'test-space', externalId: 'instance-1' },
+  { space: 'test-space', externalId: 'instance-2' }
+];
+
+const mockNode3D: Node3D = {
+  id: 123,
+  name: 'Test Node',
+  treeIndex: 456,
+  boundingBox: { min: [0, 0, 0], max: [1, 1, 1] },
+  parentId: 0,
+  depth: 1,
+  subtreeSize: 1
+};
+
+const mockFdmKey: FdmKey = 'test-space/instance-1';
+
+const mockMappingsMap = new Map<FdmKey, Node3D[]>([
+  [mockFdmKey, [mockNode3D]]
+]);
+
+const mockThreeDModelFdmMappings: ThreeDModelFdmMappings[] = [
+  {
+    modelId: mockModels[0].modelId,
+    revisionId: mockModels[0].revisionId,
+    mappings: mockMappingsMap
+  },
+  {
+    modelId: mockModels[1].modelId,
+    revisionId: mockModels[1].revisionId,
+    mappings: mockMappingsMap
+  }
+];
+
+const mockClassicCadAssetMappingCache = new Mock<ClassicCadAssetMappingCache>()
+  .setup((p) => p.getNodesForInstanceIds)
+  .returns(vi.fn())
+  .object();
+
+const mockUseClassicCadAssetMappingCache = vi.fn<() => ClassicCadAssetMappingCache>();
+
+const mockDependencies: UseHybridMappingsForAssetInstancesDependencies = {
+  useClassicCadAssetMappingCache: mockUseClassicCadAssetMappingCache
+};
+
+const wrapper: FC<PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <UseHybridMappingsForAssetInstancesContext.Provider value={mockDependencies}>
+      {children}
+    </UseHybridMappingsForAssetInstancesContext.Provider>
+  </QueryClientProvider>
+);
+
+describe(useHybridMappingsForAssetInstances.name, () => {
+  beforeEach(() => {
+    queryClient.clear();
+
+    mockUseClassicCadAssetMappingCache.mockReturnValue(mockClassicCadAssetMappingCache);
+    vi.mocked(mockClassicCadAssetMappingCache.getNodesForInstanceIds).mockResolvedValue(
+      mockMappingsMap
+    );
+  });
+
+  it('should return mappings for asset instance IDs', async () => {
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances(mockModels, mockAssetInstanceIds),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
+      mockModels[0].modelId,
+      mockModels[0].revisionId,
+      mockAssetInstanceIds
+    );
+  });
+
+  it('should handle empty asset instance IDs', async () => {
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances(mockModels, []),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([
+        {
+          mappings: { items: [] },
+          model: mockModels[0]
+        },
+        {
+          mappings: { items: [] },
+          model: mockModels[1]
+        }
+      ]);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).not.toHaveBeenCalled();
+  });
+
+  it('should handle empty models array', async () => {
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances([], mockAssetInstanceIds),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).not.toHaveBeenCalled();
+  });
+
+  it('should handle single model', async () => {
+    const singleModel = [mockModels[0]];
+    const expectedResult = [mockThreeDModelFdmMappings[0]];
+
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances(singleModel, mockAssetInstanceIds),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(expectedResult);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(1);
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
+      mockModels[0].modelId,
+      mockModels[0].revisionId,
+      mockAssetInstanceIds
+    );
+  });
+
+  it('should handle cache returning empty mappings', async () => {
+    vi.mocked(mockClassicCadAssetMappingCache.getNodesForInstanceIds).mockResolvedValue(
+      new Map()
+    );
+
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances(mockModels, mockAssetInstanceIds),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([
+        {
+          modelId: mockModels[0].modelId,
+          revisionId: mockModels[0].revisionId,
+          mappings: new Map()
+        },
+        {
+          modelId: mockModels[1].modelId,
+          revisionId: mockModels[1].revisionId,
+          mappings: new Map()
+        }
+      ]);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(2);
+  });
+
+  it('should have infinite staleTime', async () => {
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances(mockModels, mockAssetInstanceIds),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it('should handle different asset instance ID formats', async () => {
+    const differentAssetInstanceIds: DmsUniqueIdentifier[] = [
+      { space: 'different-space', externalId: 'external-1' },
+      { space: 'another-space', externalId: 'external-2' }
+    ];
+
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances(mockModels, differentAssetInstanceIds),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
+      mockModels[0].modelId,
+      mockModels[0].revisionId,
+      differentAssetInstanceIds
+    );
+  });
+
+  it('should call cache for each model when fetching mappings', async () => {
+    const { result } = renderHook(
+      () => useHybridMappingsForAssetInstances(mockModels, mockAssetInstanceIds),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(2);
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenNthCalledWith(
+      1,
+      mockModels[0].modelId,
+      mockModels[0].revisionId,
+      mockAssetInstanceIds
+    );
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenNthCalledWith(
+      2,
+      mockModels[1].modelId,
+      mockModels[1].revisionId,
+      mockAssetInstanceIds
+    );
+  });
+
+  it('should refetch when models change', async () => {
+    const { result, rerender } = renderHook(
+      ({ models }) => useHybridMappingsForAssetInstances(models, mockAssetInstanceIds),
+      {
+        wrapper,
+        initialProps: { models: [mockModels[0]] }
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([mockThreeDModelFdmMappings[0]]);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(1);
+
+    rerender({ models: mockModels });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(3);
+  });
+
+  it('should refetch when asset instance IDs change', async () => {
+    const initialInstanceIds = [mockAssetInstanceIds[0]];
+    const { result, rerender } = renderHook(
+      ({ instanceIds }) => useHybridMappingsForAssetInstances(mockModels, instanceIds),
+      {
+        wrapper,
+        initialProps: { instanceIds: initialInstanceIds }
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
+      mockModels[0].modelId,
+      mockModels[0].revisionId,
+      initialInstanceIds
+    );
+
+    rerender({ instanceIds: mockAssetInstanceIds });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
+    });
+
+    expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
+      mockModels[0].modelId,
+      mockModels[0].revisionId,
+      mockAssetInstanceIds
+    );
+  });
+}); 

--- a/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
@@ -111,24 +111,21 @@ describe(useHybridMappingsForAssetInstances.name, () => {
       expect(result.current.data).toEqual(mockThreeDModelFdmMappings);
     });
 
-    expect(result.current.data).toHaveLength(2);
-    expect(result.current.data?.[0]).toMatchObject({
-      modelId: modelsMock[0].modelId,
-      revisionId: modelsMock[0].revisionId,
-      mappings: firstMappingsMock
-    });
-    expect(result.current.data?.[1]).toMatchObject({
-      modelId: modelsMock[1].modelId,
-      revisionId: modelsMock[1].revisionId,
-      mappings: secondMappingsMock
-    });
-
     modelsMock.forEach((model) => {
       expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledWith(
         model.modelId,
         model.revisionId,
         assetInstanceIdsMock
       );
+    });
+
+    expect(result.current.data).toHaveLength(2);
+    result.current.data?.forEach((item, idx) => {
+      expect(item).toMatchObject({
+        modelId: modelsMock[idx].modelId,
+        revisionId: modelsMock[idx].revisionId,
+        mappings: idx === 0 ? firstMappingsMock : secondMappingsMock
+      });
     });
   });
 
@@ -138,34 +135,11 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     });
 
     await waitFor(() => {
-      expect(result.current.data).toHaveLength(modelsMock.length);
-      result.current.data?.forEach((item, idx) => {
-        expect(item).toMatchObject({
-          modelId: modelsMock[idx].modelId,
-          revisionId: modelsMock[idx].revisionId,
-          mappings: emptyMappingsMock
-        });
-      });
+      expect(result.current.data).toBeUndefined();
     });
 
-    expect(result.current.data).toHaveLength(modelsMock.length);
-    result.current.data?.forEach((item, idx) => {
-      expect(item).toMatchObject({
-        mappings: emptyMappingsMock,
-        modelId: modelsMock[idx].modelId,
-        revisionId: modelsMock[idx].revisionId
-      });
-    });
-
-    expect(result.current.data).toHaveLength(modelsMock.length);
-    result.current.data?.forEach((item, idx) => {
-      expect(item).toMatchObject({
-        mappings: emptyMappingsMock,
-        modelId: modelsMock[idx].modelId,
-        revisionId: modelsMock[idx].revisionId
-      });
-    });
-
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).not.toHaveBeenCalled();
   });
 
@@ -217,7 +191,7 @@ describe(useHybridMappingsForAssetInstances.name, () => {
         expect(item).toMatchObject({
           modelId: modelsMock[idx].modelId,
           revisionId: modelsMock[idx].revisionId,
-          mappings: new Map()
+          mappings: emptyMappingsMock
         });
       });
     });
@@ -302,15 +276,12 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     });
 
     expect(result.current.data).toHaveLength(2);
-    expect(result.current.data![0]).toMatchObject({
-      modelId: modelsMock[0].modelId,
-      revisionId: modelsMock[0].revisionId,
-      mappings: firstMappingsMock
-    });
-    expect(result.current.data![1]).toMatchObject({
-      modelId: modelsMock[1].modelId,
-      revisionId: modelsMock[1].revisionId,
-      mappings: secondMappingsMock
+    result.current.data?.forEach((item, idx) => {
+      expect(item).toMatchObject({
+        modelId: modelsMock[idx].modelId,
+        revisionId: modelsMock[idx].revisionId,
+        mappings: idx === 0 ? firstMappingsMock : secondMappingsMock
+      });
     });
 
     expect(mockClassicCadAssetMappingCache.getNodesForInstanceIds).toHaveBeenCalledTimes(2);

--- a/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
@@ -185,7 +185,9 @@ describe(useHybridMappingsForAssetInstances.name, () => {
   });
 
   it('should handle cache returning empty mappings', async () => {
-    vi.mocked(mockClassicCadAssetMappingCache.getNodesForInstanceIds).mockResolvedValue(new Map());
+    vi.mocked(mockClassicCadAssetMappingCache.getNodesForInstanceIds).mockResolvedValue(
+      emptyMappingsMock
+    );
 
     const { result } = renderHook(
       () => useHybridMappingsForAssetInstances(modelsMock, assetInstanceIdsMock),

--- a/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.test.tsx
@@ -53,6 +53,8 @@ const secondMappingsMock = new Map<FdmKey, Node3D[]>([
   ['test-space/instance-2', [secondNode3DMock]]
 ]);
 
+const emptyMappingsMock = new Map<FdmKey, Node3D[]>();
+
 const mockThreeDModelFdmMappings: ThreeDModelFdmMappings[] = [
   {
     modelId: modelsMock[0].modelId,
@@ -136,23 +138,31 @@ describe(useHybridMappingsForAssetInstances.name, () => {
     });
 
     await waitFor(() => {
-      expect(result.current.data).toEqual([
-        {
-          mappings: { items: [] },
-          model: modelsMock[0]
-        },
-        {
-          mappings: { items: [] },
-          model: modelsMock[1]
-        }
-      ]);
+      expect(result.current.data).toHaveLength(modelsMock.length);
+      result.current.data?.forEach((item, idx) => {
+        expect(item).toMatchObject({
+          modelId: modelsMock[idx].modelId,
+          revisionId: modelsMock[idx].revisionId,
+          mappings: emptyMappingsMock
+        });
+      });
     });
 
     expect(result.current.data).toHaveLength(modelsMock.length);
     result.current.data?.forEach((item, idx) => {
       expect(item).toMatchObject({
-        mappings: { items: [] },
-        model: modelsMock[idx]
+        mappings: emptyMappingsMock,
+        modelId: modelsMock[idx].modelId,
+        revisionId: modelsMock[idx].revisionId
+      });
+    });
+
+    expect(result.current.data).toHaveLength(modelsMock.length);
+    result.current.data?.forEach((item, idx) => {
+      expect(item).toMatchObject({
+        mappings: emptyMappingsMock,
+        modelId: modelsMock[idx].modelId,
+        revisionId: modelsMock[idx].revisionId
       });
     });
 

--- a/react-components/src/query/useHybridMappingsForAssetInstances.ts
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.ts
@@ -5,6 +5,8 @@ import { type ThreeDModelFdmMappings } from '../hooks';
 import { queryKeys } from '../utilities/queryKeys';
 import { UseHybridMappingsForAssetInstancesContext } from './useHybridMappingsForAssetInstances.context';
 import { useContext } from 'react';
+import { type InstanceKey } from '../utilities/instanceIds';
+import { type Node3D } from '@cognite/sdk';
 
 export const useHybridMappingsForAssetInstances = (
   models: AddModelOptions[],
@@ -21,7 +23,11 @@ export const useHybridMappingsForAssetInstances = (
     queryFn: async () => {
       const currentPagesOfAssetMappingsPromises = models.map(async (model) => {
         if (assetInstanceIds.length === 0) {
-          return { mappings: { items: [] }, model };
+          return {
+            modelId: model.modelId,
+            revisionId: model.revisionId,
+            mappings: new Map<InstanceKey, Node3D[]>()
+          };
         }
 
         const mappings = await hybridCache.getNodesForInstanceIds(

--- a/react-components/src/query/useHybridMappingsForAssetInstances.ts
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.ts
@@ -1,18 +1,16 @@
-import { AddModelOptions } from "@cognite/reveal";
-import { UseQueryResult, useQuery } from "@tanstack/react-query";
-import { DmsUniqueIdentifier } from "../data-providers";
-import { ThreeDModelFdmMappings } from "../hooks";
-import { queryKeys } from "../utilities/queryKeys";
-import { UseHybridMappingsForAssetInstancesContext } from "./useHybridMappingsForAssetInstances.context";
-import { useContext } from "react";
+import { type AddModelOptions } from '@cognite/reveal';
+import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+import { type DmsUniqueIdentifier } from '../data-providers';
+import { type ThreeDModelFdmMappings } from '../hooks';
+import { queryKeys } from '../utilities/queryKeys';
+import { UseHybridMappingsForAssetInstancesContext } from './useHybridMappingsForAssetInstances.context';
+import { useContext } from 'react';
 
 export const useHybridMappingsForAssetInstances = (
   models: AddModelOptions[],
   assetInstanceIds: DmsUniqueIdentifier[]
 ): UseQueryResult<ThreeDModelFdmMappings[]> => {
-  const {
-    useClassicCadAssetMappingCache,
-  } = useContext(UseHybridMappingsForAssetInstancesContext);
+  const { useClassicCadAssetMappingCache } = useContext(UseHybridMappingsForAssetInstancesContext);
   const hybridCache = useClassicCadAssetMappingCache();
 
   return useQuery({
@@ -20,13 +18,17 @@ export const useHybridMappingsForAssetInstances = (
       models.map((model) => `${model.modelId}-${model.revisionId}`),
       assetInstanceIds
     ),
-    queryFn: async() => {
+    queryFn: async () => {
       const currentPagesOfAssetMappingsPromises = models.map(async (model) => {
         if (assetInstanceIds.length === 0) {
           return { mappings: { items: [] }, model };
         }
 
-        const mappings = await hybridCache.getNodesForInstanceIds(model.modelId, model.revisionId, assetInstanceIds);
+        const mappings = await hybridCache.getNodesForInstanceIds(
+          model.modelId,
+          model.revisionId,
+          assetInstanceIds
+        );
 
         return { modelId: model.modelId, revisionId: model.revisionId, mappings };
       });

--- a/react-components/src/query/useHybridMappingsForAssetInstances.ts
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.ts
@@ -1,0 +1,40 @@
+import { AddModelOptions } from "@cognite/reveal";
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import { DmsUniqueIdentifier } from "../data-providers";
+import { ThreeDModelFdmMappings } from "../hooks";
+import { queryKeys } from "../utilities/queryKeys";
+import { UseHybridMappingsForAssetInstancesContext } from "./useHybridMappingsForAssetInstances.context";
+import { useContext } from "react";
+
+export const useHybridMappingsForAssetInstances = (
+  models: AddModelOptions[],
+  assetInstanceIds: DmsUniqueIdentifier[]
+): UseQueryResult<ThreeDModelFdmMappings[]> => {
+  const {
+    useClassicCadAssetMappingCache,
+  } = useContext(UseHybridMappingsForAssetInstancesContext);
+  const hybridCache = useClassicCadAssetMappingCache();
+
+  return useQuery({
+    queryKey: queryKeys.hybridDmAssetMappingsForInstances(
+      models.map((model) => `${model.modelId}-${model.revisionId}`),
+      assetInstanceIds
+    ),
+    queryFn: async() => {
+      const currentPagesOfAssetMappingsPromises = models.map(async (model) => {
+        if (assetInstanceIds.length === 0) {
+          return { mappings: { items: [] }, model };
+        }
+
+        const mappings = await hybridCache.getNodesForInstanceIds(model.modelId, model.revisionId, assetInstanceIds);
+
+        return { modelId: model.modelId, revisionId: model.revisionId, mappings };
+      });
+
+      const currentPagesOfAssetMappings = await Promise.all(currentPagesOfAssetMappingsPromises);
+
+      return currentPagesOfAssetMappings;
+    },
+    staleTime: Infinity
+  });
+};

--- a/react-components/src/query/useHybridMappingsForAssetInstances.ts
+++ b/react-components/src/query/useHybridMappingsForAssetInstances.ts
@@ -5,8 +5,6 @@ import { type ThreeDModelFdmMappings } from '../hooks';
 import { queryKeys } from '../utilities/queryKeys';
 import { UseHybridMappingsForAssetInstancesContext } from './useHybridMappingsForAssetInstances.context';
 import { useContext } from 'react';
-import { type InstanceKey } from '../utilities/instanceIds';
-import { type Node3D } from '@cognite/sdk';
 
 export const useHybridMappingsForAssetInstances = (
   models: AddModelOptions[],
@@ -22,14 +20,6 @@ export const useHybridMappingsForAssetInstances = (
     ),
     queryFn: async () => {
       const currentPagesOfAssetMappingsPromises = models.map(async (model) => {
-        if (assetInstanceIds.length === 0) {
-          return {
-            modelId: model.modelId,
-            revisionId: model.revisionId,
-            mappings: new Map<InstanceKey, Node3D[]>()
-          };
-        }
-
         const mappings = await hybridCache.getNodesForInstanceIds(
           model.modelId,
           model.revisionId,
@@ -43,6 +33,7 @@ export const useHybridMappingsForAssetInstances = (
 
       return currentPagesOfAssetMappings;
     },
+    enabled: assetInstanceIds.length > 0,
     staleTime: Infinity
   });
 };

--- a/react-components/src/utilities/queryKeys.ts
+++ b/react-components/src/utilities/queryKeys.ts
@@ -42,7 +42,9 @@ export const queryKeys = {
     [...revisions, 'model-revision-id', revisionKeys] as const,
   timeseriesFromRelationship: () => [...timeseries, 'timeseries-relationship'] as const,
   modelsForAssetPerInstanceReference: (instance: InstanceReference | undefined) =>
-    ['react-components', 'models-for-assets-per-instance-reference', instance] as const
+    ['react-components', 'models-for-assets-per-instance-reference', instance] as const,
+  hybridDmAssetMappingsForInstances: (modelKeys: string[], instances: DmsUniqueIdentifier[]) =>
+    ['react-components', 'hybrid-dm-asset-mappings-for-instances', modelKeys, instances] as const
 } as const;
 
 const assets: string[] = [...queryKeys.all, 'assets'];


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
Added support for fetching asset mapping for hybrid mapping instances. This is part of [Hybrid CAD: Instance-to-bounding box query](https://cognitedata.atlassian.net/browse/BND3D-5828). Here I have added new hook `useHybridMappingsForAssetInstances()` which return hybrid asset mapping data to be used in `Unified-3D` for clicked assets to style nodes and zoom to 3D Nodes when selected from FRS panel list.

Video Ref:

https://github.com/user-attachments/assets/f55a71a4-cf69-424b-98b4-af6e535a7b24

## How has this been tested? :mag:

In `Unified-3D` through local build


## Test instructions :information_source:

- In `react-components` folder run `yarn && yarn build`
- Link this local build of `react-components` to `fusion` branch `pramodcog/add-boungdingbox-selected-hybrid-asset`
- Load `unified-3d` application with `3d-test` project
- Load `Hakon scene` which contain Hybrid asset mapping.
- Click on a `Show Contextualized asset` button from toolbar
- Click on `Tank` at the end of CAD model which should highlight and `Asset 10` details should be expanded in FRS Panel

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
