### PR TITLE
feat(react-components): update fdm hook fetch all threed connections with properties rule based coloring

### DIFF
--- a/react-components/src/query/useAll3dDirectConnectionsWithProperties.context.ts
+++ b/react-components/src/query/useAll3dDirectConnectionsWithProperties.context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import { useFdmSdk } from '../components/RevealCanvas/SDKProvider';
+
+export type UseAll3dDirectConnectionsWithPropertiesDependencies = {
+  useFdmSdk: typeof useFdmSdk;
+};
+
+export const defaultUseAll3dDirectConnectionsWithPropertiesDependencies: UseAll3dDirectConnectionsWithPropertiesDependencies =
+  {
+    useFdmSdk
+  };
+
+export const UseAll3dDirectConnectionsWithPropertiesContext =
+  createContext<UseAll3dDirectConnectionsWithPropertiesDependencies>(
+    defaultUseAll3dDirectConnectionsWithPropertiesDependencies
+  );

--- a/react-components/src/query/useAll3dDirectConnectionsWithProperties.test.tsx
+++ b/react-components/src/query/useAll3dDirectConnectionsWithProperties.test.tsx
@@ -61,7 +61,6 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
     views: [{ space: 'view-space', externalId: 'view-id', version: '1', type: 'view' as const }]
   };
 
-
   const mockConnectionWithNode2: FdmConnectionWithNode = {
     connection: {
       instance: { space: 'test-space', externalId: 'test-id-2' },
@@ -141,7 +140,11 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
 
   it('should process connections and return multiple instance data', async () => {
     const { result } = renderHook(
-      () => useAll3dDirectConnectionsWithProperties([mockConnectionWithNode, mockConnectionWithNodeSameInstance]),
+      () =>
+        useAll3dDirectConnectionsWithProperties([
+          mockConnectionWithNode,
+          mockConnectionWithNodeSameInstance
+        ]),
       { wrapper }
     );
 

--- a/react-components/src/query/useAll3dDirectConnectionsWithProperties.test.tsx
+++ b/react-components/src/query/useAll3dDirectConnectionsWithProperties.test.tsx
@@ -22,6 +22,11 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
   const ARBITRARY_MODEL_ID = 123;
   const ARBITRARY_REVISION_ID = 456;
 
+  const baseDmsUniqueIdentifier = {
+    space: 'test-space',
+    externalId: 'test-id'
+  };
+
   const node3d1 = createCadNodeMock({
     id: 100,
     treeIndex: ARBITRARY_TREE_INDEX,
@@ -36,7 +41,7 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
 
   const mockConnectionWithNode: FdmConnectionWithNode = {
     connection: {
-      instance: { space: 'test-space', externalId: 'test-id' },
+      instance: baseDmsUniqueIdentifier,
       modelId: ARBITRARY_MODEL_ID,
       revisionId: ARBITRARY_REVISION_ID,
       treeIndex: ARBITRARY_TREE_INDEX
@@ -44,6 +49,18 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
     cadNode: node3d1,
     views: [{ space: 'view-space', externalId: 'view-id', version: '1', type: 'view' as const }]
   };
+
+  const mockConnectionWithNodeSameInstance: FdmConnectionWithNode = {
+    connection: {
+      instance: baseDmsUniqueIdentifier,
+      modelId: ARBITRARY_MODEL_ID,
+      revisionId: ARBITRARY_REVISION_ID,
+      treeIndex: ARBITRARY_TREE_INDEX + 1
+    },
+    cadNode: node3d2,
+    views: [{ space: 'view-space', externalId: 'view-id', version: '1', type: 'view' as const }]
+  };
+
 
   const mockConnectionWithNode2: FdmConnectionWithNode = {
     connection: {
@@ -57,9 +74,8 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
   };
 
   const mockFdmInstanceData = {
+    ...baseDmsUniqueIdentifier,
     instanceType: 'node' as const,
-    space: 'test-space',
-    externalId: 'test-id',
     version: 1,
     createdTime: 11111,
     lastUpdatedTime: 11111,
@@ -67,9 +83,8 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
   };
 
   const mockInspectResultItem = {
+    ...baseDmsUniqueIdentifier,
     instanceType: 'node' as const,
-    space: 'test-space',
-    externalId: 'test-id',
     inspectionResults: {
       involvedViews: [
         { space: 'view-space', externalId: 'view-id', version: '1', type: 'view' as const }
@@ -124,9 +139,9 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  it('should process connections and return instance data', async () => {
+  it('should process connections and return multiple instance data', async () => {
     const { result } = renderHook(
-      () => useAll3dDirectConnectionsWithProperties([mockConnectionWithNode]),
+      () => useAll3dDirectConnectionsWithProperties([mockConnectionWithNode, mockConnectionWithNodeSameInstance]),
       { wrapper }
     );
 
@@ -142,6 +157,14 @@ describe(useAll3dDirectConnectionsWithProperties.name, () => {
         connection: mockConnectionWithNode.connection,
         cadNode: mockConnectionWithNode.cadNode,
         views: mockConnectionWithNode.views,
+        items: [mockFdmInstanceData],
+        instanceType: 'node' as const,
+        typing: {}
+      },
+      {
+        connection: mockConnectionWithNodeSameInstance.connection,
+        cadNode: mockConnectionWithNodeSameInstance.cadNode,
+        views: mockConnectionWithNodeSameInstance.views,
         items: [mockFdmInstanceData],
         instanceType: 'node' as const,
         typing: {}

--- a/react-components/src/query/useAll3dDirectConnectionsWithProperties.test.tsx
+++ b/react-components/src/query/useAll3dDirectConnectionsWithProperties.test.tsx
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useAll3dDirectConnectionsWithProperties } from './useAll3dDirectConnectionsWithProperties';
+import {
+  defaultUseAll3dDirectConnectionsWithPropertiesDependencies,
+  UseAll3dDirectConnectionsWithPropertiesContext
+} from './useAll3dDirectConnectionsWithProperties.context';
+import { type FdmConnectionWithNode } from '../components/CacheProvider/types';
+import { type FdmSDK } from '../data-providers/FdmSDK';
+import { Mock } from 'moq.ts';
+import type { FC, PropsWithChildren } from 'react';
+import { getMocksByDefaultDependencies } from '#test-utils/vitest-extensions/getMocksByDefaultDependencies';
+import { FdmSdkContext } from '../components/RevealCanvas/FdmDataProviderContext';
+import { createCadNodeMock } from '#test-utils/fixtures/cadNode';
+
+describe(useAll3dDirectConnectionsWithProperties.name, () => {
+  const queryClient = new QueryClient();
+
+  const ARBITRARY_DATA_SET_SIZE = 1500;
+  const ARBITRARY_TREE_INDEX = 789;
+  const ARBITRARY_MODEL_ID = 123;
+  const ARBITRARY_REVISION_ID = 456;
+
+  const node3d1 = createCadNodeMock({
+    id: 100,
+    treeIndex: ARBITRARY_TREE_INDEX,
+    subtreeSize: 1
+  });
+
+  const node3d2 = createCadNodeMock({
+    id: 101,
+    treeIndex: ARBITRARY_TREE_INDEX + 1,
+    subtreeSize: 1
+  });
+
+  const mockConnectionWithNode: FdmConnectionWithNode = {
+    connection: {
+      instance: { space: 'test-space', externalId: 'test-id' },
+      modelId: ARBITRARY_MODEL_ID,
+      revisionId: ARBITRARY_REVISION_ID,
+      treeIndex: ARBITRARY_TREE_INDEX
+    },
+    cadNode: node3d1,
+    views: [{ space: 'view-space', externalId: 'view-id', version: '1', type: 'view' as const }]
+  };
+
+  const mockConnectionWithNode2: FdmConnectionWithNode = {
+    connection: {
+      instance: { space: 'test-space', externalId: 'test-id-2' },
+      modelId: ARBITRARY_MODEL_ID,
+      revisionId: ARBITRARY_REVISION_ID,
+      treeIndex: ARBITRARY_TREE_INDEX + 1
+    },
+    cadNode: node3d2,
+    views: [{ space: 'view-space-2', externalId: 'view-id-2', version: '1', type: 'view' as const }]
+  };
+
+  const mockFdmInstanceData = {
+    instanceType: 'node' as const,
+    space: 'test-space',
+    externalId: 'test-id',
+    version: 1,
+    createdTime: 11111,
+    lastUpdatedTime: 11111,
+    properties: { testProperty: { value: 'testValue' } }
+  };
+
+  const mockInspectResultItem = {
+    instanceType: 'node' as const,
+    space: 'test-space',
+    externalId: 'test-id',
+    inspectionResults: {
+      involvedViews: [
+        { space: 'view-space', externalId: 'view-id', version: '1', type: 'view' as const }
+      ],
+      involvedContainers: []
+    }
+  };
+
+  const mockInspectResultList = [mockInspectResultItem];
+
+  const mockFdmSdk = new Mock<FdmSDK>()
+    .setup((p) => p.getByExternalIds)
+    .returns(vi.fn())
+    .setup((p) => p.inspectInstances)
+    .returns(vi.fn())
+    .object();
+
+  const mockDependencies = getMocksByDefaultDependencies(
+    defaultUseAll3dDirectConnectionsWithPropertiesDependencies
+  );
+
+  mockDependencies.useFdmSdk.mockReturnValue(mockFdmSdk);
+
+  const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <FdmSdkContext.Provider value={{ fdmSdk: mockFdmSdk }}>
+        {children}
+        <UseAll3dDirectConnectionsWithPropertiesContext.Provider value={mockDependencies}>
+          {children}
+        </UseAll3dDirectConnectionsWithPropertiesContext.Provider>
+      </FdmSdkContext.Provider>
+    </QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient.clear();
+
+    vi.mocked(mockFdmSdk.getByExternalIds).mockResolvedValue({
+      items: [mockFdmInstanceData],
+      typing: {}
+    });
+
+    vi.mocked(mockFdmSdk.inspectInstances).mockResolvedValue({
+      items: mockInspectResultList
+    });
+  });
+
+  it('should return empty result when no connections provided', async () => {
+    const { result } = renderHook(() => useAll3dDirectConnectionsWithProperties([]), { wrapper });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should process connections and return instance data', async () => {
+    const { result } = renderHook(
+      () => useAll3dDirectConnectionsWithProperties([mockConnectionWithNode]),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    await waitFor(() => {
+      expect(mockFdmSdk.getByExternalIds).toHaveBeenCalled();
+    });
+
+    const expectedData = [
+      {
+        connection: mockConnectionWithNode.connection,
+        cadNode: mockConnectionWithNode.cadNode,
+        views: mockConnectionWithNode.views,
+        items: [mockFdmInstanceData],
+        instanceType: 'node' as const,
+        typing: {}
+      }
+    ];
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(expectedData);
+    });
+    await waitFor(() => {
+      expect(mockFdmSdk.inspectInstances).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle empty instance data response', async () => {
+    vi.mocked(mockFdmSdk.getByExternalIds).mockResolvedValue({
+      items: [],
+      typing: {}
+    });
+
+    vi.mocked(mockFdmSdk.inspectInstances).mockResolvedValue({
+      items: []
+    });
+
+    const { result } = renderHook(
+      () => useAll3dDirectConnectionsWithProperties([mockConnectionWithNode]),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('should try to fetch fdm nodes without views', async () => {
+    const connectionWithoutViews: FdmConnectionWithNode = {
+      ...mockConnectionWithNode,
+      views: undefined
+    };
+
+    const { result } = renderHook(
+      () => useAll3dDirectConnectionsWithProperties([connectionWithoutViews]),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFdmSdk.getByExternalIds).toHaveBeenCalledWith(expect.any(Array), undefined);
+  });
+
+  it('should chunk large datasets correctly', async () => {
+    const connections = Array.from({ length: ARBITRARY_DATA_SET_SIZE }, (_, i) => ({
+      ...mockConnectionWithNode,
+      connection: {
+        ...mockConnectionWithNode.connection,
+        instance: { space: 'space', externalId: `id${i}` },
+        treeIndex: ARBITRARY_TREE_INDEX + i
+      }
+    }));
+
+    vi.mocked(mockFdmSdk.getByExternalIds).mockResolvedValue({
+      items: [],
+      typing: {}
+    });
+
+    vi.mocked(mockFdmSdk.inspectInstances).mockResolvedValue({
+      items: []
+    });
+
+    const { result } = renderHook(() => useAll3dDirectConnectionsWithProperties(connections), {
+      wrapper
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // Should call getByExternalIds multiple times due to chunking
+    expect(mockFdmSdk.getByExternalIds).toHaveBeenCalledTimes(2); // 2 chunks of 1000 each
+  });
+
+  it('should refetch when connections change', async () => {
+    const { result, rerender } = renderHook(
+      ({ connections }) => useAll3dDirectConnectionsWithProperties(connections),
+      {
+        wrapper,
+        initialProps: { connections: [mockConnectionWithNode] }
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const initialCallCount = vi.mocked(mockFdmSdk.getByExternalIds).mock.calls.length;
+
+    rerender({ connections: [mockConnectionWithNode, mockConnectionWithNode2] });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(vi.mocked(mockFdmSdk.getByExternalIds).mock.calls.length).toBeGreaterThan(
+      initialCallCount
+    );
+  });
+});

--- a/react-components/src/query/useAll3dDirectConnectionsWithProperties.ts
+++ b/react-components/src/query/useAll3dDirectConnectionsWithProperties.ts
@@ -1,5 +1,4 @@
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
-import { useFdmSdk } from '../components/RevealCanvas/SDKProvider';
 import { type FdmKey, type FdmConnectionWithNode } from '../components/CacheProvider/types';
 import { type InstanceType } from '@cognite/sdk';
 import { chunk, uniqBy } from 'lodash';
@@ -7,17 +6,19 @@ import {
   type FdmInstanceNodeWithConnectionAndProperties,
   type FdmInstanceWithPropertiesAndTyping
 } from '../components/RuleBasedOutputs/types';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { createFdmKey } from '../components/CacheProvider/idAndKeyTranslation';
 import { executeParallel } from '../utilities/executeParallel';
 import { isDefined } from '../utilities/isDefined';
 import { concatenateMapValues } from '../utilities/map/concatenateMapValues';
+import { UseAll3dDirectConnectionsWithPropertiesContext } from './useAll3dDirectConnectionsWithProperties.context';
 
 const MAX_PARALLEL_QUERIES = 4;
 
 export function useAll3dDirectConnectionsWithProperties(
   connectionWithNodeAndView: FdmConnectionWithNode[]
 ): UseQueryResult<FdmInstanceNodeWithConnectionAndProperties[]> {
+  const { useFdmSdk } = useContext(UseAll3dDirectConnectionsWithPropertiesContext);
   const fdmSdk = useFdmSdk();
 
   const connectionKeys = useMemo(() => {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->
It is part of the Hybrid for rule base coloring support: https://github.com/cognitedata/reveal/pull/5254

https://cognitedata.atlassian.net/browse/

## Description :pencil:
This is an update of the hook `useAll3dDirectConnectionsWithProperties` to support multiple connections for a single `instanceWithData` and also add a unit test file for the main cases


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am happy with this implementation.
- [X] I have performed a self-review of my own code.
- [X] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [X] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
