### PR TITLE
fix: remove sync CAD intersection to fix PIXEL_PACK buffer WebGL error and bump version to 4.32.1

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "description": "WebGL based 3D viewer for CAD and point clouds processed in Cognite Data Fusion.",
   "homepage": "https://github.com/cognitedata/reveal/tree/master/viewer",
   "repository": {

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1714,7 +1714,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
       return intersection;
     }
     const modelIntersection = await this.intersectModels(pixelCoords.x, pixelCoords.y, {
-      asyncCADIntersection: false
+      asyncCADIntersection: true
     });
     if (modelIntersection !== null) {
       intersection = modelIntersection;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
`getAnyIntersectionFromPixel` was hardcoded to `asyncCADIntersection: false`, forcing the sync `readRenderTargetPixels` path. WebGL2 prohibits synchronous `readPixels` while a `PIXEL_PACK_BUFFER` is bound. The PBO gets bound in the same frame by concurrent `readRenderTargetPixelsAsync` call (e.g. from point cloud picking) causing the collision. This PR fixes the issue

## How has this been tested? :mag:

In Examples

## Test instructions :information_source:

- Load [examples](https://localhost:3549/?project=3d-test&env=greenfield-3d&modelId=4923307033982497&revisionId=3100284276970593)
- Now Select Models option and input modelId=8213983532852438 & revisionId=5600749419552430 and Load the secondary model (point cloud)
- Now click on point cloud or cad node, in Dev Tools we should not see any warning related to WebGL

`WebGL: INVALID_OPERATION: readPixels: PIXEL_PACK buffer should not be bound`


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
