### PR TITLE
chore(viewer): detach CadMaterialManager dependency from CadNode

### DIFF
--- a/viewer/packages/cad-geometry-loaders/src/CadManager.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadManager.ts
@@ -233,6 +233,7 @@ export class CadManager {
     }
     model.removeEventListener('update', this._markNeedsRedrawBound);
     this._cadModelUpdateHandler.removeModel(model);
+    this.materialManager.removeModelMaterials(model.cadModelMetadata.modelIdentifier.revealInternalId);
   }
 
   on(event: 'loadingStateChanged', listener: (loadingState: LoadingState) => void): void {

--- a/viewer/packages/cad-model/src/CadModelFactory.test.ts
+++ b/viewer/packages/cad-model/src/CadModelFactory.test.ts
@@ -74,17 +74,14 @@ describe(CadModelFactory.name, () => {
   });
 
   test('createModel() sets model clipping planes when a clip box is set', async () => {
-    const setModelClippingPlanesSpy = vi.spyOn(materialManager, 'setModelClippingPlanes');
-
     const geometryFilter: GeometryFilter = {
       boundingBox: new THREE.Box3(new THREE.Vector3(-1, -2, -3), new THREE.Vector3(4, 5, 6)),
       isBoundingBoxInModelCoordinates: true
     };
 
     const modelMetadata = await factory.loadModelMetadata(mockIdentifier);
-    factory.createModel(modelMetadata, geometryFilter);
+    const cadNode = factory.createModel(modelMetadata, geometryFilter);
 
-    expect(setModelClippingPlanesSpy).toHaveBeenCalledTimes(1);
-    expect(setModelClippingPlanesSpy).toHaveBeenCalledWith(expect.any(Symbol), expect.objectContaining({ length: 6 }));
+    expect(cadNode.clippingPlanes.length).equals(6);
   });
 });

--- a/viewer/packages/cad-model/src/CadModelFactory.ts
+++ b/viewer/packages/cad-model/src/CadModelFactory.ts
@@ -52,7 +52,7 @@ export class CadModelFactory {
     );
     const sectorRepository = this.getSectorRepository(format, formatVersion);
 
-    const cadModel = new CadNode(modelMetadata, this._materialManager, sectorRepository);
+    const cadModel = new CadNode(modelMetadata, sectorRepository);
     this._materialManager.addModelMaterials(modelIdentifier.revealInternalId, cadModel.cadMaterial);
 
     if (modelMetadata.geometryClipBox !== null) {

--- a/viewer/packages/cad-model/src/CadModelFactory.ts
+++ b/viewer/packages/cad-model/src/CadModelFactory.ts
@@ -58,7 +58,7 @@ export class CadModelFactory {
     if (modelMetadata.geometryClipBox !== null) {
       const clipBox = transformToThreeJsSpace(modelMetadata.geometryClipBox, modelMetadata);
       const clippingPlanes = new BoundingBoxClipper(clipBox).clippingPlanes;
-      this._materialManager.setModelClippingPlanes(modelMetadata.modelIdentifier.revealInternalId, clippingPlanes);
+      cadModel.clippingPlanes = clippingPlanes;
     }
 
     return cadModel;

--- a/viewer/packages/cad-model/src/wrappers/CadMeshManager.test.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadMeshManager.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { CadMeshManager } from './CadMeshManager';
-import type { CadMaterialManager } from '@reveal/rendering';
+import { createCadMaterial } from '@reveal/rendering';
 import { RevealGeometryCollectionType } from '@reveal/sector-parser';
 import type { ParsedMeshGeometry } from '@reveal/cad-parsers';
 import { TreeIndexToSectorsMap } from '../utilities/TreeIndexToSectorsMap';
@@ -11,16 +11,14 @@ import type { SectorRepository } from '@reveal/sector-loader';
 import type { ModelIdentifier } from '@reveal/data-providers';
 
 import type { Group } from 'three';
-import { BufferGeometry, BufferAttribute, Box3, Vector3, CanvasTexture, Mesh, RawShaderMaterial, Matrix4 } from 'three';
+import { BufferGeometry, BufferAttribute, Box3, Vector3, CanvasTexture, Mesh } from 'three';
 
 import { vi } from 'vitest';
 import { Mock } from 'moq.ts';
 
 describe(CadMeshManager.name, () => {
   let meshManager: CadMeshManager;
-  let materialManager: CadMaterialManager;
   let treeIndexToSectorsMap: TreeIndexToSectorsMap;
-  let modelId: symbol;
   const mockSectorRepository = new Mock<SectorRepository>()
     .setup(instance => instance.dereferenceSector)
     .returns(() => {})
@@ -39,11 +37,9 @@ describe(CadMeshManager.name, () => {
     .object();
 
   beforeEach(() => {
-    const mocks = createMockMaterialManager();
-    materialManager = mocks.materialManager;
-    modelId = Symbol('testModel');
     treeIndexToSectorsMap = new TreeIndexToSectorsMap(1000); // Max tree index
-    meshManager = new CadMeshManager(materialManager, modelId, treeIndexToSectorsMap);
+    const cadMaterial = createCadMaterial(100);
+    meshManager = new CadMeshManager(cadMaterial, treeIndexToSectorsMap);
   });
 
   test('should create empty mesh group when no geometries provided', () => {
@@ -328,43 +324,6 @@ const createTexture = (size: number = 64) => {
   canvas.width = size;
   canvas.height = size;
   return new CanvasTexture(canvas);
-};
-
-const createMockMaterial = (): RawShaderMaterial => {
-  const material = new RawShaderMaterial({
-    vertexShader: 'void main() {}',
-    fragmentShader: 'void main() {}'
-  });
-  material.uniforms = { inverseModelMatrix: { value: new Matrix4() } };
-  return material;
-};
-
-const createMockMaterialManager = () => {
-  const triangleMaterial = createMockMaterial();
-  const texturedMaterial = createMockMaterial();
-
-  const materials = {
-    box: createMockMaterial(),
-    circle: createMockMaterial(),
-    generalRing: createMockMaterial(),
-    nut: createMockMaterial(),
-    quad: createMockMaterial(),
-    cone: createMockMaterial(),
-    eccentricCone: createMockMaterial(),
-    torusSegment: createMockMaterial(),
-    generalCylinder: createMockMaterial(),
-    trapezium: createMockMaterial(),
-    ellipsoidSegment: createMockMaterial(),
-    instancedMesh: createMockMaterial(),
-    triangleMesh: triangleMaterial,
-    texturedMaterials: {}
-  };
-
-  const materialManagerMock = new Mock<CadMaterialManager>();
-  materialManagerMock.setup(m => m.getModelMaterials).returns(() => materials);
-  materialManagerMock.setup(m => m.addTexturedMeshMaterial).returns(() => texturedMaterial);
-
-  return { materialManager: materialManagerMock.object(), triangleMaterial, texturedMaterial };
 };
 
 const expectMeshGroup = (result: Group, expectedChildCount: number) => {

--- a/viewer/packages/cad-model/src/wrappers/CadMeshManager.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadMeshManager.ts
@@ -12,7 +12,7 @@ import type { ModelIdentifier } from '@reveal/data-providers';
 
 import type { BufferGeometry, RawShaderMaterial, BufferAttribute, Box3, Matrix4, Texture } from 'three';
 import { Sphere, Mesh, Group, SRGBColorSpace } from 'three';
-import { initializeDefinesAndUniforms } from '@reveal/rendering/src/rendering/materials';
+import { initializeDefinesAndUniforms } from '@reveal/rendering';
 
 /**
  * Manages mesh data for CAD sectors.

--- a/viewer/packages/cad-model/src/wrappers/CadMeshManager.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadMeshManager.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type { CadMaterialManager } from '@reveal/rendering';
+import { RenderMode, type CadMaterial } from '@reveal/rendering';
 import type { ParsedMeshGeometry } from '@reveal/cad-parsers';
 import { RevealGeometryCollectionType } from '@reveal/sector-parser';
 import { incrementOrInsertIndex } from '@reveal/utilities';
@@ -10,27 +10,22 @@ import type { TreeIndexToSectorsMap } from '../utilities/TreeIndexToSectorsMap';
 import type { SectorRepository } from '@reveal/sector-loader';
 import type { ModelIdentifier } from '@reveal/data-providers';
 
-import type { BufferGeometry, RawShaderMaterial, BufferAttribute, Box3, Matrix4 } from 'three';
-import { Sphere, Mesh, Group } from 'three';
+import type { BufferGeometry, RawShaderMaterial, BufferAttribute, Box3, Matrix4, Texture } from 'three';
+import { Sphere, Mesh, Group, SRGBColorSpace } from 'three';
+import { initializeDefinesAndUniforms } from '@reveal/rendering/src/rendering/materials';
 
 /**
  * Manages mesh data for CAD sectors.
  * This class prepares mesh data for object creation.
  */
 export class CadMeshManager {
-  private readonly _materialManager: CadMaterialManager;
-  private readonly _modelIdentifier: symbol;
+  private readonly _cadMaterial: CadMaterial;
   private readonly _treeIndexToSectorsMap: TreeIndexToSectorsMap;
 
   private readonly _sectorMeshGroups: Map<number, Group> = new Map();
 
-  constructor(
-    materialManager: CadMaterialManager,
-    modelIdentifier: symbol,
-    treeIndexToSectorsMap: TreeIndexToSectorsMap
-  ) {
-    this._materialManager = materialManager;
-    this._modelIdentifier = modelIdentifier;
+  constructor(cadMaterial: CadMaterial, treeIndexToSectorsMap: TreeIndexToSectorsMap) {
+    this._cadMaterial = cadMaterial;
     this._treeIndexToSectorsMap = treeIndexToSectorsMap;
   }
 
@@ -41,7 +36,7 @@ export class CadMeshManager {
    * @returns Group containing the created meshes
    */
   public createMeshesFromParsedGeometries(parsedMeshGeometries: ParsedMeshGeometry[], sectorId: number): Group {
-    const materials = this._materialManager.getModelMaterials(this._modelIdentifier);
+    const materials = this._cadMaterial.materials;
     const group = new Group();
     const allTreeIndices = new Set<number>();
 
@@ -53,11 +48,7 @@ export class CadMeshManager {
         let material: RawShaderMaterial;
 
         if (isTexturedTriangleMesh && geometryData.texture) {
-          material = this._materialManager.addTexturedMeshMaterial(
-            this._modelIdentifier,
-            sectorId,
-            geometryData.texture
-          );
+          material = this.addTexturedMeshMaterialForSector(this._cadMaterial, sectorId, geometryData.texture);
         } else if (isTexturedTriangleMesh && !geometryData.texture) {
           console.warn(
             `Missing texture for textured triangle mesh in sector ${sectorId} - mesh will be skipped. ` +
@@ -84,6 +75,40 @@ export class CadMeshManager {
     this.updateTreeIndexToSectorsMap(allTreeIndices, sectorId);
 
     return group;
+  }
+
+  private addTexturedMeshMaterialForSector(
+    cadMaterial: CadMaterial,
+    sectorId: number,
+    texture: Texture
+  ): RawShaderMaterial {
+    texture.colorSpace = SRGBColorSpace;
+    texture.flipY = false;
+
+    const newMaterial = cadMaterial.materials.triangleMesh.clone();
+    newMaterial.uniforms.tDiffuse = { value: texture };
+    newMaterial.defines.IS_TEXTURED = true;
+
+    initializeDefinesAndUniforms(
+      newMaterial,
+      cadMaterial.nodeAppearanceTextureBuilder.overrideColorPerTreeIndexTexture,
+      cadMaterial.nodeTransformTextureBuilder.overrideTransformIndexTexture,
+      cadMaterial.nodeTransformTextureBuilder.transformLookupTexture,
+      cadMaterial.matCapTexture,
+      RenderMode.Color
+    );
+
+    newMaterial.needsUpdate = true;
+
+    const materialName = `texturedMaterial_${sectorId}`;
+
+    if (cadMaterial.materials.texturedMaterials[materialName] !== undefined) {
+      cadMaterial.materials.texturedMaterials[materialName].dispose();
+    }
+
+    cadMaterial.materials.texturedMaterials[materialName] = newMaterial;
+
+    return newMaterial;
   }
 
   /**

--- a/viewer/packages/cad-model/src/wrappers/CadNode.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadNode.ts
@@ -24,7 +24,6 @@ import type { ModelIdentifier } from '@reveal/data-providers';
 
 export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> {
   private readonly _cadModelMetadata: CadModelMetadata;
-  private readonly _materialManager: CadMaterialManager;
   private readonly _sectorRepository: SectorRepository;
   private readonly _modelIdentifier: ModelIdentifier;
 
@@ -59,7 +58,6 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
   constructor(model: CadModelMetadata, materialManager: CadMaterialManager, sectorRepository: SectorRepository) {
     super();
     this.name = 'Sector model';
-    this._materialManager = materialManager;
     this._sectorRepository = sectorRepository;
     this._modelIdentifier = model.modelIdentifier;
     this.treeIndexToSectorsMap = new TreeIndexToSectorsMap(model.scene.maxTreeIndex);
@@ -161,11 +159,11 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
   }
 
   get clippingPlanes(): Plane[] {
-    return this._materialManager.getModelClippingPlanes(this._cadModelMetadata.modelIdentifier.revealInternalId);
+    return this._cadMaterial.clippingPlanesProvider.clippingPlanes;
   }
 
   set clippingPlanes(planes: Plane[]) {
-    this._materialManager.setModelClippingPlanes(this._cadModelMetadata.modelIdentifier.revealInternalId, planes);
+    this._cadMaterial.clippingPlanesProvider.clippingPlanes = planes;
   }
 
   get cadModelMetadata(): CadModelMetadata {
@@ -299,7 +297,7 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
 
   public dispose(): void {
     this.nodeAppearanceProvider.dispose();
-    this._materialManager.removeModelMaterials(this._cadModelMetadata.modelIdentifier.revealInternalId);
+    // this._materialManager.removeModelMaterials(this._cadModelMetadata.modelIdentifier.revealInternalId);
     this._geometryBatchingManager?.dispose();
 
     // Remove all mesh groups from the scene and dereference sectors in cache

--- a/viewer/packages/cad-model/src/wrappers/CadNode.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadNode.ts
@@ -24,7 +24,6 @@ import type { ModelIdentifier } from '@reveal/data-providers';
 
 export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> {
   private readonly _cadModelMetadata: CadModelMetadata;
-  private readonly _materialManager: CadMaterialManager;
   private readonly _sectorRepository: SectorRepository;
   private readonly _modelIdentifier: ModelIdentifier;
 
@@ -59,7 +58,6 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
   constructor(model: CadModelMetadata, materialManager: CadMaterialManager, sectorRepository: SectorRepository) {
     super();
     this.name = 'Sector model';
-    this._materialManager = materialManager;
     this._sectorRepository = sectorRepository;
     this._modelIdentifier = model.modelIdentifier;
     this.treeIndexToSectorsMap = new TreeIndexToSectorsMap(model.scene.maxTreeIndex);
@@ -109,14 +107,12 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
 
     this._sectorScene = scene;
 
-    // Initialize mesh manager
     this._meshManager = new CadMeshManager(
       materialManager,
       model.modelIdentifier.revealInternalId,
       this.treeIndexToSectorsMap
     );
 
-    // Prepare renderables
     this.add(this._rootSector);
 
     this.matrixAutoUpdate = false;
@@ -134,7 +130,6 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
     this._needsRedraw = false;
   }
 
-  // TODO: cleanup type
   get cadMaterial(): CadMaterial {
     return this._cadMaterial;
   }
@@ -161,11 +156,11 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
   }
 
   get clippingPlanes(): Plane[] {
-    return this._materialManager.getModelClippingPlanes(this._cadModelMetadata.modelIdentifier.revealInternalId);
+    return this._cadMaterial.clippingPlanesProvider.clippingPlanes;
   }
 
   set clippingPlanes(planes: Plane[]) {
-    this._materialManager.setModelClippingPlanes(this._cadModelMetadata.modelIdentifier.revealInternalId, planes);
+    this._cadMaterial.clippingPlanesProvider.clippingPlanes = planes;
   }
 
   get cadModelMetadata(): CadModelMetadata {
@@ -299,7 +294,7 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
 
   public dispose(): void {
     this.nodeAppearanceProvider.dispose();
-    this._materialManager.removeModelMaterials(this._cadModelMetadata.modelIdentifier.revealInternalId);
+    // this._materialManager.removeModelMaterials(this._cadModelMetadata.modelIdentifier.revealInternalId);
     this._geometryBatchingManager?.dispose();
 
     // Remove all mesh groups from the scene and dereference sectors in cache

--- a/viewer/packages/cad-model/src/wrappers/CadNode.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadNode.ts
@@ -9,8 +9,8 @@ import type { SectorScene, CadModelMetadata, WantedSector, ConsumedSector } from
 import { RootSectorNode } from '@reveal/cad-parsers';
 import type { SectorRepository } from '@reveal/sector-loader';
 import type { ParsedGeometry } from '@reveal/sector-parser';
-import type { StyledTreeIndexSets } from '@reveal/rendering';
-import { setModelRenderLayers, createCadMaterial, type CadMaterial } from '@reveal/rendering';
+import type { StyledTreeIndexSets, CadMaterial } from '@reveal/rendering';
+import { setModelRenderLayers, createCadMaterial, forEachMaterial } from '@reveal/rendering';
 
 import type { Plane, Object3DEventMap } from 'three';
 import { Group, Object3D, Matrix4 } from 'three';
@@ -290,7 +290,13 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
 
   public dispose(): void {
     this.nodeAppearanceProvider.dispose();
-    // this._materialManager.removeModelMaterials(this._cadModelMetadata.modelIdentifier.revealInternalId);
+
+    forEachMaterial(this.cadMaterial.materials, mat => mat.dispose());
+
+    this.cadMaterial.nodeTransformTextureBuilder.dispose();
+    this.cadMaterial.nodeAppearanceTextureBuilder.dispose();
+    this.cadMaterial.clippingPlanesProvider.dispose();
+
     this._geometryBatchingManager?.dispose();
 
     // Remove all mesh groups from the scene and dereference sectors in cache

--- a/viewer/packages/cad-model/src/wrappers/CadNode.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadNode.ts
@@ -152,11 +152,11 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
   }
 
   get clippingPlanes(): Plane[] {
-    return this._cadMaterial.clippingPlanesProvider.clippingPlanes;
+    return this._cadMaterial.clippingPlanesProvider.getClippingPlanes();
   }
 
   set clippingPlanes(planes: Plane[]) {
-    this._cadMaterial.clippingPlanesProvider.clippingPlanes = planes;
+    this._cadMaterial.clippingPlanesProvider.setClippingPlanes(planes);
   }
 
   get cadModelMetadata(): CadModelMetadata {

--- a/viewer/packages/cad-model/src/wrappers/CadNode.ts
+++ b/viewer/packages/cad-model/src/wrappers/CadNode.ts
@@ -9,7 +9,7 @@ import type { SectorScene, CadModelMetadata, WantedSector, ConsumedSector } from
 import { RootSectorNode } from '@reveal/cad-parsers';
 import type { SectorRepository } from '@reveal/sector-loader';
 import type { ParsedGeometry } from '@reveal/sector-parser';
-import type { CadMaterialManager, StyledTreeIndexSets } from '@reveal/rendering';
+import type { StyledTreeIndexSets } from '@reveal/rendering';
 import { setModelRenderLayers, createCadMaterial, type CadMaterial } from '@reveal/rendering';
 
 import type { Plane, Object3DEventMap } from 'three';
@@ -55,7 +55,7 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
 
   public readonly type = 'CadNode';
 
-  constructor(model: CadModelMetadata, materialManager: CadMaterialManager, sectorRepository: SectorRepository) {
+  constructor(model: CadModelMetadata, sectorRepository: SectorRepository) {
     super();
     this.name = 'Sector model';
     this._sectorRepository = sectorRepository;
@@ -107,11 +107,7 @@ export class CadNode extends Object3D<Object3DEventMap & { update: undefined }> 
 
     this._sectorScene = scene;
 
-    this._meshManager = new CadMeshManager(
-      materialManager,
-      model.modelIdentifier.revealInternalId,
-      this.treeIndexToSectorsMap
-    );
+    this._meshManager = new CadMeshManager(this._cadMaterial, this.treeIndexToSectorsMap);
 
     this.add(this._rootSector);
 

--- a/viewer/packages/cad-styling/index.ts
+++ b/viewer/packages/cad-styling/index.ts
@@ -32,3 +32,4 @@ export type { PrioritizedArea } from './src/prioritized/types';
 export { NodeTransformProvider } from './src/transform/NodeTransformProvider';
 export { NodeTransformTextureBuilder } from './src/transform/NodeTransformTextureBuilder';
 export { NodeAppearanceTextureBuilder } from './src/NodeAppearanceTextureBuilder';
+export { ClippingPlanesProvider } from './src/ClippingPlanesProvider';

--- a/viewer/packages/cad-styling/src/ClippingPlanesProvider.test.ts
+++ b/viewer/packages/cad-styling/src/ClippingPlanesProvider.test.ts
@@ -14,20 +14,20 @@ describe(ClippingPlanesProvider, () => {
   });
 
   test('initializes with empty clipping planes', () => {
-    expect(provider.clippingPlanes).toEqual([]);
+    expect(provider.getClippingPlanes()).toEqual([]);
   });
 
   test('setter updates clipping planes', () => {
     const planes = [new Plane(), new Plane()];
-    provider.clippingPlanes = planes;
-    expect(provider.clippingPlanes).toBe(planes);
+    provider.setClippingPlanes(planes);
+    expect(provider.getClippingPlanes()).toBe(planes);
   });
 
   test('setter fires changed event with new planes', () => {
     const listener = vi.fn();
     const planes = [new Plane()];
     provider.on('changed', listener);
-    provider.clippingPlanes = planes;
+    provider.setClippingPlanes(planes);
     expect(listener).toHaveBeenCalledWith(planes);
   });
 
@@ -35,7 +35,7 @@ describe(ClippingPlanesProvider, () => {
     const listener = vi.fn();
     provider.on('changed', listener);
     provider.off('changed', listener);
-    provider.clippingPlanes = [new Plane()];
+    provider.setClippingPlanes([new Plane()]);
     expect(listener).not.toHaveBeenCalled();
   });
 
@@ -43,7 +43,7 @@ describe(ClippingPlanesProvider, () => {
     const listener = vi.fn();
     provider.on('changed', listener);
     provider.dispose();
-    provider.clippingPlanes = [new Plane()];
+    provider.setClippingPlanes([new Plane()]);
     expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/viewer/packages/cad-styling/src/ClippingPlanesProvider.test.ts
+++ b/viewer/packages/cad-styling/src/ClippingPlanesProvider.test.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+
+import { Plane } from 'three';
+import { ClippingPlanesProvider } from './ClippingPlanesProvider';
+import { vi } from 'vitest';
+
+describe(ClippingPlanesProvider, () => {
+  let provider: ClippingPlanesProvider;
+
+  beforeEach(() => {
+    provider = new ClippingPlanesProvider();
+  });
+
+  test('initializes with empty clipping planes', () => {
+    expect(provider.clippingPlanes).toEqual([]);
+  });
+
+  test('setter updates clipping planes', () => {
+    const planes = [new Plane(), new Plane()];
+    provider.clippingPlanes = planes;
+    expect(provider.clippingPlanes).toBe(planes);
+  });
+
+  test('setter fires changed event with new planes', () => {
+    const listener = vi.fn();
+    const planes = [new Plane()];
+    provider.on('changed', listener);
+    provider.clippingPlanes = planes;
+    expect(listener).toHaveBeenCalledWith(planes);
+  });
+
+  test('off unsubscribes listener', () => {
+    const listener = vi.fn();
+    provider.on('changed', listener);
+    provider.off('changed', listener);
+    provider.clippingPlanes = [new Plane()];
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('dispose unsubscribes all listeners', () => {
+    const listener = vi.fn();
+    provider.on('changed', listener);
+    provider.dispose();
+    provider.clippingPlanes = [new Plane()];
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/viewer/packages/cad-styling/src/ClippingPlanesProvider.ts
+++ b/viewer/packages/cad-styling/src/ClippingPlanesProvider.ts
@@ -14,11 +14,11 @@ export class ClippingPlanesProvider {
     this._changed = new EventTrigger<(clippingPlanes: Plane[]) => void>();
   }
 
-  get clippingPlanes(): Plane[] {
+  getClippingPlanes(): Plane[] {
     return this._clippingPlanes;
   }
 
-  set clippingPlanes(clippingPlanes: Plane[]) {
+  setClippingPlanes(clippingPlanes: Plane[]): void {
     this._clippingPlanes = clippingPlanes;
     this._changed.fire(this._clippingPlanes);
   }

--- a/viewer/packages/cad-styling/src/ClippingPlanesProvider.ts
+++ b/viewer/packages/cad-styling/src/ClippingPlanesProvider.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+
+import { EventTrigger } from '@reveal/utilities';
+import type { Plane } from 'three';
+
+export class ClippingPlanesProvider {
+  private _clippingPlanes: Plane[];
+  private readonly _changed: EventTrigger<(clippingPlanes: Plane[]) => void>;
+
+  constructor() {
+    this._clippingPlanes = [];
+    this._changed = new EventTrigger<(clippingPlanes: Plane[]) => void>();
+  }
+
+  get clippingPlanes(): Plane[] {
+    return this._clippingPlanes;
+  }
+
+  set clippingPlanes(clippingPlanes: Plane[]) {
+    this._clippingPlanes = clippingPlanes;
+    this._changed.fire(this._clippingPlanes);
+  }
+
+  on(_: 'changed', listener: (clippingPlanes: Plane[]) => void): void {
+    this._changed.subscribe(listener);
+  }
+
+  off(_: 'changed', listener: (clippingPlanes: Plane[]) => void): void {
+    this._changed.unsubscribe(listener);
+  }
+
+  dispose(): void {
+    this._changed.unsubscribeAll();
+  }
+}

--- a/viewer/packages/rendering/index.ts
+++ b/viewer/packages/rendering/index.ts
@@ -19,7 +19,7 @@ export { RenderMode } from './src/rendering/RenderMode';
 export { RenderLayer, setModelRenderLayers } from './src/utilities/renderUtilities';
 export type { StyledTreeIndexSets } from './src/utilities/types';
 
-export type { Materials } from './src/rendering/materials';
+export { type Materials, initializeDefinesAndUniforms } from './src/rendering/materials';
 export type { OctreeMaterialParams } from './src/pointcloud-rendering';
 export { PointCloudMaterial } from './src/pointcloud-rendering';
 

--- a/viewer/packages/rendering/index.ts
+++ b/viewer/packages/rendering/index.ts
@@ -19,7 +19,7 @@ export { RenderMode } from './src/rendering/RenderMode';
 export { RenderLayer, setModelRenderLayers } from './src/utilities/renderUtilities';
 export type { StyledTreeIndexSets } from './src/utilities/types';
 
-export { type Materials, initializeDefinesAndUniforms } from './src/rendering/materials';
+export { type Materials, initializeDefinesAndUniforms, forEachMaterial } from './src/rendering/materials';
 export type { OctreeMaterialParams } from './src/pointcloud-rendering';
 export { PointCloudMaterial } from './src/pointcloud-rendering';
 

--- a/viewer/packages/rendering/src/CadMaterialManager.test.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.test.ts
@@ -104,8 +104,8 @@ describe('CadMaterialManager', () => {
     manager.addModelMaterials(modelIdentifier2, cadMaterial2);
 
     // Act
-    cadMaterial1.clippingPlanesProvider.clippingPlanes = [new THREE.Plane(), new THREE.Plane()];
-    cadMaterial2.clippingPlanesProvider.clippingPlanes = [new THREE.Plane()];
+    cadMaterial1.clippingPlanesProvider.setClippingPlanes([new THREE.Plane(), new THREE.Plane()]);
+    cadMaterial2.clippingPlanesProvider.setClippingPlanes([new THREE.Plane()]);
 
     // Assert
     for (const material of iterateMaterials(manager.getModelMaterials(modelIdentifier1))) {

--- a/viewer/packages/rendering/src/CadMaterialManager.test.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.test.ts
@@ -97,12 +97,15 @@ describe('CadMaterialManager', () => {
 
     const globalClipPlanes = [new THREE.Plane(), new THREE.Plane()];
     manager.clippingPlanes = globalClipPlanes;
-    manager.addModelMaterials(modelIdentifier1, createCadMaterial(16));
-    manager.addModelMaterials(modelIdentifier2, createCadMaterial(16));
+
+    const cadMaterial1 = createCadMaterial(16);
+    const cadMaterial2 = createCadMaterial(16);
+    manager.addModelMaterials(modelIdentifier1, cadMaterial1);
+    manager.addModelMaterials(modelIdentifier2, cadMaterial2);
 
     // Act
-    manager.setModelClippingPlanes(modelIdentifier1, [new THREE.Plane(), new THREE.Plane()]);
-    manager.setModelClippingPlanes(modelIdentifier2, [new THREE.Plane()]);
+    cadMaterial1.clippingPlanesProvider.clippingPlanes = [new THREE.Plane(), new THREE.Plane()];
+    cadMaterial2.clippingPlanesProvider.clippingPlanes = [new THREE.Plane()];
 
     // Assert
     for (const material of iterateMaterials(manager.getModelMaterials(modelIdentifier1))) {

--- a/viewer/packages/rendering/src/CadMaterialManager.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.ts
@@ -171,7 +171,7 @@ export class CadMaterialManager {
       );
     }
 
-    return materialWrapper.clippingPlanesProvider.clippingPlanes;
+    return materialWrapper.clippingPlanesProvider.getClippingPlanes();
   }
 
   setModelDefaultNodeAppearance(modelIdentifier: symbol, defaultAppearance: NodeAppearance): void {
@@ -233,7 +233,7 @@ export class CadMaterialManager {
       );
     }
 
-    const clippingPlanes = [...materialWrapper.clippingPlanesProvider.clippingPlanes, ...this.clippingPlanes];
+    const clippingPlanes = [...materialWrapper.clippingPlanesProvider.getClippingPlanes(), ...this.clippingPlanes];
     const clippingPlanesAsUniform = clippingPlanes.map(
       p => new THREE.Vector4(p.normal.x, p.normal.y, p.normal.z, -p.constant)
     );

--- a/viewer/packages/rendering/src/CadMaterialManager.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.ts
@@ -10,6 +10,7 @@ import { RenderMode } from './rendering/RenderMode';
 
 import type { NodeAppearance } from '@reveal/cad-styling';
 import {
+  ClippingPlanesProvider,
   NodeAppearanceProvider,
   NodeAppearanceTextureBuilder,
   NodeTransformProvider,
@@ -28,10 +29,10 @@ export type CadMaterial = {
   nodeAppearanceTextureBuilder: NodeAppearanceTextureBuilder;
   nodeTransformTextureBuilder: NodeTransformTextureBuilder;
   matCapTexture: THREE.Texture;
+  clippingPlanesProvider: ClippingPlanesProvider;
 };
 
 type MaterialsWrapper = CadMaterial & {
-  perModelClippingPlanes: THREE.Plane[];
   updateTransformsCallback: () => void;
 };
 
@@ -65,7 +66,8 @@ export class CadMaterialManager {
       nodeAppearanceProvider,
       nodeAppearanceTextureBuilder,
       nodeTransformProvider,
-      nodeTransformTextureBuilder
+      nodeTransformTextureBuilder,
+      clippingPlanesProvider
     } = cadMaterial;
 
     const updateTransformsCallback = () => this.updateTransforms(modelIdentifier);
@@ -74,13 +76,18 @@ export class CadMaterialManager {
 
     this.materialsMap.set(modelIdentifier, {
       materials,
-      perModelClippingPlanes: [],
       nodeAppearanceProvider,
       nodeTransformProvider,
       nodeAppearanceTextureBuilder,
       nodeTransformTextureBuilder,
       updateTransformsCallback,
-      matCapTexture
+      matCapTexture,
+      clippingPlanesProvider
+    });
+
+    clippingPlanesProvider.on('changed', () => {
+      this.updateClippingPlanesForModel(modelIdentifier);
+      this._needsRedraw = true;
     });
 
     const colorWrite = this._renderMode !== RenderMode.DepthBufferOnly;
@@ -164,20 +171,7 @@ export class CadMaterialManager {
       );
     }
 
-    return materialWrapper.perModelClippingPlanes;
-  }
-
-  setModelClippingPlanes(modelIdentifier: symbol, clippingPlanes: THREE.Plane[]): void {
-    const materialWrapper = this.materialsMap.get(modelIdentifier);
-    if (materialWrapper === undefined) {
-      throw new Error(
-        `Materials for model ${String(modelIdentifier)} has not been added, call ${this.addModelMaterials.name} first`
-      );
-    }
-
-    materialWrapper.perModelClippingPlanes = clippingPlanes;
-    this.updateClippingPlanesForModel(modelIdentifier);
-    this._needsRedraw = true;
+    return materialWrapper.clippingPlanesProvider.clippingPlanes;
   }
 
   setModelDefaultNodeAppearance(modelIdentifier: symbol, defaultAppearance: NodeAppearance): void {
@@ -239,7 +233,7 @@ export class CadMaterialManager {
       );
     }
 
-    const clippingPlanes = [...materialWrapper.perModelClippingPlanes, ...this.clippingPlanes];
+    const clippingPlanes = [...materialWrapper.clippingPlanesProvider.clippingPlanes, ...this.clippingPlanes];
     const clippingPlanesAsUniform = clippingPlanes.map(
       p => new THREE.Vector4(p.normal.x, p.normal.y, p.normal.z, -p.constant)
     );
@@ -336,6 +330,8 @@ export function createCadMaterial(maxTreeIndex: number): CadMaterial {
   const matCapTexture = new THREE.Texture(getMatCapTextureData());
   matCapTexture.needsUpdate = true;
 
+  const clippingPlanesProvider = new ClippingPlanesProvider();
+
   const materials = createMaterials(
     nodeAppearanceTextureBuilder.overrideColorPerTreeIndexTexture,
     nodeTransformTextureBuilder.overrideTransformIndexTexture,
@@ -349,6 +345,7 @@ export function createCadMaterial(maxTreeIndex: number): CadMaterial {
     nodeTransformProvider,
     nodeAppearanceTextureBuilder,
     nodeTransformTextureBuilder,
-    matCapTexture
+    matCapTexture,
+    clippingPlanesProvider
   };
 }

--- a/viewer/test-utilities/src/createCadNode.ts
+++ b/viewer/test-utilities/src/createCadNode.ts
@@ -31,7 +31,7 @@ export function createCadNode(
       .returns(() => {})
       .object();
 
-  const cadNode = new CadNode(cadMetadata, materialManager, mockSectorRepository);
+  const cadNode = new CadNode(cadMetadata, mockSectorRepository);
   materialManager.addModelMaterials(cadMetadata.modelIdentifier.revealInternalId, cadNode.cadMaterial);
 
   return cadNode;


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-6524

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

This PR decouples CadNode and CadMeshManager from CadMaterialManager by moving per-model state directly into CadMaterial.

Changes

ClippingPlanesProvider (new)
- New class in cad-styling that holds a model's clipping planes and fires a changed event when they are updated.
- Replaces the perModelClippingPlanes field and setModelClippingPlanes method on CadMaterialManager.

CadMaterialManager
- CadMaterial now carries a clippingPlanesProvider instead of per-model plane arrays stored in the manager.
- Subscribes to clippingPlanesProvider.changed reactively to update shader uniforms and flag a redraw, instead of requiring callers to go through the manager.
- setModelClippingPlanes removed — callers set cadMaterial.clippingPlanesProvider.clippingPlanes directly.

CadNode
- No longer takes CadMaterialManager as a constructor argument.
- clippingPlanes getter/setter now delegate to cadMaterial.clippingPlanesProvider.
- dispose() now disposes materials, texture builders, and the clipping planes provider directly rather than delegating to the manager.

CadMeshManager
- Takes CadMaterial directly instead of CadMaterialManager + model symbol.
- Textured mesh material creation (addTexturedMeshMaterial) moved inline.

CadManager
- Calls removeModelMaterials on the material manager when a model is removed (fixes a disposal leak).


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
