### PR TITLE
fix(react-components): use new asset mapping filter endpoint capabilities

### DIFF
--- a/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/CadInstanceMappingsCacheImpl.ts
@@ -7,7 +7,6 @@ import {
   type ModelRevisionId,
   type ModelRevisionKey
 } from '../types';
-import { partition } from 'lodash';
 import { createFdmKey, createModelRevisionKey } from '../idAndKeyTranslation';
 import { executeParallel } from '../../../utilities/executeParallel';
 import { isDefined } from '../../../utilities/isDefined';
@@ -53,7 +52,7 @@ class CadInstanceMappingsCacheImpl implements CadInstanceMappingsCache {
       return new Map();
     }
 
-    const [dmsInstances, internalIds] = partition(instances, isDmsInstance);
+    const dmsInstances = instances.filter(isDmsInstance);
 
     const dmResults = await this._dmCache?.getMappingsForFdmInstances(dmsInstances, models);
 
@@ -64,7 +63,7 @@ class CadInstanceMappingsCacheImpl implements CadInstanceMappingsCache {
         const nodeResult = await this._classicCache?.getNodesForInstanceIds(
           model.modelId,
           model.revisionId,
-          internalIds
+          instances
         );
 
         if (nodeResult === undefined) {

--- a/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
+++ b/react-components/src/components/CacheProvider/cad/ClassicCadAssetMappingCacheImpl.ts
@@ -1,4 +1,4 @@
-import { Filter3DAssetMappingsQuery, type CogniteClient, type Node3D } from '@cognite/sdk';
+import { type Filter3DAssetMappingsQuery, type CogniteClient, type Node3D } from '@cognite/sdk';
 import {
   type ModelId,
   type RevisionId,
@@ -34,8 +34,8 @@ import {
 import { type HybridCadCacheIndexType } from './types';
 import { convertToHybridAssetMapping } from './rawAssetMappingTypes';
 import { isDefined } from '../../../utilities/isDefined';
-import { DmsUniqueIdentifier } from '../../../data-providers';
-import { RawHybridAssetMapping } from '../../../query/network/cad/fetchHybridAssetMappingsForModels';
+import { type DmsUniqueIdentifier } from '../../../data-providers';
+import { type RawHybridAssetMapping } from '../../../query/network/cad/fetchHybridAssetMappingsForModels';
 
 export function createClassicCadAssetMappingCache(sdk: CogniteClient): ClassicCadAssetMappingCache {
   return new ClassicCadAssetMappingCacheImpl(sdk);
@@ -241,11 +241,11 @@ class ClassicCadAssetMappingCacheImpl implements ClassicCadAssetMappingCache {
     modelId: ModelId,
     revisionId: RevisionId
   ): Promise<HybridCadAssetMapping[]> {
-    const rawAssetMappings = await (() => {
+    const rawAssetMappings = await (async () => {
       if (filterType === 'nodeIds') {
-        return this.fetchAssetMappingsByNodeIds(currentChunk, modelId, revisionId);
+        return await this.fetchAssetMappingsByNodeIds(currentChunk, modelId, revisionId);
       } else {
-        return this.fetchAssetMappingsByInstanceIds(currentChunk, modelId, revisionId);
+        return await this.fetchAssetMappingsByInstanceIds(currentChunk, modelId, revisionId);
       }
     })();
 

--- a/react-components/src/components/CacheProvider/idAndKeyTranslation.ts
+++ b/react-components/src/components/CacheProvider/idAndKeyTranslation.ts
@@ -28,6 +28,11 @@ export function createFdmKey(id: DmsUniqueIdentifier): FdmKey {
   return `${id.space}/${id.externalId}`;
 }
 
+export function fdmKeyToId(fdmKey: FdmKey): DmsUniqueIdentifier {
+  const components = split(fdmKey, '/');
+  return { space: components[0], externalId: components[1] };
+}
+
 export function createInstanceKey(id: InstanceId): InstanceKey {
   if (isClassicInstanceId(id)) {
     return id;

--- a/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.tsx
+++ b/react-components/src/components/Reveal3DResources/hooks/useCalculateCadStyling.tsx
@@ -7,12 +7,7 @@ import {
 import { NumericRange, type NodeAppearance, IndexSet } from '@cognite/reveal';
 import { type Node3D } from '@cognite/sdk';
 import { createContext, useContext, useMemo } from 'react';
-import {
-  type AssetId,
-  type FdmKey,
-  type CadNodeTreeData,
-  type ModelRevisionKey
-} from '../../CacheProvider/types';
+import { type AssetId, type FdmKey, type CadNodeTreeData } from '../../CacheProvider/types';
 import {
   type CadStylingGroup,
   type NodeStylingGroup,
@@ -25,16 +20,12 @@ import {
 import { isSameModel } from '../../../utilities/isSameModel';
 import { useQuery } from '@tanstack/react-query';
 import { DEFAULT_QUERY_STALE_TIME } from '../../../utilities/constants';
-import {
-  useCadMappingsCache,
-  useClassicCadAssetMappingCache
-} from '../../CacheProvider/CacheProvider';
+import { useCadMappingsCache } from '../../CacheProvider/CacheProvider';
 import { isDefined } from '../../../utilities/isDefined';
 import { getInstanceKeysFromStylingGroup } from '../utils';
 import { createModelRevisionKey } from '../../CacheProvider/idAndKeyTranslation';
 import { type CadModelTreeIndexMappings } from '../../CacheProvider/cad/CadInstanceMappingsCache';
 import { type InstanceKey } from '../../../utilities/instanceIds';
-import { chunk } from 'lodash';
 import { useIsCoreDmOnly } from '../../../hooks/useIsCoreDmOnly';
 
 type ModelStyleGroup = {
@@ -60,12 +51,10 @@ export type StyledModel = {
 
 export type UseCalculateCadStylingDependencies = {
   useCadMappingsCache: typeof useCadMappingsCache;
-  useClassicCadAssetMappingCache: typeof useClassicCadAssetMappingCache;
 };
 
 export const defaultUseCalculateCadStylingDependencies: UseCalculateCadStylingDependencies = {
-  useCadMappingsCache,
-  useClassicCadAssetMappingCache
+  useCadMappingsCache
 };
 
 export const UseCalculateCadStylingContext = createContext<UseCalculateCadStylingDependencies>(
@@ -168,12 +157,9 @@ function useCalculateInstanceStyling(
     .filter(isClassicAssetMappingStylingGroup)
     .flatMap((instanceGroup) => instanceGroup.assetIds);
 
-  const { useCadMappingsCache, useClassicCadAssetMappingCache } = useContext(
-    UseCalculateCadStylingContext
-  );
+  const { useCadMappingsCache } = useContext(UseCalculateCadStylingContext);
 
   const cadCache = useCadMappingsCache();
-  const classicCadAssetMappingCache = useClassicCadAssetMappingCache();
   const isCoreDm = useIsCoreDmOnly();
 
   const {
@@ -212,8 +198,6 @@ function useCalculateInstanceStyling(
           };
         })
         .filter(isDefined);
-
-      console.log('Mapped over models ', models, ' to form style groups', modelStyleGroups);
 
       return modelStyleGroups;
     },

--- a/react-components/src/hooks/useIsCoreDmOnly.ts
+++ b/react-components/src/hooks/useIsCoreDmOnly.ts
@@ -2,6 +2,5 @@ import { useRenderTarget } from '../components/RevealCanvas/ViewerContext';
 
 export function useIsCoreDmOnly(): boolean {
   const renderTarget = useRenderTarget();
-  const isCoreDmOnly = renderTarget.cdfCaches.coreDmOnly;
-  return isCoreDmOnly ?? false;
+  return renderTarget.cdfCaches.coreDmOnly;
 }

--- a/react-components/src/query/network/cad/fetchHybridAssetMappingsForModels.ts
+++ b/react-components/src/query/network/cad/fetchHybridAssetMappingsForModels.ts
@@ -18,7 +18,7 @@ const MODEL_CHUNK_SIZE = 10;
 
 export type HybridDataType = 'dm' | 'classic';
 
-export type RawHybridAssetMapping<T extends HybridDataType> = T extends 'dm'
+export type RawHybridAssetMapping<T extends HybridDataType = HybridDataType> = T extends 'dm'
   ? RawCdfHybridDmCadAssetMapping
   : RawCdfHybridClassicCadAssetMapping;
 

--- a/react-components/src/query/useModelsForInstanceQuery.ts
+++ b/react-components/src/query/useModelsForInstanceQuery.ts
@@ -53,9 +53,11 @@ export const useModelsForInstanceQuery = (
         if (!isCoreDm) {
           return await getCadModelsForHybridDmInstance(instance, cogniteClient);
         }
+
         if (fdm3dDataProvider === undefined) {
           return [];
         }
+
         return await getModelsForDmsInstance(
           instance,
           fdmSdk,


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Make use of the new `mappings/filter` endpoint capabilities in the CAD node cache to fetch classic asset mappings filtered by DM instance ids. In particular, this styling by DM instance IDs in hybrid CDF environments. Note that this functionality was partially working earlier as well, since we were explicitly filling up the cache on load, although it could take some time until all relevant items were loaded, while now they will also be loaded directly on demand which may give a significant speedup. 

Closes https://cognitedata.atlassian.net/browse/BND3D-5837

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In Fusion


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Open Unified 3D in 3d-test, Håkon's Scene
- Click the contextualized CAD tank that is positioned some way from the other contextualization (this is a hybrid-DM-contextualized asset)
- See that it gets properly styled on click. 

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
