### PR TITLE
fix: browser cache storage quota full error 

### DIFF
--- a/viewer/packages/utilities/src/cache/DataFileCacheManager.test.ts
+++ b/viewer/packages/utilities/src/cache/DataFileCacheManager.test.ts
@@ -301,6 +301,29 @@ describe(DataFileCacheManager.name, () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
+    test('should treat Safari iOS quota error as quota error and evict', async () => {
+      jest.useFakeTimers();
+
+      const storageMap: Map<string, Map<string, Response>> = new Map();
+      const manager = new DataFileCacheManager(
+        { cacheName: 'safari-cache' },
+        createFailingPutCacheStorage(storageMap, n => n === 6, new Error('The quota has been exceeded.'))
+      );
+
+      const urls = Array.from({ length: 5 }, (_, i) => `https://example.com/file${i}.bin`);
+      for (const url of urls) {
+        await manager.storeResponse(url, new ArrayBuffer(100), TEST_CONTENT_TYPE);
+        jest.advanceTimersByTime(1000);
+      }
+
+      await manager.storeResponse('https://example.com/new.bin', new ArrayBuffer(100), TEST_CONTENT_TYPE);
+
+      const cache = storageMap.get('safari-cache')!;
+      expect(cache.has(urls[0])).toBe(false);
+      expect(cache.has('https://example.com/new.bin')).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     test('should warn without throwing when retry still fails after eviction', async () => {
       const storageMap: Map<string, Map<string, Response>> = new Map();
       // All puts fail — eviction has nothing to clear, retry also fails

--- a/viewer/packages/utilities/src/cache/DataFileCacheManager.test.ts
+++ b/viewer/packages/utilities/src/cache/DataFileCacheManager.test.ts
@@ -273,7 +273,7 @@ describe(DataFileCacheManager.name, () => {
 
       const cache = storageMap.get('lru-cache')!;
       expect(cache.has(urlB)).toBe(false); // B evicted (LRU)
-      expect(cache.has(urlA)).toBe(true);  // A kept (recently accessed)
+      expect(cache.has(urlA)).toBe(true); // A kept (recently accessed)
       expect(warnSpy).not.toHaveBeenCalled();
     });
 

--- a/viewer/packages/utilities/src/cache/DataFileCacheManager.test.ts
+++ b/viewer/packages/utilities/src/cache/DataFileCacheManager.test.ts
@@ -158,11 +158,15 @@ describe(DataFileCacheManager.name, () => {
       failingMock
     );
 
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     await expect(errorManager.getCachedResponse(TEST_FILE_URL)).rejects.toThrow('Cache error');
-    await expect(errorManager.storeResponse(TEST_FILE_URL, new ArrayBuffer(100), TEST_CONTENT_TYPE)).rejects.toThrow(
-      'Failed to store in cache'
-    );
+    // storeResponse no longer throws — it warns on non-quota errors
+    await errorManager.storeResponse(TEST_FILE_URL, new ArrayBuffer(100), TEST_CONTENT_TYPE);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[DataFileCacheManager] Failed to store in cache'));
     await expect(errorManager.clear()).rejects.toThrow('Delete error');
+
+    warnSpy.mockRestore();
   });
 
   test('should handle invalid header values gracefully', async () => {
@@ -178,5 +182,140 @@ describe(DataFileCacheManager.name, () => {
 
     const hasCache = await cacheManager.has(INVALID_FILE_URL);
     expect(hasCache).toBe(false);
+  });
+
+  describe('LRU eviction on quota exceeded', () => {
+    // Wraps createMockCacheStorage and intercepts put() to throw on calls matching failPredicate.
+    function createFailingPutCacheStorage(
+      storageMap: Map<string, Map<string, Response>>,
+      failPredicate: (callNumber: number) => boolean,
+      error: unknown
+    ): CacheStorage {
+      let putCallCount = 0;
+      const storage = createMockCacheStorage(storageMap);
+      const originalOpen = storage.open.bind(storage);
+      storage.open = async (cacheName: string) => {
+        const cache = await originalOpen(cacheName);
+        const originalPut = cache.put.bind(cache);
+        cache.put = async (key: RequestInfo | URL, response: Response) => {
+          putCallCount++;
+          if (failPredicate(putCallCount)) throw error;
+          return originalPut(key, response);
+        };
+        return cache;
+      };
+      return storage;
+    }
+
+    let warnSpy: ReturnType<typeof jest.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      jest.useRealTimers();
+    });
+
+    test('should evict oldest 20% of entries on QuotaExceededError and retry', async () => {
+      jest.useFakeTimers();
+
+      const storageMap: Map<string, Map<string, Response>> = new Map();
+      // Puts 1-5 succeed (storing the 5 initial entries), put 6 triggers quota
+      const manager = new DataFileCacheManager(
+        { cacheName: 'evict-cache' },
+        createFailingPutCacheStorage(storageMap, n => n === 6, new DOMException('quota exceeded', 'QuotaExceededError'))
+      );
+
+      const urls = Array.from({ length: 5 }, (_, i) => `https://example.com/file${i}.bin`);
+      for (const url of urls) {
+        await manager.storeResponse(url, new ArrayBuffer(100), TEST_CONTENT_TYPE);
+        jest.advanceTimersByTime(1000);
+      }
+
+      const NEW_URL = 'https://example.com/new.bin';
+      await manager.storeResponse(NEW_URL, new ArrayBuffer(100), TEST_CONTENT_TYPE);
+
+      const cache = storageMap.get('evict-cache')!;
+      // 20% of 5 = 1 entry evicted — the oldest (file0)
+      expect(cache.has(urls[0])).toBe(false);
+      // Remaining entries untouched
+      expect(cache.has(urls[1])).toBe(true);
+      // New entry stored after retry
+      expect(cache.has(NEW_URL)).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('should use in-memory last-accessed time for LRU ordering', async () => {
+      jest.useFakeTimers();
+
+      const storageMap: Map<string, Map<string, Response>> = new Map();
+      // Puts 1-5 succeed, put 6 triggers quota
+      const manager = new DataFileCacheManager(
+        { cacheName: 'lru-cache' },
+        createFailingPutCacheStorage(storageMap, n => n === 6, new DOMException('quota exceeded', 'QuotaExceededError'))
+      );
+
+      const [urlA, urlB, urlC, urlD, urlE] = Array.from({ length: 5 }, (_, i) => `https://example.com/file${i}.bin`);
+      // Store A–E at t=0,1000,2000,3000,4000 ms — _lastAccessed mirrors store time
+      for (const url of [urlA, urlB, urlC, urlD, urlE]) {
+        await manager.storeResponse(url, new ArrayBuffer(100), TEST_CONTENT_TYPE);
+        jest.advanceTimersByTime(1000);
+      }
+
+      // Access A at t=5000 — promotes it above B in LRU order
+      await manager.getCachedResponse(urlA);
+      jest.advanceTimersByTime(1000);
+
+      // 6th put triggers quota → evicts least recently accessed (B, lastAccessed=1000)
+      await manager.storeResponse('https://example.com/new.bin', new ArrayBuffer(100), TEST_CONTENT_TYPE);
+
+      const cache = storageMap.get('lru-cache')!;
+      expect(cache.has(urlB)).toBe(false); // B evicted (LRU)
+      expect(cache.has(urlA)).toBe(true);  // A kept (recently accessed)
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('should treat Firefox No device space error as quota error and evict', async () => {
+      jest.useFakeTimers();
+
+      const storageMap: Map<string, Map<string, Response>> = new Map();
+      const manager = new DataFileCacheManager(
+        { cacheName: 'ff-cache' },
+        createFailingPutCacheStorage(storageMap, n => n === 6, new Error('File error: No device space'))
+      );
+
+      const urls = Array.from({ length: 5 }, (_, i) => `https://example.com/file${i}.bin`);
+      for (const url of urls) {
+        await manager.storeResponse(url, new ArrayBuffer(100), TEST_CONTENT_TYPE);
+        jest.advanceTimersByTime(1000);
+      }
+
+      await manager.storeResponse('https://example.com/new.bin', new ArrayBuffer(100), TEST_CONTENT_TYPE);
+
+      const cache = storageMap.get('ff-cache')!;
+      // Firefox error treated as quota → eviction + retry succeeded
+      expect(cache.has(urls[0])).toBe(false);
+      expect(cache.has('https://example.com/new.bin')).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('should warn without throwing when retry still fails after eviction', async () => {
+      const storageMap: Map<string, Map<string, Response>> = new Map();
+      // All puts fail — eviction has nothing to clear, retry also fails
+      const manager = new DataFileCacheManager(
+        { cacheName: 'always-fail-cache' },
+        createFailingPutCacheStorage(storageMap, () => true, new DOMException('quota exceeded', 'QuotaExceededError'))
+      );
+
+      await expect(
+        manager.storeResponse('https://example.com/file.bin', new ArrayBuffer(100), TEST_CONTENT_TYPE)
+      ).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[DataFileCacheManager] Failed to store in cache after LRU eviction')
+      );
+    });
   });
 });

--- a/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
+++ b/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
@@ -163,7 +163,9 @@ export class DataFileCacheManager {
       }
     }
 
-    inMemory.sort((a, b) => a.lastAccessed - b.lastAccessed);
+    if (notInMemory.length < evictCount) {
+      inMemory.sort((a, b) => a.lastAccessed - b.lastAccessed);
+    }
     const toEvict = [...notInMemory, ...inMemory.map(e => e.url)].slice(0, evictCount);
 
     await Promise.all(
@@ -183,7 +185,13 @@ function isExpired(response: Response, maxAge: number): boolean {
 
 function isQuotaError(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'QuotaExceededError') return true;
-  // Firefox throws NS_ERROR_FILE_NO_DEVICE_SPACE instead of a standard QuotaExceededError
   const message = error instanceof Error ? error.message : String(error);
-  return message.includes('QuotaExceededError') || message.includes('No device space');
+  // Firefox: NS_ERROR_FILE_NO_DEVICE_SPACE
+  // Safari iOS (pre-spec): "The quota has been exceeded."
+  // Older WebKit/Blink: message may contain 'QuotaExceededError'
+  return (
+    message.includes('QuotaExceededError') ||
+    message.includes('No device space') ||
+    message.includes('quota has been exceeded')
+  );
 }

--- a/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
+++ b/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
@@ -32,12 +32,14 @@ import { safeParseInt } from './utils';
 export class DataFileCacheManager {
   private readonly DEFAULT_CONFIG: CacheConfig = {
     cacheName: BINARY_FILES_CACHE_NAME,
-    maxAge: Infinity, // Cache forever until browser evicts
-    maxCacheSize: Infinity // No limit - browser manages storage quota
+    maxAge: Infinity,
+    maxCacheSize: Infinity
   };
 
   private readonly _config: CacheConfig = { ...this.DEFAULT_CONFIG };
   private readonly _caches: CacheStorage;
+  // In-memory LRU tracker: url → last accessed timestamp (not persisted, used for eviction ordering)
+  private readonly _lastAccessed = new Map<string, number>();
 
   get cacheConfig(): CacheConfig {
     return this._config;
@@ -89,41 +91,86 @@ export class DataFileCacheManager {
 
     if (isExpired(response, this._config.maxAge)) {
       await cache.delete(url);
+      this._lastAccessed.delete(url);
       return undefined;
     }
 
+    this._lastAccessed.set(url, Date.now());
     return response.clone();
   }
 
   /**
-   * Store data in cache
-   * Browser will automatically evict old entries when quota is reached
+   * Store data in cache. On quota exceeded, evicts LRU entries and retries once.
    */
   async storeResponse(url: string, data: ArrayBuffer, contentType: string = 'application/octet-stream'): Promise<void> {
     try {
-      const cache = await this._caches.open(this._config.cacheName);
-
-      const size = data.byteLength;
-      const now = Date.now();
-
-      const headers = new Headers({
-        'Content-Type': contentType,
-        'Content-Length': size.toString(),
-        [BINARY_FILES_CACHE_HEADER_DATE]: now.toString(),
-        [BINARY_FILES_CACHE_HEADER_SIZE]: size.toString()
-      });
-
-      const cachedResponse = new Response(data, {
-        status: 200,
-        statusText: 'OK',
-        headers
-      });
-
-      await cache.put(url, cachedResponse);
+      await this.putInCache(url, data, contentType);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`[DataFileCacheManager] Failed to store in cache: ${message}`, { cause: error });
+      if (isQuotaError(error)) {
+        await this.evictLeastRecentlyUsedEntries();
+        try {
+          await this.putInCache(url, data, contentType);
+        } catch (retryError) {
+          const message = retryError instanceof Error ? retryError.message : String(retryError);
+          console.warn(`[DataFileCacheManager] Failed to store in cache after LRU eviction: ${message}`);
+        }
+      } else {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[DataFileCacheManager] Failed to store in cache: ${message}`);
+      }
     }
+  }
+
+  private async putInCache(url: string, data: ArrayBuffer, contentType: string): Promise<void> {
+    const cache = await this._caches.open(this._config.cacheName);
+    const now = Date.now();
+    const size = data.byteLength;
+
+    const headers = new Headers({
+      'Content-Type': contentType,
+      'Content-Length': size.toString(),
+      [BINARY_FILES_CACHE_HEADER_DATE]: now.toString(),
+      [BINARY_FILES_CACHE_HEADER_SIZE]: size.toString()
+    });
+
+    const cachedResponse = new Response(data, {
+      status: 200,
+      statusText: 'OK',
+      headers
+    });
+
+    await cache.put(url, cachedResponse);
+
+    this._lastAccessed.set(url, now);
+  }
+
+  private async evictLeastRecentlyUsedEntries(): Promise<void> {
+    const cache = await this._caches.open(this._config.cacheName);
+    const keys = await cache.keys();
+    if (keys.length === 0) return;
+
+    const entries: Array<{ url: string; lastAccessed: number }> = await Promise.all(
+      keys.map(async request => {
+        const inMemory = this._lastAccessed.get(request.url);
+        if (inMemory !== undefined) {
+          return { url: request.url, lastAccessed: inMemory };
+        }
+        // Fall back to stored date for entries not seen in this session
+        const response = await cache.match(request);
+        const storedAt = response ? (safeParseInt(response.headers.get(BINARY_FILES_CACHE_HEADER_DATE)) ?? 0) : 0;
+        return { url: request.url, lastAccessed: storedAt };
+      })
+    );
+
+    entries.sort((a, b) => a.lastAccessed - b.lastAccessed);
+
+    const evictCount = Math.max(1, Math.floor(entries.length * 0.2));
+    await Promise.all(
+      entries.slice(0, evictCount).map(async entry => {
+        await cache.delete(entry.url);
+        this._lastAccessed.delete(entry.url);
+      })
+    );
   }
 }
 
@@ -131,4 +178,11 @@ function isExpired(response: Response, maxAge: number): boolean {
   const cachedAt = safeParseInt(response.headers.get(BINARY_FILES_CACHE_HEADER_DATE));
   if (cachedAt === undefined) return true;
   return Date.now() - cachedAt > maxAge;
+}
+
+function isQuotaError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'QuotaExceededError') return true;
+  // Firefox throws NS_ERROR_FILE_NO_DEVICE_SPACE instead of a standard QuotaExceededError
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('QuotaExceededError') || message.includes('No device space');
 }

--- a/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
+++ b/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
@@ -163,17 +163,16 @@ export class DataFileCacheManager {
       }
     }
 
-    if (notInMemory.length < evictCount) {
+    let toEvict: string[];
+    if (notInMemory.length >= evictCount) {
+      toEvict = notInMemory.slice(0, evictCount);
+    } else {
       inMemory.sort((a, b) => a.lastAccessed - b.lastAccessed);
+      toEvict = [...notInMemory, ...inMemory.map(e => e.url)].slice(0, evictCount);
     }
-    const toEvict = [...notInMemory, ...inMemory.map(e => e.url)].slice(0, evictCount);
 
-    await Promise.all(
-      toEvict.map(async url => {
-        await cache.delete(url);
-        this._lastAccessed.delete(url);
-      })
-    );
+    await Promise.all(toEvict.map(url => cache.delete(url)));
+    toEvict.forEach(url => this._lastAccessed.delete(url));
   }
 }
 

--- a/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
+++ b/viewer/packages/utilities/src/cache/DataFileCacheManager.ts
@@ -149,26 +149,27 @@ export class DataFileCacheManager {
     const keys = await cache.keys();
     if (keys.length === 0) return;
 
-    const entries: Array<{ url: string; lastAccessed: number }> = await Promise.all(
-      keys.map(async request => {
-        const inMemory = this._lastAccessed.get(request.url);
-        if (inMemory !== undefined) {
-          return { url: request.url, lastAccessed: inMemory };
-        }
-        // Fall back to stored date for entries not seen in this session
-        const response = await cache.match(request);
-        const storedAt = response ? (safeParseInt(response.headers.get(BINARY_FILES_CACHE_HEADER_DATE)) ?? 0) : 0;
-        return { url: request.url, lastAccessed: storedAt };
-      })
-    );
+    const evictCount = Math.max(1, Math.floor(keys.length * 0.2));
+    const notInMemory: string[] = [];
+    const inMemory: Array<{ url: string; lastAccessed: number }> = [];
 
-    entries.sort((a, b) => a.lastAccessed - b.lastAccessed);
+    for (const request of keys) {
+      const lastAccessed = this._lastAccessed.get(request.url);
+      if (lastAccessed !== undefined) {
+        inMemory.push({ url: request.url, lastAccessed });
+      } else {
+        // Not seen this session — treat as older than anything in _lastAccessed
+        notInMemory.push(request.url);
+      }
+    }
 
-    const evictCount = Math.max(1, Math.floor(entries.length * 0.2));
+    inMemory.sort((a, b) => a.lastAccessed - b.lastAccessed);
+    const toEvict = [...notInMemory, ...inMemory.map(e => e.url)].slice(0, evictCount);
+
     await Promise.all(
-      entries.slice(0, evictCount).map(async entry => {
-        await cache.delete(entry.url);
-        this._lastAccessed.delete(entry.url);
+      toEvict.map(async url => {
+        await cache.delete(url);
+        this._lastAccessed.delete(url);
       })
     );
   }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

[BND3D-6974](https://cognitedata.atlassian.net/browse/BND3D-6974)

## Description :pencil:
When browser cache storage become full, reveal would throw error until browser evicts the cache on its discretion. In this PR, I have added explicit clearing of cache entries (20%) based on least recently used data and retires to write the new data into cache.

## How has this been tested? :mag:

No idea other than unit test validation. Reverted the fix and run the test which fails

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.


[BND3D-6974]: https://cognitedata.atlassian.net/browse/BND3D-6974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ