### PR TITLE
refactor(react-components): Change type of uniqueId and buttonType in the entire code

### DIFF
--- a/react-components/src/architecture/base/commands/BaseCommand.ts
+++ b/react-components/src/architecture/base/commands/BaseCommand.ts
@@ -3,6 +3,7 @@ import { isTranslatedString, type TranslationInput } from '../utilities/Translat
 import { clear, remove } from '../utilities/extensions/arrayUtils';
 import { isMacOs } from '../utilities/extensions/isMacOs';
 import { translate } from '../utilities/translateUtils';
+import { type ButtonType, type UniqueId } from '../utilities/types';
 
 /**
  * Represents a delegate function for updating a command.
@@ -20,8 +21,6 @@ export type CommandUpdateDelegate = (command: BaseCommand, change?: symbol) => v
  */
 
 export abstract class BaseCommand {
-  private static _counter: number = 0; // Counter for the unique index
-
   // ==================================================
   // INSTANCE FIELDS
   // ==================================================
@@ -31,9 +30,9 @@ export abstract class BaseCommand {
 
   // Unique id for the command, used by in React to force rerender
   // when the command changes for a button.
-  private readonly _uniqueId: number;
+  private readonly _uniqueId: UniqueId;
 
-  public get uniqueId(): number {
+  public get uniqueId(): UniqueId {
     return this._uniqueId;
   }
 
@@ -42,8 +41,7 @@ export abstract class BaseCommand {
   // ==================================================
 
   public constructor() {
-    BaseCommand._counter++;
-    this._uniqueId = BaseCommand._counter;
+    this._uniqueId = crypto.randomUUID();
   }
 
   // ==================================================
@@ -81,7 +79,7 @@ export abstract class BaseCommand {
     return undefined; // Means no icon
   }
 
-  public get buttonType(): string {
+  public get buttonType(): ButtonType {
     return 'ghost';
   }
 

--- a/react-components/src/architecture/base/commands/BaseCommand.ts
+++ b/react-components/src/architecture/base/commands/BaseCommand.ts
@@ -3,7 +3,7 @@ import { isTranslatedString, type TranslationInput } from '../utilities/Translat
 import { clear, remove } from '../utilities/extensions/arrayUtils';
 import { isMacOs } from '../utilities/extensions/isMacOs';
 import { translate } from '../utilities/translateUtils';
-import { type ButtonType, type UniqueId } from '../utilities/types';
+import { generateUniqueId, type ButtonType, type UniqueId } from '../utilities/types';
 
 /**
  * Represents a delegate function for updating a command.
@@ -41,7 +41,7 @@ export abstract class BaseCommand {
   // ==================================================
 
   public constructor() {
-    this._uniqueId = crypto.randomUUID();
+    this._uniqueId = generateUniqueId();
   }
 
   // ==================================================

--- a/react-components/src/architecture/base/concreteCommands/DeleteDomainObjectCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/DeleteDomainObjectCommand.ts
@@ -3,6 +3,7 @@ import { type DomainObject } from '../domainObjects/DomainObject';
 import { DomainObjectCommand } from '../commands/DomainObjectCommand';
 import { Changes } from '../domainObjectsHelpers/Changes';
 import { type IconName } from '../../base/utilities/IconName';
+import { type ButtonType } from '../utilities/types';
 
 export class DeleteDomainObjectCommand extends DomainObjectCommand<DomainObject> {
   public override get tooltip(): TranslationInput {
@@ -13,7 +14,7 @@ export class DeleteDomainObjectCommand extends DomainObjectCommand<DomainObject>
     return 'Delete';
   }
 
-  public override get buttonType(): string {
+  public override get buttonType(): ButtonType {
     return 'ghost-destructive';
   }
 

--- a/react-components/src/architecture/base/domainObjects/DomainObject.ts
+++ b/react-components/src/architecture/base/domainObjects/DomainObject.ts
@@ -31,6 +31,7 @@ import {
 } from '../../../advanced-tree-view';
 import { getRenderTarget } from './getRoot';
 import { translate } from '../utilities/translateUtils';
+import { type UniqueId } from '../utilities/types';
 
 /**
  * Represents an abstract base class for domain objects.
@@ -66,15 +67,14 @@ export abstract class DomainObject implements TreeNodeType {
   // Views and listeners
   public readonly views: Views = new Views();
 
-  // Unique index for the domain object, used as soft reference
-  private _uniqueId: number;
-  private static _counter: number = 0; // Counter for the unique index
+  // Unique guid for the domain object, used as soft reference
+  private _uniqueId: UniqueId;
 
-  public get uniqueId(): number {
+  public get uniqueId(): UniqueId {
     return this._uniqueId;
   }
 
-  public set uniqueId(value: number) {
+  protected set uniqueId(value: UniqueId) {
     this._uniqueId = value;
   }
 
@@ -83,8 +83,7 @@ export abstract class DomainObject implements TreeNodeType {
   // ==================================================
 
   public constructor() {
-    DomainObject._counter++;
-    this._uniqueId = DomainObject._counter;
+    this._uniqueId = crypto.randomUUID();
   }
 
   // ==================================================
@@ -788,7 +787,7 @@ export abstract class DomainObject implements TreeNodeType {
     return undefined;
   }
 
-  public getThisOrDescendantByUniqueId(uniqueId: number): DomainObject | undefined {
+  public getThisOrDescendantByUniqueId(uniqueId: UniqueId): DomainObject | undefined {
     for (const descendant of this.getThisAndDescendants()) {
       if (descendant.uniqueId === uniqueId) {
         return descendant;

--- a/react-components/src/architecture/base/domainObjects/DomainObject.ts
+++ b/react-components/src/architecture/base/domainObjects/DomainObject.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../advanced-tree-view';
 import { getRenderTarget } from './getRoot';
 import { translate } from '../utilities/translateUtils';
-import { type UniqueId } from '../utilities/types';
+import { generateUniqueId, type UniqueId } from '../utilities/types';
 
 /**
  * Represents an abstract base class for domain objects.
@@ -83,7 +83,7 @@ export abstract class DomainObject implements TreeNodeType {
   // ==================================================
 
   public constructor() {
-    this._uniqueId = crypto.randomUUID();
+    this._uniqueId = generateUniqueId();
   }
 
   // ==================================================

--- a/react-components/src/architecture/base/domainObjects/DomainObject.ts
+++ b/react-components/src/architecture/base/domainObjects/DomainObject.ts
@@ -91,7 +91,7 @@ export abstract class DomainObject implements TreeNodeType {
   // ==================================================
 
   public get id(): string {
-    return this.uniqueId.toString();
+    return this.uniqueId;
   }
 
   public get isVisibleInTree(): boolean {

--- a/react-components/src/architecture/base/renderTarget/RevealRenderTarget.ts
+++ b/react-components/src/architecture/base/renderTarget/RevealRenderTarget.ts
@@ -39,6 +39,7 @@ import { CdfCaches } from './CdfCaches';
 import { type DmsUniqueIdentifier } from '../../../data-providers';
 import { type Image360Model, type PointCloud } from '../../concrete/reveal/RevealTypes';
 import { RevealSettingsController } from '../../concrete/reveal/RevealSettingsController';
+import { type UniqueId } from '../utilities/types';
 
 const DIRECTIONAL_LIGHT_NAME = 'DirectionalLight';
 
@@ -63,7 +64,7 @@ export class RevealRenderTarget {
   private _ambientLight: AmbientLight | undefined;
   private _directionalLight: DirectionalLight | undefined;
   private _clippedBoundingBox: Box3 | undefined;
-  private _cropBoxUniqueId: number | undefined = undefined;
+  private _cropBoxUniqueId: UniqueId | undefined = undefined;
   private _axisGizmoTool: AxisGizmoTool | undefined;
   private _config: BaseRevealConfig | undefined = undefined;
 

--- a/react-components/src/architecture/base/undo/Transaction.ts
+++ b/react-components/src/architecture/base/undo/Transaction.ts
@@ -1,6 +1,7 @@
 import { type DomainObject } from '../domainObjects/DomainObject';
 import { Changes } from '../domainObjectsHelpers/Changes';
 import { type RevealRenderTarget } from '../renderTarget/RevealRenderTarget';
+import { type UniqueId } from '../utilities/types';
 
 export abstract class Transaction {
   // ==================================================
@@ -8,8 +9,8 @@ export abstract class Transaction {
   // ==================================================
 
   public readonly changed: symbol;
-  public readonly uniqueId: number;
-  private readonly _parentUniqueId?: number;
+  public readonly uniqueId: UniqueId;
+  private readonly _parentUniqueId?: UniqueId;
   public readonly timeStamp = Date.now();
 
   // ==================================================

--- a/react-components/src/architecture/base/undo/UndoManager.ts
+++ b/react-components/src/architecture/base/undo/UndoManager.ts
@@ -1,4 +1,5 @@
 import { type RevealRenderTarget } from '../renderTarget/RevealRenderTarget';
+import { type UniqueId } from '../utilities/types';
 import { type Transaction } from './Transaction';
 
 export class UndoManager {
@@ -56,7 +57,7 @@ export class UndoManager {
     return this._transactions.length > 0;
   }
 
-  public hasUniqueId(uniqueId: number): boolean {
+  public hasUniqueId(uniqueId: UniqueId): boolean {
     return this._transactions.find((a) => a.uniqueId === uniqueId) !== undefined;
   }
 }

--- a/react-components/src/architecture/base/utilities/types.ts
+++ b/react-components/src/architecture/base/utilities/types.ts
@@ -1,0 +1,3 @@
+export type UniqueId = string;
+
+export type ButtonType = 'ghost' | 'ghost-destructive' | 'primary';

--- a/react-components/src/architecture/base/utilities/types.ts
+++ b/react-components/src/architecture/base/utilities/types.ts
@@ -1,3 +1,7 @@
+export type ButtonType = 'ghost' | 'ghost-destructive' | 'primary';
+
 export type UniqueId = string;
 
-export type ButtonType = 'ghost' | 'ghost-destructive' | 'primary';
+export function generateUniqueId(): UniqueId {
+  return crypto.randomUUID();
+}

--- a/react-components/src/architecture/concrete/annotation360/DeleteSelectedImage360AnnotationCommand.ts
+++ b/react-components/src/architecture/concrete/annotation360/DeleteSelectedImage360AnnotationCommand.ts
@@ -4,6 +4,7 @@ import { Changes } from '../../base/domainObjectsHelpers/Changes';
 import { FocusType } from '../../base/domainObjectsHelpers/FocusType';
 import { type IconName } from '../../base/utilities/IconName';
 import { type TranslationInput } from '../../base/utilities/TranslateInput';
+import { type ButtonType } from '../../base/utilities/types';
 import { Image360AnnotationDomainObject } from './Image360AnnotationDomainObject';
 
 export class DeleteSelectedImage360AnnotationCommand extends InstanceCommand {
@@ -15,7 +16,7 @@ export class DeleteSelectedImage360AnnotationCommand extends InstanceCommand {
     return 'Delete';
   }
 
-  public override get buttonType(): string {
+  public override get buttonType(): ButtonType {
     return 'ghost-destructive';
   }
 

--- a/react-components/src/architecture/concrete/annotations/commands/AnnotationsDeleteCommand.ts
+++ b/react-components/src/architecture/concrete/annotations/commands/AnnotationsDeleteCommand.ts
@@ -1,6 +1,7 @@
 import { RenderTargetCommand } from '../../../base/commands/RenderTargetCommand';
 import { type IconName } from '../../../base/utilities/IconName';
 import { type TranslationInput } from '../../../base/utilities/TranslateInput';
+import { type ButtonType } from '../../../base/utilities/types';
 import { AnnotationsDomainObject } from '../AnnotationsDomainObject';
 
 export class AnnotationsDeleteCommand extends RenderTargetCommand {
@@ -16,7 +17,7 @@ export class AnnotationsDeleteCommand extends RenderTargetCommand {
     return 'Delete';
   }
 
-  public override get buttonType(): string {
+  public override get buttonType(): ButtonType {
     return 'ghost-destructive';
   }
 

--- a/react-components/src/architecture/concrete/clipping/commands/ApplyClipCommand.ts
+++ b/react-components/src/architecture/concrete/clipping/commands/ApplyClipCommand.ts
@@ -5,6 +5,7 @@ import { SliceDomainObject } from '../SliceDomainObject';
 import { FocusType } from '../../../base/domainObjectsHelpers/FocusType';
 import { type IconName } from '../../../base/utilities/IconName';
 import { setClippingPlanes } from './setClippingPlanes';
+import { type ButtonType } from '../../../base/utilities/types';
 
 export class ApplyClipCommand extends RenderTargetCommand {
   // ==================================================
@@ -21,7 +22,7 @@ export class ApplyClipCommand extends RenderTargetCommand {
     return 'Crop';
   }
 
-  public override get buttonType(): string {
+  public override get buttonType(): ButtonType {
     return 'primary';
   }
 

--- a/react-components/src/architecture/concrete/example/commands/DeleteAllExamplesCommand.ts
+++ b/react-components/src/architecture/concrete/example/commands/DeleteAllExamplesCommand.ts
@@ -4,6 +4,7 @@ import { type DomainObject } from '../../../base/domainObjects/DomainObject';
 import { Changes } from '../../../base/domainObjectsHelpers/Changes';
 import { type TranslationInput } from '../../../base/utilities/TranslateInput';
 import { ExampleDomainObject } from '../ExampleDomainObject';
+import { type ButtonType } from '../../../base/utilities/types';
 
 export class DeleteAllExamplesCommand extends InstanceCommand {
   // ==================================================
@@ -18,7 +19,7 @@ export class DeleteAllExamplesCommand extends InstanceCommand {
     return 'Delete';
   }
 
-  public override get buttonType(): string {
+  public override get buttonType(): ButtonType {
     return 'ghost-destructive';
   }
 

--- a/react-components/src/architecture/concrete/pointsOfInterest/DeletePointsOfInterestCommand.ts
+++ b/react-components/src/architecture/concrete/pointsOfInterest/DeletePointsOfInterestCommand.ts
@@ -1,7 +1,7 @@
 import { type TranslationInput } from '../../base/utilities/TranslateInput';
-import { type ButtonType } from '../../../components/Architecture/types';
 import { PointsOfInterestCommand } from './PointsOfInterestCommand';
 import { type IconName } from '../../base/utilities/IconName';
+import { type ButtonType } from '../../base/utilities/types';
 
 export class DeleteSelectedPointsOfInterestCommand<
   PoiIdType

--- a/react-components/src/components/Architecture/CommandButton.tsx
+++ b/react-components/src/components/Architecture/CommandButton.tsx
@@ -2,7 +2,7 @@ import { type ReactElement } from 'react';
 import { useRenderTarget } from '../RevealCanvas/ViewerContext';
 import { Button, Tooltip as CogsTooltip } from '@cognite/cogs.js';
 import { type BaseCommand } from '../../architecture/base/commands/BaseCommand';
-import { getButtonType, getTooltipPlacement } from './utilities';
+import { getTooltipPlacement } from './utilities';
 import { LabelWithShortcut } from './LabelWithShortcut';
 import { IconComponent } from './Factories/IconFactory';
 import { type PlacementType } from './types';
@@ -33,7 +33,7 @@ export const CommandButton = ({
       enterDelay={TOOLTIP_DELAY}
       placement={getTooltipPlacement(placement)}>
       <Button
-        type={getButtonType(command)}
+        type={command.buttonType}
         icon={<IconComponent iconName={icon} />}
         key={uniqueId}
         disabled={!isEnabled}

--- a/react-components/src/components/Architecture/CommandButtons.tsx
+++ b/react-components/src/components/Architecture/CommandButtons.tsx
@@ -18,6 +18,7 @@ import { InputField } from './InputField';
 import { BaseInputCommand } from '../../architecture/base/commands/BaseInputCommand';
 import { CustomBaseInputCommand } from '../../architecture/base/commands/CustomBaseInputCommand';
 import { CustomInputField } from './CustomInputField';
+import { type UniqueId } from '../../architecture/base/utilities/types';
 
 export function createButton(command: BaseCommand, placement: PlacementType): ReactElement {
   if (command instanceof BaseFilterCommand) {
@@ -82,9 +83,9 @@ export const CommandButtons = ({
   );
 };
 
-function getKey(command: BaseCommand | undefined, index: number): number {
+function getKey(command: BaseCommand | undefined, index: number): UniqueId {
   if (command === undefined) {
-    return -index;
+    return `undefined${index.toString()}`;
   }
   return command.uniqueId;
 }

--- a/react-components/src/components/Architecture/DropdownButton.tsx
+++ b/react-components/src/components/Architecture/DropdownButton.tsx
@@ -4,7 +4,7 @@ import { useState, type ReactElement, type SetStateAction, type Dispatch } from 
 
 import { type BaseCommand } from '../../architecture/base/commands/BaseCommand';
 import { type BaseOptionCommand } from '../../architecture/base/commands/BaseOptionCommand';
-import { getButtonType, getTooltipPlacement } from './utilities';
+import { getTooltipPlacement } from './utilities';
 import { LabelWithShortcut } from './LabelWithShortcut';
 import { DEFAULT_PADDING, TOOLTIP_DELAY } from './constants';
 
@@ -70,7 +70,7 @@ const DropdownElement = ({
             style={{
               padding: '8px 4px'
             }}
-            type={getButtonType(command)}
+            type={command.buttonType}
             icon={<OpenButtonIcon />}
             key={uniqueId}
             disabled={!isEnabled}

--- a/react-components/src/components/Architecture/FilterButton.tsx
+++ b/react-components/src/components/Architecture/FilterButton.tsx
@@ -13,7 +13,7 @@ import {
   Flex
 } from '@cognite/cogs.js';
 import { Menu, SelectPanel } from '@cognite/cogs-lab';
-import { getButtonType, getTooltipPlacement } from './utilities';
+import { getTooltipPlacement } from './utilities';
 import { LabelWithShortcut } from './LabelWithShortcut';
 import { BaseFilterCommand } from '../../architecture/base/commands/BaseFilterCommand';
 import { FilterItem } from './FilterItem';
@@ -113,7 +113,7 @@ const FilterMenu = ({
           disabled={isOpen || label === undefined}
           placement={placement}>
           <Button
-            type={getButtonType(command)}
+            type={command.buttonType}
             icon={<IconComponent iconName={iconName} />}
             disabled={!isEnabled}
             toggled={isOpen}

--- a/react-components/src/components/Architecture/SettingsButton.tsx
+++ b/react-components/src/components/Architecture/SettingsButton.tsx
@@ -9,7 +9,7 @@ import { DividerCommand } from '../../architecture/base/commands/DividerCommand'
 import { Dropdown, Menu } from '@cognite/cogs-lab';
 import { DropdownButton } from './DropdownButton';
 import { FilterButton } from './FilterButton';
-import { getButtonType, getFlexDirection, getTooltipPlacement } from './utilities';
+import { getFlexDirection, getTooltipPlacement } from './utilities';
 import { IconComponent } from './Factories/IconFactory';
 import { LabelWithShortcut } from './LabelWithShortcut';
 import { SectionCommand } from '../../architecture/base/commands/SectionCommand';
@@ -71,7 +71,7 @@ export const SettingsButton = ({
         enterDelay={TOOLTIP_DELAY}
         placement={getTooltipPlacement(placement)}>
         <Button
-          type={getButtonType(command)}
+          type={command.buttonType}
           icon={<IconComponent iconName={icon} />}
           disabled={!isEnabled}
           toggled={isOpen}

--- a/react-components/src/components/Architecture/hooks/useCommandProps.tsx
+++ b/react-components/src/components/Architecture/hooks/useCommandProps.tsx
@@ -2,10 +2,11 @@ import { type BaseCommand } from '../../../architecture/base/commands/BaseComman
 import { type BaseSliderCommand } from '../../../architecture';
 import { type IconName } from '../../../architecture/base/utilities/IconName';
 import { useCommandProperty } from './useCommandProperty';
+import { type UniqueId } from '../../../architecture/base/utilities/types';
 
 type CommonCommandProps = {
   icon: IconName;
-  uniqueId: number;
+  uniqueId: UniqueId;
   isVisible: boolean;
   isEnabled: boolean;
   isChecked: boolean;
@@ -25,7 +26,7 @@ export function useCommandIcon(command: BaseCommand): IconName {
   return useCommandProperty(command, () => command.icon);
 }
 
-export function useCommandUniqueId(command: BaseCommand): number {
+export function useCommandUniqueId(command: BaseCommand): UniqueId {
   return useCommandProperty(command, () => command.uniqueId);
 }
 

--- a/react-components/src/components/Architecture/types.ts
+++ b/react-components/src/components/Architecture/types.ts
@@ -1,5 +1,3 @@
-export type ButtonType = 'ghost' | 'ghost-destructive' | 'primary';
-
 type Side = 'top' | 'right' | 'bottom' | 'left';
 
 type Alignment = 'start' | 'end';

--- a/react-components/src/components/Architecture/utilities.ts
+++ b/react-components/src/components/Architecture/utilities.ts
@@ -1,7 +1,7 @@
 import { type BaseCommand } from '../../architecture/base/commands/BaseCommand';
 import { type RevealRenderTarget } from '../../architecture/base/renderTarget/RevealRenderTarget';
 import { RenderTargetCommand } from '../../architecture/base/commands/RenderTargetCommand';
-import { type PlacementType, type ButtonType, type FlexDirection } from './types';
+import { type PlacementType, type FlexDirection } from './types';
 
 export function getFlexDirection(placement: PlacementType): FlexDirection {
   return placement === 'top' || placement === 'bottom' ? 'row' : 'column';
@@ -25,11 +25,6 @@ export function getTooltipPlacement(toolbarPlacement: PlacementType): PlacementT
     default:
       return 'top';
   }
-}
-
-export function getButtonType(command: BaseCommand): ButtonType {
-  // This was the only way it went through compiler: (more button types will be added in the future)
-  return command.buttonType as ButtonType;
 }
 
 export function getDefaultCommand<T extends BaseCommand>(


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Refactor](https://img.shields.io/badge/Type-Refactor-lightgrey) 

## Description :pencil:

1. Now, the `uniqueId `is made from Guid (before it was made from a counter)
2. Let buttonType return `ByttonType `type instead of string
3. Move `ButtonType  `and `UniqueId `to architecture/utility/types.ts


## How has this been tested? :mag:

I relay on the unit tests

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
