### PR TITLE
fix: 360 image icon proximity issue when user enters into 360 image entity

### DIFF
--- a/viewer/packages/360-images/src/icons/IconCollection.test.ts
+++ b/viewer/packages/360-images/src/icons/IconCollection.test.ts
@@ -421,6 +421,23 @@ describe(IconCollection.name, () => {
       collection.dispose();
     });
 
+    it('floor disc mesh visible property starts false and is toggled by setFloorMode', () => {
+      const collection = createCollection([new Vector3(0, 1.5, 0)]);
+      const floorDiscMesh = addedObjects.find(isFloorDiscMesh);
+      assert(floorDiscMesh, 'Floor disc mesh not found');
+
+      // Mesh starts invisible so origin-positioned instances do not corrupt sceneBoundingBox
+      expect(floorDiscMesh.visible).toBe(false);
+
+      collection.setFloorMode(true);
+      expect(floorDiscMesh.visible).toBe(true);
+
+      collection.setFloorMode(false);
+      expect(floorDiscMesh.visible).toBe(false);
+
+      collection.dispose();
+    });
+
     it('floor disc meshes are shown after render in floor mode and hidden after exit', () => {
       const collection = createCollection([new Vector3(0, 1.5, 0)]);
       const floorDiscMesh = addedObjects.find(isFloorDiscMesh);

--- a/viewer/packages/360-images/src/icons/IconCollection.ts
+++ b/viewer/packages/360-images/src/icons/IconCollection.ts
@@ -171,9 +171,11 @@ export class IconCollection {
       this._preFloorPointsObjectVisible = this._pointsObject.visible;
       this._preFloorCullingScheme = this._iconCullingScheme;
       this._pointsObject.visible = false;
+      this._floorDiscMesh.visible = true;
       this.setCullingScheme('proximity');
     } else {
       this._pointsObject.visible = this._preFloorPointsObjectVisible;
+      this._floorDiscMesh.visible = false;
       for (let i = 0; i < this._activeFloorDiscCount; i++) {
         this._floorDiscMesh.setMatrixAt(i, this._hiddenMatrix);
       }
@@ -778,9 +780,8 @@ export class IconCollection {
       depthWrite: false,
       side: DoubleSide
     });
-    // Keep count = capacity (never 0) to avoid empty bounding box causing near/far plane issues.
-    // Inactive instances are hidden via a zero-scale matrix.
     const mesh = new InstancedMesh(geometry, material, capacity);
+    mesh.visible = false; // Hidden until floor mode is activated; prevents origin from poisoning sceneBoundingBox
     mesh.frustumCulled = false;
     mesh.renderOrder = 4;
     for (let i = 0; i < capacity; i++) {

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
@@ -457,6 +457,20 @@ describe(Image360ApiHelper.name, () => {
       floorHelper.dispose();
     });
 
+    test('switches to proximity culling on enter and restores clustered on exit when enableFloorIcons is false', async () => {
+      const { mockEntity } = createFloorModeFixture();
+      const cullingSetSpy = jest.spyOn(Image360Facade.prototype, 'allIconCullingScheme', 'set');
+
+      await enterImage(mockEntity);
+
+      expect(cullingSetSpy).toHaveBeenCalledWith('proximity');
+
+      cullingSetSpy.mockClear();
+      helper.exit360Image();
+
+      expect(cullingSetSpy).toHaveBeenCalledWith('clustered');
+    });
+
     test('calls setFloorMode(false) on ALL collections when exiting regardless of enableFloorIcons', async () => {
       const { helper: floorHelper } = createTestHelper(domElement, sdk, 'mock', { enableFloorIcons: true });
       const { mockEntity } = createFloorModeFixture();

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -368,6 +368,10 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     collectionVisibilities.forEach((v, i) => this._image360Facade.collections[i].setIconsVisibility(v));
     if (this._enableFloorIcons) {
       this._image360Facade.collections.forEach(c => c.setFloorMode(true));
+    } else {
+      // Switch to proximity culling when inside a 360 image so nearby icons
+      // are shown without clustering (mirrors the behaviour when floor mode is on).
+      this._image360Facade.allIconCullingScheme = 'proximity';
     }
     if (this._hasEventListeners) {
       this._domElement.addEventListener('keydown', this.onKeyPressed);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
When a 360 image collection contains large amount of 360 Image entities and when user enters into 360 image entity, the 360 image icon proximity was not enabled and also there was a edge case where for specific image collection icons was not visible where all it's 360 image entities was at same position. This PR fixes the issue.

## How has this been tested? :mag:

In `unified-3d` application


## Test instructions :information_source:

- Link local build of viewer into fusion repo
- Load unified-3d application with Hakon' Scene
- Enter into any 360 image entity and check icons are only near by 360 image entity are visible 

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
