### PR TITLE
chore(react-components): Make set uniqueId on domainobject public again

### DIFF
--- a/react-components/src/architecture/base/domainObjects/DomainObject.ts
+++ b/react-components/src/architecture/base/domainObjects/DomainObject.ts
@@ -78,7 +78,7 @@ export abstract class DomainObject implements TreeNodeType {
     return this._uniqueId;
   }
 
-  protected set uniqueId(value: UniqueId) {
+  public set uniqueId(value: UniqueId) {
     this._uniqueId = value;
   }
 


### PR DESCRIPTION
#### Type of change
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
[BND3D-5960](https://cognitedata.atlassian.net/browse/BND3D-5960)

## Description :pencil:
Set uniqueId in DomainObject was made `protected` in the following PR: https://github.com/cognitedata/reveal/pull/5249. This is a breaking change and has to be reverted as other applications depend on this functionality.