### PR TITLE
feat: added JPEG stream parsing utility function

### DIFF
--- a/viewer/packages/360-images/src/utils/JpegDataStreamParser.test.ts
+++ b/viewer/packages/360-images/src/utils/JpegDataStreamParser.test.ts
@@ -4,7 +4,7 @@
 
 import { detectJpegType, findProgressiveScanCutpoints, makePartialJpegBlob } from './JpegDataStreamParser';
 
-describe('detectJpegType', () => {
+describe(detectJpegType.name, () => {
   test('returns unknown for buffer shorter than 4 bytes', () => {
     expect(detectJpegType(new Uint8Array([0xff, 0xd8, 0xff]))).toBe('unknown');
     expect(detectJpegType(new Uint8Array([]))).toBe('unknown');
@@ -47,7 +47,7 @@ describe('detectJpegType', () => {
   });
 });
 
-describe('findProgressiveScanCutpoints', () => {
+describe(findProgressiveScanCutpoints.name, () => {
   test('returns empty array for non-JPEG buffer', () => {
     expect(findProgressiveScanCutpoints(new Uint8Array([0x00, 0x01, 0x02, 0x03]))).toEqual([]);
     expect(findProgressiveScanCutpoints(new Uint8Array([]))).toEqual([]);
@@ -90,7 +90,7 @@ function readBlobBytes(blob: Blob): Promise<Uint8Array<ArrayBuffer>> {
   });
 }
 
-describe('makePartialJpegBlob', () => {
+describe(makePartialJpegBlob.name, () => {
   test('creates blob of size cutpoint+2', () => {
     const buffer = new Uint8Array([0xff, 0xd8, 0xab, 0xcd, 0xef]);
     const cutpoint = 3;

--- a/viewer/packages/360-images/src/utils/JpegDataStreamParser.test.ts
+++ b/viewer/packages/360-images/src/utils/JpegDataStreamParser.test.ts
@@ -1,0 +1,125 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+
+import { detectJpegType, findProgressiveScanCutpoints, makePartialJpegBlob } from './JpegDataStreamParser';
+
+describe('detectJpegType', () => {
+  test('returns unknown for buffer shorter than 4 bytes', () => {
+    expect(detectJpegType(new Uint8Array([0xff, 0xd8, 0xff]))).toBe('unknown');
+    expect(detectJpegType(new Uint8Array([]))).toBe('unknown');
+    expect(detectJpegType(new Uint8Array([0xff, 0xd8]))).toBe('unknown');
+  });
+
+  test('returns unknown for non-JPEG (no FF D8 at start)', () => {
+    expect(detectJpegType(new Uint8Array([0x00, 0x00, 0x00, 0x00]))).toBe('unknown');
+    expect(detectJpegType(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))).toBe('unknown');
+  });
+
+  test('returns progressive when SOF2 (FF C2) found after segment headers', () => {
+    // SOI + APP0 (length=4, 2 data bytes) + SOF2
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x00, 0x00, 0xff, 0xc2]);
+    expect(detectJpegType(buffer)).toBe('progressive');
+  });
+
+  test('returns baseline when SOF0 (FF C0) found after segment headers', () => {
+    // SOI + APP0 (length=4, 2 data bytes) + SOF0
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x00, 0x00, 0xff, 0xc0]);
+    expect(detectJpegType(buffer)).toBe('baseline');
+  });
+
+  test('returns baseline when SOF1 (FF C1) found after segment headers', () => {
+    // SOI + APP0 (length=4, 2 data bytes) + SOF1
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x00, 0x00, 0xff, 0xc1]);
+    expect(detectJpegType(buffer)).toBe('baseline');
+  });
+
+  test('returns unknown when buffer runs out before SOF marker is found', () => {
+    // SOI + APP0 header only, no SOF follows (truncated after data bytes)
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x00, 0x00]);
+    expect(detectJpegType(buffer)).toBe('unknown');
+  });
+
+  test('returns unknown when EOI (FF D9) found before SOF (malformed)', () => {
+    // SOI + EOI immediately — no SOF
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
+    expect(detectJpegType(buffer)).toBe('unknown');
+  });
+});
+
+describe('findProgressiveScanCutpoints', () => {
+  test('returns empty array for non-JPEG buffer', () => {
+    expect(findProgressiveScanCutpoints(new Uint8Array([0x00, 0x01, 0x02, 0x03]))).toEqual([]);
+    expect(findProgressiveScanCutpoints(new Uint8Array([]))).toEqual([]);
+  });
+
+  test('returns cutpoint at position of EOI marker for a simple terminated buffer', () => {
+    // SOI + EOI — i=2: FF D9 → push(2), break
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
+    expect(findProgressiveScanCutpoints(buffer)).toEqual([2]);
+  });
+
+  test('returns cutpoint after SOS entropy data ends when next real marker found', () => {
+    // SOI + SOS (marker=DA, length=4, 2 header bytes 0x00 0x00) + entropy [0xAB, 0xCD] + real marker FF C0
+    // SOS at i=2: hdrLen=(0x00<<8)|0x04=4; i advances to 2+2+4=8 (first entropy byte)
+    // entropy: 0xAB (i=8→9), 0xCD (i=9→10), then FF C0 at i=10 → real marker → foundEndOfScan=true, cutpoint=10
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xda, 0x00, 0x04, 0x00, 0x00, 0xab, 0xcd, 0xff, 0xc0]);
+    expect(findProgressiveScanCutpoints(buffer)).toEqual([10]);
+  });
+
+  test('does not push cutpoint if buffer runs out mid-scan (incomplete data)', () => {
+    // SOI + SOS (length=4, 2 header bytes) + entropy [0xAB] — buffer ends, no terminating marker
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xda, 0x00, 0x04, 0x00, 0x00, 0xab]);
+    expect(findProgressiveScanCutpoints(buffer)).toEqual([]);
+  });
+
+  test('handles byte stuffing: FF 00 inside entropy data is NOT treated as a marker', () => {
+    // SOI + SOS (length=4, 2 header bytes) + entropy [FF 00 (stuffed), 0xAB] + real marker FF C0
+    // FF 00 is byte stuffing → skip 2 bytes; then 0xAB; then FF C0 → cutpoint at 11
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xda, 0x00, 0x04, 0x00, 0x00, 0xff, 0x00, 0xab, 0xff, 0xc0]);
+    expect(findProgressiveScanCutpoints(buffer)).toEqual([11]);
+  });
+});
+
+function readBlobBytes(blob: Blob): Promise<Uint8Array<ArrayBuffer>> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.onerror = reject;
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+describe('makePartialJpegBlob', () => {
+  test('creates blob of size cutpoint+2', () => {
+    const buffer = new Uint8Array([0xff, 0xd8, 0xab, 0xcd, 0xef]);
+    const cutpoint = 3;
+    const blob = makePartialJpegBlob(buffer, cutpoint);
+    expect(blob.size).toBe(cutpoint + 2);
+  });
+
+  test('last two bytes are 0xFF, 0xD9 (EOI)', async () => {
+    const buffer = new Uint8Array([0xff, 0xd8, 0xab, 0xcd]);
+    const cutpoint = 2;
+    const blob = makePartialJpegBlob(buffer, cutpoint);
+    const bytes = await readBlobBytes(blob);
+    expect(bytes[bytes.length - 2]).toBe(0xff);
+    expect(bytes[bytes.length - 1]).toBe(0xd9);
+  });
+
+  test('blob type is image/jpeg', () => {
+    const buffer = new Uint8Array([0xff, 0xd8, 0xab]);
+    const blob = makePartialJpegBlob(buffer, 2);
+    expect(blob.type).toBe('image/jpeg');
+  });
+
+  test('blob contains the original bytes up to cutpoint', async () => {
+    const buffer = new Uint8Array([0xff, 0xd8, 0xaa, 0xbb, 0xcc]);
+    const cutpoint = 3;
+    const blob = makePartialJpegBlob(buffer, cutpoint);
+    const bytes = await readBlobBytes(blob);
+    expect(bytes[0]).toBe(0xff);
+    expect(bytes[1]).toBe(0xd8);
+    expect(bytes[2]).toBe(0xaa);
+  });
+});

--- a/viewer/packages/360-images/src/utils/JpegDataStreamParser.ts
+++ b/viewer/packages/360-images/src/utils/JpegDataStreamParser.ts
@@ -15,6 +15,10 @@ export function detectJpegType(buffer: Uint8Array): 'progressive' | 'baseline' |
   while (i < buffer.length - 1) {
     if (buffer[i] !== 0xff) return 'unknown';
     const marker = buffer[i + 1];
+    if (marker === 0xff) {
+      i++;
+      continue;
+    }
     if (marker === 0xc0 || marker === 0xc1) return 'baseline'; // SOF0 / SOF1
     if (marker === 0xc2) return 'progressive'; // SOF2
     if (marker === 0xd9) return 'unknown'; // EOI before SOF — malformed
@@ -59,6 +63,10 @@ export function findProgressiveScanCutpoints(buffer: Uint8Array): number[] {
     }
 
     const marker = buffer[i + 1];
+    if (marker === 0xff) {
+      i++;
+      continue;
+    }
 
     if (marker === 0xd9) {
       // EOI — full image complete; treat current position as a cutpoint
@@ -97,7 +105,7 @@ export function findProgressiveScanCutpoints(buffer: Uint8Array): number[] {
         i++;
       }
 
-      if (foundEndOfScan) {
+      if (foundEndOfScan && buffer[i + 1] !== 0xd9) {
         cutpoints.push(i); // buffer[0..i] + EOI = decodable JPEG
       }
       continue;
@@ -116,10 +124,6 @@ export function findProgressiveScanCutpoints(buffer: Uint8Array): number[] {
  * Creates a Blob containing a valid JPEG by taking the first `cutpoint` bytes
  * of `buffer` and appending an EOI (FF D9) marker.
  */
-export function makePartialJpegBlob(buffer: Uint8Array, cutpoint: number): Blob {
-  const partial = new Uint8Array(cutpoint + 2);
-  partial.set(buffer.subarray(0, cutpoint));
-  partial[cutpoint] = 0xff;
-  partial[cutpoint + 1] = 0xd9;
-  return new Blob([partial], { type: 'image/jpeg' });
+export function makePartialJpegBlob(buffer: Uint8Array<ArrayBuffer>, cutpoint: number): Blob {
+  return new Blob([buffer.subarray(0, cutpoint), new Uint8Array([0xff, 0xd9])], { type: 'image/jpeg' });
 }

--- a/viewer/packages/360-images/src/utils/JpegDataStreamParser.ts
+++ b/viewer/packages/360-images/src/utils/JpegDataStreamParser.ts
@@ -1,0 +1,125 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+
+/**
+ * Scans a JPEG byte buffer and returns whether it is progressive (SOF2) or
+ * baseline (SOF0/SOF1) by fecthing segment headers until the SOF marker is found.
+ * Returns 'unknown' if the buffer does not yet contain the SOF marker.
+ *
+ * The SOF marker appears in the first 1–4 KB of any JPEG file, well before image data.
+ */
+export function detectJpegType(buffer: Uint8Array): 'progressive' | 'baseline' | 'unknown' {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) return 'unknown';
+  let i = 2;
+  while (i < buffer.length - 1) {
+    if (buffer[i] !== 0xff) return 'unknown';
+    const marker = buffer[i + 1];
+    if (marker === 0xc0 || marker === 0xc1) return 'baseline'; // SOF0 / SOF1
+    if (marker === 0xc2) return 'progressive'; // SOF2
+    if (marker === 0xd9) return 'unknown'; // EOI before SOF — malformed
+    if (i + 3 >= buffer.length) return 'unknown'; // need more data
+    const segLen = (buffer[i + 2] << 8) | buffer[i + 3];
+    i += 2 + segLen;
+  }
+  return 'unknown';
+}
+
+/**
+ * Scans a JPEG byte buffer and returns the byte offsets at which each progressive
+ * scan ends (i.e. where the next segment marker begins after the entropy-coded data).
+ *
+ * Taking buffer[0..cutpoint] + FF D9 (EOI) produces a valid, decodable JPEG that
+ * shows the image quality as of that scan pass.
+ *
+ * Progressive JPEG structure:
+ * SOI -> APP... -> DQT -> SOF2 -> (DHT -> SOS -> <entropy data>)* -> EOI
+ *
+ * Inside entropy-coded scan data, FF bytes are escaped as FF 00 (byte stuffing).
+ * FF D0-D7 are restart markers (RST) and are also valid inside scan data.
+ * FF FF sequences are fill bytes before a real marker and must be skipped.
+ * Any other FF XX sequence is a real segment marker and ends the current scan.
+ *
+ * A cutpoint is only recorded when the terminating marker is actually found in
+ * the buffer. If the buffer runs out mid-scan, no cutpoint is recorded for that
+ * scan — the caller should wait for more data.
+ */
+export function findProgressiveScanCutpoints(buffer: Uint8Array): number[] {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) {
+    return [];
+  }
+
+  const cutpoints: number[] = [];
+  let i = 2; // skip SOI (FF D8)
+
+  while (i < buffer.length - 1) {
+    if (buffer[i] !== 0xff) {
+      i++;
+      continue;
+    }
+
+    const marker = buffer[i + 1];
+
+    if (marker === 0xd9) {
+      // EOI — full image complete; treat current position as a cutpoint
+      cutpoints.push(i);
+      break;
+    }
+
+    if (marker === 0xda) {
+      // SOS — Start of Scan; skip the scan header then walk entropy-coded data
+      if (i + 3 >= buffer.length) break; // need more bytes
+      const hdrLen = (buffer[i + 2] << 8) | buffer[i + 3];
+      i += 2 + hdrLen; // now at first byte of entropy-coded scan data
+
+      // Walk entropy data until a real segment marker appears.
+      // Only record a cutpoint when we actually find the terminating marker —
+      // if the buffer runs out first, this scan is incomplete; don't push.
+      let foundEndOfScan = false;
+      while (i < buffer.length - 1) {
+        if (buffer[i] === 0xff) {
+          const b = buffer[i + 1];
+          if (b === 0x00) {
+            i += 2; // byte stuffing — literal 0xFF in data
+            continue;
+          }
+          if (b >= 0xd0 && b <= 0xd7) {
+            i += 2; // RST0-RST7 restart marker — valid inside scan data
+            continue;
+          }
+          if (b === 0xff) {
+            i++; // fill byte (FF FF ... FF XX) — skip and re-examine
+            continue;
+          }
+          foundEndOfScan = true;
+          break; // real marker: scan data has ended
+        }
+        i++;
+      }
+
+      if (foundEndOfScan) {
+        cutpoints.push(i); // buffer[0..i] + EOI = decodable JPEG
+      }
+      continue;
+    }
+
+    // All other segments have a 2-byte length field immediately after the marker byte
+    if (i + 3 >= buffer.length) break; // need more bytes
+    const segLen = (buffer[i + 2] << 8) | buffer[i + 3];
+    i += 2 + segLen;
+  }
+
+  return cutpoints;
+}
+
+/**
+ * Creates a Blob containing a valid JPEG by taking the first `cutpoint` bytes
+ * of `buffer` and appending an EOI (FF D9) marker.
+ */
+export function makePartialJpegBlob(buffer: Uint8Array, cutpoint: number): Blob {
+  const partial = new Uint8Array(cutpoint + 2);
+  partial.set(buffer.subarray(0, cutpoint));
+  partial[cutpoint] = 0xff;
+  partial[cutpoint + 1] = 0xd9;
+  return new Blob([partial], { type: 'image/jpeg' });
+}


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/

## Description :pencil:
As part of supporting Jpeg progressive image file for 360 collection, added utility functions `detectJpegType`, `findProgressiveScanCutpoints` and `makePartialJpegBlob` which will be used in next PR which will contain actual support of progressive Jpeg in reveal for 360 image file loading

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
