### PR TITLE
fix: improve 360 image transition smoothness

### DIFF
--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
@@ -491,6 +491,15 @@ describe(Image360ApiHelper.name, () => {
       expect(jest.mocked(mockCollection2.setFloorMode)).toHaveBeenCalledExactlyOnceWith(false);
       floorHelper.dispose();
     });
+
+    test('calls applyFullResolutionTextures on first entry', async () => {
+      const { mockEntity } = createFloorModeFixture();
+      const applyFullResSpy = jest.spyOn(helper as any, 'applyFullResolutionTextures').mockResolvedValue(undefined);
+
+      await enterImage(mockEntity);
+
+      expect(applyFullResSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('cursor pointer on hover', () => {

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
@@ -123,7 +123,8 @@ function createTestHelper(
   domElement: HTMLElement,
   sdk: CogniteClient,
   cameraManagerType: CameraManagerType = 'mock',
-  iconsOptions?: { enableFloorIcons?: boolean }
+  iconsOptions?: { enableFloorIcons?: boolean },
+  hasEventListeners = false
 ): { helper: Image360ApiHelper<DataSourceType>; innerCameraManager: CameraManager } {
   const mockCamera = new PerspectiveCamera();
   mockCamera.position.set(0, 0, 10);
@@ -171,7 +172,7 @@ function createTestHelper(
     proxyCameraManager,
     mockInputHandler,
     onBeforeSceneRendered,
-    false,
+    hasEventListeners,
     iconsOptions
   );
 
@@ -504,6 +505,110 @@ describe(Image360ApiHelper.name, () => {
       await enterImage(mockEntity);
 
       expect(applyFullResolutionMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('executes transition and applies full-res textures when switching between two entities', async () => {
+      const applyFullResMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const revision2 = new Mock<Image360RevisionEntity<DataSourceType>>()
+        .setup(r => r.applyFullResolutionTextures())
+        .callback(() => applyFullResMock());
+
+      const entity1 = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+      const entity2 = createMockEntity(createMockIcon(), createMockVisualization(), revision2.object());
+
+      createFloorModeFixture();
+
+      // Enter entity1 first (first-entry path — no transition)
+      await enterImage(entity1);
+
+      // Enter entity2: triggers transition() from entity1 to entity2
+      const enter2Promise = helper.enter360ImageInternal(entity2);
+      await Promise.resolve();
+      TWEEN.update(TWEEN.now() + 2000);
+      await enter2Promise;
+
+      // applyFullResolutionTextures is called after transition completes (not on first entry)
+      expect(applyFullResMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('re-entering same entity with a different revision activates annotations without camera transition', async () => {
+      const revision1 = createMockRevision();
+      const revision2 = createMockRevision();
+      const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), revision1);
+
+      createFloorModeFixture();
+
+      // First entry — uses revision1 via getMostRecentRevision
+      await enterImage(mockEntity);
+
+      // Second entry with explicit revision2 — lastEntered === mockEntity, so takes the same-entity branch
+      const secondPromise = helper.enter360ImageInternal(mockEntity, revision2);
+      await Promise.resolve();
+      TWEEN.update(TWEEN.now() + 2000);
+      const result = await secondPromise;
+
+      expect(result).toBe(true);
+    });
+
+    test('first-entry with FlexibleCameraManager uses camera position tween', async () => {
+      const { helper: flexHelper } = createTestHelper(domElement, sdk, 'flexible');
+      const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+      const mockCollection = createMockCollection();
+
+      jest.spyOn(Image360Facade.prototype, 'preload').mockResolvedValue(undefined);
+      jest.spyOn(Image360Facade.prototype, 'getCollectionContainingEntity').mockReturnValue(mockCollection);
+      jest.spyOn(Image360Facade.prototype, 'collections', 'get').mockReturnValue([mockCollection]);
+
+      const enterPromise = flexHelper.enter360ImageInternal(mockEntity);
+      await Promise.resolve();
+      TWEEN.update(TWEEN.now() + 2000);
+      const result = await enterPromise;
+
+      expect(result).toBe(true);
+      flexHelper.dispose();
+    });
+
+    test('registers keydown listener on enter when hasEventListeners is true', async () => {
+      const { helper: listenerHelper } = createTestHelper(domElement, sdk, 'mock', undefined, true);
+      const addEventSpy = jest.spyOn(domElement, 'addEventListener');
+
+      const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+      createFloorModeFixture();
+
+      const enterPromise = listenerHelper.enter360ImageInternal(mockEntity);
+      await Promise.resolve();
+      TWEEN.update(TWEEN.now() + 2000);
+      await enterPromise;
+
+      const keydownCalls = addEventSpy.mock.calls.filter(([event]) => event === 'keydown');
+      expect(keydownCalls.length).toBeGreaterThan(0);
+      listenerHelper.dispose();
+    });
+
+    test('transition between entities with FlexibleCameraManager uses camera and fov tweens', async () => {
+      const { helper: flexHelper } = createTestHelper(domElement, sdk, 'flexible');
+      const entity1 = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+      const entity2 = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+      const mockCollection = createMockCollection();
+
+      jest.spyOn(Image360Facade.prototype, 'preload').mockResolvedValue(undefined);
+      jest.spyOn(Image360Facade.prototype, 'getCollectionContainingEntity').mockReturnValue(mockCollection);
+      jest.spyOn(Image360Facade.prototype, 'collections', 'get').mockReturnValue([mockCollection]);
+
+      // First entry (no transition)
+      const enter1 = flexHelper.enter360ImageInternal(entity1);
+      await Promise.resolve();
+      TWEEN.update(TWEEN.now() + 2000);
+      await enter1;
+
+      // Second entry: triggers transition() through the FlexibleCameraManager branch
+      const enter2 = flexHelper.enter360ImageInternal(entity2);
+      await Promise.resolve();
+      TWEEN.update(TWEEN.now() + 2000);
+      const result = await enter2;
+
+      expect(result).toBe(true);
+      flexHelper.dispose();
     });
   });
 

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
@@ -754,11 +754,11 @@ describe(Image360ApiHelper.name, () => {
 
   describe('wait cursor', () => {
     function hasWaitCursorOverlay(): boolean {
-      return Array.from(document.body.children).some(el => (el as HTMLElement).style?.cursor === 'wait');
+      return Array.from(domElement.children).some(el => (el as HTMLElement).style?.cursor === 'wait');
     }
 
     function waitCursorOverlayCount(): number {
-      return Array.from(document.body.children).filter(el => (el as HTMLElement).style?.cursor === 'wait').length;
+      return Array.from(domElement.children).filter(el => (el as HTMLElement).style?.cursor === 'wait').length;
     }
 
     test('enter360Image adds wait cursor overlay synchronously and removes it on completion', async () => {

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
@@ -493,12 +493,17 @@ describe(Image360ApiHelper.name, () => {
     });
 
     test('calls applyFullResolutionTextures on first entry', async () => {
-      const { mockEntity } = createFloorModeFixture();
-      const applyFullResSpy = jest.spyOn(helper as any, 'applyFullResolutionTextures').mockResolvedValue(undefined);
+      const applyFullResolutionMock = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const mockRevision = new Mock<Image360RevisionEntity<DataSourceType>>()
+        .setup(r => r.applyFullResolutionTextures())
+        .callback(() => applyFullResolutionMock());
+      const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), mockRevision.object());
+
+      createFloorModeFixture(); // sets up facade preload, getCollectionContainingEntity, collections spies
 
       await enterImage(mockEntity);
 
-      expect(applyFullResSpy).toHaveBeenCalledTimes(1);
+      expect(applyFullResolutionMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -639,6 +644,95 @@ describe(Image360ApiHelper.name, () => {
 
       const result = helper.findBestNext360ImageEntity(new Vector3(10, 0, 0));
       expect(result?.image360).toBe(forward);
+    });
+  });
+
+  describe('wait cursor', () => {
+    function hasWaitCursorOverlay(): boolean {
+      return Array.from(document.body.children).some(el => (el as HTMLElement).style?.cursor === 'wait');
+    }
+
+    function waitCursorOverlayCount(): number {
+      return Array.from(document.body.children).filter(el => (el as HTMLElement).style?.cursor === 'wait').length;
+    }
+
+    test('enter360Image adds wait cursor overlay synchronously and removes it on completion', async () => {
+      jest.spyOn(helper, 'enter360ImageInternal').mockResolvedValue(true);
+      const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+
+      const enterPromise = helper.enter360Image(mockEntity);
+
+      // showWaitCursor runs synchronously before the first await inside enter360Image
+      expect(hasWaitCursorOverlay()).toBe(true);
+
+      await enterPromise;
+
+      // hideWaitCursor called in finally block after enter360ImageInternal resolves
+      expect(hasWaitCursorOverlay()).toBe(false);
+    });
+
+    test('concurrent enter360Image calls share one overlay and remove it only when all complete', async () => {
+      let resolve1!: (v: boolean) => void;
+      let resolve2!: (v: boolean) => void;
+      let callCount = 0;
+      jest.spyOn(helper, 'enter360ImageInternal').mockImplementation(() => {
+        if (callCount++ === 0)
+          return new Promise<boolean>(r => {
+            resolve1 = r;
+          });
+        return new Promise<boolean>(r => {
+          resolve2 = r;
+        });
+      });
+
+      const entity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+      const p1 = helper.enter360Image(entity);
+      const p2 = helper.enter360Image(entity);
+
+      // Only one overlay is created even for two concurrent calls
+      expect(waitCursorOverlayCount()).toBe(1);
+
+      resolve1(true);
+      await p1;
+      // Second call still in progress — overlay must remain
+      expect(hasWaitCursorOverlay()).toBe(true);
+
+      resolve2(true);
+      await p2;
+      // Both complete — overlay removed
+      expect(hasWaitCursorOverlay()).toBe(false);
+    });
+
+    test('onClick shows wait cursor when an icon is hit and removes it on completion', async () => {
+      const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
+      const mockIconIntersection: Image360IconIntersectionData<DataSourceType> = {
+        image360Collection: new Mock<DefaultImage360Collection<DataSourceType>>().object(),
+        image360: mockEntity,
+        point: new Vector3(0, 0, 0),
+        distanceToCamera: 10
+      };
+
+      jest.spyOn(helper, 'intersect360ImageClusters').mockReturnValue(undefined);
+      jest.spyOn(helper, 'intersect360ImageIcons').mockReturnValue(mockIconIntersection);
+
+      let resolveEnter!: (v: boolean) => void;
+      jest.spyOn(helper, 'enter360ImageInternal').mockImplementation(
+        () =>
+          new Promise<boolean>(r => {
+            resolveEnter = r;
+          })
+      );
+
+      const clickPromise = helper.onClick({ offsetX: 320, offsetY: 240 });
+
+      // showWaitCursor runs synchronously before the first await in enter360ImageOnIntersect
+      expect(hasWaitCursorOverlay()).toBe(true);
+
+      resolveEnter(true);
+      await clickPromise;
+
+      // hideWaitCursor called in finally block after enter360ImageInternal resolves
+      expect(hasWaitCursorOverlay()).toBe(false);
     });
   });
 });

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.test.ts
@@ -6,6 +6,7 @@ import { Matrix4, PerspectiveCamera, Scene, Vector3 } from 'three';
 import TWEEN from '@tweenjs/tween.js';
 import { CogniteClient } from '@cognite/sdk';
 import { jest } from '@jest/globals';
+import assert from 'assert';
 
 import { Image360ApiHelper } from './Image360ApiHelper';
 import { SceneHandler, InputHandler, EventTrigger, BeforeSceneRenderedDelegate } from '@reveal/utilities';
@@ -420,7 +421,8 @@ describe(Image360ApiHelper.name, () => {
         .object();
     }
 
-    function createFloorModeFixture() {
+    // Sets up the three facade spies (preload, getCollectionContainingEntity, collections)
+    function mockFacadeForEntry() {
       const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
       const mockCollection = createMockCollection();
 
@@ -432,7 +434,7 @@ describe(Image360ApiHelper.name, () => {
     }
 
     test('does not call setFloorMode(true) on enter when enableFloorIcons is false (default)', async () => {
-      const { mockEntity } = createFloorModeFixture();
+      const { mockEntity } = mockFacadeForEntry();
       const mockCollection = createMockCollection();
       jest.spyOn(Image360Facade.prototype, 'collections', 'get').mockReturnValue([mockCollection]);
 
@@ -443,7 +445,7 @@ describe(Image360ApiHelper.name, () => {
 
     test('calls setFloorMode(true) on ALL collections on enter when enableFloorIcons is true', async () => {
       const { helper: floorHelper } = createTestHelper(domElement, sdk, 'mock', { enableFloorIcons: true });
-      const { mockEntity } = createFloorModeFixture();
+      const { mockEntity } = mockFacadeForEntry();
       const mockCollection1 = createMockCollection();
       const mockCollection2 = createMockCollection();
       jest.spyOn(Image360Facade.prototype, 'collections', 'get').mockReturnValue([mockCollection1, mockCollection2]);
@@ -459,7 +461,7 @@ describe(Image360ApiHelper.name, () => {
     });
 
     test('switches to proximity culling on enter and restores clustered on exit when enableFloorIcons is false', async () => {
-      const { mockEntity } = createFloorModeFixture();
+      const { mockEntity } = mockFacadeForEntry();
       const cullingSetSpy = jest.spyOn(Image360Facade.prototype, 'allIconCullingScheme', 'set');
 
       await enterImage(mockEntity);
@@ -474,7 +476,7 @@ describe(Image360ApiHelper.name, () => {
 
     test('calls setFloorMode(false) on ALL collections when exiting regardless of enableFloorIcons', async () => {
       const { helper: floorHelper } = createTestHelper(domElement, sdk, 'mock', { enableFloorIcons: true });
-      const { mockEntity } = createFloorModeFixture();
+      const { mockEntity } = mockFacadeForEntry();
       const mockCollection1 = createMockCollection();
       const mockCollection2 = createMockCollection();
       jest.spyOn(Image360Facade.prototype, 'collections', 'get').mockReturnValue([mockCollection1, mockCollection2]);
@@ -500,7 +502,7 @@ describe(Image360ApiHelper.name, () => {
         .callback(() => applyFullResolutionMock());
       const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), mockRevision.object());
 
-      createFloorModeFixture(); // sets up facade preload, getCollectionContainingEntity, collections spies
+      mockFacadeForEntry();
 
       await enterImage(mockEntity);
 
@@ -516,7 +518,7 @@ describe(Image360ApiHelper.name, () => {
       const entity1 = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
       const entity2 = createMockEntity(createMockIcon(), createMockVisualization(), revision2.object());
 
-      createFloorModeFixture();
+      mockFacadeForEntry();
 
       // Enter entity1 first (first-entry path — no transition)
       await enterImage(entity1);
@@ -536,10 +538,16 @@ describe(Image360ApiHelper.name, () => {
       const revision2 = createMockRevision();
       const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), revision1);
 
-      createFloorModeFixture();
+      mockFacadeForEntry();
+
+      // transition() calls applyFullResolutionTextures on the revision — if skipped, this stays at 0
+      const applyFullResSpy = jest.spyOn(revision2, 'applyFullResolutionTextures');
 
       // First entry — uses revision1 via getMostRecentRevision
       await enterImage(mockEntity);
+
+      // Spy after first entry so we only count calls from the same-entity branch
+      const activateAnnotationsSpy = jest.spyOn(mockEntity, 'activateAnnotations');
 
       // Second entry with explicit revision2 — lastEntered === mockEntity, so takes the same-entity branch
       const secondPromise = helper.enter360ImageInternal(mockEntity, revision2);
@@ -548,16 +556,13 @@ describe(Image360ApiHelper.name, () => {
       const result = await secondPromise;
 
       expect(result).toBe(true);
+      expect(activateAnnotationsSpy).toHaveBeenCalledTimes(1);
+      expect(applyFullResSpy).not.toHaveBeenCalled();
     });
 
     test('first-entry with FlexibleCameraManager uses camera position tween', async () => {
       const { helper: flexHelper } = createTestHelper(domElement, sdk, 'flexible');
-      const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
-      const mockCollection = createMockCollection();
-
-      jest.spyOn(Image360Facade.prototype, 'preload').mockResolvedValue(undefined);
-      jest.spyOn(Image360Facade.prototype, 'getCollectionContainingEntity').mockReturnValue(mockCollection);
-      jest.spyOn(Image360Facade.prototype, 'collections', 'get').mockReturnValue([mockCollection]);
+      const { mockEntity } = mockFacadeForEntry();
 
       const enterPromise = flexHelper.enter360ImageInternal(mockEntity);
       await Promise.resolve();
@@ -573,7 +578,7 @@ describe(Image360ApiHelper.name, () => {
       const addEventSpy = jest.spyOn(domElement, 'addEventListener');
 
       const mockEntity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
-      createFloorModeFixture();
+      mockFacadeForEntry();
 
       const enterPromise = listenerHelper.enter360ImageInternal(mockEntity);
       await Promise.resolve();
@@ -589,11 +594,7 @@ describe(Image360ApiHelper.name, () => {
       const { helper: flexHelper } = createTestHelper(domElement, sdk, 'flexible');
       const entity1 = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
       const entity2 = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
-      const mockCollection = createMockCollection();
-
-      jest.spyOn(Image360Facade.prototype, 'preload').mockResolvedValue(undefined);
-      jest.spyOn(Image360Facade.prototype, 'getCollectionContainingEntity').mockReturnValue(mockCollection);
-      jest.spyOn(Image360Facade.prototype, 'collections', 'get').mockReturnValue([mockCollection]);
+      mockFacadeForEntry();
 
       // First entry (no transition)
       const enter1 = flexHelper.enter360ImageInternal(entity1);
@@ -753,12 +754,12 @@ describe(Image360ApiHelper.name, () => {
   });
 
   describe('wait cursor', () => {
-    function hasWaitCursorOverlay(): boolean {
-      return Array.from(domElement.children).some(el => (el as HTMLElement).style?.cursor === 'wait');
-    }
-
     function waitCursorOverlayCount(): number {
       return Array.from(domElement.children).filter(el => (el as HTMLElement).style?.cursor === 'wait').length;
+    }
+
+    function hasWaitCursorOverlay(): boolean {
+      return waitCursorOverlayCount() > 0;
     }
 
     test('enter360Image adds wait cursor overlay synchronously and removes it on completion', async () => {
@@ -777,18 +778,12 @@ describe(Image360ApiHelper.name, () => {
     });
 
     test('concurrent enter360Image calls share one overlay and remove it only when all complete', async () => {
-      let resolve1!: (v: boolean) => void;
-      let resolve2!: (v: boolean) => void;
-      let callCount = 0;
-      jest.spyOn(helper, 'enter360ImageInternal').mockImplementation(() => {
-        if (callCount++ === 0)
-          return new Promise<boolean>(r => {
-            resolve1 = r;
-          });
-        return new Promise<boolean>(r => {
-          resolve2 = r;
-        });
-      });
+      let resolve1: ((v: boolean) => void) | undefined;
+      let resolve2: ((v: boolean) => void) | undefined;
+      jest
+        .spyOn(helper, 'enter360ImageInternal')
+        .mockImplementationOnce(() => new Promise<boolean>(r => (resolve1 = r)))
+        .mockImplementationOnce(() => new Promise<boolean>(r => (resolve2 = r)));
 
       const entity = createMockEntity(createMockIcon(), createMockVisualization(), createMockRevision());
       const p1 = helper.enter360Image(entity);
@@ -797,11 +792,13 @@ describe(Image360ApiHelper.name, () => {
       // Only one overlay is created even for two concurrent calls
       expect(waitCursorOverlayCount()).toBe(1);
 
+      assert(resolve1 !== undefined);
       resolve1(true);
       await p1;
       // Second call still in progress — overlay must remain
       expect(hasWaitCursorOverlay()).toBe(true);
 
+      assert(resolve2 !== undefined);
       resolve2(true);
       await p2;
       // Both complete — overlay removed
@@ -820,7 +817,7 @@ describe(Image360ApiHelper.name, () => {
       jest.spyOn(helper, 'intersect360ImageClusters').mockReturnValue(undefined);
       jest.spyOn(helper, 'intersect360ImageIcons').mockReturnValue(mockIconIntersection);
 
-      let resolveEnter!: (v: boolean) => void;
+      let resolveEnter: ((v: boolean) => void) | undefined;
       jest.spyOn(helper, 'enter360ImageInternal').mockImplementation(
         () =>
           new Promise<boolean>(r => {
@@ -833,6 +830,7 @@ describe(Image360ApiHelper.name, () => {
       // showWaitCursor runs synchronously before the first await in enter360ImageOnIntersect
       expect(hasWaitCursorOverlay()).toBe(true);
 
+      assert(resolveEnter !== undefined);
       resolveEnter(true);
       await clickPromise;
 

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -64,6 +64,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
   private readonly _image360Facade: Image360Facade<DataSourceT>;
   private readonly _domElement: HTMLElement;
   private _transitionInProgress: boolean = false;
+  private _waitCursorOverlay: HTMLDivElement | undefined;
   private readonly _raycaster = new Raycaster();
   private _needsRedraw: boolean = false;
   private readonly _hasEventListeners: boolean;
@@ -286,7 +287,12 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     image360Entity: Image360Entity<DataSourceT>,
     revision?: Image360RevisionEntity<DataSourceT>
   ): Promise<void> {
-    await this.enter360ImageInternal(image360Entity, revision);
+    this.showWaitCursor();
+    try {
+      await this.enter360ImageInternal(image360Entity, revision);
+    } finally {
+      this.hideWaitCursor();
+    }
   }
 
   public async enter360ImageInternal(
@@ -386,6 +392,18 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       this._history.start(image360Entity);
     }
     return true;
+  }
+
+  private showWaitCursor(): void {
+    const overlay = document.createElement('div');
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;cursor:wait;';
+    document.body.appendChild(overlay);
+    this._waitCursorOverlay = overlay;
+  }
+
+  private hideWaitCursor(): void {
+    this._waitCursorOverlay?.remove();
+    this._waitCursorOverlay = undefined;
   }
 
   private async applyFullResolutionTextures(revision: Image360RevisionEntity<DataSourceT>) {
@@ -636,9 +654,9 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     return targetDate ? image360Entity.getRevisionClosestToDate(targetDate) : image360Entity.getMostRecentRevision();
   }
 
-  private enter360ImageOnIntersect(event: PointerEventData): Promise<boolean> {
+  private async enter360ImageOnIntersect(event: PointerEventData): Promise<boolean> {
     if (this._transitionInProgress) {
-      return Promise.resolve(false);
+      return false;
     }
 
     // First, check for cluster intersection
@@ -650,9 +668,15 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     // Fall back to individual icon intersection
     const intersection = this.intersect360ImageIcons(event.offsetX, event.offsetY);
     if (intersection === undefined) {
-      return Promise.resolve(false);
+      return false;
     }
-    return this.enter360ImageInternal(intersection.image360);
+
+    this.showWaitCursor();
+    try {
+      return await this.enter360ImageInternal(intersection.image360);
+    } finally {
+      this.hideWaitCursor();
+    }
   }
 
   public intersect360ImageIcons(

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -65,6 +65,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
   private readonly _domElement: HTMLElement;
   private _transitionInProgress: boolean = false;
   private _waitCursorOverlay: HTMLDivElement | undefined;
+  private _waitCursorCount = 0;
   private readonly _raycaster = new Raycaster();
   private _needsRedraw: boolean = false;
   private readonly _hasEventListeners: boolean;
@@ -396,6 +397,10 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
   }
 
   private showWaitCursor(): void {
+    this._waitCursorCount++;
+    if (this._waitCursorOverlay) {
+      return;
+    }
     const overlay = document.createElement('div');
     overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;cursor:wait;';
     document.body.appendChild(overlay);
@@ -403,8 +408,11 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
   }
 
   private hideWaitCursor(): void {
-    this._waitCursorOverlay?.remove();
-    this._waitCursorOverlay = undefined;
+    this._waitCursorCount = Math.max(0, this._waitCursorCount - 1);
+    if (this._waitCursorCount === 0 && this._waitCursorOverlay) {
+      this._waitCursorOverlay.remove();
+      this._waitCursorOverlay = undefined;
+    }
   }
 
   private async applyFullResolutionTextures(revision: Image360RevisionEntity<DataSourceT>) {

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -378,7 +378,6 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     // Restore icon visibility before entering floor mode so setFloorMode saves the correct state.
     collectionVisibilities.forEach((v, i) => this._image360Facade.collections[i].setIconsVisibility(v));
     if (this._enableFloorIcons) {
-      this._image360Facade.setReferenceIcon(image360Entity.icon);
       this._image360Facade.collections.forEach(c => c.setFloorMode(true));
     } else {
       // Switch to proximity culling when inside a 360 image so nearby icons
@@ -431,15 +430,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
 
     setPreTransitionState();
 
-    // Use the authoritative collection opacity as the starting value for FROM.
-    // Reading fromVisualizationCube.opacity directly is unreliable — a concurrent
-    // exit tween or other code may have already reduced it, making the transition
-    // appear instant. Reset FROM to the expected value before the fade starts.
     fromVisualizationCube.opacity = expectedOpacity;
-    // Keep TO at full opacity throughout so FROM + TO combined always equals 1,
-    // preventing any underlying geometry (e.g. point clouds) from bleeding through.
-    // FROM fades out on top (renderOrder+1), revealing TO underneath — this is
-    // visually identical to a crossfade.
     toVisualizationCube.opacity = expectedOpacity;
 
     from360Entity.deactivateAnnotations();
@@ -562,7 +553,6 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     const imageCollection = this._image360Facade.getCollectionContainingEntity(
       this._interactionState.currentImage360Entered
     );
-    this._image360Facade.setReferenceIcon(undefined);
     this._image360Facade.collections.forEach(collection => collection.setFloorMode(false));
     this._interactionState.currentImage360Entered.icon.setVisible(imageCollection.isCollectionVisible);
     imageCollection.events.image360Exited.fire();

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -46,7 +46,8 @@ import {
   InputHandler,
   getNormalizedPixelCoordinates,
   PointerEventData,
-  SceneHandler
+  SceneHandler,
+  WaitCursor
 } from '@reveal/utilities';
 import {
   CameraManager,
@@ -64,8 +65,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
   private readonly _image360Facade: Image360Facade<DataSourceT>;
   private readonly _domElement: HTMLElement;
   private _transitionInProgress: boolean = false;
-  private _waitCursorOverlay: HTMLDivElement | undefined;
-  private _waitCursorCount = 0;
+  private readonly _waitCursor: WaitCursor;
   private readonly _raycaster = new Raycaster();
   private _needsRedraw: boolean = false;
   private readonly _hasEventListeners: boolean;
@@ -174,6 +174,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     this._image360Facade = new Image360Facade<DataSourceT>(image360EntityFactory);
 
     this._domElement = domElement;
+    this._waitCursor = new WaitCursor(domElement);
     this._interactionState = {};
 
     this._activeCameraManager = activeCameraManager;
@@ -288,11 +289,11 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     image360Entity: Image360Entity<DataSourceT>,
     revision?: Image360RevisionEntity<DataSourceT>
   ): Promise<void> {
-    this.showWaitCursor();
+    this._waitCursor.show();
     try {
       await this.enter360ImageInternal(image360Entity, revision);
     } finally {
-      this.hideWaitCursor();
+      this._waitCursor.hide();
     }
   }
 
@@ -352,7 +353,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
           await this.transition(lastEntered360ImageEntity, image360Entity, currentOpacity);
           // Apply full-res textures after the transition so texture quality swaps don't
           // happen mid-fade and create a perceived "instant" transition.
-          this.applyFullResolutionTextures(revisionToEnter);
+          await this.applyFullResolutionTextures(revisionToEnter);
           MetricsLogger.trackEvent('360ImageEntered', {});
         } else {
           const transitionDuration = 1000;
@@ -370,7 +371,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
               this.tweenVisualizationAlpha(image360Entity, 0, currentOpacity, transitionDuration)
             ]);
           }
-          this.applyFullResolutionTextures(revisionToEnter);
+          await this.applyFullResolutionTextures(revisionToEnter);
           image360Entity.activateAnnotations();
           MetricsLogger.trackEvent('360ImageTransitioned', {});
         }
@@ -397,25 +398,6 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       this._history.start(image360Entity);
     }
     return true;
-  }
-
-  private showWaitCursor(): void {
-    this._waitCursorCount++;
-    if (this._waitCursorOverlay) {
-      return;
-    }
-    const overlay = document.createElement('div');
-    overlay.style.cssText = 'position:absolute;inset:0;z-index:99999;cursor:wait;';
-    this._domElement.appendChild(overlay);
-    this._waitCursorOverlay = overlay;
-  }
-
-  private hideWaitCursor(): void {
-    this._waitCursorCount = Math.max(0, this._waitCursorCount - 1);
-    if (this._waitCursorCount === 0 && this._waitCursorOverlay) {
-      this._waitCursorOverlay.remove();
-      this._waitCursorOverlay = undefined;
-    }
   }
 
   private async applyFullResolutionTextures(revision: Image360RevisionEntity<DataSourceT>) {
@@ -651,6 +633,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       this._stationaryCameraManager.dispose();
     }
     this._image360Facade.dispose();
+    this._waitCursor.dispose();
   }
 
   private findRevisionIdToEnter(image360Entity: Image360Entity<DataSourceT>): Image360RevisionEntity<DataSourceT> {
@@ -675,11 +658,11 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       return false;
     }
 
-    this.showWaitCursor();
+    this._waitCursor.show();
     try {
       return await this.enter360ImageInternal(intersection.image360);
     } finally {
-      this.hideWaitCursor();
+      this._waitCursor.hide();
     }
   }
 

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -368,6 +368,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
             this.tweenVisualizationAlpha(image360Entity, 0, currentOpacity, transitionDuration)
           ]);
         }
+        this.applyFullResolutionTextures(revisionToEnter);
         image360Entity.activateAnnotations();
         MetricsLogger.trackEvent('360ImageTransitioned', {});
       }
@@ -377,6 +378,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     // Restore icon visibility before entering floor mode so setFloorMode saves the correct state.
     collectionVisibilities.forEach((v, i) => this._image360Facade.collections[i].setIconsVisibility(v));
     if (this._enableFloorIcons) {
+      this._image360Facade.setReferenceIcon(image360Entity.icon);
       this._image360Facade.collections.forEach(c => c.setFloorMode(true));
     } else {
       // Switch to proximity culling when inside a 360 image so nearby icons
@@ -560,6 +562,7 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     const imageCollection = this._image360Facade.getCollectionContainingEntity(
       this._interactionState.currentImage360Entered
     );
+    this._image360Facade.setReferenceIcon(undefined);
     this._image360Facade.collections.forEach(collection => collection.setFloorMode(false));
     this._interactionState.currentImage360Entered.icon.setVisible(imageCollection.isCollectionVisible);
     imageCollection.events.image360Exited.fire();

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -347,33 +347,36 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       this._needsRedraw = true;
     } else {
       this._transitionInProgress = true;
-      if (lastEntered360ImageEntity !== undefined) {
-        await this.transition(lastEntered360ImageEntity, image360Entity, currentOpacity);
-        // Apply full-res textures after the transition so texture quality swaps don't
-        // happen mid-fade and create a perceived "instant" transition.
-        this.applyFullResolutionTextures(revisionToEnter);
-        MetricsLogger.trackEvent('360ImageEntered', {});
-      } else {
-        const transitionDuration = 1000;
-        const position = new Vector3().setFromMatrixPosition(image360Entity.transform);
-        image360Entity.image360Visualization.opacity = 0;
-        const flexibleCameraManager = FlexibleCameraManager.as(this._activeCameraManager.innerCameraManager);
-        if (flexibleCameraManager) {
-          await Promise.all([
-            moveCameraPositionTo(flexibleCameraManager, position, transitionDuration),
-            this.tweenVisualizationAlpha(image360Entity, 0, currentOpacity, transitionDuration)
-          ]);
-        } else if (this._stationaryCameraManager) {
-          await Promise.all([
-            this._stationaryCameraManager.moveTo(position, transitionDuration),
-            this.tweenVisualizationAlpha(image360Entity, 0, currentOpacity, transitionDuration)
-          ]);
+      try {
+        if (lastEntered360ImageEntity !== undefined) {
+          await this.transition(lastEntered360ImageEntity, image360Entity, currentOpacity);
+          // Apply full-res textures after the transition so texture quality swaps don't
+          // happen mid-fade and create a perceived "instant" transition.
+          this.applyFullResolutionTextures(revisionToEnter);
+          MetricsLogger.trackEvent('360ImageEntered', {});
+        } else {
+          const transitionDuration = 1000;
+          const position = new Vector3().setFromMatrixPosition(image360Entity.transform);
+          image360Entity.image360Visualization.opacity = 0;
+          const flexibleCameraManager = FlexibleCameraManager.as(this._activeCameraManager.innerCameraManager);
+          if (flexibleCameraManager) {
+            await Promise.all([
+              moveCameraPositionTo(flexibleCameraManager, position, transitionDuration),
+              this.tweenVisualizationAlpha(image360Entity, 0, currentOpacity, transitionDuration)
+            ]);
+          } else if (this._stationaryCameraManager) {
+            await Promise.all([
+              this._stationaryCameraManager.moveTo(position, transitionDuration),
+              this.tweenVisualizationAlpha(image360Entity, 0, currentOpacity, transitionDuration)
+            ]);
+          }
+          this.applyFullResolutionTextures(revisionToEnter);
+          image360Entity.activateAnnotations();
+          MetricsLogger.trackEvent('360ImageTransitioned', {});
         }
-        this.applyFullResolutionTextures(revisionToEnter);
-        image360Entity.activateAnnotations();
-        MetricsLogger.trackEvent('360ImageTransitioned', {});
+      } finally {
+        this._transitionInProgress = false;
       }
-      this._transitionInProgress = false;
     }
 
     // Restore icon visibility before entering floor mode so setFloorMode saves the correct state.
@@ -402,8 +405,8 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       return;
     }
     const overlay = document.createElement('div');
-    overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;cursor:wait;';
-    document.body.appendChild(overlay);
+    overlay.style.cssText = 'position:absolute;inset:0;z-index:99999;cursor:wait;';
+    this._domElement.appendChild(overlay);
     this._waitCursorOverlay = overlay;
   }
 

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -289,11 +289,11 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     image360Entity: Image360Entity<DataSourceT>,
     revision?: Image360RevisionEntity<DataSourceT>
   ): Promise<void> {
-    this._waitCursor.show();
+    this._waitCursor.refAndUpdate();
     try {
       await this.enter360ImageInternal(image360Entity, revision);
     } finally {
-      this._waitCursor.hide();
+      this._waitCursor.derefAndUpdate();
     }
   }
 
@@ -658,11 +658,11 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       return false;
     }
 
-    this._waitCursor.show();
+    this._waitCursor.refAndUpdate();
     try {
       return await this.enter360ImageInternal(intersection.image360);
     } finally {
-      this._waitCursor.hide();
+      this._waitCursor.derefAndUpdate();
     }
   }
 

--- a/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
+++ b/viewer/packages/api/src/api-helpers/Image360ApiHelper.ts
@@ -341,11 +341,15 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     } else {
       this._transitionInProgress = true;
       if (lastEntered360ImageEntity !== undefined) {
-        await this.transition(lastEntered360ImageEntity, image360Entity);
+        await this.transition(lastEntered360ImageEntity, image360Entity, currentOpacity);
+        // Apply full-res textures after the transition so texture quality swaps don't
+        // happen mid-fade and create a perceived "instant" transition.
+        this.applyFullResolutionTextures(revisionToEnter);
         MetricsLogger.trackEvent('360ImageEntered', {});
       } else {
         const transitionDuration = 1000;
         const position = new Vector3().setFromMatrixPosition(image360Entity.transform);
+        image360Entity.image360Visualization.opacity = 0;
         const flexibleCameraManager = FlexibleCameraManager.as(this._activeCameraManager.innerCameraManager);
         if (flexibleCameraManager) {
           await Promise.all([
@@ -376,7 +380,6 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     if (this._hasEventListeners) {
       this._domElement.addEventListener('keydown', this.onKeyPressed);
     }
-    this.applyFullResolutionTextures(revisionToEnter);
 
     imageCollection.events.image360Entered.fire(image360Entity, revisionToEnter);
     if (updateHistory) {
@@ -390,9 +393,13 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
     this._needsRedraw = true;
   }
 
-  private async transition(from360Entity: Image360Entity<DataSourceT>, to360Entity: Image360Entity<DataSourceT>) {
+  private async transition(
+    from360Entity: Image360Entity<DataSourceT>,
+    to360Entity: Image360Entity<DataSourceT>,
+    expectedOpacity: number
+  ) {
     const cameraTransitionDuration = 1000;
-    const alphaTweenDuration = 800;
+    const fovTweenDuration = 800;
     const default360ImageRenderOrder = 3;
 
     const toVisualizationCube = to360Entity.image360Visualization;
@@ -404,7 +411,16 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
 
     setPreTransitionState();
 
-    const currentFromOpacity = fromVisualizationCube.opacity;
+    // Use the authoritative collection opacity as the starting value for FROM.
+    // Reading fromVisualizationCube.opacity directly is unreliable — a concurrent
+    // exit tween or other code may have already reduced it, making the transition
+    // appear instant. Reset FROM to the expected value before the fade starts.
+    fromVisualizationCube.opacity = expectedOpacity;
+    // Keep TO at full opacity throughout so FROM + TO combined always equals 1,
+    // preventing any underlying geometry (e.g. point clouds) from bleeding through.
+    // FROM fades out on top (renderOrder+1), revealing TO underneath — this is
+    // visually identical to a crossfade.
+    toVisualizationCube.opacity = expectedOpacity;
 
     from360Entity.deactivateAnnotations();
     const flexibleCameraManager = FlexibleCameraManager.as(this._activeCameraManager.innerCameraManager);
@@ -412,21 +428,21 @@ export class Image360ApiHelper<DataSourceT extends DataSourceType> {
       flexibleCameraManager.controls.isStationary = true;
       await Promise.all([
         moveCameraPositionTo(flexibleCameraManager, toPosition, cameraTransitionDuration),
-        tweenCameraToDefaultFov(flexibleCameraManager, alphaTweenDuration),
-        this.tweenVisualizationAlpha(from360Entity, currentFromOpacity, 0, alphaTweenDuration)
+        tweenCameraToDefaultFov(flexibleCameraManager, fovTweenDuration),
+        this.tweenVisualizationAlpha(from360Entity, expectedOpacity, 0, cameraTransitionDuration)
       ]);
     } else if (this._stationaryCameraManager) {
       const fromZoom = this._stationaryCameraManager.getCamera().fov;
       const toZoom = this._stationaryCameraManager.defaultFOV;
       await Promise.all([
         this._stationaryCameraManager.moveTo(toPosition, cameraTransitionDuration),
-        this.tweenVisualizationZoom(this._stationaryCameraManager, fromZoom, toZoom, alphaTweenDuration),
-        this.tweenVisualizationAlpha(from360Entity, currentFromOpacity, 0, alphaTweenDuration)
+        this.tweenVisualizationZoom(this._stationaryCameraManager, fromZoom, toZoom, cameraTransitionDuration),
+        this.tweenVisualizationAlpha(from360Entity, expectedOpacity, 0, cameraTransitionDuration)
       ]);
     }
     to360Entity.activateAnnotations();
 
-    restorePostTransitionState(currentFromOpacity);
+    restorePostTransitionState(expectedOpacity);
 
     function setPreTransitionState() {
       const fillingScaleMagnitude = length * 2;

--- a/viewer/packages/utilities/index.ts
+++ b/viewer/packages/utilities/index.ts
@@ -97,3 +97,4 @@ export * from './src/assetMappings';
 
 export * from './src/shapes';
 export * from './src/linalg';
+export { WaitCursor } from './src/WaitCursor';

--- a/viewer/packages/utilities/src/WaitCursor.test.ts
+++ b/viewer/packages/utilities/src/WaitCursor.test.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+
+import { WaitCursor } from './WaitCursor';
+
+describe(WaitCursor.name, () => {
+  let container: HTMLDivElement;
+
+  const overlayCount = () => container.children.length;
+  const hasOverlay = () => overlayCount() === 1;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  test('show adds overlay to container', () => {
+    const wc = new WaitCursor(container);
+    wc.show();
+    expect(hasOverlay()).toBe(true);
+  });
+
+  test('hide after single show removes overlay', () => {
+    const wc = new WaitCursor(container);
+    wc.show();
+    wc.hide();
+    expect(hasOverlay()).toBe(false);
+  });
+
+  test('multiple show calls create only one overlay', () => {
+    const wc = new WaitCursor(container);
+    wc.show();
+    wc.show();
+    wc.show();
+    expect(overlayCount()).toBe(1);
+  });
+
+  test('overlay persists until all show calls are matched by hide', () => {
+    const wc = new WaitCursor(container);
+    wc.show();
+    wc.show();
+    wc.hide();
+    expect(hasOverlay()).toBe(true);
+    wc.hide();
+    expect(hasOverlay()).toBe(false);
+  });
+
+  test('extra hide calls below zero do not throw or leave inconsistent state', () => {
+    const wc = new WaitCursor(container);
+    wc.hide();
+    wc.hide();
+    expect(hasOverlay()).toBe(false);
+    wc.show();
+    expect(hasOverlay()).toBe(true);
+    wc.hide();
+    expect(hasOverlay()).toBe(false);
+  });
+
+  test('overlay has correct styles', () => {
+    const wc = new WaitCursor(container);
+    wc.show();
+    const overlay = container.children[0] as HTMLElement;
+    expect(overlay.style.position).toBe('absolute');
+    expect(overlay.style.cursor).toBe('wait');
+    expect(overlay.style.zIndex).toBe('99999');
+  });
+
+  test('dispose removes overlay and resets state', () => {
+    const wc = new WaitCursor(container);
+    wc.show();
+    wc.show();
+    wc.dispose();
+    expect(hasOverlay()).toBe(false);
+    wc.show();
+    expect(hasOverlay()).toBe(true);
+    wc.hide();
+    expect(hasOverlay()).toBe(false);
+  });
+
+  test('dispose when no overlay is a no-op', () => {
+    const wc = new WaitCursor(container);
+    expect(() => wc.dispose()).not.toThrow();
+    expect(hasOverlay()).toBe(false);
+  });
+});

--- a/viewer/packages/utilities/src/WaitCursor.test.ts
+++ b/viewer/packages/utilities/src/WaitCursor.test.ts
@@ -14,51 +14,51 @@ describe(WaitCursor.name, () => {
     container = document.createElement('div');
   });
 
-  test('show adds overlay to container', () => {
+  test('refAndUpdate adds overlay to container', () => {
     const wc = new WaitCursor(container);
-    wc.show();
+    wc.refAndUpdate();
     expect(hasOverlay()).toBe(true);
   });
 
-  test('hide after single show removes overlay', () => {
+  test('derefAndUpdate after single refAndUpdate removes overlay', () => {
     const wc = new WaitCursor(container);
-    wc.show();
-    wc.hide();
+    wc.refAndUpdate();
+    wc.derefAndUpdate();
     expect(hasOverlay()).toBe(false);
   });
 
-  test('multiple show calls create only one overlay', () => {
+  test('multiple refAndUpdate calls create only one overlay', () => {
     const wc = new WaitCursor(container);
-    wc.show();
-    wc.show();
-    wc.show();
+    wc.refAndUpdate();
+    wc.refAndUpdate();
+    wc.refAndUpdate();
     expect(overlayCount()).toBe(1);
   });
 
-  test('overlay persists until all show calls are matched by hide', () => {
+  test('overlay persists until all refAndUpdate calls are matched by derefAndUpdate', () => {
     const wc = new WaitCursor(container);
-    wc.show();
-    wc.show();
-    wc.hide();
+    wc.refAndUpdate();
+    wc.refAndUpdate();
+    wc.derefAndUpdate();
     expect(hasOverlay()).toBe(true);
-    wc.hide();
+    wc.derefAndUpdate();
     expect(hasOverlay()).toBe(false);
   });
 
-  test('extra hide calls below zero do not throw or leave inconsistent state', () => {
+  test('extra derefAndUpdate calls below zero do not throw or leave inconsistent state', () => {
     const wc = new WaitCursor(container);
-    wc.hide();
-    wc.hide();
+    wc.derefAndUpdate();
+    wc.derefAndUpdate();
     expect(hasOverlay()).toBe(false);
-    wc.show();
+    wc.refAndUpdate();
     expect(hasOverlay()).toBe(true);
-    wc.hide();
+    wc.derefAndUpdate();
     expect(hasOverlay()).toBe(false);
   });
 
   test('overlay has correct styles', () => {
     const wc = new WaitCursor(container);
-    wc.show();
+    wc.refAndUpdate();
     const overlay = container.children[0] as HTMLElement;
     expect(overlay.style.position).toBe('absolute');
     expect(overlay.style.cursor).toBe('wait');
@@ -67,13 +67,13 @@ describe(WaitCursor.name, () => {
 
   test('dispose removes overlay and resets state', () => {
     const wc = new WaitCursor(container);
-    wc.show();
-    wc.show();
+    wc.refAndUpdate();
+    wc.refAndUpdate();
     wc.dispose();
     expect(hasOverlay()).toBe(false);
-    wc.show();
+    wc.refAndUpdate();
     expect(hasOverlay()).toBe(true);
-    wc.hide();
+    wc.derefAndUpdate();
     expect(hasOverlay()).toBe(false);
   });
 

--- a/viewer/packages/utilities/src/WaitCursor.ts
+++ b/viewer/packages/utilities/src/WaitCursor.ts
@@ -3,13 +3,13 @@
  */
 
 export class WaitCursor {
-  private _count = 0;
+  private _refCount = 0;
   private _overlay: HTMLDivElement | undefined;
 
   constructor(private readonly _container: HTMLElement) {}
 
-  public show(): void {
-    this._count++;
+  public refAndUpdate(): void {
+    this._refCount++;
     if (this._overlay) {
       return;
     }
@@ -19,9 +19,9 @@ export class WaitCursor {
     this._overlay = overlay;
   }
 
-  public hide(): void {
-    this._count = Math.max(0, this._count - 1);
-    if (this._count === 0 && this._overlay) {
+  public derefAndUpdate(): void {
+    this._refCount = Math.max(0, this._refCount - 1);
+    if (this._refCount === 0 && this._overlay) {
       this._overlay.remove();
       this._overlay = undefined;
     }
@@ -32,6 +32,6 @@ export class WaitCursor {
       this._overlay.remove();
       this._overlay = undefined;
     }
-    this._count = 0;
+    this._refCount = 0;
   }
 }

--- a/viewer/packages/utilities/src/WaitCursor.ts
+++ b/viewer/packages/utilities/src/WaitCursor.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+
+export class WaitCursor {
+  private _count = 0;
+  private _overlay: HTMLDivElement | undefined;
+
+  constructor(private readonly _container: HTMLElement) {}
+
+  public show(): void {
+    this._count++;
+    if (this._overlay) {
+      return;
+    }
+    const overlay = document.createElement('div');
+    overlay.style.cssText = 'position:absolute;inset:0;z-index:99999;cursor:wait;';
+    this._container.appendChild(overlay);
+    this._overlay = overlay;
+  }
+
+  public hide(): void {
+    this._count = Math.max(0, this._count - 1);
+    if (this._count === 0 && this._overlay) {
+      this._overlay.remove();
+      this._overlay = undefined;
+    }
+  }
+
+  public dispose(): void {
+    if (this._overlay) {
+      this._overlay.remove();
+      this._overlay = undefined;
+    }
+    this._count = 0;
+  }
+}


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

[BND3D-6732](https://cognitedata.atlassian.net/browse/BND3D-6732)

## Description :pencil:
Improves the 360 image entry and transition experience, here I have made below changes
- Shows a wait cursor during the transition
- Fixes first entry fade-in  where 360 images now fades in instead of popping
- Fixes instant transition appearance by delaying full resolution texture swap until after the fade
- Aligns fade and camera movement durations to 1000ms

## How has this been tested? :mag:

In `examples`

## Test instructions :information_source:

- Load examples with any 360 image collection
- Click a 360 image icon, wait cursor should appear while loading
- When inside 360 image, click another station/icon, cross-fade should be smooth with no mid-fade texture flash
- And also on first entry image 360 should fade in, not pop in


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.


[BND3D-6732]: https://cognitedata.atlassian.net/browse/BND3D-6732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ