### PR TITLE
fix: gracefully handle undefined object3Ds in point cloud volumes

### DIFF
--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.test.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.test.ts
@@ -14,7 +14,11 @@ const PAGE1_SIZE = 1000;
 const PAGE2_SIZE = 500;
 const TOTAL_VOLUMES = PAGE1_SIZE + PAGE2_SIZE;
 
-function createVolume(index: number, page: number): ExhaustedQueryResult['pointCloudVolumes'][number] {
+function createVolume(
+  index: number,
+  page: number,
+  noObject3D: boolean = false
+): ExhaustedQueryResult['pointCloudVolumes'][number] {
   const id = page * VOLUME_LIMIT + index;
   const obj3dId = `obj3d_${id}`;
   return {
@@ -31,7 +35,7 @@ function createVolume(index: number, page: number): ExhaustedQueryResult['pointC
           volumeReferences: [],
           volumeType: 'Box',
           volume: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
-          object3D: { externalId: obj3dId, space: 'objSpace' }
+          object3D: noObject3D ? undefined : { externalId: obj3dId, space: 'objSpace' }
         }
       }
     }
@@ -158,5 +162,22 @@ describe(getDMPointCloudObjects.name, () => {
     const result = await getDMPointCloudObjects(dmsSdkMock.object(), modelIdentifier);
 
     expect(result).toHaveLength(singlePageSize);
+  });
+
+  test('gracefully ignore annotations with  undefined object3Ds', async () => {
+    const volumes = [createVolume(0, 0), createVolume(1, 0, true)];
+    const assets = Array.from({ length: 2 }, (_, i) => createAsset(i, 0));
+    const page = {
+      pointCloudVolumes: volumes,
+      assets
+    };
+
+    const dmsSdkMock = new Mock<DataModelsSdk>()
+      .setup(m => m.queryNodesAndEdges(It.IsAny(), It.IsAny()))
+      .returns(Promise.resolve(page));
+
+    const result = await getDMPointCloudObjects(dmsSdkMock.object(), modelIdentifier);
+
+    expect(result).toHaveLength(1);
   });
 });

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
@@ -68,7 +68,7 @@ export async function getDMPointCloudObjects(
   const object3DAndAssetPairs = result.assets
     .map(asset => {
       const object3D = asset.properties.cdf_cdm['CogniteAsset/v1'].object3D;
-      if (object3D === undefined || !isDmIdentifier(object3D)) {
+      if (!isDmIdentifier(object3D)) {
         return undefined;
       }
       return [dmInstanceRefToKey(object3D), asset] as const;
@@ -88,7 +88,7 @@ export async function getDMPointCloudObjects(
       );
 
       const object3D = volume.properties.cdf_cdm['CognitePointCloudVolume/v1'].object3D;
-      if (object3D === undefined || !isDmIdentifier(object3D)) {
+      if (!isDmIdentifier(object3D)) {
         return undefined;
       }
 

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
@@ -65,48 +65,46 @@ export async function getDMPointCloudObjects(
     nextCursor = currentCursor?.pointCloudVolumes ? { pointCloudVolumes: currentCursor.pointCloudVolumes } : undefined;
   }
 
-  const object3DAndAssetPairs = result.assets
-    .map(asset => {
-      const object3D = asset.properties.cdf_cdm['CogniteAsset/v1'].object3D;
-      if (!isDmIdentifier(object3D)) {
-        return undefined;
-      }
-      return [dmInstanceRefToKey(object3D), asset] as const;
-    })
-    .filter(isDefined);
+  const object3DAndAssetPairs = result.assets.flatMap(asset => {
+    const object3D = asset.properties.cdf_cdm['CogniteAsset/v1'].object3D;
+    if (!isDmIdentifier(object3D)) {
+      return [];
+    }
+    return [[dmInstanceRefToKey(object3D), asset] as const];
+  });
 
   const object3DToAssetMap = new Map<DMInstanceKey, AssetResult>(object3DAndAssetPairs);
 
-  const annotations: CdfPointCloudObjectAnnotation[] = result.pointCloudVolumes
-    .map(volume => {
-      const pointCloudVolumeProperties = volume.properties.cdf_cdm[
-        'CognitePointCloudVolume/v1'
-      ] as unknown as PointCloudVolumeObject3DProperties;
-      const region = pointCloudVolumeToRevealShapes(
-        pointCloudVolumeProperties.volume,
-        pointCloudVolumeProperties.volumeType
-      );
+  const annotations: CdfPointCloudObjectAnnotation[] = result.pointCloudVolumes.flatMap(volume => {
+    const pointCloudVolumeProperties = volume.properties.cdf_cdm[
+      'CognitePointCloudVolume/v1'
+    ] as unknown as PointCloudVolumeObject3DProperties;
+    const region = pointCloudVolumeToRevealShapes(
+      pointCloudVolumeProperties.volume,
+      pointCloudVolumeProperties.volumeType
+    );
 
-      const object3D = volume.properties.cdf_cdm['CognitePointCloudVolume/v1'].object3D;
-      if (!isDmIdentifier(object3D)) {
-        return undefined;
-      }
+    const object3D = volume.properties.cdf_cdm['CognitePointCloudVolume/v1'].object3D;
+    if (!isDmIdentifier(object3D)) {
+      return [];
+    }
 
-      const asset = object3DToAssetMap.get(dmInstanceRefToKey(object3D));
+    const asset = object3DToAssetMap.get(dmInstanceRefToKey(object3D));
 
-      if (asset === undefined) {
-        return undefined;
-      }
+    if (asset === undefined) {
+      return [];
+    }
 
-      return {
+    return [
+      {
         volumeMetadata: {
           instanceRef: { externalId: volume.externalId, space: volume.space },
           asset: { externalId: asset.externalId, space: asset.space }
         },
         region: [region]
-      };
-    })
-    .filter(result => result !== undefined);
+      }
+    ];
+  });
 
   return annotations;
 }

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
@@ -11,7 +11,7 @@ import { PointCloudVolumeObject3DProperties } from './types';
 import { CdfPointCloudObjectAnnotation } from '../types';
 import { QueryNextCursors } from '../../types';
 
-import { IShape, Box, Cylinder, DMInstanceKey, dmInstanceRefToKey, DMInstanceRef } from '@reveal/utilities';
+import { IShape, Box, Cylinder, DMInstanceKey, dmInstanceRefToKey, isDefined, isDmIdentifier } from '@reveal/utilities';
 import { DMModelIdentifierType } from '../../DataSourceType';
 
 type QueryResult = Awaited<ReturnType<typeof DataModelsSdk.prototype.queryNodesAndEdges<CdfDMPointCloudVolumeQuery>>>;
@@ -65,10 +65,15 @@ export async function getDMPointCloudObjects(
     nextCursor = currentCursor?.pointCloudVolumes ? { pointCloudVolumes: currentCursor.pointCloudVolumes } : undefined;
   }
 
-  const object3DAndAssetPairs: [DMInstanceKey, AssetResult][] = result.assets.map(asset => [
-    dmInstanceRefToKey(asset.properties.cdf_cdm['CogniteAsset/v1'].object3D as DMInstanceRef),
-    asset
-  ]);
+  const object3DAndAssetPairs = result.assets
+    .map(asset => {
+      const object3D = asset.properties.cdf_cdm['CogniteAsset/v1'].object3D;
+      if (object3D === undefined || !isDmIdentifier(object3D)) {
+        return undefined;
+      }
+      return [dmInstanceRefToKey(object3D), asset] as const;
+    })
+    .filter(isDefined);
 
   const object3DToAssetMap = new Map<DMInstanceKey, AssetResult>(object3DAndAssetPairs);
 
@@ -82,9 +87,12 @@ export async function getDMPointCloudObjects(
         pointCloudVolumeProperties.volumeType
       );
 
-      const asset = object3DToAssetMap.get(
-        dmInstanceRefToKey(volume.properties.cdf_cdm['CognitePointCloudVolume/v1'].object3D as DMInstanceRef)
-      );
+      const object3D = volume.properties.cdf_cdm['CognitePointCloudVolume/v1'].object3D;
+      if (object3D === undefined || !isDmIdentifier(object3D)) {
+        return undefined;
+      }
+
+      const asset = object3DToAssetMap.get(dmInstanceRefToKey(object3D));
 
       if (asset === undefined) {
         return undefined;

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/pointcloud-volume-data-providers/getDMPointCloudObjects.ts
@@ -11,7 +11,7 @@ import { PointCloudVolumeObject3DProperties } from './types';
 import { CdfPointCloudObjectAnnotation } from '../types';
 import { QueryNextCursors } from '../../types';
 
-import { IShape, Box, Cylinder, DMInstanceKey, dmInstanceRefToKey, isDefined, isDmIdentifier } from '@reveal/utilities';
+import { IShape, Box, Cylinder, DMInstanceKey, dmInstanceRefToKey, isDmIdentifier } from '@reveal/utilities';
 import { DMModelIdentifierType } from '../../DataSourceType';
 
 type QueryResult = Awaited<ReturnType<typeof DataModelsSdk.prototype.queryNodesAndEdges<CdfDMPointCloudVolumeQuery>>>;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

If a point cloud's annotation is not connected to an `object3D` (which may happen if that object is deleted by the user without deleting the annotation), Reveal would fail in loading the point cloud. I observed this on point cloud 
```
{
  revisionExternalId: 'cog_3d_revision_329097335014617',
  revisionSpace: 'threed_data',
}
```
in 3d-dev-quickstart

This PR makes sure we ignore annotations with undefined Object3D

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->

- In reveal-react-components storybook

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Try to open the above point cloud in `/examples`

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
