### PR TITLE
feat(react-components): Make point type selector better with exponential values

### DIFF
--- a/react-components/src/architecture/concrete/reveal/pointCloud/commands/SetPointSizeCommand.test.ts
+++ b/react-components/src/architecture/concrete/reveal/pointCloud/commands/SetPointSizeCommand.test.ts
@@ -1,4 +1,4 @@
-import { SetPointSizeCommand } from './SetPointSizeCommand';
+import { POINT_SIZES, SetPointSizeCommand } from './SetPointSizeCommand';
 import { createFullRenderTargetMock } from '#test-utils/fixtures/createFullRenderTargetMock';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { isEmpty } from '../../../../base/utilities/translation/TranslateInput';
@@ -22,13 +22,25 @@ describe(SetPointSizeCommand.name, () => {
   });
 
   test('Should have the same value as the point cloud', () => {
-    expect(command.value).toBe(domainObject.pointSize());
+    expect(command.pointSize).toBe(domainObject.pointSize());
   });
 
   test('Should change pointSize at the point cloud', () => {
     const expectedValue = 3;
     expect(domainObject.pointSize()).not.toBe(expectedValue);
-    command.value = expectedValue;
+    command.pointSize = expectedValue;
     expect(domainObject.pointSize()).toBe(expectedValue);
+  });
+
+  test('Should get and set index value', () => {
+    command.value = 2;
+    expect(command.value).toBe(2);
+  });
+
+  test('Should set point size index outside the legal values', () => {
+    command.pointSize = POINT_SIZES[5] + 0.0001;
+    expect(command.value).toBe(5);
+    command.pointSize = POINT_SIZES[5] - 0.0001;
+    expect(command.value).toBe(5);
   });
 });

--- a/react-components/src/architecture/concrete/reveal/pointCloud/commands/SetPointSizeCommand.ts
+++ b/react-components/src/architecture/concrete/reveal/pointCloud/commands/SetPointSizeCommand.ts
@@ -3,9 +3,9 @@ import { BaseSliderCommand } from '../../../../base/commands/BaseSliderCommand';
 import { PointCloudDomainObject } from '../PointCloudDomainObject';
 import { type RevealRenderTarget } from '../../../../base/renderTarget/RevealRenderTarget';
 
-const MIN_POINT_SIZE = 0.0;
-const MAX_POINT_SIZE = 4;
-const STEP_POINT_SIZE = 0.1;
+export const POINT_SIZES = [
+  0, 0.025, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.8, 1, 1.5, 2, 2.5, 3, 4
+];
 
 export class SetPointSizeCommand extends BaseSliderCommand {
   // ==================================================
@@ -13,9 +13,16 @@ export class SetPointSizeCommand extends BaseSliderCommand {
   // ==================================================
 
   public constructor() {
-    super(MIN_POINT_SIZE, MAX_POINT_SIZE, STEP_POINT_SIZE);
+    super(0, POINT_SIZES.length - 1, 1);
   }
 
+  public override getValueLabel(): string {
+    const value = this.settingsController.pointSize();
+    if (value === 0) {
+      return 'Minimum';
+    }
+    return value.toString();
+  }
   // ==================================================
   // OVERRIDES
   // ==================================================
@@ -29,10 +36,23 @@ export class SetPointSizeCommand extends BaseSliderCommand {
   }
 
   public override get value(): number {
+    const value = this.pointSize;
+    const index = POINT_SIZES.findIndex((size) => size === value);
+    if (index >= 0) {
+      return index;
+    }
+    return getClosestIndex(POINT_SIZES, value);
+  }
+
+  public override set value(index: number) {
+    this.pointSize = POINT_SIZES[index];
+  }
+
+  public get pointSize(): number {
     return this.settingsController.pointSize();
   }
 
-  public override set value(value: number) {
+  public set pointSize(value: number) {
     this.settingsController.pointSize(value);
   }
 
@@ -40,4 +60,12 @@ export class SetPointSizeCommand extends BaseSliderCommand {
     super.attach(renderTarget);
     this.listenTo(this.settingsController.pointSize);
   }
+}
+
+function getClosestIndex(array: number[], value: number): number {
+  return array.reduce(
+    (bestIndex, size, index, array) =>
+      Math.abs(size - value) < Math.abs(array[bestIndex] - value) ? index : bestIndex,
+    0
+  );
 }


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:

Now the slider will use these values:

export const POINT_SIZES = [
  0, 0.025, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.8, 1, 1.5, 2, 2.5, 3, 4
];


## How has this been tested? :mag:

Unit test and manual test

## Test instructions :information_source:

1. yarn storybook
2. open setting at left toolbar
3. change the point size

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
