### PR TITLE
fix: 360 hover not registering for some perspectives

### DIFF
--- a/viewer/packages/360-images/src/Image360Facade.test.ts
+++ b/viewer/packages/360-images/src/Image360Facade.test.ts
@@ -1,6 +1,3 @@
-/*!
- * Copyright 2025 Cognite AS
- */
 import { Mock, It } from 'moq.ts';
 import { Image360Facade } from './Image360Facade';
 
@@ -109,33 +106,28 @@ function createFacadeWithCollection(params?: {
   entityPosition?: Vector3;
   collectionTransformation?: Matrix4;
 }): Image360Facade<DataSourceType> {
-  const entityPosition = params?.entityPosition ?? new Vector3(0, 0, 0);
-  const collectionTransformation = params?.collectionTransformation ?? new Matrix4();
-
-  const mockEntity = new Mock<Image360Entity<DataSourceType>>()
-    .setup(p => p.icon)
-    .returns(
-      new Overlay3DIcon(
-        {
-          position: entityPosition,
-          minPixelSize: 10,
-          maxPixelSize: 80,
-          iconRadius: 0.1
-        },
-        {}
-      )
-    )
-    .setup(p => p.image360Visualization.visible)
-    .returns(false)
-    .setup(p => p.transform)
-    .returns(new Matrix4().makeTranslation(entityPosition).multiply(collectionTransformation))
-    .object();
-
   const mockCollection = new Mock<DefaultImage360Collection<DataSourceType>>()
     .setup(p => p.getModelTransformation(It.IsAny()))
-    .callback(({ args }) => args[0].copy(collectionTransformation))
+    .callback(({ args }) => args[0].copy(params?.collectionTransformation ?? new Matrix4()))
     .setup(p => p.image360Entities)
-    .returns([mockEntity])
+    .returns([
+      new Mock<Image360Entity<DataSourceType>>()
+        .setup(p => p.icon)
+        .returns(
+          new Overlay3DIcon(
+            {
+              position: params?.entityPosition ?? new Vector3(0, 0, 0),
+              minPixelSize: 10,
+              maxPixelSize: 80,
+              iconRadius: 0.1
+            },
+            {}
+          )
+        )
+        .setup(p => p.image360Visualization.visible)
+        .returns(false)
+        .object()
+    ])
     .object();
 
   const facade = new Image360Facade(

--- a/viewer/packages/360-images/src/Image360Facade.test.ts
+++ b/viewer/packages/360-images/src/Image360Facade.test.ts
@@ -1,0 +1,143 @@
+import { Mock, It } from 'moq.ts';
+import { Image360Facade } from './Image360Facade';
+
+import { Image360CollectionFactory } from './collection/Image360CollectionFactory';
+import { DataSourceType } from 'api-entry-points/core';
+import { DefaultImage360Collection } from './collection/DefaultImage360Collection';
+import { Matrix4, PerspectiveCamera, Vector2, Vector3 } from 'three';
+import { Image360Entity } from './entity/Image360Entity';
+import { Overlay3DIcon } from '@reveal/3d-overlays';
+
+import SeededRandom from 'random-seed';
+
+describe(Image360Facade.name, () => {
+  describe('intersect', () => {
+    const ARBITRARY_POSITION = new Vector3(80, -223, 13);
+
+    const ARBITRARY_TRANSFORMATION = new Matrix4()
+      .makeTranslation(new Vector3(89, 1, -23))
+      .multiply(new Matrix4().makeRotationAxis(new Vector3(0.1, 0.2, 0.3), 16));
+
+    test('intersects entity properly from all angles+positions:', () => {
+      const facade = createFacadeWithCollection();
+      createPseudoRandomPositions('seed').forEach(position => {
+        const camera = new PerspectiveCamera();
+        camera.position.copy(position);
+        camera.lookAt(new Vector3(0, 0, 0));
+        camera.updateMatrixWorld();
+
+        const result = facade.intersect(new Vector2(0, 0), camera);
+        expect(result).toBeDefined();
+      });
+    });
+
+    test('does not intersect entity when angle is off', () => {
+      const facade = createFacadeWithCollection();
+      createPseudoRandomPositions('seed').forEach(position => {
+        const camera = new PerspectiveCamera();
+        camera.position.copy(position);
+        camera.lookAt(new Vector3(0, 0, 0));
+        camera.rotateOnAxis(new Vector3(1, 0, 0), 1.5);
+        camera.updateMatrixWorld();
+
+        const result = facade.intersect(new Vector2(0, 0), camera);
+        expect(result).toBeUndefined();
+      });
+    });
+
+    test('intersects entity also when entity and collection has transform', () => {
+      const finalEntityPosition = ARBITRARY_POSITION.clone().applyMatrix4(ARBITRARY_TRANSFORMATION);
+
+      const facade = createFacadeWithCollection({
+        entityPosition: ARBITRARY_POSITION,
+        collectionTransformation: ARBITRARY_TRANSFORMATION
+      });
+
+      createPseudoRandomPositions('seed').forEach(position => {
+        const camera = new PerspectiveCamera();
+        camera.position.copy(position.clone().add(finalEntityPosition));
+        camera.lookAt(finalEntityPosition);
+        camera.updateMatrixWorld();
+
+        const result = facade.intersect(new Vector2(0, 0), camera);
+        expect(result).toBeDefined();
+      });
+    });
+
+    test('does not intersect entity when angle is off also when entity and collection has transform', () => {
+      const finalEntityPosition = ARBITRARY_POSITION.clone().applyMatrix4(ARBITRARY_TRANSFORMATION);
+
+      const facade = createFacadeWithCollection({
+        entityPosition: ARBITRARY_POSITION,
+        collectionTransformation: ARBITRARY_TRANSFORMATION
+      });
+
+      createPseudoRandomPositions('seed').forEach(position => {
+        const camera = new PerspectiveCamera();
+        camera.position.copy(position.clone().add(finalEntityPosition));
+        camera.lookAt(finalEntityPosition);
+        camera.rotateOnAxis(new Vector3(1, 0, 0), 1.5);
+        camera.updateMatrixWorld();
+
+        const result = facade.intersect(new Vector2(0, 0), camera);
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});
+
+function createPseudoRandomPositions(seed: string, count = 100): Array<Vector3> {
+  const random = SeededRandom.create(seed);
+
+  return new Array(count).map(() => {
+    const theta = random.floatBetween(-Math.PI, Math.PI);
+    const phi = random.floatBetween(-Math.PI / 2, Math.PI / 2);
+    const radius = random.floatBetween(1.5, 200);
+
+    return new Vector3(
+      Math.sin(theta) * Math.cos(phi) * radius,
+      Math.sin(phi) * radius,
+      Math.cos(theta) * Math.cos(phi) * radius
+    );
+  });
+}
+
+function createFacadeWithCollection(params?: {
+  entityPosition?: Vector3;
+  collectionTransformation?: Matrix4;
+}): Image360Facade<DataSourceType> {
+  const mockCollection = new Mock<DefaultImage360Collection<DataSourceType>>()
+    .setup(p => p.getModelTransformation(It.IsAny()))
+    .callback(({ args }) => args[0].copy(params?.collectionTransformation ?? new Matrix4()))
+    .setup(p => p.image360Entities)
+    .returns([
+      new Mock<Image360Entity<DataSourceType>>()
+        .setup(p => p.icon)
+        .returns(
+          new Overlay3DIcon(
+            {
+              position: params?.entityPosition ?? new Vector3(0, 0, 0),
+              minPixelSize: 10,
+              maxPixelSize: 80,
+              iconRadius: 0.1
+            },
+            {}
+          )
+        )
+        .setup(p => p.image360Visualization.visible)
+        .returns(false)
+        .object()
+    ])
+    .object();
+
+  const facade = new Image360Facade(
+    new Mock<Image360CollectionFactory>()
+      .setup(p => p.create(It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny()))
+      .returnsAsync(mockCollection)
+      .object()
+  );
+
+  facade.create({ siteId: 'siteId' });
+
+  return facade;
+}

--- a/viewer/packages/360-images/src/Image360Facade.test.ts
+++ b/viewer/packages/360-images/src/Image360Facade.test.ts
@@ -1,3 +1,6 @@
+/*!
+ * Copyright 2025 Cognite AS
+ */
 import { Mock, It } from 'moq.ts';
 import { Image360Facade } from './Image360Facade';
 
@@ -106,28 +109,28 @@ function createFacadeWithCollection(params?: {
   entityPosition?: Vector3;
   collectionTransformation?: Matrix4;
 }): Image360Facade<DataSourceType> {
+  const mockEntity = new Mock<Image360Entity<DataSourceType>>()
+    .setup(p => p.icon)
+    .returns(
+      new Overlay3DIcon(
+        {
+          position: params?.entityPosition ?? new Vector3(0, 0, 0),
+          minPixelSize: 10,
+          maxPixelSize: 80,
+          iconRadius: 0.1
+        },
+        {}
+      )
+    )
+    .setup(p => p.image360Visualization.visible)
+    .returns(false)
+    .object();
+
   const mockCollection = new Mock<DefaultImage360Collection<DataSourceType>>()
     .setup(p => p.getModelTransformation(It.IsAny()))
     .callback(({ args }) => args[0].copy(params?.collectionTransformation ?? new Matrix4()))
     .setup(p => p.image360Entities)
-    .returns([
-      new Mock<Image360Entity<DataSourceType>>()
-        .setup(p => p.icon)
-        .returns(
-          new Overlay3DIcon(
-            {
-              position: params?.entityPosition ?? new Vector3(0, 0, 0),
-              minPixelSize: 10,
-              maxPixelSize: 80,
-              iconRadius: 0.1
-            },
-            {}
-          )
-        )
-        .setup(p => p.image360Visualization.visible)
-        .returns(false)
-        .object()
-    ])
+    .returns([mockEntity])
     .object();
 
   const facade = new Image360Facade(

--- a/viewer/packages/360-images/src/Image360Facade.test.ts
+++ b/viewer/packages/360-images/src/Image360Facade.test.ts
@@ -1,3 +1,6 @@
+/*!
+ * Copyright 2025 Cognite AS
+ */
 import { Mock, It } from 'moq.ts';
 import { Image360Facade } from './Image360Facade';
 
@@ -106,28 +109,33 @@ function createFacadeWithCollection(params?: {
   entityPosition?: Vector3;
   collectionTransformation?: Matrix4;
 }): Image360Facade<DataSourceType> {
+  const entityPosition = params?.entityPosition ?? new Vector3(0, 0, 0);
+  const collectionTransformation = params?.collectionTransformation ?? new Matrix4();
+
+  const mockEntity = new Mock<Image360Entity<DataSourceType>>()
+    .setup(p => p.icon)
+    .returns(
+      new Overlay3DIcon(
+        {
+          position: entityPosition,
+          minPixelSize: 10,
+          maxPixelSize: 80,
+          iconRadius: 0.1
+        },
+        {}
+      )
+    )
+    .setup(p => p.image360Visualization.visible)
+    .returns(false)
+    .setup(p => p.transform)
+    .returns(new Matrix4().makeTranslation(entityPosition).multiply(collectionTransformation))
+    .object();
+
   const mockCollection = new Mock<DefaultImage360Collection<DataSourceType>>()
     .setup(p => p.getModelTransformation(It.IsAny()))
-    .callback(({ args }) => args[0].copy(params?.collectionTransformation ?? new Matrix4()))
+    .callback(({ args }) => args[0].copy(collectionTransformation))
     .setup(p => p.image360Entities)
-    .returns([
-      new Mock<Image360Entity<DataSourceType>>()
-        .setup(p => p.icon)
-        .returns(
-          new Overlay3DIcon(
-            {
-              position: params?.entityPosition ?? new Vector3(0, 0, 0),
-              minPixelSize: 10,
-              maxPixelSize: 80,
-              iconRadius: 0.1
-            },
-            {}
-          )
-        )
-        .setup(p => p.image360Visualization.visible)
-        .returns(false)
-        .object()
-    ])
+    .returns([mockEntity])
     .object();
 
   const facade = new Image360Facade(

--- a/viewer/packages/360-images/src/Image360Facade.ts
+++ b/viewer/packages/360-images/src/Image360Facade.ts
@@ -141,7 +141,7 @@ export class Image360Facade<T extends DataSourceType> {
           continue;
         }
         // The intersection is in model coordinates
-        intersection.setFromMatrixPosition(entity.transform);
+        intersection.copy(entity.icon.getPosition());
         if (!isInRayDirection(intersection, modelRay)) {
           continue;
         }
@@ -166,7 +166,7 @@ export class Image360Facade<T extends DataSourceType> {
     }
 
     function isInRayDirection(position: Vector3, ray: Ray): boolean {
-      const direction = new Vector3().subVectors(position, camera.position);
+      const direction = new Vector3().subVectors(position, ray.origin);
       return direction.dot(ray.direction) > 0 && direction.lengthSq() > 0.00001;
     }
 

--- a/viewer/packages/360-images/src/Image360Facade.ts
+++ b/viewer/packages/360-images/src/Image360Facade.ts
@@ -141,7 +141,7 @@ export class Image360Facade<T extends DataSourceType> {
           continue;
         }
         // The intersection is in model coordinates
-        intersection.copy(entity.icon.getPosition());
+        intersection.setFromMatrixPosition(entity.transform);
         if (!isInRayDirection(intersection, modelRay)) {
           continue;
         }
@@ -166,7 +166,7 @@ export class Image360Facade<T extends DataSourceType> {
     }
 
     function isInRayDirection(position: Vector3, ray: Ray): boolean {
-      const direction = new Vector3().subVectors(position, ray.origin);
+      const direction = new Vector3().subVectors(position, camera.position);
       return direction.dot(ray.direction) > 0 && direction.lengthSq() > 0.00001;
     }
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-6065

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Fixes an issue where hovering/clicking on 360-icons would yield no response when the 360-collection has a non-identity transform, for certain camera angles+positions

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In Fusion

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Open scene with transformed 360-collections (`anders: test 360 collection rotation` in 3d-test is fine)
- Confirm that hovering/clicking on all 360-position from all camera positions/angles works

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
