### PR TITLE
chore: downgrade wasm-pack to v0.13.1 to fix build issue

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -134,7 +134,7 @@
     "ts-loader": "^9.5.1",
     "tsc-alias": "^1.8.8",
     "typescript": "^6.0.3",
-    "wasm-pack": "^0.14.0",
+    "wasm-pack": "^0.13.1",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4",

--- a/viewer/yarn.lock
+++ b/viewer/yarn.lock
@@ -518,7 +518,7 @@ __metadata:
     ts-loader: "npm:^9.5.1"
     tsc-alias: "npm:^1.8.8"
     typescript: "npm:^6.0.3"
-    wasm-pack: "npm:^0.14.0"
+    wasm-pack: "npm:^0.13.1"
     webpack: "npm:^5.91.0"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.0.4"
@@ -3205,7 +3205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary-install@npm:^1.1.2":
+"binary-install@npm:^1.0.1":
   version: 1.1.2
   resolution: "binary-install@npm:1.1.2"
   dependencies:
@@ -10675,14 +10675,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wasm-pack@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "wasm-pack@npm:0.14.0"
+"wasm-pack@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "wasm-pack@npm:0.13.1"
   dependencies:
-    binary-install: "npm:^1.1.2"
+    binary-install: "npm:^1.0.1"
   bin:
     wasm-pack: run.js
-  checksum: 10/914c7750c8cdefdef61cb9a727a70e8685c5eb164c1261627e9e6dc0d693ce7a3f95456eb535270b309d3c0d587c53fc33af5f513af7666103da4f88282f6eff
+  checksum: 10/5031151cc085487707e7f5e3a4057fb27b1dbc5ac5663a1a46725488ff3d4672f49a8a11ebdff8247857c03adce1cdf7615ce0790f19c622400e926a6e24796d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
Downgrading `wasm-pack` to `v0.13.1 `due to broken link with `v0.14.0` refer https://github.com/wasm-bindgen/wasm-pack/issues/1577 which is causing all CI and local build of reveal to fail check https://github.com/cognitedata/reveal/actions/runs/25782851532/job/75729666130?pr=5580

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
