### PR TITLE
feat: point cloud bounding volumes with DM instanceRef

### DIFF
--- a/examples/src/pages/Viewer.tsx
+++ b/examples/src/pages/Viewer.tsx
@@ -453,7 +453,9 @@ export function Viewer() {
                 const { point, model } = intersection;
 
                 console.log(
-                  `Clicked point assigned to the object with annotationId: ${intersection.annotationId} and assetId: ${intersection?.assetRef?.id} at`,
+                  `Clicked point assigned to the object with annotationId: ${intersection.annotationId} and volume metadata`,
+                  intersection.volumeMetadata,
+                  'at',
                   point
                 );
                 if (intersection.volumeMetadata !== undefined && 'annotationId' in intersection.volumeMetadata) {

--- a/viewer/packages/data-providers/src/DataSourceType.ts
+++ b/viewer/packages/data-providers/src/DataSourceType.ts
@@ -28,10 +28,11 @@ export type ClassicDataSourceType = {
    */
   modelIdentifier: ClassicModelIdentifierType;
   /**
-   * The classic point cloud volume metadata containing reference associated with the object which includes annotationId
-   * and asset reference if any.
+   * The classic point cloud volume metadata containing reference associated with the object
+   * which includes annotationId and asset reference, if any. The instanceRef field is
+   * similarily a reference to a contextualized DM instance, if any.
    */
-  pointCloudVolumeMetadata: { annotationId: number; assetRef?: AnnotationsAssetRef };
+  pointCloudVolumeMetadata: { annotationId: number; assetRef?: AnnotationsAssetRef; instanceRef?: DMInstanceRef };
 
   /**
    * Point cloud volume collection type

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/CdfPointCloudStylableObjectProvider.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/CdfPointCloudStylableObjectProvider.ts
@@ -14,7 +14,7 @@ import { CdfPointCloudObjectAnnotation, PointCloudObject } from './types';
 import { PointCloudStylableObjectProvider } from '../PointCloudStylableObjectProvider';
 
 import * as THREE from 'three';
-import { cdfAnnotationsToObjectInfo } from './cdfAnnotationsToObjects';
+import { cdfAnnotationsToObjects } from './cdfAnnotationsToObjects';
 import { ClassicDataSourceType, ClassicModelIdentifierType } from '../DataSourceType';
 
 // The SDK type is out of date with the API. This type more accurately reflects the type of annotation
@@ -83,6 +83,6 @@ export class CdfPointCloudStylableObjectProvider implements PointCloudStylableOb
   async getPointCloudObjects(modelIdentifier: ClassicModelIdentifierType): Promise<PointCloudObject[]> {
     const annotations = await this.fetchAnnotations(modelIdentifier);
 
-    return cdfAnnotationsToObjectInfo(annotations);
+    return cdfAnnotationsToObjects(annotations);
   }
 }

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/CdfPointCloudStylableObjectProvider.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/CdfPointCloudStylableObjectProvider.ts
@@ -8,7 +8,7 @@ import {
   AnnotationsBoundingVolume,
   AnnotationsTypesPrimitivesGeometry3DGeometry as AnnotationsGeometry
 } from '@cognite/sdk';
-import { IShape, Box, Cylinder } from '@reveal/utilities';
+import { IShape, Box, Cylinder, DMInstanceRef } from '@reveal/utilities';
 import assert from 'assert';
 import { CdfPointCloudObjectAnnotation, PointCloudObject } from './types';
 import { PointCloudStylableObjectProvider } from '../PointCloudStylableObjectProvider';
@@ -16,6 +16,10 @@ import { PointCloudStylableObjectProvider } from '../PointCloudStylableObjectPro
 import * as THREE from 'three';
 import { cdfAnnotationsToObjectInfo } from './cdfAnnotationsToObjects';
 import { ClassicDataSourceType, ClassicModelIdentifierType } from '../DataSourceType';
+
+// The SDK type is out of date with the API. This type more accurately reflects the type of annotation
+// the API provides
+type AnnotationWithInstanceRefData = AnnotationsBoundingVolume & { instanceRef?: DMInstanceRef };
 
 export class CdfPointCloudStylableObjectProvider implements PointCloudStylableObjectProvider<ClassicDataSourceType> {
   private readonly _sdk: CogniteClient;
@@ -40,7 +44,7 @@ export class CdfPointCloudStylableObjectProvider implements PointCloudStylableOb
     throw Error('Annotation geometry type not recognized');
   }
 
-  private is3dObjectAnnotation(annotationData: AnnotationData): annotationData is AnnotationsBoundingVolume {
+  private is3dObjectAnnotation(annotationData: AnnotationData): annotationData is AnnotationWithInstanceRefData {
     return (annotationData as AnnotationsBoundingVolume).region !== undefined;
   }
 
@@ -58,7 +62,7 @@ export class CdfPointCloudStylableObjectProvider implements PointCloudStylableOb
       })
       .autoPagingToArray({ limit: Infinity });
 
-    const annotations = modelAnnotations.map(annotation => {
+    return modelAnnotations.map(annotation => {
       assert(this.is3dObjectAnnotation(annotation.data));
 
       const region = annotation.data.region.map(geometry => {
@@ -68,13 +72,12 @@ export class CdfPointCloudStylableObjectProvider implements PointCloudStylableOb
       return {
         volumeMetadata: {
           annotationId: annotation.id,
-          asset: annotation.data.assetRef
+          asset: annotation.data.assetRef,
+          assetInstanceRef: annotation.data.instanceRef
         },
         region
       };
     });
-
-    return annotations;
   }
 
   async getPointCloudObjects(modelIdentifier: ClassicModelIdentifierType): Promise<PointCloudObject[]> {

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects.ts
@@ -8,10 +8,10 @@ import { PointCloudObject, CdfPointCloudObjectAnnotation, isVolumeDMReference } 
 import { StylableObject } from './StylableObject';
 import { DataSourceType } from '../DataSourceType';
 
-function cdfAnnotationsToPointCloudObjects<T extends DataSourceType>(
+export function cdfAnnotationsToObjectInfo<T extends DataSourceType>(
   cdfAnnotations: CdfPointCloudObjectAnnotation[]
 ): PointCloudObject<T>[] {
-  const resultAnnotations = cdfAnnotations.map((cdfAnnotation, index) => {
+  return cdfAnnotations.map((cdfAnnotation, index) => {
     const shapes = cdfAnnotation.region;
 
     const compShape = new CompositeShape(shapes);
@@ -20,24 +20,18 @@ function cdfAnnotationsToPointCloudObjects<T extends DataSourceType>(
       objectId: index + 1
     };
 
-    const volumeMetadata = isVolumeDMReference(cdfAnnotation.volumeMetadata)
+    const volumeMetadata: T['pointCloudVolumeMetadata'] = isVolumeDMReference(cdfAnnotation.volumeMetadata)
       ? { volumeInstanceRef: cdfAnnotation.volumeMetadata.instanceRef, assetRef: cdfAnnotation.volumeMetadata.asset }
-      : { annotationId: cdfAnnotation.volumeMetadata.annotationId, assetRef: cdfAnnotation.volumeMetadata.asset };
+      : {
+          annotationId: cdfAnnotation.volumeMetadata.annotationId,
+          assetRef: cdfAnnotation.volumeMetadata.asset,
+          instanceRef: cdfAnnotation.volumeMetadata.assetInstanceRef
+        };
 
-    const pointCloudObject = {
+    return {
       boundingBox: stylableObject.shape.createBoundingBox(),
-      ...(volumeMetadata as T['pointCloudVolumeMetadata']),
-      stylableObject
+      stylableObject,
+      ...volumeMetadata
     };
-
-    return pointCloudObject;
   });
-
-  return resultAnnotations;
-}
-
-export function cdfAnnotationsToObjectInfo<T extends DataSourceType>(
-  annotations: CdfPointCloudObjectAnnotation[]
-): PointCloudObject<T>[] {
-  return cdfAnnotationsToPointCloudObjects(annotations);
 }

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects.ts
@@ -8,7 +8,7 @@ import { PointCloudObject, CdfPointCloudObjectAnnotation, isVolumeDMReference } 
 import { StylableObject } from './StylableObject';
 import { DataSourceType } from '../DataSourceType';
 
-export function cdfAnnotationsToObjectInfo<T extends DataSourceType>(
+export function cdfAnnotationsToObjects<T extends DataSourceType>(
   cdfAnnotations: CdfPointCloudObjectAnnotation[]
 ): PointCloudObject<T>[] {
   return cdfAnnotations.map((cdfAnnotation, index) => {

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/CdfPointCloudDMStylableObjectProvider.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/CdfPointCloudDMStylableObjectProvider.ts
@@ -6,7 +6,7 @@ import { CogniteClient } from '@cognite/sdk';
 import { DataModelsSdk } from '../../DataModelsSdk';
 import { PointCloudStylableObjectProvider } from '../../PointCloudStylableObjectProvider';
 import { getDMPointCloudObjects } from './getDMPointCloudObjects';
-import { cdfAnnotationsToObjectInfo } from '../cdfAnnotationsToObjects';
+import { cdfAnnotationsToObjects } from '../cdfAnnotationsToObjects';
 import { PointCloudObject } from '../types';
 import { DMDataSourceType, DMModelIdentifierType } from '../../DataSourceType';
 
@@ -23,6 +23,6 @@ export class CdfPointCloudDMStylableObjectProvider implements PointCloudStylable
     }
     const annotations = await getDMPointCloudObjects(this._dmsSdk, modelIdentifier);
 
-    return cdfAnnotationsToObjectInfo<DMDataSourceType>(annotations);
+    return cdfAnnotationsToObjects<DMDataSourceType>(annotations);
   }
 }

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/types.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/types.ts
@@ -9,12 +9,13 @@ import { Box3 } from 'three';
 import { AnnotationsAssetRef } from '@cognite/sdk';
 import { ClassicDataSourceType, DataSourceType } from '../DataSourceType';
 
-type VolumeAnnotation = {
+export type VolumeAnnotation = {
   annotationId: number;
   asset?: AnnotationsAssetRef;
   assetInstanceRef?: DMInstanceRef;
 };
-type VolumeDMReference = {
+
+export type VolumeDMReference = {
   instanceRef: DMInstanceRef;
   asset?: DMInstanceRef;
 };

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/types.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/types.ts
@@ -12,6 +12,7 @@ import { ClassicDataSourceType, DataSourceType } from '../DataSourceType';
 type VolumeAnnotation = {
   annotationId: number;
   asset?: AnnotationsAssetRef;
+  assetInstanceRef?: DMInstanceRef;
 };
 type VolumeDMReference = {
   instanceRef: DMInstanceRef;

--- a/viewer/packages/pointclouds/src/PointCloudNode.test.ts
+++ b/viewer/packages/pointclouds/src/PointCloudNode.test.ts
@@ -12,6 +12,7 @@ import { IPointCloudTreeGeometryNode } from './potree-three-loader/geometry/IPoi
 import jest from 'jest-mock';
 import { DEFAULT_CLASSIFICATION, PointCloudMaterial } from '../../rendering';
 import { PointCloudObjectAppearanceTexture } from '../../rendering/src/pointcloud-rendering';
+import { Cylinder } from '@reveal/utilities';
 
 describe(PointCloudNode.name, () => {
   test('getModelTransformation returns transformation set by setModelTransformation', () => {
@@ -24,6 +25,43 @@ describe(PointCloudNode.name, () => {
     const receivedTransform = node.getModelTransformation();
 
     expect(receivedTransform).toEqual(transform);
+  });
+
+  describe('stylableVolumeMetadata', () => {
+    test('returns empty volume list when no annotation is provided', () => {
+      const node = createPointCloudNode({ annotations: [] });
+      expect(node.stylableVolumeMetadata).toEqual([]);
+    });
+
+    test('returns volume objects from annotation list', () => {
+      const shape = new Cylinder(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1), 1);
+      const boundingBox = shape.createBoundingBox();
+      const annotations = [
+        {
+          annotationId: 123,
+          assetRef: { id: 345 },
+          boundingBox,
+          stylableObject: {
+            shape,
+            objectId: 1
+          }
+        },
+        {
+          annotationId: 124,
+          instanceRef: { externalId: 'some-external-id', space: 'some-space' },
+          boundingBox,
+          stylableObject: {
+            shape,
+            objectId: 2
+          }
+        }
+      ];
+
+      const node = createPointCloudNode({ annotations });
+      const result = [...node.stylableVolumeMetadata];
+
+      expect([...result]).toEqual(annotations);
+    });
   });
 
   describe('getSubtreePointsByBox', () => {

--- a/viewer/packages/pointclouds/src/PointCloudNode.ts
+++ b/viewer/packages/pointclouds/src/PointCloudNode.ts
@@ -254,7 +254,8 @@ export class PointCloudNode<T extends DataSourceType = DataSourceType> extends G
         return {
           ...baseObject,
           annotationId: a.annotationId,
-          assetRef: a.assetRef
+          assetRef: a.assetRef,
+          instanceRef: a.instanceRef
         };
       } else if (isDMPointCloudVolumeObject(a)) {
         return {

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
@@ -82,7 +82,8 @@ export class PointCloudPickingHandler {
               pointCloudNode: pointCloudNode as PointCloudNode<ClassicDataSourceType>,
               volumeMetadata: {
                 annotationId: pointCloudObject.annotationId,
-                assetRef: pointCloudObject.assetRef
+                assetRef: pointCloudObject.assetRef,
+                instanceRef: pointCloudObject.instanceRef
               }
             };
 

--- a/viewer/packages/pointclouds/visual-tests/PointCloudColorStyling.VisualTest.ts
+++ b/viewer/packages/pointclouds/visual-tests/PointCloudColorStyling.VisualTest.ts
@@ -7,7 +7,7 @@ import {
   StreamingVisualTestFixture
 } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
 import { PointCloudFactory } from '../src/PointCloudFactory';
-import { cdfAnnotationsToObjectInfo } from '../../data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects';
+import { cdfAnnotationsToObjects } from '../../data-providers/src/pointcloud-stylable-object-providers/cdfAnnotationsToObjects';
 import {
   ClassicDataSourceType,
   ClassicModelIdentifierType,
@@ -40,7 +40,7 @@ class CustomAnnotationProvider implements PointCloudStylableObjectProvider<Class
       }
     ];
 
-    return cdfAnnotationsToObjectInfo(cdfAnnotations);
+    return cdfAnnotationsToObjects(cdfAnnotations);
   }
 }
 
@@ -55,7 +55,7 @@ class CustomDMProvider implements PointCloudStylableObjectProvider<DMDataSourceT
       }
     ];
 
-    return cdfAnnotationsToObjectInfo(cdfAnnotations);
+    return cdfAnnotationsToObjects(cdfAnnotations);
   }
 }
 

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -388,6 +388,7 @@ export type ClassicDataSourceType = {
     pointCloudVolumeMetadata: {
         annotationId: number;
         assetRef?: AnnotationsAssetRef;
+        instanceRef?: DMInstanceRef;
     };
     pointCloudCollectionType: PointCloudAnnotationVolumeCollection;
     image360Identifier: {

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -13,7 +13,7 @@ import { IPointCloudTreeGeometry } from '../../packages/pointclouds/src/potree-t
 import { DEFAULT_CLASSIFICATION, PointCloudMaterial } from '../../packages/rendering';
 import { PointCloudObjectAppearanceTexture } from '../../packages/rendering/src/pointcloud-rendering/PointCloudObjectAppearanceTexture';
 import { DataSourceType } from '../../packages/data-providers/src/DataSourceType';
-import { PointCloudObject } from '@reveal/data-providers';
+import { PointCloudObject } from '../../packages/data-providers';
 
 export function createPointCloudModel<T extends DataSourceType>(
   modelId: number,

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -13,6 +13,7 @@ import { IPointCloudTreeGeometry } from '../../packages/pointclouds/src/potree-t
 import { DEFAULT_CLASSIFICATION, PointCloudMaterial } from '../../packages/rendering';
 import { PointCloudObjectAppearanceTexture } from '../../packages/rendering/src/pointcloud-rendering/PointCloudObjectAppearanceTexture';
 import { DataSourceType } from '../../packages/data-providers/src/DataSourceType';
+import { PointCloudObject } from '@reveal/data-providers';
 
 export function createPointCloudModel<T extends DataSourceType>(
   modelId: number,
@@ -23,7 +24,9 @@ export function createPointCloudModel<T extends DataSourceType>(
   return new CognitePointCloudModel<T>({ modelId, revisionId }, pointCloudNode);
 }
 
-export function createPointCloudNode<T extends DataSourceType>(): PointCloudNode<T> {
+export function createPointCloudNode<T extends DataSourceType>(params?: {
+  annotations?: PointCloudObject<T>[];
+}): PointCloudNode<T> {
   const pointCloudOctree = new PointCloudOctree(
     new Mock<Potree>().object(),
     new Mock<IPointCloudTreeGeometry>()
@@ -42,5 +45,7 @@ export function createPointCloudNode<T extends DataSourceType>(): PointCloudNode
       .object()
   );
 
-  return new PointCloudNode(Symbol(), new THREE.Matrix4(), pointCloudOctree, [], { classificationSets: [] });
+  return new PointCloudNode(Symbol(), new THREE.Matrix4(), pointCloudOctree, params?.annotations ?? [], {
+    classificationSets: []
+  });
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

Closes https://cognitedata.atlassian.net/browse/BND3D-5947

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Introduces the new `instanceField` in point cloud volume metadata, to enable users of Reveal to use hybrid contextualization in point clouds. This involves both returning this field as part of the stylable objects available from the point clouds, and in point cloud intersection results.

Note that only the first commit in the history actually contains the functional changes. The rest are small refactorings, chore work and tests

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In examples

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Start the `examples` dev server and navigate to https://localhost:3549/?project=3d-test&env=greenfield-3d&modelId=8778813986451799&revisionId=2950725735925141 (from cog-3d, 3d-test)
- Click the left-most annotation here: 
<img width="2344" height="1782" alt="bg0" src="https://github.com/user-attachments/assets/763681e5-5d4b-4e4d-b14b-4a9411a0f812" />
- Observe in the console that the annotation contains an instanceRef
- Evaluate `viewer.models[0].stylableObjects` in the console and see that the same annotation (look for the annotationId) has an instanceRef as well


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
