### PR TITLE
feat(react-components): apply default visibility for scene models

### DIFF
--- a/react-components/src/architecture/concrete/reveal/RevealModelsUtils.ts
+++ b/react-components/src/architecture/concrete/reveal/RevealModelsUtils.ts
@@ -62,18 +62,22 @@ export class RevealModelsUtils {
 
   public static async addCadModel(
     renderTarget: RevealRenderTarget,
-    options: AddModelOptions
+    options: AddModelOptions,
+    defaultVisible?: boolean
   ): Promise<CogniteCadModel> {
     const root = renderTarget.root;
     if (root === undefined) {
       throw new Error('Root domain object is not set');
     }
     const model = await renderTarget.viewer.addCadModel(options);
+
+    console.log('Cad had default visible', defaultVisible);
+    model.visible = defaultVisible ?? true;
+
     const domainObject = new CadDomainObject(model);
     root.addChildInteractive(domainObject);
-    if (model.visible) {
-      domainObject.setVisibleInteractive(true);
-    }
+
+    domainObject.setVisibleInteractive(model.visible);
 
     try {
       domainObject.name = await RevealModelsUtils.getName(renderTarget.root.sdk, model);
@@ -85,18 +89,19 @@ export class RevealModelsUtils {
 
   public static async addPointCloud(
     renderTarget: RevealRenderTarget,
-    options: AddModelOptions<DataSourceType>
+    options: AddModelOptions<DataSourceType>,
+    defaultVisible?: boolean
   ): Promise<PointCloud> {
     const root = renderTarget.root;
     if (root === undefined) {
       throw new Error('Root domain object is not set');
     }
     const model = await renderTarget.viewer.addPointCloudModel(options);
+    console.log('Point cloud had default visible', defaultVisible);
+    model.visible = defaultVisible ?? true;
     const domainObject = new PointCloudDomainObject(model);
     root.addChildInteractive(domainObject);
-    if (model.visible) {
-      domainObject.setVisibleInteractive(true);
-    }
+    domainObject.setVisibleInteractive(model.visible);
 
     try {
       domainObject.name = await RevealModelsUtils.getName(renderTarget.root.sdk, model);
@@ -108,40 +113,40 @@ export class RevealModelsUtils {
 
   public static async addImage360Collection(
     renderTarget: RevealRenderTarget,
-    options: AddImage360CollectionOptions
+    options: AddImage360CollectionOptions,
+    defaultVisible?: boolean
   ): Promise<Image360Collection<DataSourceType>> {
     const root = renderTarget.root;
     if (root === undefined) {
       throw new Error('Root domain object is not set');
     }
 
-    if (options.source === 'events') {
-      return await renderTarget.viewer
-        .add360ImageSet('events', { site_id: options.siteId }, { preMultipliedRotation: false })
-        .then((model) => {
-          const domainObject = new Image360CollectionDomainObject(model);
-          root.addChildInteractive(domainObject);
-          if (model.getIconsVisibility()) {
-            domainObject.setVisibleInteractive(true);
-          }
-          return model;
-        });
-    } else {
-      return await renderTarget.viewer
-        .add360ImageSet('datamodels', {
+    const model = await (async () => {
+      if (options.source === 'events') {
+        return await renderTarget.viewer.add360ImageSet(
+          'events',
+          { site_id: options.siteId },
+          { preMultipliedRotation: false }
+        );
+      } else {
+        return await renderTarget.viewer.add360ImageSet('datamodels', {
           source: options.source,
           image360CollectionExternalId: options.externalId,
           space: options.space
-        })
-        .then((model) => {
-          const domainObject = new Image360CollectionDomainObject(model);
-          root.addChildInteractive(domainObject);
-          if (model.getIconsVisibility()) {
-            domainObject.setVisibleInteractive(true);
-          }
-          return model;
         });
-    }
+      }
+    })();
+
+    console.log('360 image collection had default visible', defaultVisible);
+
+    model.setIconsVisibility(defaultVisible ?? true);
+    const domainObject = new Image360CollectionDomainObject(model);
+    root.addChildInteractive(domainObject);
+    domainObject.setVisibleInteractive(model.getIconsVisibility());
+
+    console.log('360 domain object visibility: ', domainObject.isVisible(renderTarget));
+
+    return model;
   }
 
   public static remove(renderTarget: RevealRenderTarget, model: RevealModel): void {

--- a/react-components/src/components/CadModelContainer/CadModelContainer.tsx
+++ b/react-components/src/components/CadModelContainer/CadModelContainer.tsx
@@ -17,6 +17,7 @@ export type CogniteCadModelProps = {
   addModelOptions: AddModelOptions<ClassicDataSourceType>;
   styling?: CadModelStyling;
   transform?: Matrix4;
+  defaultVisible?: boolean;
   onLoad?: (model: CogniteCadModel) => void;
   onLoadError?: (options: AddModelOptions<ClassicDataSourceType>, error: any) => void;
 };
@@ -25,6 +26,7 @@ export function CadModelContainer({
   addModelOptions,
   transform,
   styling,
+  defaultVisible,
   onLoad,
   onLoadError
 }: CogniteCadModelProps): ReactElement {
@@ -112,10 +114,10 @@ export function CadModelContainer({
         );
       });
       if (viewerModel !== undefined) {
-        return await Promise.resolve(viewerModel as CogniteCadModel);
+        return viewerModel as CogniteCadModel;
       }
       initializingModelsGeometryFilter.current = geometryFilter;
-      return await createCadDomainObject(renderTarget, addModelOptions);
+      return await createCadDomainObject(renderTarget, addModelOptions, defaultVisible);
     }
   }
 

--- a/react-components/src/components/Image360CollectionContainer/Image360CollectionContainer.tsx
+++ b/react-components/src/components/Image360CollectionContainer/Image360CollectionContainer.tsx
@@ -22,6 +22,7 @@ import { RevealModelsUtils } from '../../architecture/concrete/reveal/RevealMode
 type Image360CollectionContainerProps = {
   addImage360CollectionOptions: AddImage360CollectionOptions;
   styling?: ImageCollectionModelStyling;
+  defaultVisible?: boolean;
   onLoad?: (image360: Image360Collection<DataSourceType>) => void;
   onLoadError?: (addOptions: AddImage360CollectionOptions, error: any) => void;
 };
@@ -29,6 +30,7 @@ type Image360CollectionContainerProps = {
 export function Image360CollectionContainer({
   addImage360CollectionOptions,
   styling,
+  defaultVisible,
   onLoad,
   onLoadError
 }: Image360CollectionContainerProps): ReactElement {
@@ -116,7 +118,8 @@ export function Image360CollectionContainer({
       }
       return await RevealModelsUtils.addImage360Collection(
         renderTarget,
-        addImage360CollectionOptions
+        addImage360CollectionOptions,
+        defaultVisible
       );
     }
   }

--- a/react-components/src/components/PointCloudContainer/PointCloudContainer.tsx
+++ b/react-components/src/components/PointCloudContainer/PointCloudContainer.tsx
@@ -26,6 +26,7 @@ export type CognitePointCloudModelProps = {
   addModelOptions: AddModelOptions<DataSourceType>;
   styling?: PointCloudModelStyling;
   transform?: Matrix4;
+  defaultVisible?: boolean;
   onLoad?: (model: CognitePointCloudModel<DataSourceType>) => void;
   onLoadError?: (options: AddModelOptions<DataSourceType>, error: any) => void;
 };
@@ -34,6 +35,7 @@ export function PointCloudContainer({
   addModelOptions,
   styling,
   transform,
+  defaultVisible,
   onLoad,
   onLoadError
 }: CognitePointCloudModelProps): ReactElement {
@@ -117,7 +119,7 @@ export function PointCloudContainer({
       if (viewerModel !== undefined) {
         return await Promise.resolve(viewerModel as CognitePointCloudModel<DataSourceType>);
       }
-      return await RevealModelsUtils.addPointCloud(renderTarget, addModelOptions);
+      return await RevealModelsUtils.addPointCloud(renderTarget, addModelOptions, defaultVisible);
     }
   }
 

--- a/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
+++ b/react-components/src/components/Reveal3DResources/Reveal3DResources.tsx
@@ -61,6 +61,10 @@ export const Reveal3DResources = ({
   const instanceStylingWithAssetMappings =
     instanceStyling?.filter(isAssetMappingStylingGroup) ?? EMPTY_ARRAY;
 
+  useEffect(() => {
+    console.log('Cad model options: ', cadModelOptions);
+  }, [cadModelOptions]);
+
   const { styledModels: styledCadModelOptions, isModelMappingsLoading } =
     hooks.useCalculateCadStyling(
       cadModelOptions,
@@ -81,6 +85,18 @@ export const Reveal3DResources = ({
   );
 
   const image360StyledGroup = hooks.useCalculateImage360Styling(instanceStyling);
+  useEffect(() => {
+    console.log(
+      'Styled cad model options: ',
+      styledCadModelOptions,
+      'styled point cloud model',
+      styledPointCloudModelOptions,
+      'image 360 styled group: ',
+      image360CollectionAddOptions,
+      'while resources was',
+      resources
+    );
+  }, [styledCadModelOptions, styledPointCloudModelOptions, image360StyledGroup]);
 
   return (
     <>
@@ -96,6 +112,7 @@ export const Reveal3DResources = ({
             addModelOptions={model}
             styling={cadStyling}
             transform={model.transform}
+            defaultVisible={model.defaultVisible}
             onLoad={onResourceIsLoaded}
             onLoadError={onResourceLoadError}
           />
@@ -118,6 +135,7 @@ export const Reveal3DResources = ({
             key={key}
             addModelOptions={model}
             styling={pcStyling}
+            defaultVisible={model.defaultVisible}
             transform={model.transform}
             onLoad={onResourceIsLoaded}
             onLoadError={onResourceLoadError}
@@ -142,6 +160,7 @@ export const Reveal3DResources = ({
               key={key}
               addImage360CollectionOptions={addModelOption}
               styling={image360Styling}
+              defaultVisible={addModelOption.defaultVisible}
               onLoad={onResourceIsLoaded}
               onLoadError={onResourceLoadError}
             />

--- a/react-components/src/components/Reveal3DResources/hooks/useTypedModels.ts
+++ b/react-components/src/components/Reveal3DResources/hooks/useTypedModels.ts
@@ -63,6 +63,7 @@ const getTypedModels = async (
   const successfullyLoadedResources = resourceLoadResults.filter(
     (p): p is TypedReveal3DModel => p.type === 'cad' || p.type === 'pointcloud'
   );
+  console.log('Returning typed models: ', successfullyLoadedResources);
 
   return successfullyLoadedResources;
 };

--- a/react-components/src/components/Reveal3DResources/types.ts
+++ b/react-components/src/components/Reveal3DResources/types.ts
@@ -28,6 +28,7 @@ export type AddImage360CollectionOptions =
 export type CommonImage360CollectionAddOptions = {
   transform?: Matrix4;
   iconCullingOptions?: { radius?: number; iconCountLimit?: number };
+  defaultVisible?: boolean;
 };
 
 export type AddImage360CollectionEventsOptions = {
@@ -76,6 +77,7 @@ export type AddPointCloudResourceOptions<T extends DataSourceType = DataSourceTy
   AddModelOptions<T> & {
     transform?: Matrix4;
     styling?: { default?: NodeAppearance; mapped?: NodeAppearance };
+    defaultVisible?: boolean;
   };
 
 export type AddCadResourceOptions = AddModelOptions<ClassicDataSourceType> & {
@@ -85,6 +87,7 @@ export type AddCadResourceOptions = AddModelOptions<ClassicDataSourceType> & {
     mapped?: NodeAppearance;
     nodeGroups?: TreeIndexStylingGroup[];
   };
+  defaultVisible?: boolean;
 };
 
 export type ClassicAdd3DModelOptions =

--- a/react-components/src/components/SceneContainer/SceneFdmTypes.tsx
+++ b/react-components/src/components/SceneContainer/SceneFdmTypes.tsx
@@ -64,6 +64,7 @@ export type SceneModelsResponse = EdgeResponse & {
 
 export type SceneModelsProperties = Transformation3d & {
   revisionId: number;
+  defaultVisible?: boolean;
 };
 
 export type Image360CollectionsResponse = EdgeResponse & {
@@ -73,6 +74,7 @@ export type Image360CollectionsResponse = EdgeResponse & {
 export type Scene360ImageCollectionsProperties = Transformation3d & {
   image360CollectionExternalId: string;
   image360CollectionSpace: string;
+  defaultVisible?: boolean;
 };
 
 export type SceneConfigurationProperties = {

--- a/react-components/src/components/SceneContainer/sceneTypes.ts
+++ b/react-components/src/components/SceneContainer/sceneTypes.ts
@@ -47,11 +47,13 @@ export type ModelIdentifier = ClassicModelIdentifier | DMModelIdenfitier;
 
 export type CadOrPointCloudModel = Transformation3d & {
   modelIdentifier: ModelIdentifier;
+  defaultVisible?: boolean;
 };
 
 export type Image360Collection = Transformation3d & {
   image360CollectionExternalId: string;
   image360CollectionSpace: string;
+  defaultVisible?: boolean;
 };
 
 export type Skybox = {

--- a/react-components/src/components/SceneContainer/types.ts
+++ b/react-components/src/components/SceneContainer/types.ts
@@ -1,7 +1,4 @@
-import {
-  type CommonResourceContainerProps,
-  type AddResourceOptions
-} from '../Reveal3DResources/types';
+import { AddResourceOptions, type CommonResourceContainerProps } from '../Reveal3DResources/types';
 
 export type SceneContainerProps = {
   sceneExternalId: string;

--- a/react-components/src/hooks/scenes/sceneResponseTypeGuard.test.ts
+++ b/react-components/src/hooks/scenes/sceneResponseTypeGuard.test.ts
@@ -1,14 +1,22 @@
-import { describe, test, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
-import { type SceneConfigurationProperties } from './types';
+import {
+  Cdf3dImage360CollectionProperties,
+  Cdf3dRevisionProperties,
+  SceneBuilderSceneConfigurationProperties
+} from '../../SceneBuilder/types';
 
-import { isSceneConfigurationProperties } from './sceneResponseTypeGuard';
+import {
+  isSceneBuilderSceneConfigurationProperties,
+  isSceneModelProperties,
+  isScene360CollectionProperties
+} from './sceneResponseTypeGuards';
 
 describe('sceneResponseTypeGuards', () => {
   // Data factory functions for test data generation
   const createValidSceneConfig = (
-    overrides: Partial<SceneConfigurationProperties> = {}
-  ): SceneConfigurationProperties => ({
+    overrides: Partial<SceneBuilderSceneConfigurationProperties> = {}
+  ) => ({
     name: 'Test Scene',
     cameraTranslationX: 1.0,
     cameraTranslationY: 2.0,
@@ -19,27 +27,57 @@ describe('sceneResponseTypeGuards', () => {
     ...overrides
   });
 
+  const createValidTransformation = (overrides: Partial<Cdf3dRevisionProperties> = {}) => ({
+    translationX: 0.0,
+    translationY: 0.0,
+    translationZ: 0.0,
+    eulerRotationX: 0.0,
+    eulerRotationY: 0.0,
+    eulerRotationZ: 0.0,
+    scaleX: 1.0,
+    scaleY: 1.0,
+    scaleZ: 1.0,
+    ...overrides
+  });
+
+  const createValidSceneModel = (overrides: Partial<Cdf3dRevisionProperties> = {}) => ({
+    ...createValidTransformation(),
+    revisionId: 123,
+    ...overrides
+  });
+
+  const createValid360Collection = (
+    overrides: Partial<Cdf3dImage360CollectionProperties> = {}
+  ) => ({
+    ...createValidTransformation(),
+    image360CollectionExternalId: 'collection-123',
+    image360CollectionSpace: 'space-123',
+    ...overrides
+  });
+
   // Common test cases
   const invalidInputs = [null, undefined, 'string', 123, true, [], {}];
 
   describe('shared behavior', () => {
-    test.each([['isSceneBuilderSceneConfigurationProperties', isSceneConfigurationProperties]])(
-      '%s should return false for invalid inputs',
-      (_, typeGuard) => {
-        invalidInputs.forEach((input) => {
-          expect(typeGuard(input)).toBe(false);
-        });
-      }
-    );
+    it.each([
+      ['isSceneBuilderSceneConfigurationProperties', isSceneBuilderSceneConfigurationProperties],
+      ['isSceneModelProperties', isSceneModelProperties],
+      ['isScene360CollectionProperties', isScene360CollectionProperties]
+    ])('%s should return false for invalid inputs', (_, typeGuard) => {
+      invalidInputs.forEach((input) => {
+        expect(typeGuard(input)).toBe(false);
+      });
+    });
   });
 
-  describe(isSceneConfigurationProperties.name, () => {
-    test('should return true for valid scene configuration', () => {
-      expect(isSceneConfigurationProperties(createValidSceneConfig())).toBe(true);
+  describe(isSceneBuilderSceneConfigurationProperties.name, () => {
+    it('should return true for valid scene configuration', () => {
+      expect(isSceneBuilderSceneConfigurationProperties(createValidSceneConfig())).toBe(true);
 
       expect(
-        isSceneConfigurationProperties(
+        isSceneBuilderSceneConfigurationProperties(
           createValidSceneConfig({
+            description: 'Test description',
             cameraTargetX: 10.0,
             cameraTargetY: 20.0,
             cameraTargetZ: 30.0
@@ -48,7 +86,7 @@ describe('sceneResponseTypeGuards', () => {
       ).toBe(true);
 
       expect(
-        isSceneConfigurationProperties(
+        isSceneBuilderSceneConfigurationProperties(
           createValidSceneConfig({
             cadBudget: 1,
             pointCloudBudget: 2,
@@ -62,7 +100,7 @@ describe('sceneResponseTypeGuards', () => {
       ).toBe(true);
     });
 
-    test.each([
+    it.each([
       ['missing name', { name: undefined }],
       ['wrong name type', { name: 123 }],
       ['missing camera translation', { cameraTranslationX: undefined }],
@@ -84,13 +122,15 @@ describe('sceneResponseTypeGuards', () => {
       ['wrong point shape type', { pointCloudPointShape: 999 }],
       ['wrong point color type', { pointCloudColor: 999 }]
     ])('should return false for %s', (_, overrides: Record<string, unknown>) => {
-      expect(isSceneConfigurationProperties(createValidSceneConfig(overrides))).toBe(false);
+      expect(isSceneBuilderSceneConfigurationProperties(createValidSceneConfig(overrides))).toBe(
+        false
+      );
     });
 
-    test('should validate pointCloudPointSize, pointCloudShape, and pointCloudColor types', () => {
+    it('should validate pointCloudPointSize, pointCloudShape, and pointCloudColor types', () => {
       // Valid cases
       expect(
-        isSceneConfigurationProperties(
+        isSceneBuilderSceneConfigurationProperties(
           createValidSceneConfig({
             pointCloudPointSize: 2,
             pointCloudPointShape: 'Circle',
@@ -100,29 +140,29 @@ describe('sceneResponseTypeGuards', () => {
       ).toBe(true);
 
       expect(
-        isSceneConfigurationProperties({
+        isSceneBuilderSceneConfigurationProperties({
           ...createValidSceneConfig(),
-          pointCloudPointSize: undefined
+          pointCloudPointSize: undefined // undefined is valid for optional properties
         })
       ).toBe(true);
 
       // Invalid cases
       expect(
-        isSceneConfigurationProperties({
+        isSceneBuilderSceneConfigurationProperties({
           ...createValidSceneConfig(),
-          pointCloudPointShape: 'NotAValidShape'
+          pointCloudPointShape: 'NotAValidShape' // Invalid enum value --- IGNORE ---
         })
       ).toBe(false);
 
       expect(
-        isSceneConfigurationProperties({
+        isSceneBuilderSceneConfigurationProperties({
           ...createValidSceneConfig(),
-          pointCloudColor: 'NotAValidColor'
+          pointCloudColor: 'NotAValidColor' // Invalid enum value --- IGNORE ---
         })
       ).toBe(false);
     });
 
-    test('should allow all individual quality settings properties to be undefined', () => {
+    it('should allow all individual quality settings properties to be undefined', () => {
       const qualitySettingsProperties = [
         'cadBudget',
         'pointCloudBudget',
@@ -136,7 +176,7 @@ describe('sceneResponseTypeGuards', () => {
       // Test each quality setting property can be undefined individually
       qualitySettingsProperties.forEach((prop) => {
         expect(
-          isSceneConfigurationProperties({
+          isSceneBuilderSceneConfigurationProperties({
             ...createValidSceneConfig(),
             [prop]: undefined
           })
@@ -150,11 +190,148 @@ describe('sceneResponseTypeGuards', () => {
       });
 
       expect(
-        isSceneConfigurationProperties({
+        isSceneBuilderSceneConfigurationProperties({
           ...createValidSceneConfig(),
           ...allUndefinedOverrides
         })
       ).toBe(true);
+    });
+
+    it('should validate quality settings properties with valid values', () => {
+      expect(
+        isSceneBuilderSceneConfigurationProperties(
+          createValidSceneConfig({
+            cadBudget: 1000000,
+            pointCloudBudget: 2000000,
+            maxRenderResolution: 1920,
+            movingCameraResolutionFactor: 0.5,
+            pointCloudPointSize: 3.5,
+            pointCloudPointShape: 'Square',
+            pointCloudColor: 'Height'
+          })
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe(isSceneModelProperties.name, () => {
+    it('should return true for valid scene model properties', () => {
+      expect(isSceneModelProperties(createValidSceneModel())).toBe(true);
+    });
+
+    it('should return true for valid scene model properties with defaultVisible', () => {
+      expect(isSceneModelProperties(createValidSceneModel({ defaultVisible: true }))).toBe(true);
+      expect(isSceneModelProperties(createValidSceneModel({ defaultVisible: false }))).toBe(true);
+    });
+
+    it('should return true when defaultVisible is undefined', () => {
+      expect(isSceneModelProperties(createValidSceneModel({ defaultVisible: undefined }))).toBe(
+        true
+      );
+    });
+
+    it.each([
+      ['missing revision ID', { revisionId: undefined }],
+      ['wrong revision ID type', { revisionId: 'not a number' }],
+      ['missing transformation', { translationX: undefined }],
+      ['wrong transformation type', { scaleX: 'not a number' }],
+      ['wrong defaultVisible type', { defaultVisible: 'not a boolean' }],
+      ['wrong defaultVisible type (number)', { defaultVisible: 1 }],
+      ['wrong defaultVisible type (object)', { defaultVisible: {} }]
+    ])('should return false for %s', (_, overrides: Record<string, unknown>) => {
+      expect(isSceneModelProperties(createValidSceneModel(overrides))).toBe(false);
+    });
+  });
+
+  describe(isScene360CollectionProperties.name, () => {
+    it('should return true for valid 360 collection properties', () => {
+      expect(isScene360CollectionProperties(createValid360Collection())).toBe(true);
+    });
+
+    it('should return true for valid 360 collection properties with defaultVisible', () => {
+      expect(
+        isScene360CollectionProperties(createValid360Collection({ defaultVisible: true }))
+      ).toBe(true);
+      expect(
+        isScene360CollectionProperties(createValid360Collection({ defaultVisible: false }))
+      ).toBe(true);
+    });
+
+    it('should return true when defaultVisible is undefined', () => {
+      expect(
+        isScene360CollectionProperties(createValid360Collection({ defaultVisible: undefined }))
+      ).toBe(true);
+    });
+
+    it.each([
+      ['missing collection external ID', { image360CollectionExternalId: undefined }],
+      ['wrong collection external ID type', { image360CollectionExternalId: 123 }],
+      ['missing collection space', { image360CollectionSpace: undefined }],
+      ['wrong collection space type', { image360CollectionSpace: 123 }],
+      ['wrong defaultVisible type', { defaultVisible: 'not a boolean' }],
+      ['wrong defaultVisible type (number)', { defaultVisible: 1 }],
+      ['wrong defaultVisible type (object)', { defaultVisible: {} }]
+    ])('should return false for %s', (_, overrides: Record<string, unknown>) => {
+      expect(isScene360CollectionProperties(createValid360Collection(overrides))).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle extra properties gracefully', () => {
+      expect(
+        isSceneBuilderSceneConfigurationProperties({
+          ...createValidSceneConfig(),
+          extra: 'ignored'
+        })
+      ).toBe(true);
+
+      expect(
+        isSceneModelProperties({
+          ...createValidSceneModel(),
+          extra: 'ignored',
+          another: 42
+        })
+      ).toBe(true);
+
+      expect(
+        isScene360CollectionProperties({
+          ...createValid360Collection(),
+          extra: 'ignored',
+          another: 42
+        })
+      ).toBe(true);
+    });
+
+    it('should reject invalid transformation properties', () => {
+      const invalidTransformations = [
+        {
+          ...createValidTransformation(),
+          translationX: null,
+          translationY: null
+        },
+        {
+          ...createValidTransformation(),
+          eulerRotationX: 'invalid',
+          eulerRotationY: 'invalid'
+        },
+        {
+          ...createValidTransformation(),
+          scaleX: {},
+          scaleY: [],
+          scaleZ: false
+        }
+      ];
+
+      invalidTransformations.forEach((transformation: Record<string, unknown>) => {
+        expect(isSceneModelProperties({ ...transformation, revisionId: 123 })).toBe(false);
+        expect(
+          isScene360CollectionProperties({
+            ...transformation,
+            image360CollectionExternalId: 'test',
+            image360CollectionSpace: 'space'
+          })
+        ).toBe(false);
+      });
     });
   });
 });

--- a/react-components/src/hooks/scenes/sceneResponseTypeGuard.ts
+++ b/react-components/src/hooks/scenes/sceneResponseTypeGuard.ts
@@ -1,31 +1,34 @@
 import { PointColorType, PointShape } from '@cognite/reveal';
-import { type SceneConfigurationProperties } from './types';
+import {
+  Cdf3dImage360CollectionProperties,
+  Cdf3dRevisionProperties,
+  SceneConfigurationProperties
+} from './types';
+import { EdgeItem } from '../../data-providers/FdmSDK';
 
 type PropertyValidator = [string, 'string' | 'number'];
-type OptionalPropertyValidator = [string, 'string' | 'number'];
+type OptionalPropertyValidator = [string, 'string' | 'number' | 'boolean'];
 
+/**
+ * Helper function to validate required properties
+ */
 function validateRequiredProperties(
   props: Record<string, unknown>,
   validators: PropertyValidator[]
 ): boolean {
-  return validators.every(([prop, expectedType]) => {
-    const valueType = typeof props[prop];
-    return (expectedType === 'string' || expectedType === 'number') && valueType === expectedType;
-  });
+  return validators.every(([prop, expectedType]) => typeof props[prop] === expectedType);
 }
 
+/**
+ * Helper function to validate optional properties (if present, must be correct type)
+ */
 function validateOptionalProperties(
   props: Record<string, unknown>,
   validators: OptionalPropertyValidator[]
 ): boolean {
-  return validators.every(([prop, expectedType]) => {
-    const value = props[prop];
-    const valueType = typeof value;
-    return (
-      value === undefined ||
-      ((expectedType === 'string' || expectedType === 'number') && valueType === expectedType)
-    );
-  });
+  return validators.every(
+    ([prop, expectedType]) => props[prop] === undefined || typeof props[prop] === expectedType
+  );
 }
 
 export function isSceneConfigurationProperties(
@@ -37,6 +40,7 @@ export function isSceneConfigurationProperties(
 
   const props = properties as Record<string, unknown>;
 
+  // Check required properties
   const requiredProperties: PropertyValidator[] = [
     ['name', 'string'],
     ['cameraTranslationX', 'number'],
@@ -51,6 +55,7 @@ export function isSceneConfigurationProperties(
     return false;
   }
 
+  // Check optional properties
   const optionalProperties: OptionalPropertyValidator[] = [
     ['description', 'string'],
     ['cameraTargetX', 'number'],
@@ -82,4 +87,92 @@ export function isSceneConfigurationProperties(
   }
 
   return true;
+}
+
+export function isSceneModelProperties(properties: unknown): properties is Cdf3dRevisionProperties {
+  if (typeof properties !== 'object' || properties === null) {
+    return false;
+  }
+
+  const props = properties as Record<string, unknown>;
+
+  // Check Transformation3d properties
+  if (!isValidTransformation3dProperties(props)) {
+    return false;
+  }
+
+  // Check required property from SceneModelProperties
+  const sceneModelProperties: PropertyValidator[] = [['revisionId', 'number']];
+
+  if (!validateRequiredProperties(props, sceneModelProperties)) {
+    return false;
+  }
+
+  return hasValidDefaultVisibleProperty(props);
+}
+
+export function isScene360CollectionProperties(
+  properties: unknown
+): properties is Cdf3dImage360CollectionProperties {
+  if (typeof properties !== 'object' || properties === null) {
+    return false;
+  }
+
+  const props = properties as Record<string, unknown>;
+
+  // Check Transformation3d properties
+  if (!isValidTransformation3dProperties(props)) {
+    return false;
+  }
+
+  // Check required properties from Scene360CollectionProperties
+  const scene360Properties: PropertyValidator[] = [
+    ['image360CollectionExternalId', 'string'],
+    ['image360CollectionSpace', 'string']
+  ];
+
+  if (!validateRequiredProperties(props, scene360Properties)) {
+    return false;
+  }
+
+  return hasValidDefaultVisibleProperty(props);
+}
+
+function isValidTransformation3dProperties(props: Record<string, unknown>): boolean {
+  // Check required properties from Transformation3dProperties
+  const transformationProperties: PropertyValidator[] = [
+    ['translationX', 'number'],
+    ['translationY', 'number'],
+    ['translationZ', 'number'],
+    ['eulerRotationX', 'number'],
+    ['eulerRotationY', 'number'],
+    ['eulerRotationZ', 'number'],
+    ['scaleX', 'number'],
+    ['scaleY', 'number'],
+    ['scaleZ', 'number']
+  ];
+
+  return validateRequiredProperties(props, transformationProperties);
+}
+
+function hasValidDefaultVisibleProperty(props: Record<string, unknown>): boolean {
+  return validateOptionalProperties(props, [['defaultVisible', 'boolean']]);
+}
+
+export function isScene3dModelEdge(
+  model: EdgeItem<{
+    scene: { ['RevisionProperties/v1']: Record<string, unknown> };
+  }>
+): model is EdgeItem<{ scene: { ['RevisionProperties/v1']: Cdf3dRevisionProperties } }> {
+  return isSceneModelProperties(model.properties.scene['RevisionProperties/v1']);
+}
+
+export function isScene360CollectionEdge(
+  model: EdgeItem<{
+    scene: { ['Image360CollectionProperties/v1']: Record<string, unknown> };
+  }>
+): model is EdgeItem<{
+  scene: { ['Image360CollectionProperties/v1']: Cdf3dImage360CollectionProperties };
+}> {
+  return isScene360CollectionProperties(model.properties.scene['Image360CollectionProperties/v1']);
 }

--- a/react-components/src/hooks/scenes/types.ts
+++ b/react-components/src/hooks/scenes/types.ts
@@ -80,11 +80,13 @@ export type GroundPlaneProperties = {
 
 export type Cdf3dRevisionProperties = Transformation3d & {
   revisionId: number;
+  defaultVisible?: boolean;
 };
 
 export type Cdf3dImage360CollectionProperties = Transformation3d & {
   image360CollectionExternalId: string;
   image360CollectionSpace: string;
+  defaultVisible?: boolean;
 };
 
 export const SCENE_SOURCE = {
@@ -163,18 +165,14 @@ export const sceneSourceWithProperties = [
 export const revisionSourceWithProperties = [
   {
     source: REVISION_SOURCE,
-    properties: ['revisionId', ...transformationSourceWithProperties[0].properties]
+    properties: ['*']
   }
 ] as const satisfies SourceSelectorV3;
 
 export const image360CollectionSourceWithProperties = [
   {
     source: IMAGE_360_COLLECTION_SOURCE,
-    properties: [
-      'image360CollectionExternalId',
-      'image360CollectionSpace',
-      ...transformationSourceWithProperties[0].properties
-    ]
+    properties: ['*']
   }
 ] as const satisfies SourceSelectorV3;
 

--- a/react-components/src/hooks/scenes/use3dScenes.tsx
+++ b/react-components/src/hooks/scenes/use3dScenes.tsx
@@ -29,6 +29,13 @@ import {
   transformationSourceWithProperties
 } from './types';
 import { tryGetModelIdFromExternalId } from '../../utilities/tryGetModelIdFromExternalId';
+import assert from 'assert';
+import {
+  isScene360CollectionEdge,
+  isScene360CollectionProperties,
+  isScene3dModelEdge,
+  isSceneModelProperties
+} from './sceneResponseTypeGuard';
 
 export type Space = string;
 export type ExternalId = string;
@@ -92,9 +99,13 @@ export const use3dScenes = (
         ]
       >(scenesQuery);
 
+      const scene3dModels = response.items.sceneModels.filter(isScene3dModelEdge);
+      const scene360Collections =
+        response.items.scene360Collections.filter(isScene360CollectionEdge);
+
       allScenes.scenes.push(...response.items.scenes);
-      allScenes.sceneModels.push(...response.items.sceneModels);
-      allScenes.scene360Collections.push(...response.items.scene360Collections);
+      allScenes.sceneModels.push(...scene3dModels);
+      allScenes.scene360Collections.push(...scene360Collections);
       allScenes.sceneGroundPlanes.push(...response.items.sceneGroundPlanes);
       allScenes.sceneGroundPlaneEdges.push(...response.items.sceneGroundPlaneEdges);
       allScenes.sceneSkybox.push(...response.items.sceneSkybox);

--- a/react-components/src/hooks/scenes/useSceneConfig.ts
+++ b/react-components/src/hooks/scenes/useSceneConfig.ts
@@ -34,7 +34,11 @@ import {
 import { tryGetModelIdFromExternalId } from '../../utilities/tryGetModelIdFromExternalId';
 import { getRevisionExternalIdAndSpace } from '../network/getRevisionExternalIdAndSpace';
 import { EMPTY_ARRAY } from '../../utilities/constants';
-import { isSceneConfigurationProperties } from './sceneResponseTypeGuard';
+import {
+  isScene360CollectionEdge,
+  isScene3dModelEdge,
+  isSceneConfigurationProperties
+} from './sceneResponseTypeGuard';
 
 const DefaultScene: Scene = {
   sceneConfiguration: {
@@ -132,8 +136,13 @@ export const useSceneConfig = (
           sceneResponse.items.groundPlanes,
           sceneResponse.items.groundPlaneEdges
         ),
-        sceneModels: await getSceneModels(sceneResponse.items.sceneModels, fdmSdk),
-        image360Collections: getImageCollections(sceneResponse.items.image360CollectionsEdges)
+        sceneModels: await getSceneModels(
+          sceneResponse.items.sceneModels.filter(isScene3dModelEdge),
+          fdmSdk
+        ),
+        image360Collections: getImageCollections(
+          sceneResponse.items.image360CollectionsEdges.filter(isScene360CollectionEdge)
+        )
       };
       return scene;
     },

--- a/react-components/src/hooks/useModelIdRevisionIdFromModelOptions.ts
+++ b/react-components/src/hooks/useModelIdRevisionIdFromModelOptions.ts
@@ -14,9 +14,10 @@ import {
   isDM3DModelIdentifier
 } from '../components/Reveal3DResources/typeGuards';
 import { ModelIdRevisionIdFromModelOptionsContext } from './useModelIdRevisionIdFromModelOptions.context';
+import { AddCadResourceOptions, AddPointCloudResourceOptions } from '..';
 
 export const useModelIdRevisionIdFromModelOptions = (
-  addModelOptionsArray: Array<AddModelOptions<DataSourceType>> | undefined
+  addModelOptionsArray: Array<AddCadResourceOptions | AddPointCloudResourceOptions> | undefined
 ): Array<AddModelOptions<ClassicDataSourceType>> => {
   const { getModelIdAndRevisionIdFromExternalId, useFdmSdk } = useContext(
     ModelIdRevisionIdFromModelOptionsContext
@@ -49,7 +50,7 @@ export const useModelIdRevisionIdFromModelOptions = (
 };
 
 async function fetchClassicModelOption(
-  addModelOptions: AddModelOptions<DataSourceType>,
+  addModelOptions: AddCadResourceOptions | AddPointCloudResourceOptions,
   fdmSdk: FdmSDK,
   getModelIdAndRevisionIdFromExternalId: (
     revisionExternalId: string,

--- a/react-components/src/hooks/useReveal3dResourcesFromScene.ts
+++ b/react-components/src/hooks/useReveal3dResourcesFromScene.ts
@@ -47,7 +47,11 @@ export const useReveal3dResourcesFromScene = (
 
         const transform = createResourceTransformation(model);
 
-        addResourceOptions.push({ ...addModelOptions, transform });
+        addResourceOptions.push({
+          ...addModelOptions,
+          transform,
+          defaultVisible: model.defaultVisible
+        });
       } else if (isDM3DModelIdentifier(model.modelIdentifier)) {
         const addModelOptions: AddModelOptions<DMDataSourceType> = {
           revisionExternalId: model.modelIdentifier.revisionExternalId,
@@ -56,7 +60,11 @@ export const useReveal3dResourcesFromScene = (
 
         const transform = createResourceTransformation(model);
 
-        addResourceOptions.push({ ...addModelOptions, transform });
+        addResourceOptions.push({
+          ...addModelOptions,
+          transform,
+          defaultVisible: model.defaultVisible
+        });
       }
     });
 
@@ -68,7 +76,11 @@ export const useReveal3dResourcesFromScene = (
         space: collection.image360CollectionSpace
       };
 
-      addResourceOptions.push({ ...addModelOptions, transform });
+      addResourceOptions.push({
+        ...addModelOptions,
+        transform,
+        defaultVisible: collection.defaultVisible
+      });
     });
     setResourceOptions(addResourceOptions);
   }, [scene.data]);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-6076

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Use the `defaultVisible` property from scene-to-model edges when initializing models through `SceneContainer`. 

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

In Fusion

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- In 3d-management, select a scene and turn models on/off as desired
- Publish scene
- Use this PR in Unified 3D
- Observe that the models in the same scene has same visibility state as when the scene was stored

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
