### PR TITLE
fix: mouse drag throwing error and point cloud node not found error

### DIFF
--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.test.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.test.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+import { jest } from '@jest/globals';
+import { PerspectiveCamera, Vector3 } from 'three';
+
+import { FlexibleControls } from './FlexibleControls';
+import { FlexibleControlsOptions } from './FlexibleControlsOptions';
+import { FlexibleControlsTranslator } from './FlexibleControlsTranslator';
+
+function makeMouseEvent(x: number, y: number): PointerEvent {
+  return new PointerEvent('pointermove', { clientX: x, clientY: y, pointerType: 'mouse' });
+}
+
+describe(FlexibleControls.name, () => {
+  let controls: FlexibleControls;
+
+  beforeEach(() => {
+    const domElement = document.createElement('div');
+    const camera = new PerspectiveCamera(60, 800 / 600, 0.1, 10000);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(new Vector3(0, 0, 0));
+    controls = new FlexibleControls(camera, domElement, new FlexibleControlsOptions());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('onPointerDrag', () => {
+    it('does not throw when onPointerUp fires while async pan pick is in flight', async () => {
+      // Block initialize with a deferred promise — same pattern as PointCloudOctreePicker.test.ts
+      let resolveInitialize!: () => void;
+      jest.spyOn(FlexibleControlsTranslator.prototype, 'initialize').mockImplementation(async () => {
+        await new Promise<void>(resolve => {
+          resolveInitialize = resolve;
+        });
+        return false;
+      });
+
+      // Start drag (sets _mouseDragInfo); use distinct coords so deltaPosition is non-zero
+      await controls.onPointerDown(makeMouseEvent(400, 300), true);
+
+      // Begin pan drag (leftButton=false triggers the translator path)
+      const dragPromise = controls.onPointerDrag(makeMouseEvent(410, 310), false);
+
+      // Simulate pointer-up while initialize is still awaiting — clears _mouseDragInfo
+      controls.onPointerUp(makeMouseEvent(410, 310), false);
+
+      // Resolve initialize — without the guard added in FlexibleControls this would crash
+      resolveInitialize();
+
+      await expect(dragPromise).resolves.not.toThrow();
+    });
+  });
+});

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.test.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.test.ts
@@ -29,7 +29,6 @@ describe(FlexibleControls.name, () => {
 
   describe('onPointerDrag', () => {
     it('does not throw when onPointerUp fires while async pan pick is in flight', async () => {
-      // Block initialize with a deferred promise — same pattern as PointCloudOctreePicker.test.ts
       let resolveInitialize!: () => void;
       jest.spyOn(FlexibleControlsTranslator.prototype, 'initialize').mockImplementation(async () => {
         await new Promise<void>(resolve => {
@@ -38,16 +37,12 @@ describe(FlexibleControls.name, () => {
         return false;
       });
 
-      // Start drag (sets _mouseDragInfo); use distinct coords so deltaPosition is non-zero
       await controls.onPointerDown(makeMouseEvent(400, 300), true);
 
-      // Begin pan drag (leftButton=false triggers the translator path)
       const dragPromise = controls.onPointerDrag(makeMouseEvent(410, 310), false);
 
-      // Simulate pointer-up while initialize is still awaiting — clears _mouseDragInfo
       controls.onPointerUp(makeMouseEvent(410, 310), false);
 
-      // Resolve initialize — without the guard added in FlexibleControls this would crash
       resolveInitialize();
 
       await expect(dragPromise).resolves.not.toThrow();

--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -443,6 +443,9 @@ export class FlexibleControls {
         translator = new FlexibleControlsTranslator(this);
         await translator.initialize(position);
       }
+      if (!this._mouseDragInfo) {
+        return;
+      }
       if (!translator.translate(position)) {
         // If not, translate in a simpler way
         deltaPosition.multiplyScalar(this._options.mousePanSpeed);

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.test.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.test.ts
@@ -60,27 +60,6 @@ describe(PointCloudPickingHandler.name, () => {
     expect(result).toEqual([]);
   });
 
-  test('intersectPointClouds throws when intersected point cannot be matched to a node', async () => {
-    const shape = new Cylinder(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1), 1);
-    const annotation: PointCloudObject<ClassicDataSourceType> = {
-      annotationId: 1,
-      boundingBox: shape.createBoundingBox(),
-      stylableObject: { shape, objectId: 1 }
-    };
-    const node = createPointCloudNode<ClassicDataSourceType>({ annotations: [annotation] });
-
-    jest.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue({
-      pointIndex: 0,
-      object: new THREE.Points(), // no parent → determinePointCloudNode returns null
-      position: new THREE.Vector3(),
-      objectId: 1
-    });
-
-    await expect(handler.intersectPointClouds([node], createMockIntersectInput())).rejects.toThrow(
-      'Could not find PointCloudNode for intersected point'
-    );
-  });
-
   test('intersectPointClouds returns Classic volume metadata when annotation has annotationId', async () => {
     const shape = new Cylinder(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1), 1);
     const annotationId = 42;

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
@@ -8,7 +8,7 @@ import { IntersectInput } from '@reveal/model-base';
 import { PointCloudNode } from './PointCloudNode';
 import { Mutex } from 'async-mutex';
 
-import { PickPoint, PointCloudOctree, PointCloudOctreePicker } from './potree-three-loader';
+import { PickPoint, PointCloudOctreePicker } from './potree-three-loader';
 import { isPointVisibleByPlanes } from '@reveal/utilities';
 import {
   ClassicDataSourceType,
@@ -46,29 +46,24 @@ export class PointCloudPickingHandler {
 
     const release = await this._mutex.acquire();
     try {
-      const intersections: PickPoint[] = [];
+      const intersections: { node: PointCloudNode<DataSourceType>; pick: PickPoint }[] = [];
 
       // Get PointCloudNodes which are visible.
       const visibleNodes = nodes.filter(node => node.visible);
 
       for (const node of visibleNodes) {
-        const intersection = await this._picker.pick(camera, this._raycaster.ray, [node.octree], {
+        const pick = await this._picker.pick(camera, this._raycaster.ray, [node.octree], {
           pickWindowSize: PointCloudPickingHandler.PickingWindowSize
         });
-        if (intersection !== null) {
-          intersections.push(intersection);
+        if (pick !== null) {
+          intersections.push({ node, pick });
         }
       }
 
       return intersections
-        .filter(x => isPointVisibleByPlanes(input.clippingPlanes, x.position))
-        .sort((x, y) => x.position.distanceTo(camera.position) - y.position.distanceTo(camera.position))
-        .map(x => {
-          const pointCloudNode = determinePointCloudNode(x.object, visibleNodes);
-          if (pointCloudNode === null) {
-            throw new Error(`Could not find PointCloudNode for intersected point`);
-          }
-
+        .filter(({ pick }) => isPointVisibleByPlanes(input.clippingPlanes, pick.position))
+        .sort((a, b) => a.pick.position.distanceTo(camera.position) - b.pick.position.distanceTo(camera.position))
+        .map(({ node: pointCloudNode, pick: x }) => {
           const pointCloudObject = pointCloudNode.getStylableObjectMetadata(x.objectId);
 
           const baseObject = {
@@ -114,17 +109,4 @@ export class PointCloudPickingHandler {
       release();
     }
   }
-}
-
-function determinePointCloudNode(
-  node: THREE.Object3D,
-  candidates: PointCloudNode<DataSourceType>[]
-): PointCloudNode<DataSourceType> | null {
-  while (node.type === 'Points' && node.parent !== null) {
-    node = node.parent;
-  }
-  if (node instanceof PointCloudOctree) {
-    return candidates.find(x => node === x.octree) || null;
-  }
-  return null;
 }

--- a/viewer/test-utilities/src/setupJest.ts
+++ b/viewer/test-utilities/src/setupJest.ts
@@ -31,6 +31,16 @@ class StubWorker {
 (window as any).TextDecoder = TextDecoder;
 (window as any).TextEncoder = TextEncoder;
 
+// jsdom does not implement PointerEvent; polyfill so instanceof checks work in tests.
+class PointerEventPolyfill extends MouseEvent {
+  readonly pointerType: string;
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init);
+    this.pointerType = init.pointerType ?? '';
+  }
+}
+(window as any).PointerEvent = PointerEventPolyfill;
+
 import packageObject from '../../package.json' with { type: 'json' };
 
 Object.assign(process.env, {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
With recent update on point cloud picking to async gpu picking, mouse drag event would generate a race condition
```
onPointerDrag
  └─ translator.initialize()
       └─ getPickedPointByPixelCoordinates()        ← FlexibleCameraManager
            └─ _raycastCallback()                   ← modelIntersectionCallback
                 └─ getAnyIntersectionFromPixel()
                      └─ _pointCloudPickingHandler.intersectPointClouds()  ← async GPU pick
```
This PR fixes the race condition.

We also saw some sentry error relating to `Could not find PointCloudNode for intersected point`, which is also addressed

## How has this been tested? :mag:

In unit test

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
