### PR TITLE
feat: add hybrid annotation support in usePointCloudAnnotationMapping…

### DIFF
--- a/react-components/src/hooks/pointClouds/usePointCloudAnnotationMappingForIntersection.context.ts
+++ b/react-components/src/hooks/pointClouds/usePointCloudAnnotationMappingForIntersection.context.ts
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+import { getInstanceDataFromIntersection } from './getInstanceDataFromIntersection';
+import { usePointCloudAnnotationCache } from '../../components/CacheProvider/CacheProvider';
+import { fetchAnnotationsForModel } from './fetchAnnotationsForModel';
+
+export type UsePointCloudAnnotationMappingForIntersectionDependencies = {
+  getInstanceDataFromIntersection: typeof getInstanceDataFromIntersection;
+  usePointCloudAnnotationCache: typeof usePointCloudAnnotationCache;
+  fetchAnnotationsForModel: typeof fetchAnnotationsForModel;
+};
+
+export const defaultUsePointCloudAnnotationMappingForIntersectionDependencies: UsePointCloudAnnotationMappingForIntersectionDependencies =
+  {
+    getInstanceDataFromIntersection,
+    usePointCloudAnnotationCache,
+    fetchAnnotationsForModel
+  };
+
+export const UsePointCloudAnnotationMappingForIntersectionContext =
+  createContext<UsePointCloudAnnotationMappingForIntersectionDependencies>(
+    defaultUsePointCloudAnnotationMappingForIntersectionDependencies
+  );

--- a/react-components/src/hooks/pointClouds/usePointCloudAnnotationMappingForIntersection.test.tsx
+++ b/react-components/src/hooks/pointClouds/usePointCloudAnnotationMappingForIntersection.test.tsx
@@ -1,0 +1,228 @@
+import { describe, expect, beforeEach, test } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type ReactElement, type ReactNode } from 'react';
+import { type IdEither } from '@cognite/sdk';
+import {
+  type PointCloudIntersection,
+  type ClassicDataSourceType,
+  type DMInstanceRef,
+  type AnyIntersection
+} from '@cognite/reveal';
+import { Vector3 } from 'three';
+import {
+  createPointCloudMock,
+  createPointCloudIntersectionMock
+} from '#test-utils/fixtures/pointCloud';
+import { cadMock } from '#test-utils/fixtures/cadModel';
+import { type PointCloudAnnotationMappedAssetData } from '../types';
+import { createAssetMock, createFdmNodeItem } from '#test-utils/fixtures/assets';
+import { getMocksByDefaultDependencies } from '#test-utils/vitest-extensions/getMocksByDefaultDependencies';
+import {
+  defaultUsePointCloudAnnotationMappingForIntersectionDependencies,
+  UsePointCloudAnnotationMappingForIntersectionContext
+} from './usePointCloudAnnotationMappingForIntersection.context';
+import { usePointCloudAnnotationMappingForIntersection } from './usePointCloudAnnotationMappingForIntersection';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false
+    }
+  }
+});
+
+const dependencies = getMocksByDefaultDependencies(
+  defaultUsePointCloudAnnotationMappingForIntersectionDependencies
+);
+
+const wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+  <QueryClientProvider client={queryClient}>
+    <UsePointCloudAnnotationMappingForIntersectionContext.Provider value={dependencies}>
+      {children}
+    </UsePointCloudAnnotationMappingForIntersectionContext.Provider>
+  </QueryClientProvider>
+);
+
+describe(usePointCloudAnnotationMappingForIntersection.name, () => {
+  const mockClassicIdEither: IdEither = { id: 123 };
+  const classicAssetInstance = createAssetMock(123);
+  const classicAssetInstance2 = createAssetMock(456);
+
+  const dmAssetInstance = createFdmNodeItem({ externalId: 'ext-id', space: 'asset-space' });
+
+  const mockDmsIdentifier: DMInstanceRef = {
+    externalId: dmAssetInstance.externalId,
+    space: dmAssetInstance.space
+  };
+
+  const pointCloudModelMock = createPointCloudMock({
+    modelId: 456,
+    revisionId: 789
+  });
+
+  const mockClassicIntersection = createPointCloudIntersectionMock({
+    model: pointCloudModelMock,
+    assetRef: mockClassicIdEither,
+    instanceRef: undefined,
+    annotationId: 1
+  });
+
+  const mockHybridIntersection = createPointCloudIntersectionMock({
+    model: pointCloudModelMock,
+    assetRef: undefined,
+    instanceRef: mockDmsIdentifier,
+    annotationId: 2
+  });
+
+  const mockFetchAnnotationsForModelReturn: PointCloudAnnotationMappedAssetData[] = [
+    { annotationId: 1, asset: classicAssetInstance },
+    { annotationId: 2, asset: classicAssetInstance2 }
+  ];
+  beforeEach(() => {
+    queryClient.clear();
+    dependencies.getInstanceDataFromIntersection.mockReturnValue({
+      classicModelIdentifier: { modelId: cadMock.modelId, revisionId: cadMock.revisionId },
+      dmsModelUniqueIdentifier: undefined,
+      reference: mockClassicIdEither
+    });
+    dependencies.fetchAnnotationsForModel.mockResolvedValue(mockFetchAnnotationsForModelReturn);
+  });
+
+  test('returns undefined when intersection is undefined', async () => {
+    const { result } = renderHook(() => usePointCloudAnnotationMappingForIntersection(undefined), {
+      wrapper
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  test('returns undefined when intersection is not pointcloud type', async () => {
+    const cadIntersection: AnyIntersection = {
+      type: 'cad',
+      model: cadMock,
+      point: new Vector3(0, 0, 0),
+      treeIndex: 0,
+      distanceToCamera: 0
+    };
+
+    const { result } = renderHook(
+      () => usePointCloudAnnotationMappingForIntersection(cadIntersection),
+      {
+        wrapper
+      }
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  test('returns annotation mappings for classic intersection with assetRef', async () => {
+    dependencies.fetchAnnotationsForModel.mockReturnValue(mockFetchAnnotationsForModelReturn);
+
+    const { result } = renderHook(
+      () => usePointCloudAnnotationMappingForIntersection(mockClassicIntersection),
+      { wrapper }
+    );
+
+    const expectedResult: PointCloudAnnotationMappedAssetData[] | undefined = [
+      { annotationId: 1, asset: classicAssetInstance },
+      { annotationId: 2, asset: classicAssetInstance2 }
+    ];
+    await waitFor(() => {
+      expect(result.current.data).toEqual(expectedResult);
+    });
+  });
+
+  test('returns annotation mappings for hybrid intersection with instanceRef', async () => {
+    const mockAnnotationMap: PointCloudAnnotationMappedAssetData[] = [
+      { annotationId: 2, asset: dmAssetInstance }
+    ];
+
+    dependencies.fetchAnnotationsForModel.mockResolvedValue(mockAnnotationMap);
+
+    const { result } = renderHook(
+      () => usePointCloudAnnotationMappingForIntersection(mockHybridIntersection),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockAnnotationMap);
+    });
+  });
+
+  test('query is disabled when intersection is not pointcloud type', async () => {
+    const cadIntersection: AnyIntersection = {
+      type: 'cad',
+      model: cadMock,
+      point: new Vector3(0, 0, 0),
+      treeIndex: 0,
+      distanceToCamera: 0
+    };
+
+    const { result } = renderHook(
+      () => usePointCloudAnnotationMappingForIntersection(cadIntersection),
+      {
+        wrapper
+      }
+    );
+
+    expect(result.current.isFetching).toBe(false);
+    expect(dependencies.fetchAnnotationsForModel).not.toHaveBeenCalled();
+  });
+
+  test('query is disabled when reference is undefined', async () => {
+    const intersectionNoRef: PointCloudIntersection<ClassicDataSourceType> = {
+      type: 'pointcloud',
+      model: pointCloudModelMock,
+      volumeMetadata: {
+        annotationId: 1
+      },
+      point: new Vector3(1, 2, 3),
+      pointIndex: 0,
+      distanceToCamera: 0,
+      annotationId: 1
+    };
+
+    dependencies.getInstanceDataFromIntersection.mockReturnValue({
+      classicModelIdentifier: { modelId: cadMock.modelId, revisionId: cadMock.revisionId },
+      dmsModelUniqueIdentifier: undefined,
+      reference: undefined
+    });
+
+    const { result } = renderHook(
+      () => usePointCloudAnnotationMappingForIntersection(intersectionNoRef),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(dependencies.fetchAnnotationsForModel).not.toHaveBeenCalled();
+    });
+  });
+
+  test('handles pointcloud intersection with multiple annotations in map', async () => {
+    const mockAnnotationMap: PointCloudAnnotationMappedAssetData[] = [
+      { annotationId: 1, asset: classicAssetInstance },
+      { annotationId: 1, asset: classicAssetInstance2 },
+      { annotationId: 2, asset: dmAssetInstance }
+    ];
+
+    dependencies.fetchAnnotationsForModel.mockResolvedValue(mockAnnotationMap);
+
+    const { result } = renderHook(
+      () => usePointCloudAnnotationMappingForIntersection(mockClassicIntersection),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([
+        { annotationId: 1, asset: classicAssetInstance },
+        { annotationId: 1, asset: classicAssetInstance2 },
+        { annotationId: 2, asset: dmAssetInstance }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
https://cognitedata.atlassian.net/browse/BND3D-5949<!--(mention JIRA ticket/s)-->

## Description :pencil:
This is the implementation for the click functionality on a Point Cloud annotation for hybrid annotations.

The functionality also involves the fundamental part of loading and caching hybrid annotations and some hooks involved that are also used for other hybrid annotation search and highlighting features.

It is also related to the PR in Fusion to connect the use of click in Unified 3D.

This is a stacked PR:
- #5369
- #5370
- #5371

## How has this been tested? :mag:

It was tested in Unified 3D in 3d-test and in the Point Clouds, where I created some hybrid annotation samples: gonza:pointcolor-test and mariudu/test-new-classification.

It also needs to be tested with the PR in Fusion to connect this functionality.


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [ ] I am happy with this implementation.
- [ ] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [ ] I have added documentation to new and changed elements; both public and internally shared ones
- [ ] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [ ] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
