### PR TITLE
chore(webpack): add GLSL import tracker loader to track import dependencies in --watch mode 

### DIFF
--- a/viewer/glsl-import-tracker-loader.cjs
+++ b/viewer/glsl-import-tracker-loader.cjs
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Helper to recursively finds all unique GLSL `import` dependencies in a file.
+ * @param {string} filePath - Absolute path to the file.
+ * @param {Set<string>} visited - Set of already visited files.
+ * @returns {Set<string>} - Set of all unique dependency file paths.
+ * @throws {Error} - If infinite recursion (circular dependency) is detected.
+ */
+function findAllDependencies(filePath, visited = new Set()) {
+  if (visited.has(filePath)) {
+    throw new Error(`Circular dependency detected in GLSL imports: ${filePath}`);
+  }
+  visited.add(filePath);
+  const deps = new Set();
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new Error(`Failed to read GLSL file: ${filePath}`);
+  }
+  const importRegex = /#pragma\s+glslify:\s+import\(['"](.+?)['"]\)/g;
+  let match;
+  const baseDir = path.dirname(filePath);
+  while ((match = importRegex.exec(content)) !== null) {
+    const importPath = match[1];
+    const resolvedPath = path.resolve(baseDir, importPath);
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`GLSL import file not found: ${resolvedPath} (imported in ${filePath})`);
+    }
+    if (!deps.has(resolvedPath)) {
+      deps.add(resolvedPath);
+      // Recursively find dependencies in the imported file
+      for (const dep of findAllDependencies(resolvedPath, visited)) {
+        deps.add(dep);
+      }
+    }
+  }
+  visited.delete(filePath);
+  return deps;
+}
+
+/**
+ * GLSL Loader for Webpack to track #pragma glslify: import dependencies.
+ * This allows Webpack to watch dependency files for changes during development.
+ *
+ * Usage: In webpack.config.js, use this loader before 'glslify-loader':
+ * {
+ *  test: /\.(glsl|vert|frag)$/,
+ *  type: 'asset/source',
+ *  use: [
+ *    path.resolve(__dirname + '/glsl-import-tracker-loader.js'),
+ *    {
+ *      loader: 'glslify-loader',
+ *      options: {
+ *        transform: ['glslify-import']
+ *      }
+ *    }
+ *  ]
+ * }
+ *
+ * @param {string} source - The source code of the GLSL file.
+ * @returns {string} - The unchanged source code.
+ */
+module.exports = function (source) {
+  // 'this' is the loader context
+  const resourcePath = this.resourcePath;
+  let dependencies;
+  try {
+    dependencies = findAllDependencies(resourcePath);
+  } catch (err) {
+    this.emitError(err);
+    // Optionally, you can throw to fail the build:
+    // throw err;
+    return source;
+  }
+  for (const dep of dependencies) {
+    this.addDependency(dep);
+  }
+  // Pass the source unchanged
+  return source;
+};

--- a/viewer/packages/webpack.config.js
+++ b/viewer/packages/webpack.config.js
@@ -100,7 +100,19 @@ module.exports = env => {
         {
           test: /\.(glsl|vert|frag)$/,
           type: 'asset/source',
-          use: ['glslify-loader']
+          use: [
+            {
+              // Help Webpack track #pragma glslify: import dependencies for --watch mode
+              loader: path.resolve(`${__dirname}/../glsl-import-tracker-loader.js`)
+            },
+            {
+              loader: 'glslify-loader',
+              options: {
+                // Enable glslify-import transform to handle #pragma glslify: import statements
+                transform: ['glslify-import']
+              }
+            }
+          ]
         },
         {
           test: /\.css$/,

--- a/viewer/packages/webpack.config.js
+++ b/viewer/packages/webpack.config.js
@@ -103,7 +103,7 @@ module.exports = env => {
           use: [
             {
               // Help Webpack track #pragma glslify: import dependencies for --watch mode
-              loader: path.resolve(`${__dirname}/../glsl-import-tracker-loader.js`)
+              loader: path.resolve(`${__dirname}/../glsl-import-tracker-loader.cjs`)
             },
             {
               loader: 'glslify-loader',

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = env => {
           use: [
             {
               // Help Webpack track #pragma glslify: import dependencies for --watch mode
-              loader: path.resolve(`${__dirname}/glsl-import-tracker-loader.js`)
+              loader: path.resolve(`${__dirname}/glsl-import-tracker-loader.cjs`)
             },
             {
               loader: 'glslify-loader',

--- a/viewer/webpack.config.js
+++ b/viewer/webpack.config.js
@@ -66,7 +66,19 @@ module.exports = env => {
         {
           test: /\.(glsl|vert|frag)$/,
           type: 'asset/source',
-          use: ['glslify-loader']
+          use: [
+            {
+              // Help Webpack track #pragma glslify: import dependencies for --watch mode
+              loader: path.resolve(`${__dirname}/glsl-import-tracker-loader.js`)
+            },
+            {
+              loader: 'glslify-loader',
+              options: {
+                // Enable glslify-import transform to handle #pragma glslify: import statements
+                transform: ['glslify-import']
+              }
+            }
+          ]
         },
         {
           test: /\.css$/,


### PR DESCRIPTION
#### Type of change
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:

N/A

## Description :pencil:

When changing shader file dependencies today you need to manually rebuild changes as webpack watch does not track dependencies for glslify imports. This PR adds a custom webpack loader to track imports.

If this change is not needed feel free to dismiss this PR.

## How has this been tested? :mag:

Tested in local development, works.

The loader does not mutate the files so there should be no runtime or build-time changes

## Test instructions :information_source:

Start viewer with `yarn build:watch` and change a .glsl file (for example updateFragmentColor.glsl) and see that webpack now will auto-rebuild.

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
