### PR TITLE
fix(react-components): export FilterItemCommand and PointClass from PointCloudFilterCommand

### DIFF
--- a/react-components/package.json
+++ b/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal-react-components",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/react-components/src/architecture/base/concreteCommands/pointCloud/PointCloudFilterCommand.ts
+++ b/react-components/src/architecture/base/concreteCommands/pointCloud/PointCloudFilterCommand.ts
@@ -102,7 +102,7 @@ export class PointCloudFilterCommand extends BaseFilterCommand {
 
 // Note: This is not exported, as it is only used internally
 
-class FilterItemCommand extends BaseFilterItemCommand {
+export class FilterItemCommand extends BaseFilterItemCommand {
   private readonly _pointClass: PointClass;
   private readonly _currentUniqueId: UniqueId;
 
@@ -153,7 +153,7 @@ class FilterItemCommand extends BaseFilterItemCommand {
   // ==================================================
 }
 
-class PointClass {
+export class PointClass {
   name: string;
   code: number | WellKnownAsprsPointClassCodes;
   color: Color;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
The `PointCloudFilterCommand` class is part of the public API and returns `FilterItemCommand[]` from its `createChildren()` method and uses `PointClass` in its implementation. However, these classes were not exported, causing TypeScript compilation errors for ref: [Fusion PR](https://github.com/cognitedata/fusion/pull/14669). This PR exposes both classes.


## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
