### PR TITLE
chore: replace wasm-pack used for point cloud package building with shell-script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5
         id: wasm_bindgen_cache
@@ -137,6 +140,9 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5
         id: wasm_bindgen_cache
@@ -185,6 +191,9 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5
@@ -296,6 +305,9 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
         if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
         working-directory: viewer
         run: |
-          rustup target add wasm32-unknown-unknown
           VERSION=$(awk '/^name = "wasm-bindgen"$/{found=1} found && /^version =/{match($0,/"([^"]+)"/,a); print a[1]; exit}' Cargo.lock)
-          cargo install wasm-bindgen-cli --version "$VERSION" --locked
+          curl -sSfL "https://github.com/rustwasm/wasm-bindgen/releases/download/${VERSION}/wasm-bindgen-${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | tar xz --strip-components=1 -C ~/.cargo/bin
 
   build-viewer:
     needs: populate-caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v5
         id: wasm_bindgen_cache
         with:
-          path: ~/.cargo/bin/wasm-bindgen
+          path: ~/.cargo/bin/wasm-bindgen**
           key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install wasm-bindgen-cli
@@ -58,8 +58,7 @@ jobs:
         working-directory: viewer
         run: |
           rustup target add wasm32-unknown-unknown
-          VERSION=$(cargo metadata --manifest-path Cargo.toml --format-version 1 \
-            | python3 -c "import sys,json; print(next(p['version'] for p in json.load(sys.stdin)['packages'] if p['name']=='wasm-bindgen'))")
+          VERSION=$(awk '/^name = "wasm-bindgen"$/{found=1} found && /^version =/{match($0,/"([^"]+)"/,a); print a[1]; exit}' Cargo.lock)
           cargo install wasm-bindgen-cli --version "$VERSION" --locked
 
   build-viewer:
@@ -86,7 +85,7 @@ jobs:
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5
         with:
-          path: ~/.cargo/bin/wasm-bindgen
+          path: ~/.cargo/bin/wasm-bindgen*
           key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check that yarn.lock is up to date
@@ -151,7 +150,7 @@ jobs:
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5
         with:
-          path: ~/.cargo/bin/wasm-bindgen
+          path: ~/.cargo/bin/wasm-bindgen*
           key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup tools for coverage tests
@@ -195,7 +194,7 @@ jobs:
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5
         with:
-          path: ~/.cargo/bin/wasm-bindgen
+          path: ~/.cargo/bin/wasm-bindgen*
           key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Execute visual tests
@@ -301,7 +300,7 @@ jobs:
       - name: Cache wasm-bindgen-cli
         uses: actions/cache@v5
         with:
-          path: ~/.cargo/bin/wasm-bindgen
+          path: ~/.cargo/bin/wasm-bindgen*
           key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build production version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
         working-directory: viewer
         run: |
-          VERSION=$(awk '/^name = "wasm-bindgen"$/{found=1} found && /^version =/{match($0,/"([^"]+)"/,a); print a[1]; exit}' Cargo.lock)
+          VERSION=$(awk -F'"' '/^name = "wasm-bindgen"$/{found=1} found && /^version =/{print $2; exit}' Cargo.lock)
           curl -sSfL "https://github.com/rustwasm/wasm-bindgen/releases/download/${VERSION}/wasm-bindgen-${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
             | tar xz --strip-components=1 -C ~/.cargo/bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,22 @@ jobs:
         continue-on-error: false
         run: cargo update --locked
 
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        id: wasm_bindgen_cache
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install wasm-bindgen-cli
+        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
+        working-directory: viewer
+        run: |
+          rustup target add wasm32-unknown-unknown
+          VERSION=$(cargo metadata --manifest-path Cargo.toml --format-version 1 \
+            | python3 -c "import sys,json; print(next(p['version'] for p in json.load(sys.stdin)['packages'] if p['name']=='wasm-bindgen'))")
+          cargo install wasm-bindgen-cli --version "$VERSION" --locked
+
   build-viewer:
     needs: populate-caches
     name: Build Reveal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,20 +67,6 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Cache wasm-bindgen-cli
-        uses: actions/cache@v5
-        id: wasm_bindgen_cache
-        with:
-          path: ~/.cargo/bin/wasm-bindgen
-          key: ${{ runner.os }}-wasm-bindgen-0.2.111
-
-      - name: Install wasm-bindgen-cli
-        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
-        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
-
       - name: Check that yarn.lock is up to date
         working-directory: viewer
         continue-on-error: false
@@ -140,20 +126,6 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Cache wasm-bindgen-cli
-        uses: actions/cache@v5
-        id: wasm_bindgen_cache
-        with:
-          path: ~/.cargo/bin/wasm-bindgen
-          key: ${{ runner.os }}-wasm-bindgen-0.2.111
-
-      - name: Install wasm-bindgen-cli
-        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
-        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
-
       - name: Setup tools for coverage tests
         working-directory: viewer
         run: |
@@ -191,20 +163,6 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
-
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Cache wasm-bindgen-cli
-        uses: actions/cache@v5
-        id: wasm_bindgen_cache
-        with:
-          path: ~/.cargo/bin/wasm-bindgen
-          key: ${{ runner.os }}-wasm-bindgen-0.2.111
-
-      - name: Install wasm-bindgen-cli
-        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
-        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
 
       - name: Execute visual tests
         id: viewerVisualTests
@@ -305,20 +263,6 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
-
-      - name: Add wasm32 target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Cache wasm-bindgen-cli
-        uses: actions/cache@v5
-        id: wasm_bindgen_cache
-        with:
-          path: ~/.cargo/bin/wasm-bindgen
-          key: ${{ runner.os }}-wasm-bindgen-0.2.111
-
-      - name: Install wasm-bindgen-cli
-        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
-        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
 
       - name: Build production version
         working-directory: viewer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,17 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        id: wasm_bindgen_cache
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-0.2.111
+
+      - name: Install wasm-bindgen-cli
+        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
+        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
+
       - name: Check that yarn.lock is up to date
         working-directory: viewer
         continue-on-error: false
@@ -126,6 +137,17 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        id: wasm_bindgen_cache
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-0.2.111
+
+      - name: Install wasm-bindgen-cli
+        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
+        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
+
       - name: Setup tools for coverage tests
         working-directory: viewer
         run: |
@@ -163,6 +185,17 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
+
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        id: wasm_bindgen_cache
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-0.2.111
+
+      - name: Install wasm-bindgen-cli
+        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
+        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
 
       - name: Execute visual tests
         id: viewerVisualTests
@@ -263,6 +296,17 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
+
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        id: wasm_bindgen_cache
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-0.2.111
+
+      - name: Install wasm-bindgen-cli
+        if: steps.wasm_bindgen_cache.outputs.cache-hit != 'true'
+        run: cargo install wasm-bindgen-cli --version 0.2.111 --locked
 
       - name: Build production version
         working-directory: viewer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Check that yarn.lock is up to date
         working-directory: viewer
         continue-on-error: false
@@ -126,6 +132,12 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
 
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Setup tools for coverage tests
         working-directory: viewer
         run: |
@@ -163,6 +175,12 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
+
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Execute visual tests
         id: viewerVisualTests
@@ -263,6 +281,12 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*', '**/Cargo.toml') }}
+
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: ${{ runner.os }}-wasm-bindgen-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build production version
         working-directory: viewer

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -58,7 +58,7 @@
     "update-api": "api-extractor run --local && shx rm -rf api-extractor-temp/",
     "ws:serve": "yarn run build:wasm && webpack-dev-server --config packages/webpack.config.js",
     "ws:test": "cd $INIT_CWD && jest --runInBand",
-    "ws:test:wasm": "cd $INIT_CWD && bash ./build-wasm.sh test --headless --chrome ./wasm",
+    "ws:test:wasm": "bash ./build-wasm.sh test --headless --chrome ./wasm",
     "ws:update-cargo-index": "cargo update --dry-run",
     "ws:lint": "cd $INIT_CWD && eslint . --ext .ts,.js --max-warnings 0 --cache"
   },

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -58,7 +58,7 @@
     "update-api": "api-extractor run --local && shx rm -rf api-extractor-temp/",
     "ws:serve": "yarn run build:wasm && webpack-dev-server --config packages/webpack.config.js",
     "ws:test": "cd $INIT_CWD && jest --runInBand",
-    "ws:test:wasm": "cd $INIT_CWD && wasm-pack test --chrome --headless ./wasm",
+    "ws:test:wasm": "cd $INIT_CWD && bash ./build-wasm.sh test --headless --chrome ./wasm",
     "ws:update-cargo-index": "cargo update --dry-run",
     "ws:lint": "cd $INIT_CWD && eslint . --ext .ts,.js --max-warnings 0 --cache"
   },
@@ -134,7 +134,6 @@
     "ts-loader": "^9.5.1",
     "tsc-alias": "^1.8.8",
     "typescript": "^6.0.3",
-    "wasm-pack": "^0.14.0",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4",

--- a/viewer/packages/pointclouds/build-wasm.sh
+++ b/viewer/packages/pointclouds/build-wasm.sh
@@ -30,7 +30,7 @@ TARGET_DIR="$WORKSPACE_DIR/target"
 
 rustup target add wasm32-unknown-unknown 2>/dev/null || true
 
-WASM_BINDGEN_VERSION=$(awk '/^name = "wasm-bindgen"$/{found=1} found && /^version =/{match($0,/"([^"]+)"/,a); print a[1]; exit}' "$WORKSPACE_DIR/Cargo.lock")
+WASM_BINDGEN_VERSION=$(awk -F'"' '/^name = "wasm-bindgen"$/{found=1} found && /^version =/{print $2; exit}' "$WORKSPACE_DIR/Cargo.lock")
 if ! command -v wasm-bindgen &>/dev/null || [[ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]]; then
   echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
   cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked

--- a/viewer/packages/pointclouds/build-wasm.sh
+++ b/viewer/packages/pointclouds/build-wasm.sh
@@ -30,8 +30,7 @@ TARGET_DIR="$WORKSPACE_DIR/target"
 
 rustup target add wasm32-unknown-unknown 2>/dev/null || true
 
-WASM_BINDGEN_VERSION=$(cargo metadata --manifest-path "$WASM_DIR/Cargo.toml" --format-version 1 2>/dev/null \
-  | python3 -c "import sys,json; print(next(p['version'] for p in json.load(sys.stdin)['packages'] if p['name']=='wasm-bindgen'))")
+WASM_BINDGEN_VERSION=$(awk '/^name = "wasm-bindgen"$/{found=1} found && /^version =/{match($0,/"([^"]+)"/,a); print a[1]; exit}' "$WORKSPACE_DIR/Cargo.lock")
 if ! command -v wasm-bindgen &>/dev/null || [[ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]]; then
   echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
   cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked

--- a/viewer/packages/pointclouds/build-wasm.sh
+++ b/viewer/packages/pointclouds/build-wasm.sh
@@ -28,6 +28,8 @@ WORKSPACE_TOML=$(cargo locate-project --workspace --message-format plain --manif
 WORKSPACE_DIR=$(dirname "$WORKSPACE_TOML")
 TARGET_DIR="$WORKSPACE_DIR/target"
 
+rustup target add wasm32-unknown-unknown 2>/dev/null || true
+
 WASM_BINDGEN_VERSION=$(grep -A2 '^name = "wasm-bindgen"$' "$WORKSPACE_DIR/Cargo.lock" | grep '^version' | head -1 | sed 's/version = "\(.*\)"/\1/')
 if ! command -v wasm-bindgen &>/dev/null || [[ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]]; then
   echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."

--- a/viewer/packages/pointclouds/build-wasm.sh
+++ b/viewer/packages/pointclouds/build-wasm.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -e
+
+# Usage:
+#   build-wasm.sh build --target <web|nodejs> <wasm-dir>
+#   build-wasm.sh test [--headless] [--chrome|--firefox|--safari|--node] <wasm-dir>
+# Minimal replacement for wasm-pack using cargo + wasm-bindgen-cli directly.
+
+COMMAND="build"
+if [[ "$1" == "build" || "$1" == "test" ]]; then
+  COMMAND="$1"
+  shift
+fi
+
+TARGET="web"
+WASM_DIR="./wasm"
+TEST_FLAGS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --target) TARGET="$2"; shift 2 ;;
+    --headless|--chrome|--firefox|--safari|--node) TEST_FLAGS+=("$1"); shift ;;
+    *) WASM_DIR="$1"; shift ;;
+  esac
+done
+
+WORKSPACE_TOML=$(cargo locate-project --workspace --message-format plain --manifest-path "$WASM_DIR/Cargo.toml")
+WORKSPACE_DIR=$(dirname "$WORKSPACE_TOML")
+TARGET_DIR="$WORKSPACE_DIR/target"
+
+WASM_BINDGEN_VERSION=$(grep -A2 '^name = "wasm-bindgen"$' "$WORKSPACE_DIR/Cargo.lock" | grep '^version' | head -1 | sed 's/version = "\(.*\)"/\1/')
+if ! command -v wasm-bindgen &>/dev/null || [[ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]]; then
+  echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
+  cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked
+fi
+
+if [[ "$COMMAND" == "test" ]]; then
+  CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
+    cargo test --manifest-path "$WASM_DIR/Cargo.toml" --target wasm32-unknown-unknown -- "${TEST_FLAGS[@]}"
+else
+  cargo build --manifest-path "$WASM_DIR/Cargo.toml" --target wasm32-unknown-unknown --release
+
+  mkdir -p "$WASM_DIR/pkg"
+  wasm-bindgen \
+    --target "$TARGET" \
+    --out-dir "$WASM_DIR/pkg" \
+    "$TARGET_DIR/wasm32-unknown-unknown/release/pointclouds_wasm.wasm"
+
+  # wasm-bindgen does not generate package.json; write one so Node.js uses
+  # the correct module system (CJS for nodejs target, ESM for everything else).
+  if [[ "$TARGET" == "nodejs" ]]; then
+    echo '{"name":"pointclouds-wasm","main":"pointclouds_wasm.js","types":"pointclouds_wasm.d.ts"}' \
+      > "$WASM_DIR/pkg/package.json"
+  else
+    echo '{"name":"pointclouds-wasm","type":"module","main":"pointclouds_wasm.js","types":"pointclouds_wasm.d.ts"}' \
+      > "$WASM_DIR/pkg/package.json"
+  fi
+fi

--- a/viewer/packages/pointclouds/build-wasm.sh
+++ b/viewer/packages/pointclouds/build-wasm.sh
@@ -30,7 +30,8 @@ TARGET_DIR="$WORKSPACE_DIR/target"
 
 rustup target add wasm32-unknown-unknown 2>/dev/null || true
 
-WASM_BINDGEN_VERSION=$(grep -A2 '^name = "wasm-bindgen"$' "$WORKSPACE_DIR/Cargo.lock" | grep '^version' | head -1 | sed 's/version = "\(.*\)"/\1/')
+WASM_BINDGEN_VERSION=$(cargo metadata --manifest-path "$WASM_DIR/Cargo.toml" --format-version 1 2>/dev/null \
+  | python3 -c "import sys,json; print(next(p['version'] for p in json.load(sys.stdin)['packages'] if p['name']=='wasm-bindgen'))")
 if ! command -v wasm-bindgen &>/dev/null || [[ "$(wasm-bindgen --version 2>/dev/null | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]]; then
   echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
   cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked
@@ -40,21 +41,26 @@ if [[ "$COMMAND" == "test" ]]; then
   CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
     cargo test --manifest-path "$WASM_DIR/Cargo.toml" --target wasm32-unknown-unknown -- "${TEST_FLAGS[@]}"
 else
+  # Derive names from Cargo.toml so the script is not tied to a specific crate.
+  CRATE_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' "$WASM_DIR/Cargo.toml" | head -1)
+  LIB_NAME=$(echo "$CRATE_NAME" | tr '-' '_')
+  CRATE_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' "$WASM_DIR/Cargo.toml" | head -1)
+
   cargo build --manifest-path "$WASM_DIR/Cargo.toml" --target wasm32-unknown-unknown --release
 
   mkdir -p "$WASM_DIR/pkg"
   wasm-bindgen \
     --target "$TARGET" \
     --out-dir "$WASM_DIR/pkg" \
-    "$TARGET_DIR/wasm32-unknown-unknown/release/pointclouds_wasm.wasm"
+    "$TARGET_DIR/wasm32-unknown-unknown/release/${LIB_NAME}.wasm"
 
   # wasm-bindgen does not generate package.json; write one so Node.js uses
   # the correct module system (CJS for nodejs target, ESM for everything else).
   if [[ "$TARGET" == "nodejs" ]]; then
-    echo '{"name":"pointclouds-wasm","main":"pointclouds_wasm.js","types":"pointclouds_wasm.d.ts"}' \
-      > "$WASM_DIR/pkg/package.json"
+    printf '{"name":"%s","version":"%s","main":"%s.js","types":"%s.d.ts","sideEffects":false}\n' \
+      "$CRATE_NAME" "$CRATE_VERSION" "$LIB_NAME" "$LIB_NAME" > "$WASM_DIR/pkg/package.json"
   else
-    echo '{"name":"pointclouds-wasm","type":"module","main":"pointclouds_wasm.js","types":"pointclouds_wasm.d.ts"}' \
-      > "$WASM_DIR/pkg/package.json"
+    printf '{"name":"%s","version":"%s","type":"module","main":"%s.js","types":"%s.d.ts","sideEffects":false}\n' \
+      "$CRATE_NAME" "$CRATE_VERSION" "$LIB_NAME" "$LIB_NAME" > "$WASM_DIR/pkg/package.json"
   fi
 fi

--- a/viewer/packages/pointclouds/package.json
+++ b/viewer/packages/pointclouds/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "yarn ws:serve --env testFixture=PointCloudColorStyling.VisualTest.ts",
     "test": "yarn ws:test --config ./../../jest.config.js",
-    "run-wasm-pack": "yarn run ws:update-cargo-index && wasm-pack",
+    "run-wasm-pack": "yarn run ws:update-cargo-index && bash ./build-wasm.sh",
     "test:wasm": "yarn ws:test:wasm",
     "lint": "yarn ws:lint"
   },

--- a/viewer/packages/pointclouds/package.json
+++ b/viewer/packages/pointclouds/package.json
@@ -6,7 +6,7 @@
     "start": "yarn ws:serve --env testFixture=PointCloudColorStyling.VisualTest.ts",
     "test": "yarn ws:test --config ./../../jest.config.js",
     "run-wasm-pack": "yarn run ws:update-cargo-index && bash ./build-wasm.sh",
-    "test:wasm": "yarn ws:test:wasm",
+    "test:wasm": "bash ./build-wasm.sh test --headless --chrome ./wasm",
     "lint": "yarn ws:lint"
   },
   "dependencies": {

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -518,7 +518,6 @@ __metadata:
     ts-loader: "npm:^9.5.1"
     tsc-alias: "npm:^1.8.8"
     typescript: "npm:^6.0.3"
-    wasm-pack: "npm:^0.14.0"
     webpack: "npm:^5.91.0"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.0.4"
@@ -2994,7 +2993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.0.0, axios@npm:^1.12.1":
+"axios@npm:^1.12.1":
   version: 1.16.0
   resolution: "axios@npm:1.16.0"
   dependencies:
@@ -3202,17 +3201,6 @@ __metadata:
   version: 2.3.0
   resolution: "binary-extensions@npm:2.3.0"
   checksum: 10/bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
-  languageName: node
-  linkType: hard
-
-"binary-install@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "binary-install@npm:1.1.2"
-  dependencies:
-    axios: "npm:^0.26.1"
-    rimraf: "npm:^3.0.2"
-    tar: "npm:^6.1.11"
-  checksum: 10/cf181e4cfea967f382a5358bc55aa1356e429106f93f1eeeb55074d78df648d149d899a2cdc57b65f378805b5cafd049d9e9d025c80aa27a5a60920beee53ba5
   languageName: node
   linkType: hard
 
@@ -10672,17 +10660,6 @@ __metadata:
   dependencies:
     makeerror: "npm:1.0.12"
   checksum: 10/ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
-  languageName: node
-  linkType: hard
-
-"wasm-pack@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "wasm-pack@npm:0.14.0"
-  dependencies:
-    binary-install: "npm:^1.1.2"
-  bin:
-    wasm-pack: run.js
-  checksum: 10/914c7750c8cdefdef61cb9a727a70e8685c5eb164c1261627e9e6dc0d693ce7a3f95456eb535270b309d3c0d587c53fc33af5f513af7666103da4f88282f6eff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
`wasm-pack's` npm package download is broken, blocking the entire viewer build. So, tis PR removes `wasm-pack` entirely and replaced it with two standard Rust tools that do the same thing directly:
- `cargo build --target wasm32-unknown-unknown --release` — compiles Rust to WASM
- `wasm-bindgen` — generates the JS wrapper and TypeScript types from the WASM binary


## How has this been tested? :mag:

Running the build locally for `viewer`, `examples` and `documentation`

## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
