### PR TITLE
fix: floored 360 icon not visible without secondary reference model & Reveal bump to v4.32.3

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/reveal",
-  "version": "4.32.2",
+  "version": "4.32.3",
   "description": "WebGL based 3D viewer for CAD and point clouds processed in Cognite Data Fusion.",
   "homepage": "https://github.com/cognitedata/reveal/tree/master/viewer",
   "repository": {

--- a/viewer/packages/360-images/src/icons/FlooredIconManager.test.ts
+++ b/viewer/packages/360-images/src/icons/FlooredIconManager.test.ts
@@ -13,6 +13,7 @@ import {
   Vector3
 } from 'three';
 import { Mock, It } from 'moq.ts';
+import { jest } from '@jest/globals';
 import { SceneHandler } from '@reveal/utilities';
 import { Overlay3DIcon } from '@reveal/3d-overlays';
 import { FlooredIconManager } from './FlooredIconManager';
@@ -203,6 +204,27 @@ describe(FlooredIconManager.name, () => {
       sameLevelMesh.getMatrixAt(1, m1);
       expect(m0.elements[12]).toBeCloseTo(9); // far icon at slot 0
       expect(m1.elements[12]).toBeCloseTo(1); // near icon at slot 1
+      manager.dispose();
+    });
+
+    test('computeBoundingBox is called only when count changes, not on every update', () => {
+      const { manager, sameLevelMesh } = createManager(5);
+      const bbSpy = jest.spyOn(sameLevelMesh, 'computeBoundingBox');
+
+      const icons = [makeIcon(new Vector3(0, 0, 0)), makeIcon(new Vector3(1, 0, 0))];
+
+      // First update: count changes from -1 to 2 — should compute
+      manager.update(icons, identity);
+      expect(bbSpy).toHaveBeenCalledTimes(1);
+
+      // Second update: same count — should skip
+      manager.update(icons, identity);
+      expect(bbSpy).toHaveBeenCalledTimes(1);
+
+      // Third update: count changes to 1 — should recompute
+      manager.update([icons[0]], identity);
+      expect(bbSpy).toHaveBeenCalledTimes(2);
+
       manager.dispose();
     });
   });

--- a/viewer/packages/360-images/src/icons/FlooredIconManager.ts
+++ b/viewer/packages/360-images/src/icons/FlooredIconManager.ts
@@ -40,6 +40,8 @@ export class FlooredIconManager {
   private readonly _sameLevelCapacity: number;
 
   private _referenceWorldY: number | undefined;
+  private _prevSameLevelCount = -1;
+  private _prevElevatedCount = -1;
 
   constructor(
     capacity: number,
@@ -137,10 +139,22 @@ export class FlooredIconManager {
     }
 
     this._floorDiscMeshSameLevel.count = sameLevelCount;
-    if (sameLevelCount > 0) this._floorDiscMeshSameLevel.instanceMatrix.needsUpdate = true;
+    if (sameLevelCount > 0) {
+      this._floorDiscMeshSameLevel.instanceMatrix.needsUpdate = true;
+      if (sameLevelCount !== this._prevSameLevelCount) {
+        this._floorDiscMeshSameLevel.computeBoundingBox();
+      }
+    }
+    this._prevSameLevelCount = sameLevelCount;
 
     this._floorDiscMeshElevated.count = elevatedCount;
-    if (elevatedCount > 0) this._floorDiscMeshElevated.instanceMatrix.needsUpdate = true;
+    if (elevatedCount > 0) {
+      this._floorDiscMeshElevated.instanceMatrix.needsUpdate = true;
+      if (elevatedCount !== this._prevElevatedCount) {
+        this._floorDiscMeshElevated.computeBoundingBox();
+      }
+    }
+    this._prevElevatedCount = elevatedCount;
   }
 
   public setHoverPosition(worldPos: Vector3): void {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
The Floored 360 icons were not visible when loaded without secondary model (PC or Cad) because `WebGLRenderer` sorts transparent objects which needs each object's `boundingSphere` and `InstancedMesh.boundingSphere` starts as `null` where renderer calls `mesh.computeBoundingSphere()`. As we use instance mesh without `geometry.boundingBox`, the bounding sphere computation fails silently or produces an empty/NaN sphere, with an invalid bounding sphere, the sort depth is wrong and the image 360 disc is sorted behind opaque geometry making it invisible.
This PR fixes the issue by triggering compute bounding box

## How has this been tested? :mag:

In examples

## Test instructions :information_source:

- Run [example](https://localhost:3549/?project=3d-test&env=greenfield-3d&modelId=4923307033982497&revisionId=3100284276970593&siteId=hibernia_rs2&space=scene&floorIcons=true)
- Remove the cad model and load the 360 image collection
- Click on any 360 image icon and check floored icon are visible


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
