### PR TITLE
chore(viewer): use named imports from three

### DIFF
--- a/viewer/packages/360-images/src/entity/Image360RevisionEntity.test.ts
+++ b/viewer/packages/360-images/src/entity/Image360RevisionEntity.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { vi } from 'vitest';
-import * as THREE from 'three';
+import { Matrix4, Texture, TextureLoader } from 'three';
 import type { IMock } from 'moq.ts';
 import { Mock, It, Times } from 'moq.ts';
 import type { SceneHandler } from '@reveal/utilities';
@@ -25,7 +25,7 @@ function makeFaces(count: number): Image360Face[] {
 
 function makeTextures(count: number): Image360Texture[] {
   const faceNames: Image360Face['face'][] = ['front', 'back', 'left', 'right', 'top', 'bottom'];
-  return faceNames.slice(0, count).map(face => ({ face, texture: new THREE.Texture() }));
+  return faceNames.slice(0, count).map(face => ({ face, texture: new Texture() }));
 }
 
 describe(Image360RevisionEntity.name, () => {
@@ -48,7 +48,7 @@ describe(Image360RevisionEntity.name, () => {
       .setup(s => s.removeObject3D(It.IsAny()))
       .callback(() => {});
 
-    vizBox = new Image360VisualizationBox(new THREE.Matrix4(), sceneHandlerMock.object(), device);
+    vizBox = new Image360VisualizationBox(new Matrix4(), sceneHandlerMock.object(), device);
 
     Object.defineProperty(URL, 'createObjectURL', {
       value: vi.fn(() => 'blob:mock-url'),
@@ -56,7 +56,7 @@ describe(Image360RevisionEntity.name, () => {
       configurable: true
     });
     Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), writable: true, configurable: true });
-    vi.spyOn(THREE.TextureLoader.prototype, 'loadAsync').mockResolvedValue(new THREE.Texture());
+    vi.spyOn(TextureLoader.prototype, 'loadAsync').mockResolvedValue(new Texture());
 
     annotationFilterer = new Image360AnnotationFilter({});
 

--- a/viewer/packages/360-images/src/entity/Image360VisualizationBox.test.ts
+++ b/viewer/packages/360-images/src/entity/Image360VisualizationBox.test.ts
@@ -4,7 +4,7 @@
 
 import type { Mock as ViMock } from 'vitest';
 import { vi } from 'vitest';
-import * as THREE from 'three';
+import { Matrix4, Texture } from 'three';
 import type { IMock } from 'moq.ts';
 import { Mock, It, Times } from 'moq.ts';
 import type { SceneHandler } from '@reveal/utilities';
@@ -15,7 +15,7 @@ import type { JpegType } from '../utils/JpegDataStreamParser';
 
 function makeSixTextures(): Image360Texture[] {
   const faceNames: Image360Face['face'][] = ['left', 'right', 'top', 'bottom', 'front', 'back'];
-  return faceNames.map(face => ({ face, texture: new THREE.Texture() }));
+  return faceNames.map(face => ({ face, texture: new Texture() }));
 }
 
 function makeStreamingFace(face: Image360Face['face'] = 'front'): Image360Face {
@@ -45,16 +45,10 @@ describe(Image360VisualizationBox.name, () => {
     loaderMock = {
       load: vi.fn<FaceTextureLoader['load']>().mockImplementation(async (face, onFirstFaceReady) => {
         onFirstFaceReady?.();
-        return { face: face.face, texture: new THREE.Texture() };
+        return { face: face.face, texture: new Texture() };
       })
     };
-    box = new Image360VisualizationBox(
-      new THREE.Matrix4(),
-      sceneHandlerMock.object(),
-      device,
-      requestRedraw,
-      loaderMock
-    );
+    box = new Image360VisualizationBox(new Matrix4(), sceneHandlerMock.object(), device, requestRedraw, loaderMock);
   });
 
   afterEach(() => {
@@ -107,7 +101,7 @@ describe(Image360VisualizationBox.name, () => {
 
   describe('getTransform', () => {
     test('returns a Matrix4', () => {
-      expect(box.getTransform()).toBeInstanceOf(THREE.Matrix4);
+      expect(box.getTransform()).toBeInstanceOf(Matrix4);
     });
   });
 
@@ -153,7 +147,7 @@ describe(Image360VisualizationBox.name, () => {
 
   describe('updateFaceTexture', () => {
     test('does not throw when mesh does not exist', () => {
-      expect(() => box.updateFaceTexture('front', new THREE.Texture())).not.toThrow();
+      expect(() => box.updateFaceTexture('front', new Texture())).not.toThrow();
     });
   });
 
@@ -189,7 +183,7 @@ describe(Image360VisualizationBox.name, () => {
       loaderMock.load.mockImplementation(
         async (face: Image360Face, _onFirstFaceReady?: () => void, onJpegTypeDetected?: (type: JpegType) => void) => {
           onJpegTypeDetected?.('progressive');
-          return { face: face.face, texture: new THREE.Texture() };
+          return { face: face.face, texture: new Texture() };
         }
       );
 

--- a/viewer/packages/360-images/src/entity/Image360VisualizationBox.ts
+++ b/viewer/packages/360-images/src/entity/Image360VisualizationBox.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Matrix4, Texture } from 'three';
+import { BackSide, BoxGeometry, Group, Material, Mesh, MeshBasicMaterial, TextureLoader, Vector3 } from 'three';
 import type { DeviceDescriptor, SceneHandler } from '@reveal/utilities';
 import { assert } from '@reveal/utilities/assert';
 import type { DataSourceType, Image360Face, Image360Texture } from '@reveal/data-providers';
@@ -14,22 +15,22 @@ import { Image360FaceTextureLoader, hasDownloadUrl, type FaceTextureLoader } fro
 type VisualizationState = {
   opacity: number;
   visible: boolean;
-  scale: THREE.Vector3;
+  scale: Vector3;
   renderOrder: number;
 };
 
 export const DEFAULT_IMAGE_360_OPACITY = 1;
 
 export class Image360VisualizationBox implements Image360Visualization {
-  private readonly _worldTransform: THREE.Matrix4;
-  private _visualizationMesh: THREE.Mesh | undefined;
-  private _faceMaterials: THREE.MeshBasicMaterial[] = [];
+  private readonly _worldTransform: Matrix4;
+  private _visualizationMesh: Mesh | undefined;
+  private _faceMaterials: MeshBasicMaterial[] = [];
   private readonly _sceneHandler: SceneHandler;
   private readonly _visualizationState: VisualizationState;
-  private readonly _textureLoader: THREE.TextureLoader;
+  private readonly _textureLoader: TextureLoader;
   private readonly _faceMaterialOrder: Image360Face['face'][] = ['left', 'right', 'top', 'bottom', 'front', 'back'];
-  private readonly _annotationsGroup: THREE.Group = new THREE.Group();
-  private readonly _localTransform: THREE.Matrix4;
+  private readonly _annotationsGroup: Group = new Group();
+  private readonly _localTransform: Matrix4;
   private readonly _loader: FaceTextureLoader;
 
   get visible(): boolean {
@@ -57,7 +58,7 @@ export class Image360VisualizationBox implements Image360Visualization {
     });
   }
 
-  set scale(value: THREE.Vector3) {
+  set scale(value: Vector3) {
     this._visualizationState.scale = value;
 
     if (this._visualizationMesh === undefined) {
@@ -88,7 +89,7 @@ export class Image360VisualizationBox implements Image360Visualization {
   }
 
   constructor(
-    worldTransform: THREE.Matrix4,
+    worldTransform: Matrix4,
     sceneHandler: SceneHandler,
     device: DeviceDescriptor,
     private readonly _requestRedraw: () => void = () => {},
@@ -97,11 +98,11 @@ export class Image360VisualizationBox implements Image360Visualization {
     this._localTransform = worldTransform.clone();
     this._worldTransform = worldTransform.clone();
     this._sceneHandler = sceneHandler;
-    this._textureLoader = new THREE.TextureLoader();
+    this._textureLoader = new TextureLoader();
     this._visualizationState = {
       opacity: DEFAULT_IMAGE_360_OPACITY,
       renderOrder: 3,
-      scale: new THREE.Vector3(1, 1, 1),
+      scale: new Vector3(1, 1, 1),
       visible: true
     };
     this._loader =
@@ -115,7 +116,7 @@ export class Image360VisualizationBox implements Image360Visualization {
       );
   }
 
-  public setWorldTransform(matrix: THREE.Matrix4): void {
+  public setWorldTransform(matrix: Matrix4): void {
     this._worldTransform.copy(matrix).multiply(this._localTransform);
 
     if (this._visualizationMesh) {
@@ -138,8 +139,8 @@ export class Image360VisualizationBox implements Image360Visualization {
     this.buildVisualizationMesh(
       this._faceMaterialOrder.map(
         face =>
-          new THREE.MeshBasicMaterial({
-            side: THREE.BackSide,
+          new MeshBasicMaterial({
+            side: BackSide,
             map: getFaceTexture(face),
             depthTest: false,
             depthWrite: false,
@@ -156,11 +157,11 @@ export class Image360VisualizationBox implements Image360Visualization {
     }
   }
 
-  private buildVisualizationMesh(faceMaterials: THREE.MeshBasicMaterial[]): void {
+  private buildVisualizationMesh(faceMaterials: MeshBasicMaterial[]): void {
     this._faceMaterials = faceMaterials;
 
-    const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
-    const visualizationMesh = new THREE.Mesh(boxGeometry, this._faceMaterials);
+    const boxGeometry = new BoxGeometry(1, 1, 1);
+    const visualizationMesh = new Mesh(boxGeometry, this._faceMaterials);
     visualizationMesh.renderOrder = this._visualizationState.renderOrder;
     visualizationMesh.position.setFromMatrixPosition(this._worldTransform);
     visualizationMesh.rotation.setFromRotationMatrix(this._worldTransform);
@@ -173,7 +174,7 @@ export class Image360VisualizationBox implements Image360Visualization {
     this._sceneHandler.addObject3D(this._visualizationMesh);
   }
 
-  public getTransform(): THREE.Matrix4 {
+  public getTransform(): Matrix4 {
     return this._worldTransform;
   }
 
@@ -210,8 +211,8 @@ export class Image360VisualizationBox implements Image360Visualization {
     this.buildVisualizationMesh(
       this._faceMaterialOrder.map(
         () =>
-          new THREE.MeshBasicMaterial({
-            side: THREE.BackSide,
+          new MeshBasicMaterial({
+            side: BackSide,
             color: 0x000000,
             depthTest: false,
             depthWrite: false,
@@ -222,7 +223,7 @@ export class Image360VisualizationBox implements Image360Visualization {
     );
   }
 
-  public updateFaceTexture(face: Image360Face['face'], texture: THREE.Texture): void {
+  public updateFaceTexture(face: Image360Face['face'], texture: Texture): void {
     if (this._visualizationMesh === undefined) return;
     const index = this._faceMaterialOrder.indexOf(face);
     if (index === -1) return;
@@ -238,11 +239,10 @@ export class Image360VisualizationBox implements Image360Visualization {
     }
     this._sceneHandler.removeObject3D(this._visualizationMesh);
     const imageContainerMaterial = this._visualizationMesh.material;
-    const materials =
-      imageContainerMaterial instanceof THREE.Material ? [imageContainerMaterial] : imageContainerMaterial;
+    const materials = imageContainerMaterial instanceof Material ? [imageContainerMaterial] : imageContainerMaterial;
 
     materials
-      .map(material => material as THREE.MeshBasicMaterial)
+      .map(material => material as MeshBasicMaterial)
       .forEach(material => {
         material.map?.dispose();
         material.dispose();

--- a/viewer/packages/360-images/unit-tests/Image360CollectionFactory.test.ts
+++ b/viewer/packages/360-images/unit-tests/Image360CollectionFactory.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 
 import type { ClassicDataSourceType, Image360Provider } from '@reveal/data-providers';
 import { It, Mock } from 'moq.ts';
@@ -20,7 +20,7 @@ describe(Image360CollectionFactory.name, () => {
           label: 'test_0',
           collectionId: '0',
           collectionLabel: 'testCollection',
-          transform: new THREE.Matrix4(),
+          transform: new Matrix4(),
           imageRevisions: [
             {
               id: 'revision_0',
@@ -33,7 +33,7 @@ describe(Image360CollectionFactory.name, () => {
           label: 'test_1',
           collectionId: '0',
           collectionLabel: 'testCollection',
-          transform: new THREE.Matrix4(),
+          transform: new Matrix4(),
           imageRevisions: [
             {
               id: 'revision_1',
@@ -46,7 +46,7 @@ describe(Image360CollectionFactory.name, () => {
           label: 'test_2',
           collectionId: '0',
           collectionLabel: 'testCollection',
-          transform: new THREE.Matrix4(),
+          transform: new Matrix4(),
           imageRevisions: [
             {
               id: 'revision_2',
@@ -66,7 +66,7 @@ describe(Image360CollectionFactory.name, () => {
       desktopDevice,
       { platformMaxPointsSize: 256 }
     );
-    const collection = await image360EntityFactory.create({ site_id: 'someString' }, new THREE.Matrix4(), true, {});
+    const collection = await image360EntityFactory.create({ site_id: 'someString' }, new Matrix4(), true, {});
 
     expect(collection.image360Entities.length).toBe(3);
   });

--- a/viewer/packages/360-images/unit-tests/Image360Entity.test.ts
+++ b/viewer/packages/360-images/unit-tests/Image360Entity.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Color, Matrix4, Vector3 } from 'three';
 
 import type { ClassicDataSourceType, Image360Provider } from '@reveal/data-providers';
 import { Image360Entity } from '../src/entity/Image360Entity';
@@ -12,13 +12,13 @@ import type { DeviceDescriptor, SceneHandler } from '@reveal/utilities';
 import type { Historical360ImageSet } from '@reveal/data-providers/src/types';
 import { Image360AnnotationFilter } from '../src/annotation/Image360AnnotationFilter';
 
-function createMockImage360(options?: { customTranslation?: THREE.Matrix4 }) {
+function createMockImage360(options?: { customTranslation?: Matrix4 }) {
   const image360Descriptor: Historical360ImageSet<ClassicDataSourceType> = {
     id: '0',
     label: 'testEntity',
     collectionId: '0',
     collectionLabel: 'test_collection',
-    transform: new THREE.Matrix4(),
+    transform: new Matrix4(),
     imageRevisions: [
       {
         id: '1',
@@ -31,11 +31,11 @@ function createMockImage360(options?: { customTranslation?: THREE.Matrix4 }) {
   const mockSceneHandler = new Mock<SceneHandler>().setup(p => p.addObject3D(It.IsAny())).returns();
   const mock360ImageProvider = new Mock<Image360Provider<any>>();
   const mock360ImageIcon = new Overlay3DIcon(
-    { position: new THREE.Vector3(), minPixelSize: 10, maxPixelSize: 10, iconRadius: 10 },
+    { position: new Vector3(), minPixelSize: 10, maxPixelSize: 10, iconRadius: 10 },
     {}
   );
 
-  const testTranslation = options?.customTranslation ?? new THREE.Matrix4();
+  const testTranslation = options?.customTranslation ?? new Matrix4();
   const desktopDevice: DeviceDescriptor = { deviceType: 'desktop' };
 
   return new Image360Entity(
@@ -51,7 +51,7 @@ function createMockImage360(options?: { customTranslation?: THREE.Matrix4 }) {
 
 describe(Image360Entity.name, () => {
   test('transformation should be respected', () => {
-    const testTranslation = new THREE.Matrix4().makeTranslation(4, 5, 6);
+    const testTranslation = new Matrix4().makeTranslation(4, 5, 6);
     const entity = createMockImage360({ customTranslation: testTranslation });
 
     expect(entity.transform.equals(testTranslation)).toBeTruthy();
@@ -64,19 +64,19 @@ describe(Image360Entity.name, () => {
 
     expect(originalColor).toBe('default');
 
-    const testColor = new THREE.Color(0.2, 0.3, 0.4);
+    const testColor = new Color(0.2, 0.3, 0.4);
     entity.setIconColor(testColor);
 
     const gottenColor = entity.getIconColor();
 
     expect(gottenColor).not.toBe('default');
-    expect((gottenColor as THREE.Color).toArray()).toEqual(testColor.toArray());
+    expect((gottenColor as Color).toArray()).toEqual(testColor.toArray());
   });
 
   test('setting undefined icon color resets image360 icon color', () => {
     const entity = createMockImage360();
 
-    const testColor = new THREE.Color(0.2, 0.3, 0.4);
+    const testColor = new Color(0.2, 0.3, 0.4);
     entity.setIconColor(testColor);
 
     const firstColor = entity.getIconColor();

--- a/viewer/packages/360-images/visual-tests/Image360.VisualTest.ts
+++ b/viewer/packages/360-images/visual-tests/Image360.VisualTest.ts
@@ -26,7 +26,7 @@ import { getNormalizedPixelCoordinates } from '@reveal/utilities';
 import type { CogniteClient } from '@cognite/sdk';
 import type { Image360Entity } from '../src/entity/Image360Entity';
 import TWEEN from '@tweenjs/tween.js';
-import type { OrbitControls } from 'three/addons';
+import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { Image360CollectionFactory } from '../src/collection/Image360CollectionFactory';
 import { IconOctree } from '@reveal/3d-overlays';
 import { OctreeHelper } from 'sparse-octree';

--- a/viewer/packages/360-images/visual-tests/Image360.VisualTest.ts
+++ b/viewer/packages/360-images/visual-tests/Image360.VisualTest.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import type { LineBasicMaterial, PerspectiveCamera, WebGLRenderer } from 'three';
+import { Color, LineSegments, Matrix4, Vector2, Vector3 } from 'three';
 
 import type {
   ClassicDataSourceType,
@@ -51,11 +52,11 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
 
     const { facade, collection } = await this.setup360Images(cogniteClient, sceneHandler, desktopDevice);
     onBeforeRender.subscribe(params => collection.updateIcons(params));
-    collection.image360Entities[1].setIconColor(new THREE.Color(1.0, 0.0, 1.0));
+    collection.image360Entities[1].setIconColor(new Color(1.0, 0.0, 1.0));
 
-    const collectionTransform = new THREE.Matrix4()
+    const collectionTransform = new Matrix4()
       .makeTranslation(10, -5, -7)
-      .multiply(new THREE.Matrix4().makeRotationX(Math.PI / 4));
+      .multiply(new Matrix4().makeRotationX(Math.PI / 4));
 
     collection.setModelTransformation(collectionTransform);
 
@@ -80,8 +81,8 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
 
     let seed = 70;
     octreeVisualization.traverse(obj => {
-      if (obj instanceof THREE.LineSegments) {
-        (obj.material as THREE.LineBasicMaterial).color = new THREE.Color(0xffffff * random(seed));
+      if (obj instanceof LineSegments) {
+        (obj.material as LineBasicMaterial).color = new Color(0xffffff * random(seed));
       }
       seed++;
     });
@@ -95,16 +96,16 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
   }
 
   private setupMouseClickEventHandler(
-    renderer: THREE.WebGLRenderer,
+    renderer: WebGLRenderer,
     facade: TestImage360Facade,
-    camera: THREE.PerspectiveCamera,
+    camera: PerspectiveCamera,
     cameraControls: OrbitControls
   ) {
     let lastClicked: Image360Entity<DataSourceType> | undefined;
     renderer.domElement.addEventListener('click', async event => {
       const { x, y } = event;
       const ndcCoordinates = getNormalizedPixelCoordinates(renderer.domElement, x, y);
-      const intersection = facade.intersect(new THREE.Vector2(ndcCoordinates.x, ndcCoordinates.y), camera);
+      const intersection = facade.intersect(new Vector2(ndcCoordinates.x, ndcCoordinates.y), camera);
 
       if (intersection === undefined) {
         this.render();
@@ -124,9 +125,9 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
       }
 
       const transform = entity.transform.toArray();
-      const image360Translation = new THREE.Vector3(transform[12], transform[13], transform[14]);
+      const image360Translation = new Vector3(transform[12], transform[13], transform[14]);
       camera.position.copy(image360Translation);
-      const cameraForward = camera.getWorldDirection(new THREE.Vector3());
+      const cameraForward = camera.getWorldDirection(new Vector3());
       cameraControls.target.copy(image360Translation.clone().add(cameraForward.multiplyScalar(0.001)));
       cameraControls.update();
       lastClicked = entity;
@@ -137,22 +138,22 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
   private transition360Image(
     lastClicked: Image360Entity<DataSourceType>,
     entity: Image360Entity<DataSourceType>,
-    camera: THREE.PerspectiveCamera,
+    camera: PerspectiveCamera,
     cameraControls: OrbitControls
   ) {
     lastClicked.image360Visualization.renderOrder = 1;
     entity.image360Visualization.renderOrder = 0;
 
     const transformTo = entity.transform.toArray();
-    const translationTo = new THREE.Vector3(transformTo[12], transformTo[13], transformTo[14]);
+    const translationTo = new Vector3(transformTo[12], transformTo[13], transformTo[14]);
 
     const transformFrom = lastClicked.transform.toArray();
-    const translationFrom = new THREE.Vector3(transformFrom[12], transformFrom[13], transformFrom[14]);
+    const translationFrom = new Vector3(transformFrom[12], transformFrom[13], transformFrom[14]);
 
-    const length = new THREE.Vector3().subVectors(translationTo, translationFrom).length();
+    const length = new Vector3().subVectors(translationTo, translationFrom).length();
 
-    lastClicked.image360Visualization.scale = new THREE.Vector3(length * 2, length * 2, length * 2);
-    entity.image360Visualization.scale = new THREE.Vector3(length * 2, length * 2, length * 2);
+    lastClicked.image360Visualization.scale = new Vector3(length * 2, length * 2, length * 2);
+    entity.image360Visualization.scale = new Vector3(length * 2, length * 2, length * 2);
 
     const renderTrigger = setInterval(() => this.render(), 16);
 
@@ -164,7 +165,7 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
       const tween = new TWEEN.Tween(from)
         .to(to, 1000)
         .onUpdate(() => {
-          const animatedPosition = new THREE.Vector3().lerpVectors(translationFrom, translationTo, from.t);
+          const animatedPosition = new Vector3().lerpVectors(translationFrom, translationTo, from.t);
           camera.position.copy(animatedPosition);
           lastClicked!.image360Visualization.opacity = 1 - from.t;
         })
@@ -176,7 +177,7 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
         tween.stop();
         clearInterval(renderTrigger);
         camera.position.copy(translationTo);
-        const cameraForward = camera.getWorldDirection(new THREE.Vector3());
+        const cameraForward = camera.getWorldDirection(new Vector3());
         cameraControls.target.copy(translationTo.clone().add(cameraForward.multiplyScalar(0.001)));
         cameraControls.update();
         lastClicked = entity;
@@ -184,15 +185,11 @@ export default class Image360VisualTestFixture extends StreamingVisualTestFixtur
     }
   }
 
-  private setupMouseMoveEventHandler(
-    renderer: THREE.WebGLRenderer,
-    facade: TestImage360Facade,
-    camera: THREE.PerspectiveCamera
-  ) {
+  private setupMouseMoveEventHandler(renderer: WebGLRenderer, facade: TestImage360Facade, camera: PerspectiveCamera) {
     renderer.domElement.addEventListener('mousemove', async event => {
       const { x, y } = event;
       const ndcCoordinates = getNormalizedPixelCoordinates(renderer.domElement, x, y);
-      const intersection = facade.intersect(new THREE.Vector2(ndcCoordinates.x, ndcCoordinates.y), camera);
+      const intersection = facade.intersect(new Vector2(ndcCoordinates.x, ndcCoordinates.y), camera);
       if (intersection === undefined) {
         this.render();
         return;

--- a/viewer/packages/api/src/public/RevealManager.test.ts
+++ b/viewer/packages/api/src/public/RevealManager.test.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { PerspectiveCamera, Plane } from 'three';
 
 import { createRevealManager } from './createRevealManager';
 import type { RevealManager, LoadingStateChangeListener } from './RevealManager';
@@ -18,8 +19,6 @@ import { LocalPointClassificationsProvider } from '@reveal/pointclouds';
 import type { SetPropertyExpression } from 'moq.ts';
 import { It, Mock } from 'moq.ts';
 import type { CameraManager } from '@reveal/camera-manager';
-import { PerspectiveCamera } from 'three';
-
 import { vi } from 'vitest';
 
 describe('RevealManager', () => {
@@ -63,7 +62,7 @@ describe('RevealManager', () => {
     onChangeListeners = [];
     onStopListeners = [];
 
-    const rendererMock = new Mock<THREE.WebGLRenderer>()
+    const rendererMock = new Mock<WebGLRenderer>()
       .setup(_ => It.Is((expression: SetPropertyExpression) => expression.name === 'info'))
       .returns({})
       .setup(p => p.domElement)
@@ -107,7 +106,7 @@ describe('RevealManager', () => {
 
   test('set clippingPlanes triggers redraw', () => {
     expect(manager.needsRedraw).toBeFalsy();
-    const planes = [new THREE.Plane(), new THREE.Plane()];
+    const planes = [new Plane(), new Plane()];
     manager.clippingPlanes = planes;
     expect(manager.needsRedraw).toBeTruthy();
   });
@@ -137,7 +136,7 @@ describe('RevealManager', () => {
   });
 
   test('loadingStateChanged is not triggered if loading state doesnt change', () => {
-    const camera = new THREE.PerspectiveCamera(60, 1, 0.5, 100);
+    const camera = new PerspectiveCamera(60, 1, 0.5, 100);
     const loadingStateChangedCb: LoadingStateChangeListener = vi.fn();
     manager.on('loadingStateChanged', loadingStateChangedCb);
 

--- a/viewer/packages/api/src/public/RevealManager.ts
+++ b/viewer/packages/api/src/public/RevealManager.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { PerspectiveCamera, Plane, Vector3, WebGLRenderTarget } from 'three';
 
 import { isEqual } from 'lodash-es';
 
@@ -66,7 +66,7 @@ export class RevealManager {
 
   private readonly _cameraManager: CameraManager;
 
-  private readonly _onCameraChange: (position: THREE.Vector3, target: THREE.Vector3) => void;
+  private readonly _onCameraChange: (position: Vector3, target: Vector3) => void;
   private readonly _onCameraStop: () => void;
 
   constructor(
@@ -85,7 +85,7 @@ export class RevealManager {
     this._subscriptions = this.initLoadingStateObserver(this._cadManager, this._pointCloudManager);
 
     this._cameraManager = cameraManager;
-    this._onCameraChange = (_position: THREE.Vector3, _target: THREE.Vector3) => (this._cameraInMotion = true);
+    this._onCameraChange = (_position: Vector3, _target: Vector3) => (this._cameraInMotion = true);
     this._onCameraStop = () => (this._cameraInMotion = false);
     this._cameraManager.on('cameraChange', this._onCameraChange);
     this._cameraManager.on('cameraStop', this._onCameraStop);
@@ -118,7 +118,7 @@ export class RevealManager {
     this._resizeHandler.resetRedraw();
   }
 
-  public setOutputRenderTarget(target: THREE.WebGLRenderTarget | null, autoSizeRenderTarget?: boolean): void {
+  public setOutputRenderTarget(target: WebGLRenderTarget | null, autoSizeRenderTarget?: boolean): void {
     this._renderPipeline.setOutputRenderTarget(target, autoSizeRenderTarget);
   }
 
@@ -130,7 +130,7 @@ export class RevealManager {
     return this._cadManager.needsRedraw || this._pointCloudManager.needsRedraw || this._resizeHandler.needsRedraw;
   }
 
-  public update(camera: THREE.PerspectiveCamera): void {
+  public update(camera: PerspectiveCamera): void {
     this._cadManager.updateCamera(camera, this._cameraInMotion);
 
     if (this._cameraInMotion) {
@@ -166,12 +166,12 @@ export class RevealManager {
     this._pointCloudManager.pointBudget = budget.numberOfPoints;
   }
 
-  public set clippingPlanes(clippingPlanes: THREE.Plane[]) {
+  public set clippingPlanes(clippingPlanes: Plane[]) {
     this._cadManager.clippingPlanes = clippingPlanes;
     this._pointCloudManager.clippingPlanes = clippingPlanes;
   }
 
-  public get clippingPlanes(): THREE.Plane[] {
+  public get clippingPlanes(): Plane[] {
     return this._cadManager.clippingPlanes;
   }
 
@@ -215,7 +215,7 @@ export class RevealManager {
     this.requestRedraw();
   }
 
-  public render(camera: THREE.PerspectiveCamera): void {
+  public render(camera: PerspectiveCamera): void {
     this._resizeHandler.handleResize(camera);
     this._pipelineExecutor.render(this._renderPipeline, camera);
     this.resetRedraw();

--- a/viewer/packages/api/src/public/RevealOptions.ts
+++ b/viewer/packages/api/src/public/RevealOptions.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { WebGLRenderTarget } from 'three';
 
 import type { RenderOptions } from '@reveal/rendering';
 import type { InternalRevealCadOptions } from '@reveal/cad-geometry-loaders';
@@ -17,7 +17,7 @@ export type RevealOptions = {
   logMetrics?: boolean;
   renderOptions?: RenderOptions;
   continuousModelStreaming?: boolean;
-  outputRenderTarget?: { target: THREE.WebGLRenderTarget; autoSize?: boolean };
+  outputRenderTarget?: { target: WebGLRenderTarget; autoSize?: boolean };
   rendererResolutionThreshold?: number;
   internal?: {
     cad?: InternalRevealCadOptions;

--- a/viewer/packages/api/src/public/createRevealManager.test.ts
+++ b/viewer/packages/api/src/public/createRevealManager.test.ts
@@ -14,7 +14,7 @@ import type {
 import type { SetPropertyExpression } from 'moq.ts';
 import { It, Mock } from 'moq.ts';
 
-import type * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
 import { SceneHandler } from '@reveal/utilities';
 import type { IPointClassificationsProvider } from '@reveal/pointclouds';
 import type { CameraManager } from '@reveal/camera-manager';
@@ -30,7 +30,7 @@ describe('createRevealManager', () => {
         new Mock<PointCloudStylableObjectProvider>().object(),
         new Mock<PointCloudStylableObjectProvider<DMDataSourceType>>().object(),
         new Mock<IPointClassificationsProvider>().object(),
-        new Mock<THREE.WebGLRenderer>()
+        new Mock<WebGLRenderer>()
           .setup(_ => It.Is((expression: SetPropertyExpression) => expression.name === 'info'))
           .returns({})
           .setup(p => p.domElement)

--- a/viewer/packages/api/src/public/createRevealManager.ts
+++ b/viewer/packages/api/src/public/createRevealManager.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import type * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
 
 import type { RevealOptions } from './RevealOptions';
 import { RevealManager } from './RevealManager';
@@ -49,7 +49,7 @@ import type { CameraManager } from '@reveal/camera-manager';
  * @returns RevealManager instance.
  */
 export function createLocalRevealManager(
-  renderer: THREE.WebGLRenderer,
+  renderer: WebGLRenderer,
   sceneHandler: SceneHandler,
   cameraManager: CameraManager,
   revealOptions: RevealOptions = {}
@@ -84,7 +84,7 @@ export function createLocalRevealManager(
  */
 export function createCdfRevealManager(
   client: CogniteClient,
-  renderer: THREE.WebGLRenderer,
+  renderer: WebGLRenderer,
   sceneHandler: SceneHandler,
   cameraManager: CameraManager,
   revealOptions: RevealOptions = {}
@@ -133,7 +133,7 @@ export function createRevealManager(
   annotationProvider: PointCloudStylableObjectProvider,
   pointCloudDMProvider: PointCloudStylableObjectProvider<DMDataSourceType>,
   pointClassificationsProvider: IPointClassificationsProvider,
-  renderer: THREE.WebGLRenderer,
+  renderer: WebGLRenderer,
   sceneHandler: SceneHandler,
   cameraManager: CameraManager,
   revealOptions: RevealOptions = {}

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.test.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.test.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { Box3, Mesh, MeshBasicMaterial, Sphere, SphereGeometry, Vector2, Vector3 } from 'three';
 import TWEEN from '@tweenjs/tween.js';
 import { CogniteClient } from '@cognite/sdk';
 import { CdfModelMetadataProvider, CdfModelDataProvider, File3dFormat } from '@reveal/data-providers';
@@ -27,7 +28,7 @@ describe('Cognite3DViewer', () => {
   const sdk = new CogniteClient({ appId: 'cognite.reveal.unittest', project: 'dummy', getToken: async () => 'dummy' });
   mockClientAuthentication(sdk);
 
-  const renderer = autoMockWebGLRenderer(new Mock<THREE.WebGLRenderer>()).object();
+  const renderer = autoMockWebGLRenderer(new Mock<WebGLRenderer>()).object();
   renderer.render = vi.fn();
   const _sectorCuller = new Mock<SectorCuller>()
     .setup(p => p.determineSectors(It.IsAny()))
@@ -106,13 +107,13 @@ describe('Cognite3DViewer', () => {
 
   test('on cameraChange triggers when position and target is changed', () => {
     // Arrange
-    const onCameraChange: (position: THREE.Vector3, target: THREE.Vector3) => void = vi.fn();
+    const onCameraChange: (position: Vector3, target: Vector3) => void = vi.fn();
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller, logMetrics: false });
     viewer.on('cameraChange', onCameraChange);
 
     // Act
-    viewer.cameraManager.setCameraState({ position: new THREE.Vector3(123, 456, 789) });
-    viewer.cameraManager.setCameraState({ target: new THREE.Vector3(1, 2, 3) });
+    viewer.cameraManager.setCameraState({ position: new Vector3(123, 456, 789) });
+    viewer.cameraManager.setCameraState({ target: new Vector3(1, 2, 3) });
 
     // Assert
     expect(onCameraChange).toHaveBeenCalledTimes(2);
@@ -125,7 +126,7 @@ describe('Cognite3DViewer', () => {
     ]);
     vi.spyOn(CdfModelDataProvider.prototype, 'getJsonFile').mockResolvedValue(sceneJson);
 
-    const onCameraChange: (position: THREE.Vector3, target: THREE.Vector3) => void = vi.fn();
+    const onCameraChange: (position: Vector3, target: Vector3) => void = vi.fn();
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller, logMetrics: false });
     viewer.on('cameraChange', onCameraChange);
 
@@ -141,8 +142,8 @@ describe('Cognite3DViewer', () => {
   test('fitCameraToBoundingBox with 0 duration, moves camera immediatly', () => {
     // Arrange
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller, logMetrics: false });
-    const bbox = new THREE.Box3(new THREE.Vector3(1, 1, 1), new THREE.Vector3(2, 2, 2));
-    const bSphere = bbox.getBoundingSphere(new THREE.Sphere());
+    const bbox = new Box3(new Vector3(1, 1, 1), new Vector3(2, 2, 2));
+    const bSphere = bbox.getBoundingSphere(new Sphere());
     bSphere.radius *= 3;
 
     // Act
@@ -151,7 +152,7 @@ describe('Cognite3DViewer', () => {
 
     // Assert
     const cameraState = viewer.cameraManager.getCameraState();
-    expect(cameraState.target).toEqual(bbox.getCenter(new THREE.Vector3()));
+    expect(cameraState.target).toEqual(bbox.getCenter(new Vector3()));
     expect(bSphere.containsPoint(cameraState.position)).toBeTruthy();
   });
 
@@ -159,9 +160,9 @@ describe('Cognite3DViewer', () => {
     // Arrange
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller, logMetrics: false });
     const cameraManager = viewer.cameraManager;
-    cameraManager.setCameraState({ position: new THREE.Vector3(30, 10, 50), target: new THREE.Vector3() });
-    const bbox = new THREE.Box3(new THREE.Vector3(1, 1, 1), new THREE.Vector3(2, 2, 2));
-    const bSphere = bbox.getBoundingSphere(new THREE.Sphere());
+    cameraManager.setCameraState({ position: new Vector3(30, 10, 50), target: new Vector3() });
+    const bbox = new Box3(new Vector3(1, 1, 1), new Vector3(2, 2, 2));
+    const bSphere = bbox.getBoundingSphere(new Sphere());
     bSphere.radius *= 3;
 
     // Act
@@ -169,19 +170,19 @@ describe('Cognite3DViewer', () => {
     const now = TWEEN.now();
     TWEEN.update(now + 500);
     const cameraState1 = viewer.cameraManager.getCameraState();
-    expect(cameraState1.target).not.toEqual(bbox.getCenter(new THREE.Vector3()));
+    expect(cameraState1.target).not.toEqual(bbox.getCenter(new Vector3()));
     expect(bSphere.containsPoint(cameraState1.position)).toBeFalsy();
     TWEEN.update(now + 1000);
 
     // Assert
     const cameraState2 = viewer.cameraManager.getCameraState();
-    expect(cameraState2.target).toEqual(bbox.getCenter(new THREE.Vector3()));
+    expect(cameraState2.target).toEqual(bbox.getCenter(new Vector3()));
     expect(bSphere.containsPoint(cameraState2.position)).toBeTruthy();
   });
 
   test('viewer can add/remove Object3d on scene', () => {
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller, logMetrics: false });
-    const obj = new THREE.Mesh(new THREE.SphereGeometry(), new THREE.MeshBasicMaterial());
+    const obj = new Mesh(new SphereGeometry(), new MeshBasicMaterial());
 
     expect(() => viewer.addObject3D(obj)).not.toThrow();
     expect(() => viewer.removeObject3D(obj)).not.toThrow();
@@ -193,7 +194,7 @@ describe('Cognite3DViewer', () => {
     // Create 10 custom objects
     const customObjects: CustomObject[] = [];
     for (let i = 0; i < 10; i++) {
-      const obj = new THREE.Mesh(new THREE.SphereGeometry(i), new THREE.MeshBasicMaterial());
+      const obj = new Mesh(new SphereGeometry(i), new MeshBasicMaterial());
       customObjects.push(new CustomObject(obj));
     }
     // Add them to the viewer
@@ -241,7 +242,7 @@ describe('Cognite3DViewer', () => {
   test('fitCameraToBoundingBox with zero duration updates camera immediatly', () => {
     // Arrange
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller, logMetrics: false });
-    const box = new THREE.Box3(new THREE.Vector3(-1001, -1001, -1001), new THREE.Vector3(-1000, -1000, -1000));
+    const box = new Box3(new Vector3(-1001, -1001, -1001), new Vector3(-1000, -1000, -1000));
     const { position: originalCameraPosition, target: originalCameraTarget } = viewer.cameraManager.getCameraState();
 
     // Act
@@ -266,7 +267,7 @@ describe('Cognite3DViewer', () => {
   test('getAnyIntersectionFromPixel returns cluster intersection when a cluster is hit', async () => {
     const mockClusterData: Image360ClusterIntersectionData<DataSourceType> = {
       image360Collection: new Mock<DefaultImage360Collection<DataSourceType>>().object(),
-      clusterPosition: new THREE.Vector3(5, 0, 0),
+      clusterPosition: new Vector3(5, 0, 0),
       clusterSize: 3,
       clusterIcons: [new Mock<Image360Entity<DataSourceType>>().object()],
       distanceToCamera: 15
@@ -278,7 +279,7 @@ describe('Cognite3DViewer', () => {
 
     const viewer = new Cognite3DViewer({ sdk, renderer, _sectorCuller, logMetrics: false });
 
-    const result = await viewer.getAnyIntersectionFromPixel(new THREE.Vector2(100, 200));
+    const result = await viewer.getAnyIntersectionFromPixel(new Vector2(100, 200));
 
     expect(result).toEqual({ type: 'image360Cluster', ...mockClusterData });
 

--- a/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
+++ b/viewer/packages/api/src/public/migration/Cognite3DViewer.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { Object3D, PerspectiveCamera, Plane } from 'three';
+import { Box3, Clock, Color, Matrix4, REVISION, Vector2, Vector3, WebGLRenderer } from 'three';
 import viewerPackageJson from '../../../../../package.json' with { type: 'json' };
 
 import TWEEN from '@tweenjs/tween.js';
@@ -147,18 +148,18 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
   }
 
   /**
-   * Returns parameters of THREE.WebGLRenderer used by the viewer.
+   * Returns parameters of WebGLRenderer used by the viewer.
    */
   get renderParameters(): RenderParameters {
     return {
-      renderSize: this._renderer.getSize(new THREE.Vector2())
+      renderSize: this._renderer.getSize(new Vector2())
     };
   }
 
   /**
    * Returns the renderer used to produce images from 3D geometry.
    */
-  private get renderer(): THREE.WebGLRenderer {
+  private get renderer(): WebGLRenderer {
     return this._renderer;
   }
 
@@ -169,7 +170,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
   private readonly _activeCameraManager: ProxyCameraManager;
   private readonly _revealManagerHelper: RevealManagerHelper;
   private readonly _domElement: HTMLElement;
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
   private readonly _ownsRenderer: boolean;
 
   private readonly _pickingHandler: PickingHandler;
@@ -191,7 +192,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
   private latestRequestId: number = -1;
   private readonly sessionLogger: SessionLogger;
 
-  private readonly cameraManagerClock = new THREE.Clock();
+  private readonly cameraManagerClock = new Clock();
   private _clippingNeedsUpdate: boolean = false;
   private _forceStopRendering: boolean = false;
 
@@ -210,9 +211,9 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * Reusable buffers used by functions in Cognite3dViewer to avoid allocations.
    */
   private readonly _boundingBoxes = {
-    nearFarPlaneBoundingBox: new THREE.Box3(),
-    sceneBoundingBox: new THREE.Box3(),
-    temporaryBox: new THREE.Box3()
+    nearFarPlaneBoundingBox: new Box3(),
+    sceneBoundingBox: new Box3(),
+    temporaryBox: new Box3()
   };
 
   /**
@@ -267,7 +268,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
 
   constructor(options: Cognite3DViewerOptions) {
     const threejsRequiredVersion = viewerPackageJson.peerDependencies.three.split('.')[1].toString();
-    if (threejsRequiredVersion != THREE.REVISION) {
+    if (threejsRequiredVersion != REVISION) {
       Log.warn(
         `The version of the dependency \"three\" is different from what Reveal expects, which may cause unexpected results.
         In case of unexpected issues, please set the version to ${viewerPackageJson.peerDependencies.three}`
@@ -901,7 +902,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
       throw new Error('Adding 360 image sets is only supported when connecting to Cognite Data Fusion');
     }
 
-    const collectionTransform = add360ImageOptions?.collectionTransform ?? new THREE.Matrix4();
+    const collectionTransform = add360ImageOptions?.collectionTransform ?? new Matrix4();
     const preMultipliedRotation = add360ImageOptions?.preMultipliedRotation ?? true;
 
     const image360Collection = await this._image360ApiHelper.add360ImageSet(
@@ -1100,18 +1101,18 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
   }
 
   /**
-   * Add a THREE.Object3D to the viewer.
+   * Add a Object3D to the viewer.
    * @param object
    * @example
    * ```js
-   * const sphere = new THREE.Mesh(
-   * new THREE.SphereGeometry(),
-   * new THREE.MeshBasicMaterial()
+   * const sphere = new Mesh(
+   * new SphereGeometry(),
+   * new MeshBasicMaterial()
    * );
    * viewer.addObject3D(sphere);
    * ```
    */
-  addObject3D(object: THREE.Object3D): void {
+  addObject3D(object: Object3D): void {
     if (this.isDisposed) {
       return;
     }
@@ -1127,9 +1128,9 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @param customObject
    * @example
    * ```js
-   * const sphere = new THREE.Mesh(
-   * new THREE.SphereGeometry(),
-   * new THREE.MeshBasicMaterial()
+   * const sphere = new Mesh(
+   * new SphereGeometry(),
+   * new MeshBasicMaterial()
    * );
    * const customObject = CustomObject(sphere);
    * customObject.isPartOfBoundingBox = false;
@@ -1150,16 +1151,16 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
   }
 
   /**
-   * Remove a THREE.Object3D from the viewer.
+   * Remove a Object3D from the viewer.
    * @param object
    * @example
    * ```js
-   * const sphere = new THREE.Mesh(new THREE.SphereGeometry(), new THREE.MeshBasicMaterial());
+   * const sphere = new Mesh(new SphereGeometry(), new MeshBasicMaterial());
    * viewer.addObject3D(sphere);
    * viewer.removeObject3D(sphere);
    * ```
    */
-  removeObject3D(object: THREE.Object3D): void {
+  removeObject3D(object: Object3D): void {
     if (this.isDisposed) {
       return;
     }
@@ -1173,7 +1174,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @param customObject
    * @example
    * ```js
-   * const sphere = new THREE.Mesh(new THREE.SphereGeometry(), new THREE.MeshBasicMaterial());
+   * const sphere = new Mesh(new SphereGeometry(), new MeshBasicMaterial());
    * const customObject = CustomObject(sphere);
    * viewer.addCustomObject(sphere);
    * viewer.removeCustomObject(sphere);
@@ -1197,14 +1198,14 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @param backgroundColor.color
    * @param backgroundColor.alpha
    */
-  setBackgroundColor(backgroundColor: { color?: THREE.Color; alpha?: number }): void {
+  setBackgroundColor(backgroundColor: { color?: Color; alpha?: number }): void {
     if (this.isDisposed) {
       return;
     }
 
     const srgbColor = backgroundColor.color?.clone().convertLinearToSRGB();
 
-    const color = srgbColor ?? this.renderer.getClearColor(new THREE.Color());
+    const color = srgbColor ?? this.renderer.getClearColor(new Color());
     const alpha = backgroundColor.alpha ?? this.renderer.getClearAlpha();
 
     this.renderer.setClearColor(color, alpha);
@@ -1218,23 +1219,23 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @example
    * ```js
    * // Hide pixels with values less than 0 in the x direction
-   * const plane = new THREE.Plane(new THREE.Vector3(1, 0, 0), 0);
+   * const plane = new Plane(new Vector3(1, 0, 0), 0);
    * viewer.setGlobalClippingPlanes([plane]);
    * ```
    * ```js
    * // Hide pixels with values greater than 20 in the x direction
-   *  const plane = new THREE.Plane(new THREE.Vector3(-1, 0, 0), 20);
+   *  const plane = new Plane(new Vector3(-1, 0, 0), 20);
    * viewer.setGlobalClippingPlanes([plane]);
    * ```
    * ```js
    * // Hide pixels with values less than 0 in the x direction or greater than 0 in the y direction
-   * const xPlane = new THREE.Plane(new THREE.Vector3(1, 0, 0), 0);
-   * const yPlane = new THREE.Plane(new THREE.Vector3(0, -1, 0), 0);
+   * const xPlane = new Plane(new Vector3(1, 0, 0), 0);
+   * const yPlane = new Plane(new Vector3(0, -1, 0), 0);
    * viewer.setGlobalClippingPlanes([xPlane, yPlane]);
    * ```
    * ```js
    * // Hide pixels behind an arbitrary, non axis-aligned plane
-   *  const plane = new THREE.Plane(new THREE.Vector3(1.5, 20, -19), 20);
+   *  const plane = new Plane(new Vector3(1.5, 20, -19), 20);
    * viewer.setGlobalClippingPlanes([plane]);
    * ```
    * ```js
@@ -1242,7 +1243,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    *  viewer.setGlobalClippingPlanes([]);
    * ```
    */
-  setGlobalClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+  setGlobalClippingPlanes(clippingPlanes: Plane[]): void {
     this.revealManager.clippingPlanes = clippingPlanes;
     this._clippingNeedsUpdate = true;
   }
@@ -1252,7 +1253,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @param clippingPlanes
    * @deprecated Use {@link Cognite3DViewer.setGlobalClippingPlanes} instead.
    */
-  setClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+  setClippingPlanes(clippingPlanes: Plane[]): void {
     this.setGlobalClippingPlanes(clippingPlanes);
   }
 
@@ -1260,14 +1261,14 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * Returns the current active global clipping planes.
    * @deprecated Use {@link Cognite3DViewer.getGlobalClippingPlanes} instead.
    */
-  getClippingPlanes(): THREE.Plane[] {
+  getClippingPlanes(): Plane[] {
     return this.getGlobalClippingPlanes();
   }
 
   /**
    * Returns the current active global clipping planes.
    */
-  getGlobalClippingPlanes(): THREE.Plane[] {
+  getGlobalClippingPlanes(): Plane[] {
     return this.revealManager.clippingPlanes.map(p => p.clone());
   }
 
@@ -1275,7 +1276,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * Returns the union of all bounding boxes in reveal, including custom objects.
    * @beta
    */
-  getSceneBoundingBox(): THREE.Box3 {
+  getSceneBoundingBox(): Box3 {
     return this._boundingBoxes.sceneBoundingBox;
   }
 
@@ -1284,14 +1285,14 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @returns The visual bounding box of the Cognite3DViewer.
    * @beta
    */
-  getVisualSceneBoundingBox(): THREE.Box3 {
-    const boundingBox = new THREE.Box3();
+  getVisualSceneBoundingBox(): Box3 {
+    const boundingBox = new Box3();
     boundingBox.makeEmpty();
 
     if (this.isDisposed) {
       return boundingBox;
     }
-    const temporaryBox = new THREE.Box3();
+    const temporaryBox = new Box3();
     for (const model of this.models) {
       if (!model.visible) {
         continue;
@@ -1357,7 +1358,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * ```
    */
   fitCameraToModel(model: CogniteModel<DataSourceT>, duration?: number): void {
-    const boundingBox = model.getModelBoundingBox(new THREE.Box3(), true);
+    const boundingBox = model.getModelBoundingBox(new Box3(), true);
     if (boundingBox.isEmpty()) {
       return;
     }
@@ -1377,10 +1378,10 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
       return;
     }
 
-    const boundingBox = cogniteModels.reduce<THREE.Box3>((combinedBoundingBox, model) => {
+    const boundingBox = cogniteModels.reduce<Box3>((combinedBoundingBox, model) => {
       combinedBoundingBox.union(model.getModelBoundingBox(undefined, restrictToMostGeometry));
       return combinedBoundingBox;
-    }, new THREE.Box3());
+    }, new Box3());
 
     this.fitCameraToBoundingBox(boundingBox, duration);
   }
@@ -1413,7 +1414,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * viewer.fitCameraToBoundingBox(boundingBox, 500, 2);
    * ```
    */
-  fitCameraToBoundingBox(boundingBox: THREE.Box3, duration?: number, radiusFactor: number = 2): void {
+  fitCameraToBoundingBox(boundingBox: Box3, duration?: number, radiusFactor: number = 2): void {
     if (boundingBox.isEmpty()) {
       return;
     }
@@ -1435,21 +1436,21 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @returns Returns 2D coordinates if the point is visible on screen, or `null` if object is outside screen.
    * @example
    * ```js
-   * const boundingBoxCenter = new THREE.Vector3();
+   * const boundingBoxCenter = new Vector3();
    * // Find center of bounding box in world space
    * model.getBoundingBox(nodeId).getCenter(boundingBoxCenter);
    * // Screen coordinates of that point
    * const screenCoordinates = viewer.worldToScreen(boundingBoxCenter);
    * ```
    * ```js
-   * const boundingBoxCenter = new THREE.Vector3();
+   * const boundingBoxCenter = new Vector3();
    * // Find center of bounding box in world space
    * model.getBoundingBox(nodeId).getCenter(boundingBoxCenter);
    * // Screen coordinates of that point normalized in the range [0,1]
    * const screenCoordinates = viewer.worldToScreen(boundingBoxCenter, true);
    * ```
    * ```js
-   * const boundingBoxCenter = new THREE.Vector3();
+   * const boundingBoxCenter = new Vector3();
    * // Find center of bounding box in world space
    * model.getBoundingBox(nodeId).getCenter(boundingBoxCenter);
    * // Screen coordinates of that point
@@ -1461,10 +1462,10 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * }
    * ```
    */
-  worldToScreen(point: THREE.Vector3, normalize?: boolean): THREE.Vector2 | null {
+  worldToScreen(point: Vector3, normalize?: boolean): Vector2 | null {
     const camera = this.cameraManager.getCamera();
     camera.updateMatrixWorld();
-    const screenPosition = new THREE.Vector3();
+    const screenPosition = new Vector3();
     if (normalize) {
       worldToNormalizedViewportCoordinates(camera, point, screenPosition);
     } else {
@@ -1485,7 +1486,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
       return null;
     }
 
-    return new THREE.Vector2(screenPosition.x, screenPosition.y);
+    return new Vector2(screenPosition.x, screenPosition.y);
   }
 
   /**
@@ -1516,7 +1517,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     }
 
     const customRenderTarget = this.renderer.getRenderTarget();
-    const { width: originalWidth, height: originalHeight } = this.renderer.getSize(new THREE.Vector2());
+    const { width: originalWidth, height: originalHeight } = this.renderer.getSize(new Vector2());
     const originalPixelRatio = this._renderer.getPixelRatio();
 
     const originalDomeStyle = {
@@ -1544,7 +1545,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
       this.domElement.style.left = '0px';
       this.domElement.style.top = '0px';
 
-      const screenshotCamera = this.cameraManager.getCamera().clone() as THREE.PerspectiveCamera;
+      const screenshotCamera = this.cameraManager.getCamera().clone() as PerspectiveCamera;
       adjustCamera(screenshotCamera, width, height);
 
       // Disregard pixelRatio to get the screenshot in requested resolution.
@@ -1612,7 +1613,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @param pixelCoords A Vector2 containing pixel coordinates relative to the 3D viewer.
    * @returns A Vector2 containing the normalized device coordinate (in range [-1, 1]).
    */
-  getNormalizedPixelCoordinates(pixelCoords: THREE.Vector2): THREE.Vector2 {
+  getNormalizedPixelCoordinates(pixelCoords: Vector2): Vector2 {
     return getNormalizedPixelCoordinates(this.domElement, pixelCoords.x, pixelCoords.y);
   }
 
@@ -1621,7 +1622,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @param event An PointerEvent or WheelEvent.
    * @returns A Vector2 containing pixel coordinates relative to the 3D viewer.
    */
-  getPixelCoordinatesFromEvent(event: PointerEvent | WheelEvent): THREE.Vector2 {
+  getPixelCoordinatesFromEvent(event: PointerEvent | WheelEvent): Vector2 {
     return getPixelCoordinatesFromEvent(event, this.domElement);
   }
 
@@ -1631,7 +1632,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @returns A CustomObjectIntersectInput ready to use.
    * @beta
    */
-  public createCustomObjectIntersectInput(pixelCoords: THREE.Vector2): CustomObjectIntersectInput {
+  public createCustomObjectIntersectInput(pixelCoords: Vector2): CustomObjectIntersectInput {
     return new CustomObjectIntersectInput(
       this.getNormalizedPixelCoordinates(pixelCoords),
       this.cameraManager.getCamera(),
@@ -1673,7 +1674,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * ```
    */
   async getIntersectionFromPixel(offsetX: number, offsetY: number): Promise<null | Intersection<DataSourceT>> {
-    const pixelCoords = new THREE.Vector2(offsetX, offsetY);
+    const pixelCoords = new Vector2(offsetX, offsetY);
     // Check cluster intersection first (clusters have priority over geometry)
     if (this.intersect360Clusters(pixelCoords) !== undefined) {
       return null;
@@ -1695,7 +1696,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @beta
    */
   public async getAnyIntersectionFromPixel(
-    pixelCoords: THREE.Vector2,
+    pixelCoords: Vector2,
     options?: {
       stopOnHitting360Icon?: boolean;
       predicate?: (customObject: ICustomObject) => boolean;
@@ -1769,7 +1770,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     return true;
   }
 
-  private intersect360Icons(vector: THREE.Vector2): Image360IconIntersection<DataSourceT> | undefined {
+  private intersect360Icons(vector: Vector2): Image360IconIntersection<DataSourceT> | undefined {
     const iconIntersection = this._image360ApiHelper?.intersect360ImageIcons(vector.x, vector.y);
     if (iconIntersection === undefined) {
       return undefined;
@@ -1781,7 +1782,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     };
   }
 
-  private intersect360Clusters(vector: THREE.Vector2): Image360ClusterIntersection<DataSourceT> | undefined {
+  private intersect360Clusters(vector: Vector2): Image360ClusterIntersection<DataSourceT> | undefined {
     const clusterIntersection = this._image360ApiHelper?.intersect360ImageClusters(vector.x, vector.y);
     if (clusterIntersection === undefined) {
       return undefined;
@@ -1816,7 +1817,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
    * @param clickedWorldPosition  World-space position of the user's click (e.g. from a point cloud intersection).
    * @returns The best matching Image360 Entity and its collection, or `undefined` if not inside a 360 image or no candidates qualify.
    */
-  findBestNext360ImageEntity(clickedWorldPosition: THREE.Vector3): Image360WithCollection<DataSourceT> | undefined {
+  findBestNext360ImageEntity(clickedWorldPosition: Vector3): Image360WithCollection<DataSourceT> | undefined {
     return this._image360ApiHelper?.findBestNext360ImageEntity(clickedWorldPosition);
   }
 
@@ -1974,7 +1975,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
   }
 
   private getCustomObjectIntersectionIfCloser(
-    pixelCoords: THREE.Vector2,
+    pixelCoords: Vector2,
     options: {
       useDepthTest: boolean;
       closestDistanceToCamera?: number;
@@ -2020,7 +2021,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     offsetY: number,
     pickBoundingBox: boolean
   ): Promise<CameraManagerCallbackData> {
-    const pixelCoords = new THREE.Vector2(offsetX, offsetY);
+    const pixelCoords = new Vector2(offsetX, offsetY);
 
     const intersection = await this.getAnyIntersectionFromPixel(pixelCoords);
     if (intersection === undefined) {
@@ -2039,7 +2040,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
       };
     }
     if (intersection.type === 'cad') {
-      const getBoundingBox = async (intersection: CadIntersection): Promise<THREE.Box3 | undefined> => {
+      const getBoundingBox = async (intersection: CadIntersection): Promise<Box3 | undefined> => {
         const model = intersection.model;
         const treeIndex = intersection.treeIndex;
         return model.getBoundingBoxByTreeIndex(treeIndex);
@@ -2127,7 +2128,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
   }
 }
 
-function adjustCamera(camera: THREE.PerspectiveCamera, width: number, height: number) {
+function adjustCamera(camera: PerspectiveCamera, width: number, height: number) {
   camera.aspect = width / height;
   camera.updateProjectionMatrix();
 }
@@ -2139,8 +2140,8 @@ function createCanvasWrapper(): HTMLElement {
   return domElement;
 }
 
-function createRenderer(): THREE.WebGLRenderer {
-  const renderer = new THREE.WebGLRenderer({ powerPreference: 'high-performance' });
+function createRenderer(): WebGLRenderer {
+  const renderer = new WebGLRenderer({ powerPreference: 'high-performance' });
   renderer.setPixelRatio(window.devicePixelRatio);
   return renderer;
 }
@@ -2205,7 +2206,7 @@ function createRevealManagerOptions(viewerOptions: Cognite3DViewerOptions, devic
   return revealOptions;
 }
 
-function getMaxPointSize(renderer: THREE.WebGLRenderer): number {
+function getMaxPointSize(renderer: WebGLRenderer): number {
   const gl = renderer.getContext();
   const maxPointSize = gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE)[1];
   return maxPointSize;

--- a/viewer/packages/api/src/storage/RevealManagerHelper.ts
+++ b/viewer/packages/api/src/storage/RevealManagerHelper.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import type * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
 
 import { createCdfRevealManager, createLocalRevealManager, createRevealManager } from '../public/createRevealManager';
 import type { RevealManager } from '../public/RevealManager';
@@ -74,7 +74,7 @@ export class RevealManagerHelper {
    * @param revealOptions
    */
   static createLocalHelper(
-    renderer: THREE.WebGLRenderer,
+    renderer: WebGLRenderer,
     sceneHandler: SceneHandler,
     cameraManager: CameraManager,
     revealOptions: RevealOptions
@@ -92,7 +92,7 @@ export class RevealManagerHelper {
    * @param sdkClient
    */
   static createCdfHelper(
-    renderer: THREE.WebGLRenderer,
+    renderer: WebGLRenderer,
     sceneHandler: SceneHandler,
     cameraManager: CameraManager,
     revealOptions: RevealOptions,
@@ -103,7 +103,7 @@ export class RevealManagerHelper {
   }
 
   static createCustomDataSourceHelper(
-    renderer: THREE.WebGLRenderer,
+    renderer: WebGLRenderer,
     sceneHandler: SceneHandler,
     cameraManager: CameraManager,
     revealOptions: RevealOptions,

--- a/viewer/packages/api/src/utilities/Spinner.test.ts
+++ b/viewer/packages/api/src/utilities/Spinner.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 import { Spinner } from './Spinner';
-import * as THREE from 'three';
+import { Color } from 'three';
 
 describe('Spinner test cases', () => {
   const styles = {
@@ -28,8 +28,8 @@ describe('Spinner test cases', () => {
   });
 
   test('.updateBackgroundColor() updates spinner color', () => {
-    const lightBackground = new THREE.Color(0.6, 0.6, 0.6);
-    const darkBackground = new THREE.Color(0.1, 0.1, 0.1);
+    const lightBackground = new Color(0.6, 0.6, 0.6);
+    const darkBackground = new Color(0.1, 0.1, 0.1);
 
     const parent = document.createElement('div');
     const spinner = new Spinner(parent);

--- a/viewer/packages/api/src/utilities/Spinner.ts
+++ b/viewer/packages/api/src/utilities/Spinner.ts
@@ -4,7 +4,7 @@
 
 import css from './spinnerStyles.module.css?inline';
 import svg from './spinnerCogniteLogo.svg?raw';
-import type * as THREE from 'three';
+import type { Color } from 'three';
 
 import { assertNever } from '@reveal/utilities';
 import { REVEAL_VERSION } from '../version';
@@ -106,7 +106,7 @@ export class Spinner {
    * @param color.g 0..1 green
    * @param color.b 0..1 blue
    */
-  updateBackgroundColor(color: Pick<THREE.Color, 'getHSL'>): void {
+  updateBackgroundColor(color: Pick<Color, 'getHSL'>): void {
     const { l: lightness } = color.getHSL({ h: 0, s: 0, l: 0 });
 
     if (lightness > 0.5) {

--- a/viewer/packages/api/src/utilities/ViewStateHelper.test.ts
+++ b/viewer/packages/api/src/utilities/ViewStateHelper.test.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { Plane, Vector3 } from 'three';
 
 import { Cognite3DViewer } from '../public/migration/Cognite3DViewer';
 import { ViewStateHelper } from './ViewStateHelper';
@@ -19,7 +20,7 @@ describe(ViewStateHelper.name, () => {
   beforeEach(() => {
     const sdk = new CogniteClient({ appId: 'reveal.test', project: 'dummy', getToken: async () => 'dummy' });
     mockClientAuthentication(sdk);
-    const renderer = autoMockWebGLRenderer(new Mock<THREE.WebGLRenderer>()).object();
+    const renderer = autoMockWebGLRenderer(new Mock<WebGLRenderer>()).object();
     renderer.render = vi.fn();
 
     viewer = new Cognite3DViewer({ sdk, renderer, logMetrics: false });
@@ -28,9 +29,9 @@ describe(ViewStateHelper.name, () => {
   test('setState() resets camera and clipping to initial state', () => {
     // Arrange
     const original = {
-      cameraPosition: new THREE.Vector3(-1, -2, -3),
-      cameraTarget: new THREE.Vector3(1, 2, 3),
-      clippingPlanes: [new THREE.Plane().setComponents(1, 2, 3, 4), new THREE.Plane().setComponents(-1, -2, -3, -4)]
+      cameraPosition: new Vector3(-1, -2, -3),
+      cameraTarget: new Vector3(1, 2, 3),
+      clippingPlanes: [new Plane().setComponents(1, 2, 3, 4), new Plane().setComponents(-1, -2, -3, -4)]
     };
     viewer.cameraManager.setCameraState({ position: original.cameraPosition, target: original.cameraTarget });
     viewer.setGlobalClippingPlanes(original.clippingPlanes);
@@ -38,8 +39,8 @@ describe(ViewStateHelper.name, () => {
     // Act
     const state = viewer.getViewState();
     viewer.cameraManager.setCameraState({
-      position: new THREE.Vector3(-10, -10, -10),
-      target: new THREE.Vector3(10, 10, 10)
+      position: new Vector3(-10, -10, -10),
+      target: new Vector3(10, 10, 10)
     });
     viewer.setGlobalClippingPlanes([]);
     viewer.setViewState(state);

--- a/viewer/packages/api/src/utilities/ViewStateHelper.ts
+++ b/viewer/packages/api/src/utilities/ViewStateHelper.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Plane, Vector3 } from 'three';
 
 import { CogniteCadModel } from '@reveal/cad-model';
 import type { Cognite3DViewer } from '../public/migration/Cognite3DViewer';
@@ -121,8 +121,8 @@ export class ViewStateHelper<T extends DataSourceType> {
     const camTarget = cameraState.target;
 
     this._cameraManager.setCameraState({
-      position: new THREE.Vector3(camPos.x, camPos.y, camPos.z),
-      target: new THREE.Vector3(camTarget.x, camTarget.y, camTarget.z)
+      position: new Vector3(camPos.x, camPos.y, camPos.z),
+      target: new Vector3(camTarget.x, camTarget.y, camTarget.z)
     });
   }
 
@@ -163,7 +163,7 @@ export class ViewStateHelper<T extends DataSourceType> {
   }
 
   private setClippingPlanesState(clippingPlanes: ClippingPlanesState[]) {
-    const planes = clippingPlanes.map(p => new THREE.Plane().setComponents(p.nx, p.ny, p.nz, p.constant));
+    const planes = clippingPlanes.map(p => new Plane().setComponents(p.nx, p.ny, p.nz, p.constant));
     this._viewer.setGlobalClippingPlanes(planes);
   }
 }

--- a/viewer/packages/api/visual-tests/ClippingPointCloud.VisualTest.ts
+++ b/viewer/packages/api/visual-tests/ClippingPointCloud.VisualTest.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Plane, Vector3 } from 'three';
 
 import { CognitePointCloudModel } from '@reveal/pointclouds';
 import { PointColorType } from '@reveal/rendering';
@@ -22,7 +22,7 @@ export default class ClippingPointCloudVisualTest extends ViewerVisualTestFixtur
     }
 
     viewer.setGlobalClippingPlanes([
-      new THREE.Plane().setFromNormalAndCoplanarPoint(new THREE.Vector3(1, 0, 0), new THREE.Vector3(0, 0, 0))
+      new Plane().setFromNormalAndCoplanarPoint(new Vector3(1, 0, 0), new Vector3(0, 0, 0))
     ]);
 
     model.pointColorType = PointColorType.Height;

--- a/viewer/packages/api/visual-tests/NodeTransform.VisualTest.ts
+++ b/viewer/packages/api/visual-tests/NodeTransform.VisualTest.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Euler, Matrix4 } from 'three';
 
 import { CogniteCadModel } from '..';
 import type { ViewerTestFixtureComponents } from '../../../visual-tests/test-fixtures/ViewerVisualTestFixture';
@@ -14,13 +14,13 @@ export default class NodeTransformVisualTest extends ViewerVisualTestFixture {
 
     const model = models[0];
 
-    const modelTransform = new THREE.Matrix4().makeTranslation(25, -5, 5);
-    modelTransform.multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(Math.PI / 4, Math.PI / 2, 0)));
+    const modelTransform = new Matrix4().makeTranslation(25, -5, 5);
+    modelTransform.multiply(new Matrix4().makeRotationFromEuler(new Euler(Math.PI / 4, Math.PI / 2, 0)));
 
     if (model instanceof CogniteCadModel) {
-      const scale = new THREE.Matrix4().makeScale(3, 3, 3);
-      const rotation = new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(Math.PI / 6, 0, 0));
-      const translation = new THREE.Matrix4().makeTranslation(-50, 25, 0);
+      const scale = new Matrix4().makeScale(3, 3, 3);
+      const rotation = new Matrix4().makeRotationFromEuler(new Euler(Math.PI / 6, 0, 0));
+      const translation = new Matrix4().makeTranslation(-50, 25, 0);
 
       const transform = translation.multiply(rotation.multiply(scale));
       model.setNodeTransform(new NumericRange(1, 1), transform);
@@ -28,7 +28,7 @@ export default class NodeTransformVisualTest extends ViewerVisualTestFixture {
       Array.from({ length: 80 - 2 }, (_, k) => k + 2).map(i => {
         return model.setNodeTransform(
           new NumericRange(i, 1),
-          new THREE.Matrix4().makeTranslation(0, (((i + 1) % 2) * 2 - 1) * 2, 0)
+          new Matrix4().makeTranslation(0, (((i + 1) % 2) * 2 - 1) * 2, 0)
         );
       });
     }

--- a/viewer/packages/api/visual-tests/Outline.VisualTest.ts
+++ b/viewer/packages/api/visual-tests/Outline.VisualTest.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Color, Euler, Matrix4 } from 'three';
 import type { NodeOutlineColor } from '@reveal/cad-styling';
 import { TreeIndexNodeCollection } from '@reveal/cad-styling';
 import { IndexSet, NumericRange } from '@reveal/utilities';
@@ -14,12 +14,12 @@ export default class OutlineVisualTest extends ViewerVisualTestFixture {
   public setup(testFixtureComponents: ViewerTestFixtureComponents): Promise<void> {
     const { viewer, models } = testFixtureComponents;
 
-    viewer.setBackgroundColor({ color: new THREE.Color('lightgray') });
+    viewer.setBackgroundColor({ color: new Color('lightgray') });
 
     const model = models[0];
 
     if (model instanceof CogniteCadModel) {
-      const matrix = new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(Math.PI / 4, 0, 0));
+      const matrix = new Matrix4().makeRotationFromEuler(new Euler(Math.PI / 4, 0, 0));
       model.setModelTransformation(matrix);
 
       const nodesPerColor = 10;

--- a/viewer/packages/api/visual-tests/ReassignNodeStyle.VisualTest.ts
+++ b/viewer/packages/api/visual-tests/ReassignNodeStyle.VisualTest.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Euler, Matrix4 } from 'three';
 
 import { DefaultNodeAppearance, TreeIndexNodeCollection } from '@reveal/cad-styling';
 import { IndexSet } from '@reveal/utilities';
@@ -38,7 +38,7 @@ export default class ReassignNodeStyleVisualTest extends ViewerVisualTestFixture
       return Promise.resolve();
     }
 
-    const matrix = new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(Math.PI / 4, 0, 0));
+    const matrix = new Matrix4().makeRotationFromEuler(new Euler(Math.PI / 4, 0, 0));
     model.setModelTransformation(matrix);
 
     const alternatingIndexSet = createAlternatingIndexSet(model.nodeCount);

--- a/viewer/packages/api/visual-tests/TwoModels.VisualTest.ts
+++ b/viewer/packages/api/visual-tests/TwoModels.VisualTest.ts
@@ -3,7 +3,7 @@
  */
 import type { Cognite3DViewer, CogniteModel } from '..';
 import { CogniteCadModel } from '..';
-import * as THREE from 'three';
+import { Matrix4, WebGLRenderer } from 'three';
 
 import type { VisualTestFixture } from '../../../visual-tests/test-fixtures/VisualTestFixture';
 import { DefaultNodeAppearance } from '@reveal/cad-styling';
@@ -12,14 +12,14 @@ import { AxisViewTool } from '../../../packages/tools';
 
 export default class TwoModelsVisualTest implements VisualTestFixture {
   private _viewer!: Cognite3DViewer;
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
 
   private _modelLoadingResolve: (() => void) | null = null;
   private _itemsLoaded = 0;
   private _itemsRequested = 0;
 
   constructor() {
-    this._renderer = new THREE.WebGLRenderer({ powerPreference: 'high-performance' });
+    this._renderer = new WebGLRenderer({ powerPreference: 'high-performance' });
     this._renderer.setPixelRatio(window.devicePixelRatio);
   }
 
@@ -88,7 +88,7 @@ export default class TwoModelsVisualTest implements VisualTestFixture {
 
     model.setDefaultNodeAppearance(DefaultNodeAppearance.Ghosted);
 
-    const translation = new THREE.Matrix4().makeTranslation(0, 5, 0);
+    const translation = new Matrix4().makeTranslation(0, 5, 0);
     const transform = model.getModelTransformation();
     transform.multiply(translation);
     model.setModelTransformation(transform);

--- a/viewer/packages/cad-geometry-loaders/src/CadManager.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadManager.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { PerspectiveCamera, Plane } from 'three';
 
 import type { ConsumedSector, CadModelMetadata } from '@reveal/cad-parsers';
 import { LevelOfDetail } from '@reveal/cad-parsers';
@@ -160,15 +160,15 @@ export class CadManager {
     );
   }
 
-  updateCamera(camera: THREE.PerspectiveCamera, cameraInMotion: boolean): void {
+  updateCamera(camera: PerspectiveCamera, cameraInMotion: boolean): void {
     this._cadModelUpdateHandler.updateCamera(camera, cameraInMotion);
   }
 
-  get clippingPlanes(): THREE.Plane[] {
+  get clippingPlanes(): Plane[] {
     return this._materialManager.clippingPlanes;
   }
 
-  set clippingPlanes(clippingPlanes: THREE.Plane[]) {
+  set clippingPlanes(clippingPlanes: Plane[]) {
     this._materialManager.clippingPlanes = clippingPlanes;
     this._cadModelUpdateHandler.clippingPlanes = clippingPlanes;
     this._needsRedraw = true;

--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { PerspectiveCamera } from 'three';
 
 import type { SectorCuller } from './sector/culling/SectorCuller';
 import { CadModelUpdateHandler } from './CadModelUpdateHandler';
@@ -76,7 +76,7 @@ describe(CadModelUpdateHandler.name, () => {
 
       const updateHandler = new CadModelUpdateHandler(mockCuller);
       updateHandler.addModel(cadNode);
-      updateHandler.updateCamera(new THREE.PerspectiveCamera(), false);
+      updateHandler.updateCamera(new PerspectiveCamera(), false);
 
       await flushPipeline();
 
@@ -90,7 +90,7 @@ describe(CadModelUpdateHandler.name, () => {
 
       const updateHandler = new CadModelUpdateHandler(mockCuller);
       updateHandler.addModel(cadNode);
-      updateHandler.updateCamera(new THREE.PerspectiveCamera(), false);
+      updateHandler.updateCamera(new PerspectiveCamera(), false);
 
       await flushPipeline();
 
@@ -108,7 +108,7 @@ describe(CadModelUpdateHandler.name, () => {
 
       const updateHandler = new CadModelUpdateHandler(mockCuller);
       updateHandler.addModel(cadNode);
-      updateHandler.updateCamera(new THREE.PerspectiveCamera(), false);
+      updateHandler.updateCamera(new PerspectiveCamera(), false);
 
       await flushPipeline();
 
@@ -124,7 +124,7 @@ describe(CadModelUpdateHandler.name, () => {
 
       const updateHandler = new CadModelUpdateHandler(mockCuller);
       updateHandler.addModel(cadNode);
-      updateHandler.updateCamera(new THREE.PerspectiveCamera(), false);
+      updateHandler.updateCamera(new PerspectiveCamera(), false);
 
       await flushPipeline();
 

--- a/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadModelUpdateHandler.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { PerspectiveCamera, Plane } from 'three';
 
 import { assertNever, EventTrigger, type EventListener } from '@reveal/utilities';
 import type { ConsumedSector } from '@reveal/cad-parsers';
@@ -46,7 +46,7 @@ export class CadModelUpdateHandler {
   private readonly _determineSectorsHandler: SectorLoader;
 
   private readonly _cameraSubject: Subject<CameraInput> = new Subject();
-  private readonly _clippingPlaneSubject: Subject<THREE.Plane[]> = new Subject();
+  private readonly _clippingPlaneSubject: Subject<Plane[]> = new Subject();
   private readonly _loadingHintsSubject: Subject<CadLoadingHints> = new Subject();
   private readonly _prioritizedLoadingHintsSubject: Subject<void> = new Subject();
   private readonly _modelSubject: Subject<{ model: CadNode; operation: 'add' | 'remove' }> = new Subject();
@@ -149,11 +149,11 @@ export class CadModelUpdateHandler {
     Object.values(this._events).forEach(eventTrigger => eventTrigger.unsubscribeAll());
   }
 
-  updateCamera(camera: THREE.PerspectiveCamera, cameraInMotion: boolean): void {
+  updateCamera(camera: PerspectiveCamera, cameraInMotion: boolean): void {
     this._cameraSubject.next(makeCameraInput([camera, cameraInMotion]));
   }
 
-  set clippingPlanes(value: THREE.Plane[]) {
+  set clippingPlanes(value: Plane[]) {
     this._clippingPlaneSubject.next(value);
   }
 
@@ -231,20 +231,20 @@ type SettingsInput = {
   budget: CadModelBudget;
 };
 type CameraInput = {
-  camera: THREE.PerspectiveCamera;
+  camera: PerspectiveCamera;
   cameraInMotion: boolean;
 };
 type ClippingInput = {
-  clippingPlanes: THREE.Plane[] | never[];
+  clippingPlanes: Plane[] | never[];
 };
 
 function makeSettingsInput([loadingHints, budget]: [CadLoadingHints, CadModelBudget]): SettingsInput {
   return { loadingHints, budget };
 }
-function makeCameraInput([camera, cameraInMotion]: [THREE.PerspectiveCamera, boolean]): CameraInput {
+function makeCameraInput([camera, cameraInMotion]: [PerspectiveCamera, boolean]): CameraInput {
   return { camera, cameraInMotion };
 }
-function makeClippingInput([clippingPlanes]: [THREE.Plane[]]): ClippingInput {
+function makeClippingInput([clippingPlanes]: [Plane[]]): ClippingInput {
   return { clippingPlanes };
 }
 

--- a/viewer/packages/cad-geometry-loaders/src/sector/ModelStateHandler.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/ModelStateHandler.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
 import type { WantedSector, ConsumedSector, SectorMetadata } from '@reveal/cad-parsers';
 import { LevelOfDetail } from '@reveal/cad-parsers';
@@ -89,8 +89,8 @@ function mockWantedSectors(id: number): {
     id,
     path: '0/',
     depth: 0,
-    subtreeBoundingBox: new THREE.Box3(),
-    geometryBoundingBox: new THREE.Box3(),
+    subtreeBoundingBox: new Box3(),
+    geometryBoundingBox: new Box3(),
     estimatedDrawCallCount: 0,
     estimatedRenderCost: 0,
     minDiagonalLength: 0.1,

--- a/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/SectorLoader.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { PerspectiveCamera } from 'three';
 
 import { asyncIteratorToArray, createCadModelMetadata, generateV9SectorTree } from '../../../../test-utilities';
 import type { CadModelMetadata, SectorMetadata, ConsumedSector, WantedSector } from '@reveal/cad-parsers';
@@ -64,7 +64,7 @@ describe('SectorLoader', () => {
       .returns([]);
 
     input = {
-      camera: new THREE.PerspectiveCamera(),
+      camera: new PerspectiveCamera(),
       budget: {
         highDetailProximityThreshold: 0,
         maximumRenderCost: 0

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/ByScreenSizeSectorCuller.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/ByScreenSizeSectorCuller.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, PerspectiveCamera, Plane, Vector3 } from 'three';
 
 import { ByScreenSizeSectorCuller } from './ByScreenSizeSectorCuller';
 
@@ -17,7 +17,7 @@ import { Mock } from 'moq.ts';
 import type { DetermineSectorsInput } from './types';
 
 describe(ByScreenSizeSectorCuller.name, () => {
-  let camera: THREE.PerspectiveCamera;
+  let camera: PerspectiveCamera;
   let model: CadModelMetadata;
   let budget: CadModelBudget;
   let allSectorsRenderCost: number;
@@ -28,17 +28,17 @@ describe(ByScreenSizeSectorCuller.name, () => {
     const root = createV9SectorMetadata([
       0,
       [
-        [1, [], new THREE.Box3().setFromArray([-1, -1, 0, 0, 1, 1])],
-        [2, [], new THREE.Box3().setFromArray([0, -1, 1, 0, 0, 1])],
-        [3, [], new THREE.Box3().setFromArray([-1, 0, 1, 0, 1, 1])],
-        [4, [], new THREE.Box3().setFromArray([0, 0, 1, 1, 1, 1])]
+        [1, [], new Box3().setFromArray([-1, -1, 0, 0, 1, 1])],
+        [2, [], new Box3().setFromArray([0, -1, 1, 0, 0, 1])],
+        [3, [], new Box3().setFromArray([-1, 0, 1, 0, 1, 1])],
+        [4, [], new Box3().setFromArray([0, 0, 1, 1, 1, 1])]
       ],
-      new THREE.Box3().setFromArray([-1, -1, -1, 1, 1, 1])
+      new Box3().setFromArray([-1, -1, -1, 1, 1, 1])
     ]);
     model = createCadModelMetadata(9, root);
     allSectorsRenderCost = model.scene.getAllSectors().reduce((sum, x) => sum + x.estimatedRenderCost, 0);
 
-    camera = new THREE.PerspectiveCamera();
+    camera = new PerspectiveCamera();
     camera.position.set(0, 0, 0);
     camera.near = 1.0;
     camera.far = 10.0;
@@ -75,7 +75,7 @@ describe(ByScreenSizeSectorCuller.name, () => {
   test('determineSectors doesnt return fully culled sectors', () => {
     budget = { ...budget, maximumRenderCost: allSectorsRenderCost / 2.0 };
     const input = createDetermineSectorInput(camera, model, budget);
-    const clipPlane = new THREE.Plane(new THREE.Vector3(1, 0, 0), -0.5);
+    const clipPlane = new Plane(new Vector3(1, 0, 0), -0.5);
     input.modelClippingPlanes = [[clipPlane]];
 
     const { wantedSectors } = culler.determineSectors(input);
@@ -92,7 +92,7 @@ describe(ByScreenSizeSectorCuller.name, () => {
   test('determineSectors prioritizes sectors intersecting prioritized areas', () => {
     budget = { ...budget, maximumRenderCost: allSectorsRenderCost / 2.0 };
     const input = createDetermineSectorInput(camera, model, budget);
-    const prioritizedAreaBounds = new THREE.Box3().setFromArray([0.5, 0.5, 0.5, 1.0, 1.0, 1.0]);
+    const prioritizedAreaBounds = new Box3().setFromArray([0.5, 0.5, 0.5, 1.0, 1.0, 1.0]);
     const expectedTopPrioritySectors = model.scene.getSectorsIntersectingBox(prioritizedAreaBounds);
     input.prioritizedAreas = [{ area: prioritizedAreaBounds, extraPriority: 10 }];
 

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/ByScreenSizeSectorCuller.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/ByScreenSizeSectorCuller.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Plane } from 'three';
+import { Box3, Matrix4 } from 'three';
 
 import type { DetermineSectorCostDelegate, DetermineSectorsInput, SectorLoadingSpent } from './types';
 import { WeightFunctionsHelper } from './WeightFunctionsHelper';
@@ -136,7 +137,7 @@ function takeSectorsWithinBudget(
 }
 
 const sortSectorsByPriorityVars = {
-  transformedBounds: new THREE.Box3()
+  transformedBounds: new Box3()
 };
 
 function sortSectorsByPriority(
@@ -176,8 +177,8 @@ function sortSectorsByPriority(
  */
 function determineCandidateSectorsByModel(
   cadModelsMetadata: CadModelMetadata[],
-  cameraWorldInverseMatrix: THREE.Matrix4,
-  cameraProjectionMatrix: THREE.Matrix4,
+  cameraWorldInverseMatrix: Matrix4,
+  cameraProjectionMatrix: Matrix4,
   input: DetermineSectorsInput
 ) {
   return cadModelsMetadata.reduce((result, model, i) => {
@@ -213,17 +214,17 @@ function initializeTakenSectorsAndWeightFunctions(
  * Determines candidate sectors, i.e.
  */
 function determineCandidateSectors(
-  cameraWorldInverseMatrix: THREE.Matrix4,
-  cameraProjectionMatrix: THREE.Matrix4,
-  modelMatrix: THREE.Matrix4,
+  cameraWorldInverseMatrix: Matrix4,
+  cameraProjectionMatrix: Matrix4,
+  modelMatrix: Matrix4,
   modelScene: SectorScene,
-  clippingPlanes: THREE.Plane[]
+  clippingPlanes: Plane[]
 ): SectorMetadata[] {
   if (modelScene.version !== 9) {
     throw new Error(`Expected model version 9, but got ${modelScene.version}`);
   }
 
-  const transformedCameraMatrixWorldInverse = new THREE.Matrix4();
+  const transformedCameraMatrixWorldInverse = new Matrix4();
   transformedCameraMatrixWorldInverse.multiplyMatrices(cameraWorldInverseMatrix, modelMatrix);
   const sectors = modelScene.getSectorsIntersectingFrustum(cameraProjectionMatrix, transformedCameraMatrixWorldInverse);
 
@@ -231,7 +232,7 @@ function determineCandidateSectors(
     return sectors;
   }
 
-  const bounds = new THREE.Box3();
+  const bounds = new Box3();
   return sectors.filter(sector => {
     bounds.copy(sector.subtreeBoundingBox);
     bounds.applyMatrix4(modelMatrix);
@@ -247,7 +248,7 @@ function determineCandidateSectors(
 function determineSectorPriority(
   weightFunctions: WeightFunctionsHelper,
   sector: SectorMetadata,
-  transformedBounds: THREE.Box3,
+  transformedBounds: Box3,
   prioritizedAreas: PrioritizedArea[]
 ) {
   const levelWeightImportance = 2.0;

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/WeightFunctionsHelper.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/WeightFunctionsHelper.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Matrix4, PerspectiveCamera, Vector3 } from 'three';
 import { WeightFunctionsHelper } from './WeightFunctionsHelper';
 
 import type { PrioritizedArea } from '@reveal/cad-styling';
@@ -12,7 +12,7 @@ import type { SectorMetadata } from '@reveal/cad-parsers';
 import { Mock } from 'moq.ts';
 import { createV9SectorMetadata } from '../../../../../test-utilities';
 
-function mockSectorMetadataFromBounds(box: THREE.Box3): SectorMetadata {
+function mockSectorMetadataFromBounds(box: Box3): SectorMetadata {
   return new Mock<SectorMetadata>()
     .setup(p => p.subtreeBoundingBox)
     .returns(box)
@@ -20,13 +20,13 @@ function mockSectorMetadataFromBounds(box: THREE.Box3): SectorMetadata {
 }
 
 describe('WeightFunctionsHelper', () => {
-  let camera: THREE.PerspectiveCamera;
+  let camera: PerspectiveCamera;
   let sectors: SectorMetadata[];
   let helper: WeightFunctionsHelper;
-  const identityMatrix = new THREE.Matrix4().identity();
+  const identityMatrix = new Matrix4().identity();
 
   beforeEach(() => {
-    camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10.0);
+    camera = new PerspectiveCamera(60, 1, 0.1, 10.0);
     camera.position.set(0, 0, 0);
     camera.lookAt(0, 0, 1);
     camera.updateProjectionMatrix();
@@ -35,10 +35,10 @@ describe('WeightFunctionsHelper', () => {
     const rootSector = createV9SectorMetadata([
       0,
       [
-        [1, [], new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.5, 1, 1))],
-        [2, [], new THREE.Box3(new THREE.Vector3(0.5, 0, 0), new THREE.Vector3(1, 1, 1))]
+        [1, [], new Box3(new Vector3(0, 0, 0), new Vector3(0.5, 1, 1))],
+        [2, [], new Box3(new Vector3(0.5, 0, 0), new Vector3(1, 1, 1))]
       ],
-      new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1))
+      new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1))
     ]);
     sectors = [];
     traverseDepthFirst(rootSector as SectorMetadata, x => {
@@ -50,11 +50,11 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('computeTransformedSectorBounds applies model matrix', () => {
-    const modelMatrix = new THREE.Matrix4().makeRotationX(Math.PI / 4);
-    const bounds = new THREE.Box3(new THREE.Vector3(-1, -2, -3), new THREE.Vector3(4, 5, 6));
+    const modelMatrix = new Matrix4().makeRotationX(Math.PI / 4);
+    const bounds = new Box3(new Vector3(-1, -2, -3), new Vector3(4, 5, 6));
     const expectedResult = bounds.clone().applyMatrix4(modelMatrix);
 
-    const result = new THREE.Box3();
+    const result = new Box3();
     helper.computeTransformedSectorBounds(bounds, modelMatrix, result);
 
     expect(result).toEqual(expectedResult);
@@ -62,7 +62,7 @@ describe('WeightFunctionsHelper', () => {
 
   test('computeDistanceToCameraWeight returns 1 for camera sector is inside', () => {
     helper.addCandidateSectors(sectors, identityMatrix);
-    const bounds = new THREE.Box3().setFromArray([0, 0, 0, 1, 1, 1]);
+    const bounds = new Box3().setFromArray([0, 0, 0, 1, 1, 1]);
     camera.position.set(0.5, 0.5, 0.5);
 
     const weight = helper.computeDistanceToCameraWeight(bounds);
@@ -84,7 +84,7 @@ describe('WeightFunctionsHelper', () => {
     camera.position.set(11, 12, 13);
     camera.updateMatrixWorld();
 
-    const bounds = new THREE.Box3().setFromArray([1000, 1000, 1000, 1001, 1001, 1001]);
+    const bounds = new Box3().setFromArray([1000, 1000, 1000, 1001, 1001, 1001]);
     const weight = helper.computeScreenAreaWeight(bounds);
     expect(weight).toBe(0.0);
   });
@@ -93,7 +93,7 @@ describe('WeightFunctionsHelper', () => {
     camera.position.set(0.5, 0.5, 0.5);
     camera.updateProjectionMatrix();
     const helper = new WeightFunctionsHelper(camera);
-    const bounds = new THREE.Box3().setFromArray([0, 0, 0, 1, 1, 1]);
+    const bounds = new Box3().setFromArray([0, 0, 0, 1, 1, 1]);
 
     const weight = helper.computeScreenAreaWeight(bounds);
 
@@ -101,7 +101,7 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('computeScreenArea returns value in range (0, 1) for sector partially overlapping view', () => {
-    const bounds = new THREE.Box3().setFromArray([-0.2, -0.2, 0.9, 0.2, 0.2, 1]);
+    const bounds = new Box3().setFromArray([-0.2, -0.2, 0.9, 0.2, 0.2, 1]);
 
     const weight = helper.computeScreenAreaWeight(bounds);
 
@@ -110,7 +110,7 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('computeFrustumDepthWeight returns 0 for sector outside frustum', () => {
-    const bounds = new THREE.Box3().setFromArray([11, 11, 11, 12, 12, 12]);
+    const bounds = new Box3().setFromArray([11, 11, 11, 12, 12, 12]);
 
     const weight = helper.computeFrustumDepthWeight(bounds);
 
@@ -118,8 +118,8 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('computeFrustumDepthWeight returns weight greater if covers more depth', () => {
-    const partialDepthBounds = new THREE.Box3().setFromArray([-0.1, -0.1, 2, 0.1, 0.1, 5]);
-    const fullDepthBounds = new THREE.Box3().setFromArray([-0.1, -0.1, 0, 0.1, 0.1, 15]);
+    const partialDepthBounds = new Box3().setFromArray([-0.1, -0.1, 2, 0.1, 0.1, 5]);
+    const fullDepthBounds = new Box3().setFromArray([-0.1, -0.1, 0, 0.1, 0.1, 15]);
 
     const partialDepthWeight = helper.computeFrustumDepthWeight(partialDepthBounds);
     const fullDepthWeight = helper.computeFrustumDepthWeight(fullDepthBounds);
@@ -128,7 +128,7 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('computeMaximumNodeScreenSizeWeight returns greater weight for large objects', () => {
-    const bounds = new THREE.Box3().setFromArray([-1, -1, 5, 1, 1, 6]);
+    const bounds = new Box3().setFromArray([-1, -1, 5, 1, 1, 6]);
 
     const smallObjectWeight = helper.computeMaximumNodeScreenSizeWeight(bounds, 0.1);
     const largeObjectWeight = helper.computeMaximumNodeScreenSizeWeight(bounds, 0.2);
@@ -139,37 +139,35 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('computeMaximumNodeScreenSizeWeight returns 1.0 for regardless of size if camera is inside sector', () => {
-    const bounds = new THREE.Box3().setFromArray([-1, -1, -1, 1, 1, 1]);
+    const bounds = new Box3().setFromArray([-1, -1, -1, 1, 1, 1]);
     expect(helper.computeMaximumNodeScreenSizeWeight(bounds, 1e-10)).toBe(1);
     expect(helper.computeMaximumNodeScreenSizeWeight(bounds, 1e10)).toBe(1);
   });
 
   test('computePrioritizedAreaWeight returns 0 when sector doesnt intersect prioritized area', () => {
-    const bounds = new THREE.Box3().setFromArray([-1, -1, -1, 1, 1, 1]);
-    const areas: PrioritizedArea[] = [
-      { area: new THREE.Box3().setFromArray([10, 10, 10, 11, 11, 11]), extraPriority: 10.0 }
-    ];
+    const bounds = new Box3().setFromArray([-1, -1, -1, 1, 1, 1]);
+    const areas: PrioritizedArea[] = [{ area: new Box3().setFromArray([10, 10, 10, 11, 11, 11]), extraPriority: 10.0 }];
     expect(helper.computePrioritizedAreaWeight(bounds, areas)).toBe(0.0);
   });
 
   test('computePrioritizedAreaWeight returns maximum extra priority when sector intersects several areas', () => {
-    const bounds = new THREE.Box3().setFromArray([-1, -1, -1, 1, 1, 1]);
+    const bounds = new Box3().setFromArray([-1, -1, -1, 1, 1, 1]);
     const areas: PrioritizedArea[] = [
-      { area: new THREE.Box3().setFromArray([-0.5, -0.5, -0.5, 0, 0, 0]), extraPriority: 2.0 },
-      { area: new THREE.Box3().setFromArray([0, 0, 0, 0.5, 0.5, 0.5]), extraPriority: 4.0 }
+      { area: new Box3().setFromArray([-0.5, -0.5, -0.5, 0, 0, 0]), extraPriority: 2.0 },
+      { area: new Box3().setFromArray([0, 0, 0, 0.5, 0.5, 0.5]), extraPriority: 4.0 }
     ];
     expect(helper.computePrioritizedAreaWeight(bounds, areas)).toBe(4.0);
   });
 
   test('addCandidateSectors keeps previously added sectors', () => {
-    const bounds0 = new THREE.Box3().setFromArray([0, 0, 1, 0, 0, 2]);
-    const bounds1 = new THREE.Box3().setFromArray([0, 0, 3, 0, 0, 4]);
-    const bounds2 = new THREE.Box3().setFromArray([0, 0, 5, 0, 0, 6]);
+    const bounds0 = new Box3().setFromArray([0, 0, 1, 0, 0, 2]);
+    const bounds1 = new Box3().setFromArray([0, 0, 3, 0, 0, 4]);
+    const bounds2 = new Box3().setFromArray([0, 0, 5, 0, 0, 6]);
 
-    helper.addCandidateSectors([mockSectorMetadataFromBounds(bounds0)], new THREE.Matrix4().identity());
+    helper.addCandidateSectors([mockSectorMetadataFromBounds(bounds0)], new Matrix4().identity());
     helper.addCandidateSectors(
       [mockSectorMetadataFromBounds(bounds1), mockSectorMetadataFromBounds(bounds2)],
-      new THREE.Matrix4().identity()
+      new Matrix4().identity()
     );
 
     const newDistance = helper.computeDistanceToCameraWeight(bounds0);
@@ -179,9 +177,9 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('distance weight is reasonable when only one sector is present', () => {
-    const bounds = new THREE.Box3().setFromArray([0, 0, 1, 1, 1, 2]);
+    const bounds = new Box3().setFromArray([0, 0, 1, 1, 1, 2]);
 
-    helper.addCandidateSectors([mockSectorMetadataFromBounds(bounds)], new THREE.Matrix4().identity());
+    helper.addCandidateSectors([mockSectorMetadataFromBounds(bounds)], new Matrix4().identity());
     const distance = helper.computeDistanceToCameraWeight(bounds);
 
     expect(distance).toBeLessThanOrEqual(1);
@@ -189,13 +187,13 @@ describe('WeightFunctionsHelper', () => {
   });
 
   test('reset() resets min/max distances', () => {
-    const bounds0 = new THREE.Box3().setFromArray([0, 0, 1, 0, 0, 2]);
-    const bounds1 = new THREE.Box3().setFromArray([0, 0, 3, 0, 0, 4]);
-    const bounds2 = new THREE.Box3().setFromArray([0, 0, 5, 0, 0, 6]);
+    const bounds0 = new Box3().setFromArray([0, 0, 1, 0, 0, 2]);
+    const bounds1 = new Box3().setFromArray([0, 0, 3, 0, 0, 4]);
+    const bounds2 = new Box3().setFromArray([0, 0, 5, 0, 0, 6]);
 
     helper.addCandidateSectors(
       [mockSectorMetadataFromBounds(bounds0), mockSectorMetadataFromBounds(bounds1)],
-      new THREE.Matrix4().identity()
+      new Matrix4().identity()
     );
     const distance = helper.computeDistanceToCameraWeight(bounds0);
 
@@ -205,7 +203,7 @@ describe('WeightFunctionsHelper', () => {
     helper.reset();
     helper.addCandidateSectors(
       [mockSectorMetadataFromBounds(bounds1), mockSectorMetadataFromBounds(bounds2)],
-      new THREE.Matrix4().identity()
+      new Matrix4().identity()
     );
 
     const newDistance = helper.computeDistanceToCameraWeight(bounds0);

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/WeightFunctionsHelper.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/WeightFunctionsHelper.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { PerspectiveCamera } from 'three';
+import { Box3, Frustum, Matrix4, Vector3 } from 'three';
 
 import { computeNdcAreaOfBox } from './computeNdcAreaOfBox';
 
@@ -10,23 +11,23 @@ import type { SectorMetadata } from '@reveal/cad-parsers';
 import type { PrioritizedArea } from '@reveal/cad-styling';
 
 const preallocated = {
-  transformedBounds: new THREE.Box3()
+  transformedBounds: new Box3()
 };
 
 type ModifiedFrustum = {
   near: number;
   far: number;
   weight: number;
-  frustum: THREE.Frustum;
+  frustum: Frustum;
 };
 
 export class WeightFunctionsHelper {
-  private readonly _camera: THREE.PerspectiveCamera;
+  private readonly _camera: PerspectiveCamera;
   private _minSectorDistance: number = Infinity;
   private _maxSectorDistance: number = -Infinity;
   private readonly _modifiedFrustums: ModifiedFrustum[];
 
-  constructor(camera: THREE.PerspectiveCamera) {
+  constructor(camera: PerspectiveCamera) {
     this._camera = camera;
 
     // Create modified projection matrices to add heuristic of how "deep" in the frustum sectors are located
@@ -40,8 +41,8 @@ export class WeightFunctionsHelper {
       { near: near + 0.4 * nearFarRange, far: near + 1.0 * nearFarRange, weight: 0.2 } // 40-100% of frustum
     ].map(modifiedFrustum => {
       const projectionMatrix = createModifiedProjectionMatrix(camera, modifiedFrustum.near, modifiedFrustum.far);
-      const frustumMatrix = new THREE.Matrix4().multiplyMatrices(projectionMatrix, this._camera.matrixWorldInverse);
-      const frustum = new THREE.Frustum().setFromProjectionMatrix(frustumMatrix);
+      const frustumMatrix = new Matrix4().multiplyMatrices(projectionMatrix, this._camera.matrixWorldInverse);
+      const frustum = new Frustum().setFromProjectionMatrix(frustumMatrix);
       return {
         ...modifiedFrustum,
         frustum
@@ -54,7 +55,7 @@ export class WeightFunctionsHelper {
     this._maxSectorDistance = -Infinity;
   }
 
-  addCandidateSectors(sectors: SectorMetadata[], modelMatrix: THREE.Matrix4): void {
+  addCandidateSectors(sectors: SectorMetadata[], modelMatrix: Matrix4): void {
     // Note! We compute distance to camera, not screen (which would probably be better)
     const { minDistance, maxDistance } = sectors.reduce(
       (minMax, sector) => {
@@ -69,7 +70,7 @@ export class WeightFunctionsHelper {
     this._maxSectorDistance = maxDistance;
   }
 
-  computeTransformedSectorBounds(sectorBounds: THREE.Box3, modelMatrix: THREE.Matrix4, out: THREE.Box3): void {
+  computeTransformedSectorBounds(sectorBounds: Box3, modelMatrix: Matrix4, out: Box3): void {
     out.copy(sectorBounds);
     out.applyMatrix4(modelMatrix);
   }
@@ -77,7 +78,7 @@ export class WeightFunctionsHelper {
   /**
    * Computes a weight in range [0-1], where 1 means close to camera and 0 means far away.
    */
-  computeDistanceToCameraWeight(transformedSectorBounds: THREE.Box3): number {
+  computeDistanceToCameraWeight(transformedSectorBounds: Box3): number {
     const minSectorDistance = this._minSectorDistance;
     const maxSectorDistance = this._maxSectorDistance;
 
@@ -96,7 +97,7 @@ export class WeightFunctionsHelper {
    * @param transformedSectorBounds
    * @returns
    */
-  computeScreenAreaWeight(transformedSectorBounds: THREE.Box3): number {
+  computeScreenAreaWeight(transformedSectorBounds: Box3): number {
     const distanceToCamera = transformedSectorBounds.distanceToPoint(this._camera.position);
     return distanceToCamera > 0.0 ? computeNdcAreaOfBox(this._camera, transformedSectorBounds) : 1.0;
   }
@@ -106,7 +107,7 @@ export class WeightFunctionsHelper {
    * in the frustum the sector is placed.
    * @param transformedSectorBounds
    */
-  computeFrustumDepthWeight(transformedSectorBounds: THREE.Box3): number {
+  computeFrustumDepthWeight(transformedSectorBounds: Box3): number {
     const frustumWeight = this._modifiedFrustums.reduce((accumulatedWeight, x) => {
       const { frustum, weight } = x;
       const accepted = frustum.intersectsBox(transformedSectorBounds);
@@ -130,7 +131,7 @@ export class WeightFunctionsHelper {
    * Computes a weight based on how large the biggest node within the sector
    * will be on screen (a number in range [0-1]).
    */
-  computeMaximumNodeScreenSizeWeight(transformedSectorBounds: THREE.Box3, maxNodeDiagonalLength: number): number {
+  computeMaximumNodeScreenSizeWeight(transformedSectorBounds: Box3, maxNodeDiagonalLength: number): number {
     const distanceToCamera = transformedSectorBounds.distanceToPoint(this._camera.position);
     if (distanceToCamera === 0.0) {
       return 1.0; // Can cover the whole screen regardless of how big the node is
@@ -140,7 +141,7 @@ export class WeightFunctionsHelper {
     // the size of this line on screen. Note that using camera distance is slightly wrong,
     // a better measurement is distance to screen but in practice this works well
     const p0 = this._camera
-      .getWorldDirection(new THREE.Vector3())
+      .getWorldDirection(new Vector3())
       .multiplyScalar(distanceToCamera)
       .add(this._camera.position);
     const p1 = p0.clone().addScaledVector(this._camera.up, maxNodeDiagonalLength);
@@ -162,7 +163,7 @@ export class WeightFunctionsHelper {
    * @param transformedSectorBounds   Bounds of sectors in "Reveal coordinates".
    * @param prioritizedAreas          Zero or more areas with associated priorities.
    */
-  computePrioritizedAreaWeight(transformedSectorBounds: THREE.Box3, prioritizedAreas: PrioritizedArea[]): number {
+  computePrioritizedAreaWeight(transformedSectorBounds: Box3, prioritizedAreas: PrioritizedArea[]): number {
     const extraPriority = prioritizedAreas.reduce((maxExtraPriority, prioritizedArea) => {
       if (transformedSectorBounds.intersectsBox(prioritizedArea.area)) {
         return Math.max(prioritizedArea.extraPriority, maxExtraPriority);
@@ -172,7 +173,7 @@ export class WeightFunctionsHelper {
     return extraPriority;
   }
 
-  private distanceToCamera(sector: SectorMetadata, modelMatrix: THREE.Matrix4) {
+  private distanceToCamera(sector: SectorMetadata, modelMatrix: Matrix4) {
     const { transformedBounds } = preallocated;
     transformedBounds.copy(sector.subtreeBoundingBox);
     transformedBounds.applyMatrix4(modelMatrix);
@@ -180,7 +181,7 @@ export class WeightFunctionsHelper {
   }
 }
 
-function createModifiedProjectionMatrix(camera: THREE.PerspectiveCamera, near: number, far: number): THREE.Matrix4 {
+function createModifiedProjectionMatrix(camera: PerspectiveCamera, near: number, far: number): Matrix4 {
   const modifiedCamera = camera.clone();
   modifiedCamera.near = near;
   modifiedCamera.far = far;

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/computeNdcAreaOfBox.test.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/computeNdcAreaOfBox.test.ts
@@ -2,19 +2,19 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, OrthographicCamera, PerspectiveCamera, Vector3 } from 'three';
 import { computeNdcAreaOfBox } from './computeNdcAreaOfBox';
 
 describe('computeNdcAreaOfBox', () => {
-  let camera: THREE.PerspectiveCamera;
+  let camera: PerspectiveCamera;
 
   beforeEach(() => {
     // At <0,0,0>, looking down negative z
-    camera = new THREE.PerspectiveCamera();
+    camera = new PerspectiveCamera();
   });
 
   test('box is out side frustum, returns 0', () => {
-    const box = new THREE.Box3(new THREE.Vector3(5, 5, 2), new THREE.Vector3(6, 6, 3));
+    const box = new Box3(new Vector3(5, 5, 2), new Vector3(6, 6, 3));
     const area = computeNdcAreaOfBox(camera, box);
     expect(area).toBe(0.0);
   });
@@ -22,7 +22,7 @@ describe('computeNdcAreaOfBox', () => {
   test('box is fully encapsulating frustum', () => {
     camera.near = 0.1;
     camera.far = 1.0;
-    const box = new THREE.Box3(new THREE.Vector3(-10, -10, 0), new THREE.Vector3(10, 10, 1));
+    const box = new Box3(new Vector3(-10, -10, 0), new Vector3(10, 10, 1));
     const area = computeNdcAreaOfBox(camera, box);
     expect(area).toBe(1.0);
   });
@@ -33,15 +33,15 @@ describe('computeNdcAreaOfBox', () => {
     camera.updateMatrixWorld();
     camera.updateProjectionMatrix();
 
-    const box = new THREE.Box3(new THREE.Vector3(-0.25, -0.25, -2), new THREE.Vector3(0.25, 0.25, -1));
+    const box = new Box3(new Vector3(-0.25, -0.25, -2), new Vector3(0.25, 0.25, -1));
     const area = computeNdcAreaOfBox(camera, box);
     expect(area).toBeGreaterThan(0.0);
     expect(area).toBeLessThan(1.0);
   });
 
   test('box intersecting frustum', () => {
-    const camera = new THREE.OrthographicCamera(-1, 1, -1, 1, 0, 1);
-    const box = new THREE.Box3(new THREE.Vector3(0.0, 0.0, 0.0), new THREE.Vector3(1.5, 1.5, 1.5));
+    const camera = new OrthographicCamera(-1, 1, -1, 1, 0, 1);
+    const box = new Box3(new Vector3(0.0, 0.0, 0.0), new Vector3(1.5, 1.5, 1.5));
     const area = computeNdcAreaOfBox(camera, box);
     expect(area).toBe(1.0 / 4.0);
   });
@@ -53,13 +53,13 @@ describe('computeNdcAreaOfBox', () => {
     camera.updateProjectionMatrix();
     camera.updateMatrixWorld();
 
-    const box = new THREE.Box3(new THREE.Vector3(-1, -1, 100.0), new THREE.Vector3(1, 1, -108.0));
+    const box = new Box3(new Vector3(-1, -1, 100.0), new Vector3(1, 1, -108.0));
     const area = computeNdcAreaOfBox(camera, box);
     expect(area).toBe(1.0);
   });
 
   test('box is behind camera', () => {
-    const box = new THREE.Box3(new THREE.Vector3(-1, -1, 10.0), new THREE.Vector3(1, 1, 20.0));
+    const box = new Box3(new Vector3(-1, -1, 10.0), new Vector3(1, 1, 20.0));
     const area = computeNdcAreaOfBox(camera, box);
     expect(area).toBe(0.0);
   });

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/computeNdcAreaOfBox.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/computeNdcAreaOfBox.ts
@@ -1,11 +1,12 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { Camera } from 'three';
+import { Box3, Vector3 } from 'three';
 import { transformBoxToNDC } from './transformBoxToNDC';
 
-const ndcSpace = new THREE.Box3(new THREE.Vector3(-1, -1, -1), new THREE.Vector3(1, 1, 1));
-const ndcBox = new THREE.Box3();
+const ndcSpace = new Box3(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
+const ndcBox = new Box3();
 
 /**
  * Computes area of the box after converting it to NDC space. The returned value will be a number
@@ -14,7 +15,7 @@ const ndcBox = new THREE.Box3();
  * @param box
  * @returns
  */
-export function computeNdcAreaOfBox(camera: THREE.Camera, box: THREE.Box3): number {
+export function computeNdcAreaOfBox(camera: Camera, box: Box3): number {
   transformBoxToNDC(box, camera, ndcBox);
   ndcBox.intersect(ndcSpace);
   if (ndcBox.isEmpty()) {

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/transformBoxToNDC.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/transformBoxToNDC.ts
@@ -2,12 +2,13 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Camera } from 'three';
+import { Box3 } from 'three';
 
 import { visitBox3CornerPoints } from '@reveal/utilities';
 
-export function transformBoxToNDC(box: THREE.Box3, camera: THREE.Camera, out?: THREE.Box3): THREE.Box3 {
-  const transformedBox = out !== undefined ? out : new THREE.Box3();
+export function transformBoxToNDC(box: Box3, camera: Camera, out?: Box3): Box3 {
+  const transformedBox = out !== undefined ? out : new Box3();
   transformedBox.makeEmpty();
 
   visitBox3CornerPoints(box, corner => {

--- a/viewer/packages/cad-geometry-loaders/src/sector/culling/types.ts
+++ b/viewer/packages/cad-geometry-loaders/src/sector/culling/types.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import type * as THREE from 'three';
+import type { PerspectiveCamera, Plane } from 'three';
 
 import type { PrioritizedArea } from '@reveal/cad-styling';
 import type { CadModelMetadata, LevelOfDetail, WantedSector } from '@reveal/cad-parsers';
@@ -11,8 +11,8 @@ import type { CadModelBudget } from '../../CadModelBudget';
 import type { CadNode } from '@reveal/cad-model';
 
 export interface DetermineSectorsInput {
-  camera: THREE.PerspectiveCamera;
-  modelClippingPlanes: THREE.Plane[][];
+  camera: PerspectiveCamera;
+  modelClippingPlanes: Plane[][];
   cadModelsMetadata: CadModelMetadata[];
   loadingHints: CadLoadingHints;
   cameraInMotion: boolean;
@@ -31,8 +31,8 @@ export interface DetermineSectorsInput {
 }
 
 export type DetermineSectorsPayload = {
-  camera: THREE.PerspectiveCamera;
-  clippingPlanes: THREE.Plane[];
+  camera: PerspectiveCamera;
+  clippingPlanes: Plane[];
   models: CadNode[];
   loadingHints: CadLoadingHints;
   cameraInMotion: boolean;

--- a/viewer/packages/cad-model/src/CadModelFactory.test.ts
+++ b/viewer/packages/cad-model/src/CadModelFactory.test.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Box3, Matrix4, Vector3 } from 'three';
 
 import { CadModelFactory } from './CadModelFactory';
 
@@ -53,9 +53,9 @@ describe(CadModelFactory.name, () => {
       .setup(p => p.getModelUri(mockIdentifier, testOutput))
       .returns(Promise.resolve(testBaseUrl))
       .setup(p => p.getModelMatrix(mockIdentifier, testOutput.format))
-      .returns(Promise.resolve(new THREE.Matrix4()))
+      .returns(Promise.resolve(new Matrix4()))
       .setup(p => p.getModelCamera(mockIdentifier))
-      .returns(Promise.resolve({ position: new THREE.Vector3(), target: new THREE.Vector3(0, 0, 1) }));
+      .returns(Promise.resolve({ position: new Vector3(), target: new Vector3(0, 0, 1) }));
 
     const mock = new Mock<ModelDataProvider>()
       .setup(p => p.getJsonFile(testBaseUrl, It.IsAny<string>()))
@@ -75,7 +75,7 @@ describe(CadModelFactory.name, () => {
 
   test('createModel() sets model clipping planes when a clip box is set', async () => {
     const geometryFilter: GeometryFilter = {
-      boundingBox: new THREE.Box3(new THREE.Vector3(-1, -2, -3), new THREE.Vector3(4, 5, 6)),
+      boundingBox: new Box3(new Vector3(-1, -2, -3), new Vector3(4, 5, 6)),
       isBoundingBoxInModelCoordinates: true
     };
 

--- a/viewer/packages/cad-model/src/CadModelFactory.ts
+++ b/viewer/packages/cad-model/src/CadModelFactory.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
 import { BoundingBoxClipper } from './utilities/BoundingBoxClipper';
 import type { GeometryFilter } from './types';
@@ -80,16 +80,13 @@ export class CadModelFactory {
   }
 }
 
-function transformToThreeJsSpace(geometryClipBox: THREE.Box3, modelMetadata: CadModelMetadata): THREE.Box3 {
+function transformToThreeJsSpace(geometryClipBox: Box3, modelMetadata: CadModelMetadata): Box3 {
   const min = geometryClipBox.min.clone().applyMatrix4(modelMetadata.modelMatrix);
   const max = geometryClipBox.max.clone().applyMatrix4(modelMetadata.modelMatrix);
-  return new THREE.Box3().setFromPoints([min, max]);
+  return new Box3().setFromPoints([min, max]);
 }
 
-function determineGeometryClipBox(
-  geometryFilter: GeometryFilter | undefined,
-  cadModel: CadModelMetadata
-): THREE.Box3 | null {
+function determineGeometryClipBox(geometryFilter: GeometryFilter | undefined, cadModel: CadModelMetadata): Box3 | null {
   if (geometryFilter === undefined || geometryFilter.boundingBox === undefined) {
     return null;
   }
@@ -102,7 +99,7 @@ function determineGeometryClipBox(
   return bbox;
 }
 
-function createClippedModel(cadModel: CadModelMetadata, geometryClipBox: THREE.Box3 | null): CadModelMetadata {
+function createClippedModel(cadModel: CadModelMetadata, geometryClipBox: Box3 | null): CadModelMetadata {
   if (geometryClipBox === null) {
     return cadModel;
   }

--- a/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.test.ts
+++ b/viewer/packages/cad-model/src/batching/MultiBufferBatchingManager.test.ts
@@ -3,7 +3,8 @@
  */
 import type { ParsedGeometry } from '@reveal/sector-parser';
 import { RevealGeometryCollectionType } from '@reveal/sector-parser';
-import * as THREE from 'three';
+import type { InstancedMesh } from 'three';
+import { BufferGeometry, Group, InterleavedBuffer, InterleavedBufferAttribute } from 'three';
 import { Mock } from 'moq.ts';
 import type { Materials, StyledTreeIndexSets } from '@reveal/rendering';
 import { MultiBufferBatchingManager } from './MultiBufferBatchingManager';
@@ -12,11 +13,11 @@ import { sum } from 'lodash-es';
 import { IndexSet } from '@reveal/utilities';
 
 describe(MultiBufferBatchingManager.name, () => {
-  let geometryGroup: THREE.Group;
+  let geometryGroup: Group;
   let manager: MultiBufferBatchingManager;
   const numberOfInstanceBuffers = 2;
   beforeEach(() => {
-    geometryGroup = new THREE.Group();
+    geometryGroup = new Group();
     const materials = new Mock<Materials>().object();
     const styledIndexSets: StyledTreeIndexSets = {
       back: new IndexSet(),
@@ -51,7 +52,7 @@ describe(MultiBufferBatchingManager.name, () => {
     manager.batchGeometries(geometries3, 3);
 
     expect(geometryGroup.children.length).toBe(numberOfInstanceBuffers);
-    expect(sum(geometryGroup.children.map(mesh => (mesh as THREE.InstancedMesh).count))).toBe(60);
+    expect(sum(geometryGroup.children.map(mesh => (mesh as InstancedMesh).count))).toBe(60);
   });
 
   test('batchGeometries() adds new geometry to group for new geometry type', () => {
@@ -85,7 +86,7 @@ describe(MultiBufferBatchingManager.name, () => {
     manager.removeSectorBatches(1);
 
     expect(geometryGroup.children.filter(mesh => mesh.visible).length).toBe(1);
-    expect(sum(geometryGroup.children.map(mesh => mesh as THREE.InstancedMesh).map(mesh => mesh.count))).toBe(20);
+    expect(sum(geometryGroup.children.map(mesh => mesh as InstancedMesh).map(mesh => mesh.count))).toBe(20);
   });
 
   test('removeSectorBatches() removes only relevant treeIndices', () => {
@@ -154,12 +155,12 @@ function createParsedGeometryWithTreeIndices(
   treeIndices: number[],
   instanceId: number
 ): ParsedGeometry {
-  const buffer = new THREE.InterleavedBuffer(new Float32Array(3 * treeIndices.length), 3);
-  const geometryBuffer = new THREE.BufferGeometry();
-  geometryBuffer.setAttribute('attribute1', new THREE.InterleavedBufferAttribute(buffer, 1, 0));
-  geometryBuffer.setAttribute('attribute2', new THREE.InterleavedBufferAttribute(buffer, 1, 1));
+  const buffer = new InterleavedBuffer(new Float32Array(3 * treeIndices.length), 3);
+  const geometryBuffer = new BufferGeometry();
+  geometryBuffer.setAttribute('attribute1', new InterleavedBufferAttribute(buffer, 1, 0));
+  geometryBuffer.setAttribute('attribute2', new InterleavedBufferAttribute(buffer, 1, 1));
 
-  const treeIndexAttribute = new THREE.InterleavedBufferAttribute(buffer, 1, 2);
+  const treeIndexAttribute = new InterleavedBufferAttribute(buffer, 1, 2);
 
   for (let i = 0; i < treeIndices.length; i++) {
     treeIndexAttribute.setX(i, treeIndices[i]);

--- a/viewer/packages/cad-model/src/picking/PickingHandler.test.ts
+++ b/viewer/packages/cad-model/src/picking/PickingHandler.test.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { PerspectiveCamera, Vector2 } from 'three';
 
 import type { CadMaterialManager } from '@reveal/rendering';
 import { RenderMode } from '@reveal/rendering';
@@ -16,12 +17,12 @@ import { createCadModel, autoMockWebGLRenderer } from '../../../../test-utilitie
 describe(PickingHandler.name, () => {
   let pickingHandler: PickingHandler;
 
-  const camera = new THREE.PerspectiveCamera();
+  const camera = new PerspectiveCamera();
 
-  const renderer = autoMockWebGLRenderer(new Mock<THREE.WebGLRenderer>()).object();
+  const renderer = autoMockWebGLRenderer(new Mock<WebGLRenderer>()).object();
 
   const input: IntersectInput = {
-    normalizedCoords: new THREE.Vector2(0.5, 0.5),
+    normalizedCoords: new Vector2(0.5, 0.5),
     renderer,
     camera,
     clippingPlanes: [],

--- a/viewer/packages/cad-model/src/picking/PickingHandler.ts
+++ b/viewer/packages/cad-model/src/picking/PickingHandler.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Box3, Object3D, PerspectiveCamera, Ray, WebGLRenderer } from 'three';
+import { Color, Raycaster, Scene, Vector3, Vector4, WebGLRenderTarget } from 'three';
 import type { IntersectInput } from '@reveal/model-base';
 import type { CadMaterialManager, RenderPipelineProvider } from '@reveal/rendering';
 import { BasicPipelineExecutor, CadGeometryRenderModePipelineProvider, RenderMode } from '@reveal/rendering';
@@ -16,8 +17,8 @@ type PickingInput = {
     x: number;
     y: number;
   };
-  camera: THREE.PerspectiveCamera;
-  renderer: THREE.WebGLRenderer;
+  camera: PerspectiveCamera;
+  renderer: WebGLRenderer;
   domElement: HTMLElement;
   cadNodes: CadNode[];
 };
@@ -28,29 +29,29 @@ type TreeIndexPickingInput = PickingInput & {
 
 type IntersectCadNodesResult = {
   distance: number;
-  point: THREE.Vector3;
+  point: Vector3;
   treeIndex: number;
   cadNode: CadNode;
-  object: THREE.Object3D; // always CadNode
+  object: Object3D; // always CadNode
 };
 
 export class PickingHandler {
-  private readonly _clearColor: THREE.Color;
+  private readonly _clearColor: Color;
   private readonly _clearAlpha: number;
-  private readonly _raycaster: THREE.Raycaster;
+  private readonly _raycaster: Raycaster;
 
   private readonly _pickPixelColorStorage: {
-    renderTarget: THREE.WebGLRenderTarget;
+    renderTarget: WebGLRenderTarget;
     pixelBuffer: Uint8Array;
   };
 
-  private readonly _rgbaVector = new THREE.Vector4();
+  private readonly _rgbaVector = new Vector4();
 
   /**
    * These factors are used for undoing the `packDepthToRGBA` GLSL operation defined by ThreeJS.
    * They are taken from https://github.com/WestLangley/three.js/blob/bc58fecba18150103b95fbde5aaa3cc7cddf95a7/src/renderers/shaders/ShaderChunk/packing.glsl.js#L19
    */
-  private readonly _unpackFactors = new THREE.Vector4(
+  private readonly _unpackFactors = new Vector4(
     255 / 256,
     255 / 256 / 256,
     255 / 256 / (256 * 256),
@@ -61,13 +62,13 @@ export class PickingHandler {
   private readonly _treeIndexRenderPipeline: CadGeometryRenderModePipelineProvider;
   private readonly _mutex = new Mutex();
 
-  constructor(renderer: THREE.WebGLRenderer, materialManager: CadMaterialManager, sceneHandler: SceneHandler) {
-    this._clearColor = new THREE.Color('black');
+  constructor(renderer: WebGLRenderer, materialManager: CadMaterialManager, sceneHandler: SceneHandler) {
+    this._clearColor = new Color('black');
     this._clearAlpha = 0;
-    this._raycaster = new THREE.Raycaster();
+    this._raycaster = new Raycaster();
 
     this._pickPixelColorStorage = {
-      renderTarget: new THREE.WebGLRenderTarget(1, 1),
+      renderTarget: new WebGLRenderTarget(1, 1),
       pixelBuffer: new Uint8Array(4)
     };
 
@@ -99,7 +100,7 @@ export class PickingHandler {
       return results;
     }
     const release = await this._mutex.acquire();
-    const scene = new THREE.Scene();
+    const scene = new Scene();
     const depthInput = { ...input, scene, cadNodes };
 
     // Identify the treeIndex associated with the position.
@@ -158,32 +159,29 @@ export class PickingHandler {
 
     return candidateCadNodes;
 
-    function getIntersection(cadNode: CadNode, ray: THREE.Ray): [CadNode, THREE.Vector3 | null] {
+    function getIntersection(cadNode: CadNode, ray: Ray): [CadNode, Vector3 | null] {
       const nodeBounds = getWorldSpaceNodeBounds(cadNode);
       // If we are inside the box, set the intersection point to the ray origin point
-      return [
-        cadNode,
-        nodeBounds.containsPoint(ray.origin) ? ray.origin : ray.intersectBox(nodeBounds, new THREE.Vector3())
-      ];
+      return [cadNode, nodeBounds.containsPoint(ray.origin) ? ray.origin : ray.intersectBox(nodeBounds, new Vector3())];
     }
 
-    function getWorldSpaceNodeBounds(node: CadNode): THREE.Box3 {
+    function getWorldSpaceNodeBounds(node: CadNode): Box3 {
       const cadNodeBoundingBox = node.cadModelMetadata.scene.root.subtreeBoundingBox.clone();
       return cadNodeBoundingBox.applyMatrix4(node.cadModelMetadata.modelMatrix);
     }
 
     function hasIntersection(
-      cadNodeIntersection: [CadNode, THREE.Vector3 | null]
-    ): cadNodeIntersection is [CadNode, THREE.Vector3] {
+      cadNodeIntersection: [CadNode, Vector3 | null]
+    ): cadNodeIntersection is [CadNode, Vector3] {
       const intersectPosition = cadNodeIntersection[1];
       return intersectPosition !== null;
     }
 
-    function byIntersectDistanceToCamera([_0, a]: [CadNode, THREE.Vector3], [_1, b]: [CadNode, THREE.Vector3]): number {
+    function byIntersectDistanceToCamera([_0, a]: [CadNode, Vector3], [_1, b]: [CadNode, Vector3]): number {
       return a.distanceToSquared(cameraPosition) - b.distanceToSquared(cameraPosition);
     }
 
-    function data(cadNodeData: [CadNode, THREE.Vector3]): { cadNode: CadNode; intersectPosition: THREE.Vector3 } {
+    function data(cadNodeData: [CadNode, Vector3]): { cadNode: CadNode; intersectPosition: Vector3 } {
       return { cadNode: cadNodeData[0], intersectPosition: cadNodeData[1] };
     }
   }
@@ -194,7 +192,7 @@ export class PickingHandler {
 
     const viewZ = this.perspectiveDepthToViewZ(depth, camera.near, camera.far);
     const point = this.getPosition(input, viewZ);
-    const distance = new THREE.Vector3().subVectors(point, camera.position).length();
+    const distance = new Vector3().subVectors(point, camera.position).length();
     return {
       distance,
       point
@@ -207,7 +205,7 @@ export class PickingHandler {
     shouldRunAsync: boolean
   ): Promise<number | undefined> {
     const { camera, normalizedCoords, renderer, domElement } = input;
-    const pickingScene = new THREE.Scene();
+    const pickingScene = new Scene();
 
     const pickInput = {
       normalizedCoords,
@@ -259,9 +257,9 @@ export class PickingHandler {
     return this.unpackRGBAToDepth(pixelBuffer);
   }
 
-  private getPosition(input: PickingInput, viewZ: number): THREE.Vector3 {
+  private getPosition(input: PickingInput, viewZ: number): Vector3 {
     const { camera, normalizedCoords } = input;
-    const position = new THREE.Vector3();
+    const position = new Vector3();
     position.set(normalizedCoords.x, normalizedCoords.y, 0.5).applyMatrix4(camera.projectionMatrixInverse);
 
     position.multiplyScalar(viewZ / position.z);
@@ -272,7 +270,7 @@ export class PickingHandler {
   private async pickPixel(
     input: PickingInput,
     renderPipeline: RenderPipelineProvider,
-    clearColor: THREE.Color,
+    clearColor: Color,
     clearAlpha: number,
     shouldRunAsync: boolean
   ) {
@@ -280,7 +278,7 @@ export class PickingHandler {
     const { camera, normalizedCoords, renderer, domElement } = input;
 
     // Prepare camera that only renders the single pixel we are interested in
-    const pickCamera = camera.clone() as THREE.PerspectiveCamera;
+    const pickCamera = camera.clone() as PerspectiveCamera;
     const absoluteCoords = {
       x: ((normalizedCoords.x + 1.0) / 2.0) * domElement.clientWidth,
       y: ((1.0 - normalizedCoords.y) / 2.0) * domElement.clientHeight

--- a/viewer/packages/cad-model/src/utilities/BoundingBoxClipper.test.ts
+++ b/viewer/packages/cad-model/src/utilities/BoundingBoxClipper.test.ts
@@ -2,20 +2,20 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 import { BoundingBoxClipper } from './BoundingBoxClipper';
 
 describe('BoundingBoxClipper', () => {
   test('Clip planes placed correctly', () => {
-    const box = new THREE.Box3(new THREE.Vector3(1.0, 2.0, 3.0), new THREE.Vector3(4.0, 5.0, 6.0));
+    const box = new Box3(new Vector3(1.0, 2.0, 3.0), new Vector3(4.0, 5.0, 6.0));
     const clipper = new BoundingBoxClipper(box);
 
-    expect(clipper.clippingPlanes[0].normal.dot(new THREE.Vector3(1, 0, 0))).toBe(1);
-    expect(clipper.clippingPlanes[1].normal.dot(new THREE.Vector3(1, 0, 0))).toBe(-1);
-    expect(clipper.clippingPlanes[2].normal.dot(new THREE.Vector3(0, 1, 0))).toBe(1);
-    expect(clipper.clippingPlanes[3].normal.dot(new THREE.Vector3(0, 1, 0))).toBe(-1);
-    expect(clipper.clippingPlanes[4].normal.dot(new THREE.Vector3(0, 0, 1))).toBe(1);
-    expect(clipper.clippingPlanes[5].normal.dot(new THREE.Vector3(0, 0, 1))).toBe(-1);
+    expect(clipper.clippingPlanes[0].normal.dot(new Vector3(1, 0, 0))).toBe(1);
+    expect(clipper.clippingPlanes[1].normal.dot(new Vector3(1, 0, 0))).toBe(-1);
+    expect(clipper.clippingPlanes[2].normal.dot(new Vector3(0, 1, 0))).toBe(1);
+    expect(clipper.clippingPlanes[3].normal.dot(new Vector3(0, 1, 0))).toBe(-1);
+    expect(clipper.clippingPlanes[4].normal.dot(new Vector3(0, 0, 1))).toBe(1);
+    expect(clipper.clippingPlanes[5].normal.dot(new Vector3(0, 0, 1))).toBe(-1);
 
     expect(clipper.clippingPlanes[0].constant).toBe(-1);
     expect(clipper.clippingPlanes[1].constant).toBe(4);
@@ -28,12 +28,12 @@ describe('BoundingBoxClipper', () => {
   test('Changing min and max values should move clip planes', () => {
     const clipper = new BoundingBoxClipper();
 
-    expect(clipper.clippingPlanes[0].normal.dot(new THREE.Vector3(1, 0, 0))).toBe(1);
-    expect(clipper.clippingPlanes[1].normal.dot(new THREE.Vector3(1, 0, 0))).toBe(-1);
-    expect(clipper.clippingPlanes[2].normal.dot(new THREE.Vector3(0, 1, 0))).toBe(1);
-    expect(clipper.clippingPlanes[3].normal.dot(new THREE.Vector3(0, 1, 0))).toBe(-1);
-    expect(clipper.clippingPlanes[4].normal.dot(new THREE.Vector3(0, 0, 1))).toBe(1);
-    expect(clipper.clippingPlanes[5].normal.dot(new THREE.Vector3(0, 0, 1))).toBe(-1);
+    expect(clipper.clippingPlanes[0].normal.dot(new Vector3(1, 0, 0))).toBe(1);
+    expect(clipper.clippingPlanes[1].normal.dot(new Vector3(1, 0, 0))).toBe(-1);
+    expect(clipper.clippingPlanes[2].normal.dot(new Vector3(0, 1, 0))).toBe(1);
+    expect(clipper.clippingPlanes[3].normal.dot(new Vector3(0, 1, 0))).toBe(-1);
+    expect(clipper.clippingPlanes[4].normal.dot(new Vector3(0, 0, 1))).toBe(1);
+    expect(clipper.clippingPlanes[5].normal.dot(new Vector3(0, 0, 1))).toBe(-1);
 
     expect(clipper.clippingPlanes[0].constant).toBe(-Infinity);
     expect(clipper.clippingPlanes[1].constant).toBe(-Infinity);
@@ -49,12 +49,12 @@ describe('BoundingBoxClipper', () => {
     clipper.maxY = 5.0;
     clipper.maxZ = 6.0;
 
-    expect(clipper.clippingPlanes[0].normal.dot(new THREE.Vector3(1, 0, 0))).toBe(1);
-    expect(clipper.clippingPlanes[1].normal.dot(new THREE.Vector3(1, 0, 0))).toBe(-1);
-    expect(clipper.clippingPlanes[2].normal.dot(new THREE.Vector3(0, 1, 0))).toBe(1);
-    expect(clipper.clippingPlanes[3].normal.dot(new THREE.Vector3(0, 1, 0))).toBe(-1);
-    expect(clipper.clippingPlanes[4].normal.dot(new THREE.Vector3(0, 0, 1))).toBe(1);
-    expect(clipper.clippingPlanes[5].normal.dot(new THREE.Vector3(0, 0, 1))).toBe(-1);
+    expect(clipper.clippingPlanes[0].normal.dot(new Vector3(1, 0, 0))).toBe(1);
+    expect(clipper.clippingPlanes[1].normal.dot(new Vector3(1, 0, 0))).toBe(-1);
+    expect(clipper.clippingPlanes[2].normal.dot(new Vector3(0, 1, 0))).toBe(1);
+    expect(clipper.clippingPlanes[3].normal.dot(new Vector3(0, 1, 0))).toBe(-1);
+    expect(clipper.clippingPlanes[4].normal.dot(new Vector3(0, 0, 1))).toBe(1);
+    expect(clipper.clippingPlanes[5].normal.dot(new Vector3(0, 0, 1))).toBe(-1);
 
     expect(clipper.clippingPlanes[0].constant).toBe(-1);
     expect(clipper.clippingPlanes[1].constant).toBe(4);

--- a/viewer/packages/cad-model/src/utilities/BoundingBoxClipper.ts
+++ b/viewer/packages/cad-model/src/utilities/BoundingBoxClipper.ts
@@ -2,21 +2,21 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Plane, Vector3 } from 'three';
 
 export class BoundingBoxClipper {
-  private readonly _box: THREE.Box3;
-  private readonly _clippingPlanes: THREE.Plane[] = [
-    new THREE.Plane(),
-    new THREE.Plane(),
-    new THREE.Plane(),
-    new THREE.Plane(),
-    new THREE.Plane(),
-    new THREE.Plane()
+  private readonly _box: Box3;
+  private readonly _clippingPlanes: Plane[] = [
+    new Plane(),
+    new Plane(),
+    new Plane(),
+    new Plane(),
+    new Plane(),
+    new Plane()
   ];
 
-  constructor(box?: THREE.Box3) {
-    this._box = box || new THREE.Box3();
+  constructor(box?: Box3) {
+    this._box = box || new Box3();
     this.updatePlanes();
   }
 
@@ -75,33 +75,15 @@ export class BoundingBoxClipper {
   }
 
   private updatePlanes() {
-    this._clippingPlanes[0].setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(1, 0, 0),
-      new THREE.Vector3(this.minX, 0, 0)
-    );
-    this._clippingPlanes[1].setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(-1, 0, 0),
-      new THREE.Vector3(this.maxX, 0, 0)
-    );
-    this._clippingPlanes[2].setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, this.minY, 0)
-    );
-    this._clippingPlanes[3].setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(0, -1, 0),
-      new THREE.Vector3(0, this.maxY, 0)
-    );
-    this._clippingPlanes[4].setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(0, 0, 1),
-      new THREE.Vector3(0, 0, this.minZ)
-    );
-    this._clippingPlanes[5].setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(0, 0, -1),
-      new THREE.Vector3(0, 0, this.maxZ)
-    );
+    this._clippingPlanes[0].setFromNormalAndCoplanarPoint(new Vector3(1, 0, 0), new Vector3(this.minX, 0, 0));
+    this._clippingPlanes[1].setFromNormalAndCoplanarPoint(new Vector3(-1, 0, 0), new Vector3(this.maxX, 0, 0));
+    this._clippingPlanes[2].setFromNormalAndCoplanarPoint(new Vector3(0, 1, 0), new Vector3(0, this.minY, 0));
+    this._clippingPlanes[3].setFromNormalAndCoplanarPoint(new Vector3(0, -1, 0), new Vector3(0, this.maxY, 0));
+    this._clippingPlanes[4].setFromNormalAndCoplanarPoint(new Vector3(0, 0, 1), new Vector3(0, 0, this.minZ));
+    this._clippingPlanes[5].setFromNormalAndCoplanarPoint(new Vector3(0, 0, -1), new Vector3(0, 0, this.maxZ));
   }
 
-  get clippingPlanes(): THREE.Plane[] {
+  get clippingPlanes(): Plane[] {
     return this._clippingPlanes;
   }
 }

--- a/viewer/packages/cad-model/src/utilities/CustomSectorBounds.test.ts
+++ b/viewer/packages/cad-model/src/utilities/CustomSectorBounds.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2023 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Matrix4 } from 'three';
 import { CustomSectorBounds } from './CustomSectorBounds';
 import type { CadNode } from '../wrappers/CadNode';
 import { Mock } from 'moq.ts';
@@ -91,7 +91,7 @@ it much easier to reason about the expected result of any given test.
 
 type DummyNode = {
   treeIndex: number;
-  originalBoundingBox: THREE.Box3;
+  originalBoundingBox: Box3;
 };
 
 describe('CustomSectorBounds', () => {
@@ -99,7 +99,7 @@ describe('CustomSectorBounds', () => {
   let cadNodeMock: Mock<CadNode>;
   let sectorMetadataRoot: SectorMetadata;
   let sectorMetadataById: Map<number, SectorMetadata>;
-  let originalSectorBounds: Map<number, THREE.Box3>;
+  let originalSectorBounds: Map<number, Box3>;
 
   const nodeA: DummyNode = { treeIndex: 1000, originalBoundingBox: boundsFrom(0, 0, 1, 1) };
   const nodeB: DummyNode = { treeIndex: 1001, originalBoundingBox: boundsFrom(3, 1, 4, 2) };
@@ -132,7 +132,7 @@ describe('CustomSectorBounds', () => {
     });
 
     // Store copy of sector bounds
-    originalSectorBounds = new Map<number, THREE.Box3>();
+    originalSectorBounds = new Map<number, Box3>();
     for (const [sectorId, sectorMetadata] of sectorMetadataById) {
       originalSectorBounds.set(sectorId, sectorMetadata.subtreeBoundingBox.clone());
     }
@@ -375,12 +375,12 @@ describe('CustomSectorBounds', () => {
     [0, 1, 3, 4, 5].forEach(i => expectOriginalBounds(i));
   });
 
-  function translation(x: number, y: number): THREE.Matrix4 {
-    return new THREE.Matrix4().setPosition(x, y, 0);
+  function translation(x: number, y: number): Matrix4 {
+    return new Matrix4().setPosition(x, y, 0);
   }
 
-  function boundsFrom(minX: number, minY: number, maxX: number, maxY: number): THREE.Box3 {
-    return new THREE.Box3().setFromArray([minX, minY, 0, maxX, maxY, 1]);
+  function boundsFrom(minX: number, minY: number, maxX: number, maxY: number): Box3 {
+    return new Box3().setFromArray([minX, minY, 0, maxX, maxY, 1]);
   }
 
   function expectOriginalBounds(sectorId: number) {
@@ -393,7 +393,7 @@ describe('CustomSectorBounds', () => {
     expect(sectorBounds.equals(originalBounds)).toBeTruthy();
   }
 
-  function expectBoundsApproximatelyEqual(sectorId: number, expected: THREE.Box3, precision = 3) {
+  function expectBoundsApproximatelyEqual(sectorId: number, expected: Box3, precision = 3) {
     const sectorBounds = sectorMetadataById.get(sectorId)?.subtreeBoundingBox;
 
     assert(sectorBounds !== undefined);

--- a/viewer/packages/cad-model/src/utilities/CustomSectorBounds.ts
+++ b/viewer/packages/cad-model/src/utilities/CustomSectorBounds.ts
@@ -2,13 +2,14 @@
  * Copyright 2023 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Box3 } from 'three';
+import { Matrix4 } from 'three';
 import type { SectorMetadata } from '@reveal/cad-parsers';
 import type { CadNode } from '../wrappers/CadNode';
 
 type TransformedNode = {
-  currentTransform: THREE.Matrix4;
-  originalBoundingBox?: THREE.Box3;
+  currentTransform: Matrix4;
+  originalBoundingBox?: Box3;
   inSectors: Set<number>;
 };
 
@@ -23,7 +24,7 @@ type TransformedNode = {
 export class CustomSectorBounds {
   private readonly _treeIndexToTransformedNodeMap = new Map<number, TransformedNode>();
   private readonly _sectorIdToTransformedNodesMap = new Map<number, Set<TransformedNode>>();
-  private readonly _originalSectorBounds = new Map<number, THREE.Box3>();
+  private readonly _originalSectorBounds = new Map<number, Box3>();
   private readonly _sectorsWithInvalidBounds = new Set<number>();
   private readonly _allSectorsSortedByDepth: SectorMetadata[];
 
@@ -47,14 +48,14 @@ export class CustomSectorBounds {
    * @param treeIndex Tree index of the transformed node
    * @param originalBoundingBox The original bounding box of this node
    */
-  registerTransformedNode(treeIndex: number, originalBoundingBox?: THREE.Box3): void {
+  registerTransformedNode(treeIndex: number, originalBoundingBox?: Box3): void {
     if (this.isRegistered(treeIndex)) {
       throw new Error(`Attempted to register already registered node (tree index ${treeIndex})`);
     }
 
     // Update mapping from tree index to transformed node
     this._treeIndexToTransformedNodeMap.set(treeIndex, {
-      currentTransform: new THREE.Matrix4(),
+      currentTransform: new Matrix4(),
       originalBoundingBox: originalBoundingBox?.clone(),
       inSectors: new Set<number>()
     });
@@ -65,7 +66,7 @@ export class CustomSectorBounds {
    * @param treeIndex Tree index of the transformed node
    * @param newTransform The transform
    */
-  updateNodeTransform(treeIndex: number, newTransform: THREE.Matrix4): void {
+  updateNodeTransform(treeIndex: number, newTransform: Matrix4): void {
     const transformedNode = this._treeIndexToTransformedNodeMap.get(treeIndex);
     if (!transformedNode) {
       throw new Error(`Attempted to update transform for non-registered node (tree index ${treeIndex})`);
@@ -142,7 +143,7 @@ export class CustomSectorBounds {
   recomputeSectorBounds(): void {
     this._sectorsWithInvalidBounds.forEach(sectorId => {
       // Compute the bounding boxes for the transformed nodes in this sector
-      const boundingBoxes: THREE.Box3[] = [];
+      const boundingBoxes: Box3[] = [];
       this._sectorIdToTransformedNodesMap.get(sectorId)?.forEach(transformedNode => {
         // Compute the intersection between the original sector bounds and the original node bounds if available,
         // otherwise just assume the node has geometry in the entire sector
@@ -190,7 +191,7 @@ export class CustomSectorBounds {
    * @param customBoundingBoxes An array of bounding boxes this sector should contain
    * @returns True if the new sector bounds are different from the original values. False otherwise
    */
-  private updateSector(sectorId: number, customBoundingBoxes: THREE.Box3[]): void {
+  private updateSector(sectorId: number, customBoundingBoxes: Box3[]): void {
     const originalSectorBounds = this.getOriginalSectorBounds(sectorId);
 
     if (customBoundingBoxes.length) {
@@ -212,7 +213,7 @@ export class CustomSectorBounds {
     this.clearCustomSectorBounds(sectorId);
   }
 
-  private getOriginalSectorBounds(sectorId: number): THREE.Box3 {
+  private getOriginalSectorBounds(sectorId: number): Box3 {
     let originalSectorBounds = this._originalSectorBounds.get(sectorId);
     if (!originalSectorBounds) {
       originalSectorBounds = this.sectorMetadata(sectorId).subtreeBoundingBox.clone();
@@ -220,7 +221,7 @@ export class CustomSectorBounds {
     return originalSectorBounds;
   }
 
-  private setCustomSectorBounds(sectorId: number, customBounds: THREE.Box3): void {
+  private setCustomSectorBounds(sectorId: number, customBounds: Box3): void {
     const sectorMetadata = this.sectorMetadata(sectorId);
 
     const existingOriginal = this._originalSectorBounds.get(sectorId);

--- a/viewer/packages/cad-model/src/wrappers/CogniteCadModel.test.ts
+++ b/viewer/packages/cad-model/src/wrappers/CogniteCadModel.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Matrix4, Vector3 } from 'three';
 import { CogniteCadModel } from './CogniteCadModel';
 
 import type { NodeAppearance } from '@reveal/cad-styling';
@@ -39,9 +39,7 @@ describe(CogniteCadModel.name, () => {
       .setup(x => x.getBoundingBoxesByNodeIds(It.IsAny(), It.IsAny(), It.IsAny()))
       .callback(expression => {
         const nodeIds: number[] = expression.args[2];
-        const bboxes = nodeIds.map(
-          id => new THREE.Box3(new THREE.Vector3(id, id, id), new THREE.Vector3(id + 1, id + 1, id + 1))
-        );
+        const bboxes = nodeIds.map(id => new Box3(new Vector3(id, id, id), new Vector3(id + 1, id + 1, id + 1)));
         return Promise.resolve(bboxes);
       });
     model = createCadModel(1, 2, 3, 3, mockApiClient.object());
@@ -108,31 +106,29 @@ describe(CogniteCadModel.name, () => {
   });
 
   test('getBoundingBoxByTreeIndex() modifies out-parameter', async () => {
-    const bbox = new THREE.Box3();
+    const bbox = new Box3();
     const result = await model.getBoundingBoxByTreeIndex(1, bbox);
     expect(result).toBe(bbox);
-    expect(result).not.toEqual(new THREE.Box3());
+    expect(result).not.toEqual(new Box3());
   });
 
   test('getBoundingBoxByNodeId() modifies out-parameter', async () => {
-    const bbox = new THREE.Box3();
+    const bbox = new Box3();
     const result = await model.getBoundingBoxByNodeId(1, bbox);
     expect(result).toBe(bbox);
-    expect(result).not.toEqual(new THREE.Box3());
+    expect(result).not.toEqual(new Box3());
   });
 
   test('getBoundingBoxByNodeIds() modifies out-parameter', async () => {
     const result = await model.getBoundingBoxesByNodeIds([1, 2]);
-    expect(result).toEqual(
-      [1, 2].map(i => new THREE.Box3(new THREE.Vector3(i, i, i), new THREE.Vector3(i + 1, i + 1, i + 1)))
-    );
+    expect(result).toEqual([1, 2].map(i => new Box3(new Vector3(i, i, i), new Vector3(i + 1, i + 1, i + 1))));
   });
 
   test('setModelTransform() changes custom transform, not source transform', () => {
     const originalCustomTransform = model.getModelTransformation();
     const originalSourceTransform = model.getCdfToDefaultModelTransformation();
 
-    const modifyingTransform = new THREE.Matrix4().setPosition(1, 2, 3);
+    const modifyingTransform = new Matrix4().setPosition(1, 2, 3);
 
     model.setModelTransformation(modifyingTransform);
 

--- a/viewer/packages/cad-model/src/wrappers/CogniteCadModel.ts
+++ b/viewer/packages/cad-model/src/wrappers/CogniteCadModel.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { Matrix4, Plane } from 'three';
+import { Box3, Vector3 } from 'three';
 import type { CogniteInternalId } from '@cognite/sdk';
 import { sortBy } from 'lodash-es';
 
@@ -256,8 +257,8 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    */
   setNodeTransform(
     treeIndices: NumericRange,
-    transformMatrix: THREE.Matrix4,
-    boundingBox?: THREE.Box3,
+    transformMatrix: Matrix4,
+    boundingBox?: Box3,
     space: 'model' | 'world' = 'world'
   ): void {
     MetricsLogger.trackCadNodeTransformOverridden(treeIndices.count, transformMatrix);
@@ -274,7 +275,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
     const transformMatrixCdf = modelToCdfTransform.clone().multiply(transformMatrix).multiply(cdfToWorldTransform);
 
     // Transform bounding box to CDF space, if given
-    let nodeBoundingBox: THREE.Box3 | undefined;
+    let nodeBoundingBox: Box3 | undefined;
     if (boundingBox) {
       nodeBoundingBox = boundingBox.clone();
       nodeBoundingBox.applyMatrix4(modelToCdfTransform);
@@ -310,7 +311,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    */
   async setNodeTransformByTreeIndex(
     treeIndex: number,
-    transform: THREE.Matrix4,
+    transform: Matrix4,
     applyToChildren = true,
     space: 'model' | 'world' = 'world'
   ): Promise<number> {
@@ -392,7 +393,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    *
    * @example
    * ```js
-   * const boundingBox = new THREE.Box3()
+   * const boundingBox = new Box3()
    * model.getModelBoundingBox(boundingBox);
    * // boundingBox now has the bounding box
    * ```
@@ -401,12 +402,12 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * const boundingBox = model.getModelBoundingBox();
    * ```
    */
-  getModelBoundingBox(outBoundingBox?: THREE.Box3, restrictToMostGeometry?: boolean): THREE.Box3 {
+  getModelBoundingBox(outBoundingBox?: Box3, restrictToMostGeometry?: boolean): Box3 {
     const bounds = restrictToMostGeometry
       ? this.cadModel.scene.getBoundsOfMostGeometry()
       : this.cadModel.scene.root.subtreeBoundingBox;
 
-    outBoundingBox = outBoundingBox || new THREE.Box3();
+    outBoundingBox = outBoundingBox || new Box3();
     outBoundingBox.copy(bounds);
     outBoundingBox.applyMatrix4(this.cadModel.modelMatrix);
     return outBoundingBox;
@@ -425,7 +426,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * Sets transformation matrix of the model. This overrides the current transformation.
    * @param matrix Transformation matrix.
    */
-  setModelTransformation(matrix: THREE.Matrix4): void {
+  setModelTransformation(matrix: Matrix4): void {
     this.cadNode.setModelTransformation(matrix);
     const cdfToWorldTransform = matrix.clone().multiply(this.getCdfToDefaultModelTransformation());
     this.nodeTransformProvider.setCdfToWorldTransform(cdfToWorldTransform);
@@ -433,9 +434,9 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
 
   /**
    * Gets transformation matrix that has previously been set with {@link CogniteCadModel.setModelTransformation}.
-   * @param out Preallocated `THREE.Matrix4` (optional).
+   * @param out Preallocated `Matrix4` (optional).
    */
-  getModelTransformation(out?: THREE.Matrix4): THREE.Matrix4 {
+  getModelTransformation(out?: Matrix4): Matrix4 {
     return this.cadNode.getModelTransformation(out);
   }
 
@@ -443,14 +444,14 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * Sets the clipping planes for this model. They will be combined with the
    * global clipping planes.
    */
-  setModelClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+  setModelClippingPlanes(clippingPlanes: Plane[]): void {
     this.cadNode.clippingPlanes = clippingPlanes;
   }
 
   /**
    * Get the clipping planes for this model.
    */
-  getModelClippingPlanes(): THREE.Plane[] {
+  getModelClippingPlanes(): Plane[] {
     return [...this.cadNode.clippingPlanes];
   }
 
@@ -458,9 +459,9 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * Gets transformation from CDF space to ThreeJS space,
    * which includes any additional "default" transformations assigned to this model.
    * Does not include any custom transformations set by {@link CogniteCadModel.setModelTransformation}
-   * @param out Preallocated `THREE.Matrix4` (optional)
+   * @param out Preallocated `Matrix4` (optional)
    */
-  getCdfToDefaultModelTransformation(out?: THREE.Matrix4): THREE.Matrix4 {
+  getCdfToDefaultModelTransformation(out?: Matrix4): Matrix4 {
     return this.cadNode.getCdfToDefaultModelTransformation(out);
   }
 
@@ -469,7 +470,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * @param point Point to compute transformation from
    * @param out Optional pre-allocated point
    */
-  mapPointFromCdfToModelCoordinates(point: THREE.Vector3, out: THREE.Vector3 = new THREE.Vector3()): THREE.Vector3 {
+  mapPointFromCdfToModelCoordinates(point: Vector3, out: Vector3 = new Vector3()): Vector3 {
     const cdfToModelTransformation = this.getModelTransformation().multiply(this.getCdfToDefaultModelTransformation());
     return out.copy(point).applyMatrix4(cdfToModelTransformation);
   }
@@ -479,7 +480,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * @param box Box to compute transformation from
    * @param out Optional pre-allocated box
    */
-  mapBoxFromCdfToModelCoordinates(box: THREE.Box3, out: THREE.Box3 = new THREE.Box3()): THREE.Box3 {
+  mapBoxFromCdfToModelCoordinates(box: Box3, out: Box3 = new Box3()): Box3 {
     const cdfToModelTransformation = this.getModelTransformation().multiply(this.getCdfToDefaultModelTransformation());
     return out.copy(box).applyMatrix4(cdfToModelTransformation);
   }
@@ -490,7 +491,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * @param box Optional. Used to write result to.
    * @example
    * ```js
-   * const box = new THREE.Box3()
+   * const box = new Box3()
    * const nodeId = 100500;
    * await model.getBoundingBoxByNodeId(nodeId, box);
    * // box now has the bounding box
@@ -500,9 +501,9 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * const box = await model.getBoundingBoxByNodeId(nodeId);
    * ```
    */
-  async getBoundingBoxByNodeId(nodeId: number, box?: THREE.Box3): Promise<THREE.Box3> {
+  async getBoundingBoxByNodeId(nodeId: number, box?: Box3): Promise<Box3> {
     const boxList = await this.getBoundingBoxesByNodeIds([nodeId]);
-    const outBox = box ?? new THREE.Box3();
+    const outBox = box ?? new Box3();
     outBox.copy(boxList[0]);
     return outBox;
   }
@@ -515,7 +516,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * const box = await model.getBoundingBoxByNodeIds([158239, 192837]);
    * ```
    */
-  async getBoundingBoxesByNodeIds(nodeIds: number[]): Promise<THREE.Box3[]> {
+  async getBoundingBoxesByNodeIds(nodeIds: number[]): Promise<Box3[]> {
     try {
       const boxesResponse = await this.nodesApiClient.getBoundingBoxesByNodeIds(this.modelId, this.revisionId, nodeIds);
       const boxesWorldSpace = boxesResponse.map(box => box.applyMatrix4(this.cadModel.modelMatrix));
@@ -536,7 +537,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * @param box Optional preallocated container to hold the bounding box.
    * @example
    * ```js
-   * const box = new THREE.Box3()
+   * const box = new Box3()
    * const treeIndex = 42;
    * await model.getBoundingBoxByTreeIndex(treeIndex, box);
    * // box now has the bounding box
@@ -546,7 +547,7 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
    * const box = await model.getBoundingBoxByTreeIndex(treeIndex);
    * ```
    */
-  async getBoundingBoxByTreeIndex(treeIndex: number, box?: THREE.Box3): Promise<THREE.Box3> {
+  async getBoundingBoxByTreeIndex(treeIndex: number, box?: Box3): Promise<Box3> {
     const nodeId = await this.nodeIdAndTreeIndexMaps.getNodeId(treeIndex);
     return this.getBoundingBoxByNodeId(nodeId, box);
   }

--- a/viewer/packages/cad-model/visual-tests/CadClipping.VisualTest.ts
+++ b/viewer/packages/cad-model/visual-tests/CadClipping.VisualTest.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 
 import { BoundingBoxClipper, CadNode } from '..';
 import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
@@ -26,9 +26,9 @@ export default class CadClippingVisualTest extends StreamingVisualTestFixture {
     };
 
     const boxClipper = new BoundingBoxClipper(
-      new THREE.Box3(
-        new THREE.Vector3(params.x - params.width / 2, params.y - params.height / 2, params.z - params.depth / 1.5),
-        new THREE.Vector3(params.x + params.width / 1.5, params.y + params.height / 2, params.z + params.depth / 2)
+      new Box3(
+        new Vector3(params.x - params.width / 2, params.y - params.height / 2, params.z - params.depth / 1.5),
+        new Vector3(params.x + params.width / 1.5, params.y + params.height / 2, params.z + params.depth / 2)
       )
     );
 

--- a/viewer/packages/cad-model/visual-tests/DebugLoadedSectorsTool.ts
+++ b/viewer/packages/cad-model/visual-tests/DebugLoadedSectorsTool.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { Object3D, Scene } from 'three';
+import { Box3Helper, Color, Group } from 'three';
 
 import type { SectorNode } from '../../cad-parsers/';
 import { LevelOfDetail } from '../../cad-parsers/';
@@ -19,12 +20,12 @@ export type DebugLoadedSectorsToolOptions = {
 };
 
 export class DebugLoadedSectorsTool {
-  private readonly _boundingBoxes = new THREE.Group();
-  private readonly _scene: THREE.Scene;
+  private readonly _boundingBoxes = new Group();
+  private readonly _scene: Scene;
   private _options: Required<DebugLoadedSectorsToolOptions>;
   private _model?: CadNode;
 
-  constructor(scene: THREE.Scene, options: DebugLoadedSectorsToolOptions = {}) {
+  constructor(scene: Scene, options: DebugLoadedSectorsToolOptions = {}) {
     this._scene = scene;
     this._scene.add(this._boundingBoxes);
     this._options = {} as any; // Force - it's set in setOptions
@@ -98,7 +99,7 @@ export class DebugLoadedSectorsTool {
       switch (options.colorBy) {
         case 'depth': {
           const s = Math.min(1.0, node.depth / 8);
-          return new THREE.Color(Colors.green).lerpHSL(Colors.red, s);
+          return new Color(Colors.green).lerpHSL(Colors.red, s);
         }
         case 'lod': {
           switch (node.levelOfDetail) {
@@ -113,7 +114,7 @@ export class DebugLoadedSectorsTool {
           }
         }
         case 'random':
-          return new THREE.Color().setHSL(Math.random(), 1.0, 0.5);
+          return new Color().setHSL(Math.random(), 1.0, 0.5);
 
         // Note! The two next modes are horribly slow since we do this for every sector,
         // but since this is a debug tool we consider it OK
@@ -121,7 +122,7 @@ export class DebugLoadedSectorsTool {
           const nodesByTimestamp = [...allSelectedNodes].sort((a, b) => a.updatedTimestamp - b.updatedTimestamp);
           const indexOfNode = nodesByTimestamp.findIndex(x => x === node);
           const s = (nodesByTimestamp.length - 1 - indexOfNode) / Math.max(nodesByTimestamp.length - 1, 1);
-          return new THREE.Color(Colors.green).lerpHSL(Colors.red, s);
+          return new Color(Colors.green).lerpHSL(Colors.red, s);
         }
         case 'drawcalls': {
           const [minDrawCalls, maxDrawCalls] = allSelectedNodes.reduce(
@@ -133,24 +134,24 @@ export class DebugLoadedSectorsTool {
           );
           const sector = model.sectorScene.getSectorById(node.sectorId)!;
           const s = (sector.estimatedDrawCallCount - minDrawCalls) / (maxDrawCalls - minDrawCalls);
-          return new THREE.Color(Colors.green).lerpHSL(Colors.red, s);
+          return new Color(Colors.green).lerpHSL(Colors.red, s);
         }
         default:
           assertNever(options.colorBy);
       }
     }
     const color = determineColor();
-    return new THREE.Box3Helper(node.bounds, color);
+    return new Box3Helper(node.bounds, color);
   }
 }
 
 const Colors = {
-  green: new THREE.Color('#00ff00'),
-  yellow: new THREE.Color('yellow'),
-  red: new THREE.Color('red')
+  green: new Color('#00ff00'),
+  yellow: new Color('yellow'),
+  red: new Color('red')
 };
 
-function isSectorNode(node: THREE.Object3D): node is SectorNode {
+function isSectorNode(node: Object3D): node is SectorNode {
   return node.name.match(/^Sector \d+$/) ? true : false;
 }
 

--- a/viewer/packages/cad-model/visual-tests/Rotation.VisualTest.ts
+++ b/viewer/packages/cad-model/visual-tests/Rotation.VisualTest.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 
 import { CadNode } from '..';
 import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
@@ -19,7 +19,7 @@ export default class RotationVisualTest extends StreamingVisualTestFixture {
     }
 
     const matrix = cadNode.getModelTransformation();
-    const newMatrix = new THREE.Matrix4().multiplyMatrices(matrix, new THREE.Matrix4().makeRotationZ(-Math.PI / 3.0));
+    const newMatrix = new Matrix4().multiplyMatrices(matrix, new Matrix4().makeRotationZ(-Math.PI / 3.0));
     cadNode.setModelTransformation(newMatrix);
 
     return Promise.resolve();

--- a/viewer/packages/cad-model/visual-tests/Scale.VisualTest.ts
+++ b/viewer/packages/cad-model/visual-tests/Scale.VisualTest.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Vector3 } from 'three';
 
 import { CadNode } from '..';
 import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
@@ -19,7 +19,7 @@ export default class ScaleVisualTest extends StreamingVisualTestFixture {
     }
 
     const matrix = cadNode.getModelTransformation();
-    const newMatrix = matrix.scale(new THREE.Vector3(5, 5, 5));
+    const newMatrix = matrix.scale(new Vector3(5, 5, 5));
     cadNode.setModelTransformation(newMatrix);
 
     return Promise.resolve();

--- a/viewer/packages/cad-model/visual-tests/SectorBoundingBoxes.VisualTest.ts
+++ b/viewer/packages/cad-model/visual-tests/SectorBoundingBoxes.VisualTest.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { BufferGeometry, Scene } from 'three';
+import { Box3Helper, Group, Mesh } from 'three';
 
 import { CadNode } from '..';
 import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
@@ -49,7 +50,7 @@ export default class SectorBoundingBoxes extends StreamingVisualTestFixture {
     return Promise.resolve();
   }
 
-  private async setupGui(cadNode: CadNode, scene: THREE.Scene) {
+  private async setupGui(cadNode: CadNode, scene: Scene) {
     this.guiState = {
       options: {
         showSimpleSectors: true,
@@ -107,21 +108,21 @@ export default class SectorBoundingBoxes extends StreamingVisualTestFixture {
     debugSectorsGui.add(guiState.statistics, 'downloadSizeMb').name('Download size (Mb)');
   }
 
-  showBoundsForAllGeometries(node: CadNode, scene: THREE.Scene): void {
-    const boxes = new THREE.Group();
+  showBoundsForAllGeometries(node: CadNode, scene: Scene): void {
+    const boxes = new Group();
     node.getModelTransformation(boxes.matrix);
     boxes.matrixWorldNeedsUpdate = true;
 
     node.traverse(x => {
-      if (x instanceof THREE.Mesh) {
+      if (x instanceof Mesh) {
         const mesh = x;
-        const geometry: THREE.BufferGeometry = mesh.geometry;
+        const geometry: BufferGeometry = mesh.geometry;
 
         if (geometry.boundingBox !== null) {
           const box = geometry.boundingBox.clone();
           box.applyMatrix4(mesh.matrixWorld);
 
-          const boxHelper = new THREE.Box3Helper(box);
+          const boxHelper = new Box3Helper(box);
           boxes.add(boxHelper);
         }
       }

--- a/viewer/packages/cad-parsers/src/cad/filterPrimitivesCommon.ts
+++ b/viewer/packages/cad-parsers/src/cad/filterPrimitivesCommon.ts
@@ -2,17 +2,17 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
 export function filterPrimitivesOutsideClipBox(
   attributesByteValues: Uint8Array,
   elementSize: number,
-  clipBox: THREE.Box3,
+  clipBox: Box3,
   getBoundsOfElementsCallback: (
     index: number,
     elementSize: number,
     attributeFloatValues: Float32Array,
-    outBox: THREE.Box3
+    outBox: Box3
   ) => void
 ): Uint8Array<ArrayBuffer> {
   const elementCount = attributesByteValues.length / elementSize;
@@ -22,7 +22,7 @@ export function filterPrimitivesOutsideClipBox(
     attributesByteValues.byteLength / Float32Array.BYTES_PER_ELEMENT
   );
 
-  const instanceBbox = new THREE.Box3();
+  const instanceBbox = new Box3();
 
   const filteredByteValues = new Uint8Array(attributesByteValues.length);
   let filteredCount = 0;

--- a/viewer/packages/cad-parsers/src/cad/filterPrimitivesV9.test.ts
+++ b/viewer/packages/cad-parsers/src/cad/filterPrimitivesV9.test.ts
@@ -4,7 +4,7 @@
 
 import { filterGeometryOutsideClipBox } from './filterPrimitivesV9';
 import { RevealGeometryCollectionType } from '@reveal/sector-parser';
-import * as THREE from 'three';
+import { Box3, Euler, Matrix4, Vector3 } from 'three';
 
 import type {
   Box,
@@ -48,7 +48,7 @@ function assertApproximateObjectEquality(obj0: any, obj1: any) {
 function testSecondFilteredAwayFromBoxAtX10Yneg10Z0(primitives: Primitive[], primitiveType: PrimitiveName) {
   const bufferGeometry = createPrimitiveInterleavedGeometry(primitiveType, primitives);
 
-  const clipBox = new THREE.Box3(new THREE.Vector3(8, -12, -2), new THREE.Vector3(12, -8, 2));
+  const clipBox = new Box3(new Vector3(8, -12, -2), new Vector3(12, -8, 2));
 
   const collectionType = getCollectionType(primitiveType);
 
@@ -101,7 +101,7 @@ describe(filterGeometryOutsideClipBox.name, () => {
 
     const bufferGeometry = createPrimitiveInterleavedGeometry(PrimitiveName.Ellipsoid, ellipsoids);
 
-    const clipBox = new THREE.Box3();
+    const clipBox = new Box3();
     clipBox.min.set(-30, -30, -30);
     clipBox.max.set(-20, -20, -20);
 
@@ -115,12 +115,12 @@ describe(filterGeometryOutsideClipBox.name, () => {
   });
 
   test('Two boxes: one accepted, one rejected - returns filtered', () => {
-    const mat0 = new THREE.Matrix4()
+    const mat0 = new Matrix4()
       .makeTranslation(10, -10, 0)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
-    const mat1 = new THREE.Matrix4()
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
+    const mat1 = new Matrix4()
       .makeTranslation(-10, 5, 10)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
     const boxes: Box[] = [
       {
@@ -135,12 +135,12 @@ describe(filterGeometryOutsideClipBox.name, () => {
   });
 
   test('Two circles: one accepted, one rejected - returns filtered', () => {
-    const mat0 = new THREE.Matrix4()
+    const mat0 = new Matrix4()
       .makeTranslation(10, -10, 0)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
-    const mat1 = new THREE.Matrix4()
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
+    const mat1 = new Matrix4()
       .makeTranslation(-10, 5, 10)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
     const circles: Circle[] = [
       {
@@ -249,13 +249,13 @@ describe(filterGeometryOutsideClipBox.name, () => {
   });
 
   test('Two general rings: one accepted, one rejected - returns filtered', () => {
-    const mat0 = new THREE.Matrix4()
+    const mat0 = new Matrix4()
       .makeTranslation(10, -10, 0)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
-    const mat1 = new THREE.Matrix4()
+    const mat1 = new Matrix4()
       .makeTranslation(-10, 5, 10)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
     const normal: [number, number, number] = [0, 1, 0];
 
@@ -280,13 +280,13 @@ describe(filterGeometryOutsideClipBox.name, () => {
   });
 
   test('Two quads: one accepted, one rejected - returns filtered', () => {
-    const mat0 = new THREE.Matrix4()
+    const mat0 = new Matrix4()
       .makeTranslation(10, -10, 0)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
-    const mat1 = new THREE.Matrix4()
+    const mat1 = new Matrix4()
       .makeTranslation(-10, 5, 10)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
     const quads: Quad[] = [
       {
@@ -301,13 +301,13 @@ describe(filterGeometryOutsideClipBox.name, () => {
   });
 
   test('Two tori: one accepted, one rejected - returns filtered', () => {
-    const mat0 = new THREE.Matrix4()
+    const mat0 = new Matrix4()
       .makeTranslation(10, -10, 0)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
-    const mat1 = new THREE.Matrix4()
+    const mat1 = new Matrix4()
       .makeTranslation(-10, 5, 10)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
     const tori: Torus[] = [
       {
@@ -347,13 +347,13 @@ describe(filterGeometryOutsideClipBox.name, () => {
   });
 
   test('Two nuts: one accepted, one rejected - returns filtered', () => {
-    const mat0 = new THREE.Matrix4()
+    const mat0 = new Matrix4()
       .makeTranslation(10, -10, 0)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
-    const mat1 = new THREE.Matrix4()
+    const mat1 = new Matrix4()
       .makeTranslation(-10, 5, 10)
-      .multiply(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, 1, 2, 'XYZ')));
+      .multiply(new Matrix4().makeRotationFromEuler(new Euler(0, 1, 2, 'XYZ')));
 
     const nuts: Nut[] = [
       {
@@ -412,7 +412,7 @@ describe(filterGeometryOutsideClipBox.name, () => {
 
     const geometries = createPrimitiveInterleavedGeometriesSharingBuffer(primitiveTypes, primitives);
 
-    const clipBox = new THREE.Box3(new THREE.Vector3(8, -12, -2), new THREE.Vector3(12, -8, 2));
+    const clipBox = new Box3(new Vector3(8, -12, -2), new Vector3(12, -8, 2));
 
     for (let i = 0; i < collectionTypes.length; i++) {
       const filtered = filterGeometryOutsideClipBox(geometries[i], collectionTypes[i], clipBox);

--- a/viewer/packages/cad-parsers/src/cad/filterPrimitivesV9.ts
+++ b/viewer/packages/cad-parsers/src/cad/filterPrimitivesV9.ts
@@ -12,13 +12,20 @@ import {
   computeBoundingBoxFromVertexAttributes
 } from '../utilities/computeBoundingBoxFromAttributes';
 import { filterPrimitivesOutsideClipBox } from './filterPrimitivesCommon';
-import * as THREE from 'three';
+import {
+  Box3,
+  BufferAttribute,
+  BufferGeometry,
+  InstancedInterleavedBuffer,
+  InterleavedBufferAttribute,
+  Vector3
+} from 'three';
 
 export function filterGeometryOutsideClipBox(
-  geometryBuffer: THREE.BufferGeometry,
+  geometryBuffer: BufferGeometry,
   type: RevealGeometryCollectionType,
-  clipBox?: THREE.Box3
-): THREE.BufferGeometry | undefined {
+  clipBox?: Box3
+): BufferGeometry | undefined {
   if (!clipBox) return geometryBuffer;
 
   if (
@@ -33,7 +40,7 @@ export function filterGeometryOutsideClipBox(
     return undefined;
   }
 
-  const interleavedAttributes = getAttributes(geometryBuffer, THREE.InterleavedBufferAttribute);
+  const interleavedAttributes = getAttributes(geometryBuffer, InterleavedBufferAttribute);
   let newArray: Uint8Array<ArrayBuffer> | undefined;
 
   switch (type) {
@@ -87,12 +94,12 @@ const _views = new Map<number, TypedArrayConstructor>([
 ]);
 
 const epsilon = 1e-4;
-const quadBoundingBox = new THREE.Box3(new THREE.Vector3(-0.5, -0.5, -epsilon), new THREE.Vector3(0.5, 0.5, epsilon));
+const quadBoundingBox = new Box3(new Vector3(-0.5, -0.5, -epsilon), new Vector3(0.5, 0.5, epsilon));
 
-const unitBoundingBox = new THREE.Box3(new THREE.Vector3(-0.5, -0.5, -0.5), new THREE.Vector3(0.5, 0.5, 0.5));
+const unitBoundingBox = new Box3(new Vector3(-0.5, -0.5, -0.5), new Vector3(0.5, 0.5, 0.5));
 
-function getAttributes<T extends THREE.BufferAttribute | THREE.InterleavedBufferAttribute>(
-  geometry: THREE.BufferGeometry,
+function getAttributes<T extends BufferAttribute | InterleavedBufferAttribute>(
+  geometry: BufferGeometry,
   filterType: new (...args: any[]) => T
 ): Map<string, T> {
   return new Map(
@@ -104,12 +111,12 @@ function getAttributes<T extends THREE.BufferAttribute | THREE.InterleavedBuffer
 
 function createNewBufferGeometry(
   array: Uint8Array<ArrayBuffer>,
-  oldGeometryBuffer: THREE.BufferGeometry,
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>
+  oldGeometryBuffer: BufferGeometry,
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>
 ) {
-  const newGeometry = new THREE.BufferGeometry();
+  const newGeometry = new BufferGeometry();
 
-  const bufferAttributeMap = getAttributes(oldGeometryBuffer, THREE.BufferAttribute);
+  const bufferAttributeMap = getAttributes(oldGeometryBuffer, BufferAttribute);
   bufferAttributeMap.forEach((attribute, name) => {
     newGeometry.setAttribute(name, attribute);
   });
@@ -121,11 +128,11 @@ function createNewBufferGeometry(
     const componentSize = (attribute.array as TypedArray).BYTES_PER_ELEMENT;
 
     const ComponentType = _views.get(componentSize)!;
-    const interleavedAttributesBuffer = new THREE.InstancedInterleavedBuffer(new ComponentType(array.buffer), stride);
+    const interleavedAttributesBuffer = new InstancedInterleavedBuffer(new ComponentType(array.buffer), stride);
 
     newGeometry.setAttribute(
       name,
-      new THREE.InterleavedBufferAttribute(
+      new InterleavedBufferAttribute(
         interleavedAttributesBuffer,
         attribute.itemSize,
         attribute.offset,
@@ -138,16 +145,16 @@ function createNewBufferGeometry(
 }
 
 function filterWithCallback(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
   computeBoundingBoxCallback: (
     index: number,
     elementSize: number,
     attributeFloatValues: Float32Array,
-    out: THREE.Box3
-  ) => THREE.Box3,
-  clipBox: THREE.Box3
+    out: Box3
+  ) => Box3,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
-  const firstInterleavedAttribute = interleavedAttributeMap.values().next().value as THREE.InterleavedBufferAttribute;
+  const firstInterleavedAttribute = interleavedAttributeMap.values().next().value as InterleavedBufferAttribute;
   const typedArray = firstInterleavedAttribute.array as TypedArray;
   const sharedArray = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
 
@@ -162,15 +169,15 @@ function filterWithCallback(
 }
 
 function filterOnInstanceMatrixAndBoundingBox(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  untransformedBoundingBox: THREE.Box3,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  untransformedBoundingBox: Box3,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   const computeBoundingBoxCallback = (
     index: number,
     elementSize: number,
     attributeFloatValues: Float32Array,
-    out: THREE.Box3
+    out: Box3
   ) => {
     const matrixAttribute = interleavedAttributeMap.get('a_instanceMatrix')!;
     const matrixByteOffset = matrixAttribute.offset * (matrixAttribute.array as TypedArray).BYTES_PER_ELEMENT;
@@ -189,8 +196,8 @@ function filterOnInstanceMatrixAndBoundingBox(
 }
 
 function filterOnCenterAndRadius(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3,
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3,
   radiusAAttributeName: string,
   radiusBAttributeName: string
 ): Uint8Array<ArrayBuffer> {
@@ -198,8 +205,8 @@ function filterOnCenterAndRadius(
     index: number,
     elementSize: number,
     attributeFloatValues: Float32Array,
-    out: THREE.Box3
-  ): THREE.Box3 => {
+    out: Box3
+  ): Box3 => {
     const centerAAttribute = interleavedAttributeMap.get('a_centerA')!;
     const centerBAttribute = interleavedAttributeMap.get('a_centerB')!;
     const radiusAAttribute = interleavedAttributeMap.get(radiusAAttributeName)!;
@@ -222,15 +229,15 @@ function filterOnCenterAndRadius(
 }
 
 function filterOnVertexAttributes(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   const computeBoundingBoxCallback = (
     index: number,
     elementSize: number,
     attributeFloatValues: Float32Array,
-    out: THREE.Box3
-  ): THREE.Box3 => {
+    out: Box3
+  ): Box3 => {
     const vertex1Attribute = interleavedAttributeMap.get('a_vertex1')!;
     const vertex2Attribute = interleavedAttributeMap.get('a_vertex2')!;
     const vertex3Attribute = interleavedAttributeMap.get('a_vertex3')!;
@@ -259,12 +266,12 @@ function filterOnVertexAttributes(
 }
 
 const filterOnTorusAttributesVars = {
-  boundingBox: new THREE.Box3()
+  boundingBox: new Box3()
 };
 
 function filterOnTorusAttributes(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   const { boundingBox } = filterOnTorusAttributesVars;
 
@@ -272,8 +279,8 @@ function filterOnTorusAttributes(
     index: number,
     elementSize: number,
     attributeFloatValues: Float32Array,
-    out: THREE.Box3
-  ): THREE.Box3 => {
+    out: Box3
+  ): Box3 => {
     const radius = interleavedAttributeMap.get('a_radius')!.getX(index);
     const tubeRadius = interleavedAttributeMap.get('a_tubeRadius')!.getX(index);
 
@@ -297,12 +304,12 @@ function filterOnTorusAttributes(
 }
 
 const filterOnEllipsoidAttributesVars = {
-  center: new THREE.Vector3()
+  center: new Vector3()
 };
 
 function filterOnEllipsoidAttributes(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   const { center } = filterOnEllipsoidAttributesVars;
 
@@ -310,8 +317,8 @@ function filterOnEllipsoidAttributes(
     index: number,
     _elementSize: number,
     _attributeFloatValues: Float32Array,
-    out: THREE.Box3
-  ): THREE.Box3 => {
+    out: Box3
+  ): Box3 => {
     const r1 = interleavedAttributeMap.get('a_horizontalRadius')!.getX(index);
     const r2 = interleavedAttributeMap.get('a_verticalRadius')!.getX(index);
     const height = interleavedAttributeMap.get('a_height')!.getX(index);
@@ -326,78 +333,78 @@ function filterOnEllipsoidAttributes(
 }
 
 function filterBoxCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnInstanceMatrixAndBoundingBox(interleavedAttributeMap, unitBoundingBox, clipBox);
 }
 
 function filterCircleCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnInstanceMatrixAndBoundingBox(interleavedAttributeMap, quadBoundingBox, clipBox);
 }
 
 function filterConeCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnCenterAndRadius(interleavedAttributeMap, clipBox, 'a_radiusA', 'a_radiusB');
 }
 
 function filterEccentricConeCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnCenterAndRadius(interleavedAttributeMap, clipBox, 'a_radiusA', 'a_radiusB');
 }
 
 function filterEllipsoidCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnEllipsoidAttributes(interleavedAttributeMap, clipBox);
 }
 
 function filterGeneralCylinderCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnCenterAndRadius(interleavedAttributeMap, clipBox, 'a_radius', 'a_radius');
 }
 
 function filterGeneralRingCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnInstanceMatrixAndBoundingBox(interleavedAttributeMap, quadBoundingBox, clipBox);
 }
 
 function filterQuadCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnInstanceMatrixAndBoundingBox(interleavedAttributeMap, quadBoundingBox, clipBox);
 }
 
 function filterTorusCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnTorusAttributes(interleavedAttributeMap, clipBox);
 }
 
 function filterTrapeziumCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnVertexAttributes(interleavedAttributeMap, clipBox);
 }
 
 function filterNutCollection(
-  interleavedAttributeMap: Map<string, THREE.InterleavedBufferAttribute>,
-  clipBox: THREE.Box3
+  interleavedAttributeMap: Map<string, InterleavedBufferAttribute>,
+  clipBox: Box3
 ): Uint8Array<ArrayBuffer> {
   return filterOnInstanceMatrixAndBoundingBox(interleavedAttributeMap, unitBoundingBox, clipBox);
 }

--- a/viewer/packages/cad-parsers/src/cad/types.ts
+++ b/viewer/packages/cad-parsers/src/cad/types.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3 } from 'three';
 
 import type { SectorMetadata } from '../metadata/types';
 import type { LevelOfDetail } from './LevelOfDetail';
@@ -45,11 +45,11 @@ export interface ConsumedSector {
 export interface WantedSector {
   modelIdentifier: ModelIdentifier;
   modelBaseUrl: string;
-  geometryClipBox: THREE.Box3 | null;
+  geometryClipBox: Box3 | null;
   levelOfDetail: LevelOfDetail;
   metadata: SectorMetadata;
 }
 
 export type ParsedMeshGeometry = ParsedGeometry & {
-  wholeSectorBoundingBox: THREE.Box3;
+  wholeSectorBoundingBox: Box3;
 };

--- a/viewer/packages/cad-parsers/src/metadata/CadModelClipper.test.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelClipper.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 import { CadModelClipper } from './CadModelClipper';
 import type { Mutable } from '../../../../test-utilities';
 import { generateV9SectorTree, createCadModelMetadata } from '../../../../test-utilities';
@@ -30,14 +30,14 @@ describe('CadModelClipper', () => {
   });
 
   test('createClippedModel() throws when there are no sectors inside clip box', () => {
-    const box = new THREE.Box3(new THREE.Vector3(9, 9, 9), new THREE.Vector3(10, 10, 10));
+    const box = new Box3(new Vector3(9, 9, 9), new Vector3(10, 10, 10));
     const clipper = new CadModelClipper(box);
 
     expect(() => clipper.createClippedModel(modelDepth2)).toThrow();
   });
 
   test('createClippedModel() only keeps sectors intersecting with clip box', () => {
-    const box = new THREE.Box3(new THREE.Vector3(-1, -1, -1), new THREE.Vector3(0.5, 0.5, 0.5));
+    const box = new Box3(new Vector3(-1, -1, -1), new Vector3(0.5, 0.5, 0.5));
     const clipper = new CadModelClipper(box);
 
     const result = clipper.createClippedModel(modelDepth2);
@@ -50,7 +50,7 @@ describe('CadModelClipper', () => {
   });
 
   test('createClippedModel() reduces estimated draw calls and render cost for clipped sectors', () => {
-    const box = new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.5, 0.5, 0.5));
+    const box = new Box3(new Vector3(0, 0, 0), new Vector3(0.5, 0.5, 0.5));
     const clipper = new CadModelClipper(box);
 
     const result = clipper.createClippedModel(modelDepth2);
@@ -66,5 +66,5 @@ describe('CadModelClipper', () => {
 
 function setBounds(sector: SectorMetadata, min: [number, number, number], max: [number, number, number]) {
   const mutable: Mutable<SectorMetadata> = sector;
-  mutable.subtreeBoundingBox = new THREE.Box3().setFromArray([...min, ...max]);
+  mutable.subtreeBoundingBox = new Box3().setFromArray([...min, ...max]);
 }

--- a/viewer/packages/cad-parsers/src/metadata/CadModelClipper.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelClipper.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Box3 } from 'three';
+import { Vector3 } from 'three';
 
 import type { CadModelMetadata } from './CadModelMetadata';
 import type { SectorMetadata } from './types';
@@ -11,9 +12,9 @@ import { SectorSceneFactory } from '../utilities/SectorSceneFactory';
 import { traverseDepthFirst } from '@reveal/utilities';
 
 export class CadModelClipper {
-  private readonly _geometryClipBox: THREE.Box3;
+  private readonly _geometryClipBox: Box3;
 
-  constructor(geometryClipBox: THREE.Box3) {
+  constructor(geometryClipBox: Box3) {
     this._geometryClipBox = geometryClipBox;
   }
 
@@ -48,7 +49,7 @@ export class CadModelClipper {
   }
 }
 
-function clipSector(sector: SectorMetadata, geometryClipBox: THREE.Box3): SectorMetadata | undefined {
+function clipSector(sector: SectorMetadata, geometryClipBox: Box3): SectorMetadata | undefined {
   const originalBounds = sector.subtreeBoundingBox;
   const subtreeBoundingBox = sector.subtreeBoundingBox.clone();
   subtreeBoundingBox.intersect(geometryClipBox);
@@ -81,10 +82,10 @@ function clipSector(sector: SectorMetadata, geometryClipBox: THREE.Box3): Sector
 }
 
 const determineVolumeVars = {
-  size: new THREE.Vector3()
+  size: new Vector3()
 };
 
-function determineVolume(b: THREE.Box3) {
+function determineVolume(b: Box3) {
   const { size } = determineVolumeVars;
 
   b.getSize(size);

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadata.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadata.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3, Matrix4 } from 'three';
 import type { SectorScene } from '../utilities/types';
 import type { CameraConfiguration } from '@reveal/utilities';
 import type { File3dFormat, ModelIdentifier } from '@reveal/data-providers';
@@ -38,16 +38,16 @@ export interface CadModelMetadata {
    * around the geometry, it must be transformed to "viewer space"
    * first.
    */
-  readonly geometryClipBox: THREE.Box3 | null;
+  readonly geometryClipBox: Box3 | null;
   /**
    * Matrix transforming from coordinates of the model to ThreeJS
    * coordinates.
    */
-  readonly modelMatrix: THREE.Matrix4;
+  readonly modelMatrix: Matrix4;
   /**
    * Inverse of {@see modelMatrix}.
    */
-  readonly inverseModelMatrix: THREE.Matrix4;
+  readonly inverseModelMatrix: Matrix4;
   /**
    * Description of the tree structure holding geometry.
    */

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.test.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.test.ts
@@ -6,7 +6,7 @@ import { CadModelMetadataRepository } from './CadModelMetadataRepository';
 import type { BlobOutputMetadata, ModelDataProvider, ModelMetadataProvider } from '@reveal/data-providers';
 import { File3dFormat, LocalModelIdentifier } from '@reveal/data-providers';
 
-import * as THREE from 'three';
+import { Matrix4, Vector3 } from 'three';
 import { createV9SceneSectorMetadata } from '../../../../test-utilities';
 import type { CadSceneRootMetadata } from './parsers/types';
 
@@ -56,10 +56,10 @@ function createMockedMetadataProvider(outputList: BlobOutputMetadata[]): ModelMe
       return urlFromBlobId(cadOutput.blobId);
     },
     getModelCamera: async () => {
-      return { position: new THREE.Vector3(), target: new THREE.Vector3() };
+      return { position: new Vector3(), target: new Vector3() };
     },
     getModelMatrix: async () => {
-      return new THREE.Matrix4();
+      return new Matrix4();
     }
   };
 }

--- a/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
+++ b/viewer/packages/cad-parsers/src/metadata/CadModelMetadataRepository.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 
 import { CadMetadataParser } from './CadMetadataParser';
 
@@ -47,7 +47,7 @@ export class CadModelMetadataRepository implements MetadataRepository<Promise<Ca
     const json = await this._modelDataProvider.getJsonFile(blobBaseUrl, this._blobFileName);
     const scene: SectorScene = this._cadSceneParser.parse(json);
     const modelMatrix = createScaleToMetersModelMatrix(scene.unit, await modelMatrixPromise);
-    const inverseModelMatrix = new THREE.Matrix4().copy(modelMatrix).invert();
+    const inverseModelMatrix = new Matrix4().copy(modelMatrix).invert();
     const cameraConfiguration = await modelCameraPromise;
 
     return {
@@ -85,11 +85,11 @@ export class CadModelMetadataRepository implements MetadataRepository<Promise<Ca
   }
 }
 
-function createScaleToMetersModelMatrix(unit: string, modelMatrix: THREE.Matrix4): THREE.Matrix4 {
+function createScaleToMetersModelMatrix(unit: string, modelMatrix: Matrix4): Matrix4 {
   const conversionFactor = getDistanceToMeterConversionFactor(unit) ?? 1;
   if (conversionFactor === undefined) {
     throw new Error(`Unknown model unit '${unit}'`);
   }
-  const scaledModelMatrix = new THREE.Matrix4().makeScale(conversionFactor, conversionFactor, conversionFactor);
+  const scaledModelMatrix = new Matrix4().makeScale(conversionFactor, conversionFactor, conversionFactor);
   return scaledModelMatrix.multiply(modelMatrix);
 }

--- a/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserGltf.test.ts
+++ b/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserGltf.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 
 import { traverseDepthFirst } from '@reveal/utilities';
 import type { SectorMetadata } from '../types';
@@ -44,9 +44,9 @@ describe('CadMetadataParserGltf', () => {
       sectors: [sectorRoot]
     };
 
-    const subtreeBoundingBox = new THREE.Box3(
-      new THREE.Vector3(sectorRoot.boundingBox.min.x, sectorRoot.boundingBox.min.y, sectorRoot.boundingBox.min.z),
-      new THREE.Vector3(sectorRoot.boundingBox.max.x, sectorRoot.boundingBox.max.y, sectorRoot.boundingBox.max.z)
+    const subtreeBoundingBox = new Box3(
+      new Vector3(sectorRoot.boundingBox.min.x, sectorRoot.boundingBox.min.y, sectorRoot.boundingBox.min.z),
+      new Vector3(sectorRoot.boundingBox.max.x, sectorRoot.boundingBox.max.y, sectorRoot.boundingBox.max.z)
     );
 
     const expectedRoot: SectorMetadata = {
@@ -193,12 +193,12 @@ describe('CadMetadataParserGltf', () => {
     expectBoxesEqual(rootBoundingBox, expectedBoundingBox);
   });
 
-  function expectBoxesEqual(box0: THREE.Box3, box1: THREE.Box3) {
+  function expectBoxesEqual(box0: Box3, box1: Box3) {
     expectVectorsEqual(box0.min, box1.min);
     expectVectorsEqual(box0.max, box1.max);
   }
 
-  function expectVectorsEqual(vec0: THREE.Vector3, vec1: THREE.Vector3) {
+  function expectVectorsEqual(vec0: Vector3, vec1: Vector3) {
     expect(vec0.x).toBe(vec1.x);
     expect(vec0.y).toBe(vec1.y);
     expect(vec0.z).toBe(vec1.z);

--- a/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserGltf.ts
+++ b/viewer/packages/cad-parsers/src/metadata/parsers/CadMetadataParserGltf.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 
 import type { SectorMetadata } from '../types';
 import type { SectorScene } from '../../utilities/types';
@@ -60,18 +60,15 @@ export function parseCadMetadataGltf(metadata: CadSceneRootMetadata): SectorScen
   return new SectorSceneImpl(metadata.version, metadata.maxTreeIndex, unit, rootSector, sectorsById);
 }
 
-export function toThreeBoundingBox(box: BoundingBox): THREE.Box3 {
-  return new THREE.Box3(
-    new THREE.Vector3(box.min.x, box.min.y, box.min.z),
-    new THREE.Vector3(box.max.x, box.max.y, box.max.z)
-  );
+export function toThreeBoundingBox(box: BoundingBox): Box3 {
+  return new Box3(new Vector3(box.min.x, box.min.y, box.min.z), new Vector3(box.max.x, box.max.y, box.max.z));
 }
 
 function createSectorMetadata(metadata: SceneSectorMetadata): SectorMetadata {
   const metadataBoundingBox = toThreeBoundingBox(metadata.boundingBox);
 
-  let geometryBoundingBox: THREE.Box3;
-  let subtreeBoundingBox: THREE.Box3;
+  let geometryBoundingBox: Box3;
+  let subtreeBoundingBox: Box3;
 
   // In earlier v9 models, geometryBoundingBox does not exist, and boundingBox
   // only encapsulates geometry in the current sector. This case must be treated differently
@@ -82,7 +79,7 @@ function createSectorMetadata(metadata: SceneSectorMetadata): SectorMetadata {
     geometryBoundingBox = metadataBoundingBox;
 
     // Compute this from children's bounding boxes later on
-    subtreeBoundingBox = new THREE.Box3();
+    subtreeBoundingBox = new Box3();
   }
 
   return {

--- a/viewer/packages/cad-parsers/src/metadata/types.ts
+++ b/viewer/packages/cad-parsers/src/metadata/types.ts
@@ -2,13 +2,13 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3 } from 'three';
 
 export type SectorMetadata = {
   readonly id: number;
   readonly path: string;
   readonly depth: number;
-  readonly subtreeBoundingBox: THREE.Box3;
+  readonly subtreeBoundingBox: Box3;
   readonly children: SectorMetadata[];
   readonly estimatedDrawCallCount: number;
   readonly estimatedRenderCost: number;
@@ -17,5 +17,5 @@ export type SectorMetadata = {
   readonly maxDiagonalLength: number;
   readonly minDiagonalLength: number;
   readonly downloadSize: number;
-  readonly geometryBoundingBox: THREE.Box3;
+  readonly geometryBoundingBox: Box3;
 };

--- a/viewer/packages/cad-parsers/src/sector/RootSectorNode.ts
+++ b/viewer/packages/cad-parsers/src/sector/RootSectorNode.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 
 import { SectorNode } from './SectorNode';
 import type { CadModelMetadata } from '../metadata/CadModelMetadata';
@@ -35,12 +35,12 @@ export class RootSectorNode extends SectorNode {
     }
   }
 
-  setModelTransformation(matrix: THREE.Matrix4): void {
+  setModelTransformation(matrix: Matrix4): void {
     this.matrix.copy(matrix);
     this.updateMatrixWorld(true);
   }
 
-  getModelTransformation(out = new THREE.Matrix4()): THREE.Matrix4 {
+  getModelTransformation(out = new Matrix4()): Matrix4 {
     return out.copy(this.matrix);
   }
 }
@@ -49,7 +49,7 @@ function buildScene(
   sector: SectorMetadata,
   parent: SectorNode,
   sectorNodeMap: Map<number, SectorNode>,
-  modelMatrix: THREE.Matrix4
+  modelMatrix: Matrix4
 ) {
   const bounds = sector.subtreeBoundingBox.clone();
   bounds.applyMatrix4(modelMatrix);

--- a/viewer/packages/cad-parsers/src/sector/SectorNode.ts
+++ b/viewer/packages/cad-parsers/src/sector/SectorNode.ts
@@ -2,20 +2,21 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Box3 } from 'three';
+import { Group } from 'three';
 import { LevelOfDetail } from '../cad/LevelOfDetail';
 
-export class SectorNode extends THREE.Group {
+export class SectorNode extends Group {
   public readonly sectorPath: string;
   public readonly sectorId: number;
-  public readonly bounds: THREE.Box3;
+  public readonly bounds: Box3;
   public readonly depth: number;
 
-  private _group?: THREE.Group;
+  private _group?: Group;
   private _lod = LevelOfDetail.Discarded;
   private _updatedTimestamp: number = Date.now();
 
-  constructor(sectorId: number, sectorPath: string, bounds: THREE.Box3) {
+  constructor(sectorId: number, sectorPath: string, bounds: Box3) {
     super();
     this.name = `Sector ${sectorPath} [id=${sectorId}]`;
     this.sectorId = sectorId;
@@ -28,7 +29,7 @@ export class SectorNode extends THREE.Group {
     return this._lod;
   }
 
-  get group(): THREE.Group | undefined {
+  get group(): Group | undefined {
     return this._group;
   }
 
@@ -36,7 +37,7 @@ export class SectorNode extends THREE.Group {
     return this._updatedTimestamp;
   }
 
-  updateGeometry(geometryGroup: THREE.Group | undefined, levelOfDetail: LevelOfDetail): void {
+  updateGeometry(geometryGroup: Group | undefined, levelOfDetail: LevelOfDetail): void {
     this.resetGeometry();
 
     this._group = geometryGroup;

--- a/viewer/packages/cad-parsers/src/utilities/SectorScene.test.ts
+++ b/viewer/packages/cad-parsers/src/utilities/SectorScene.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, PerspectiveCamera, Vector3 } from 'three';
 
 import type { SectorMetadata } from '../metadata/types';
 import { SectorSceneImpl } from './SectorScene';
@@ -14,10 +14,10 @@ describe('SectorSceneImpl', () => {
   const root = createV9SectorMetadata([
     0,
     [
-      [1, [], new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.5, 1, 1))],
-      [2, [], new THREE.Box3(new THREE.Vector3(0.5, 0, 0), new THREE.Vector3(1, 1, 1))]
+      [1, [], new Box3(new Vector3(0, 0, 0), new Vector3(0.5, 1, 1))],
+      [2, [], new Box3(new Vector3(0.5, 0, 0), new Vector3(1, 1, 1))]
     ],
-    new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1))
+    new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1))
   ]) as SectorMetadata;
   const sectorsById = new Map<number, SectorMetadata>();
   traverseDepthFirst(root, x => {
@@ -28,28 +28,28 @@ describe('SectorSceneImpl', () => {
   test('getSectorsContainingPoint', () => {
     const scene = new SectorSceneImpl(8, 3, 'Meters', root, sectorsById);
 
-    expect(sectorIds(scene.getSectorsContainingPoint(new THREE.Vector3(0.2, 0.5, 0.5)))).toEqual([0, 1]);
-    expect(sectorIds(scene.getSectorsContainingPoint(new THREE.Vector3(0.75, 0.5, 0.5)))).toEqual([0, 2]);
-    expect(sectorIds(scene.getSectorsContainingPoint(new THREE.Vector3(2, 0.5, 0.5)))).toEqual([]);
+    expect(sectorIds(scene.getSectorsContainingPoint(new Vector3(0.2, 0.5, 0.5)))).toEqual([0, 1]);
+    expect(sectorIds(scene.getSectorsContainingPoint(new Vector3(0.75, 0.5, 0.5)))).toEqual([0, 2]);
+    expect(sectorIds(scene.getSectorsContainingPoint(new Vector3(2, 0.5, 0.5)))).toEqual([]);
   });
 
   test('getSectorsIntersectingBox', () => {
     const scene = new SectorSceneImpl(8, 3, 'Meters', root, sectorsById);
-    expect(
-      sectorIds(scene.getSectorsIntersectingBox(new THREE.Box3().setFromArray([-10, -10, -10, 10, 10, 10])))
-    ).toEqual([0, 1, 2]);
-    expect(sectorIds(scene.getSectorsIntersectingBox(new THREE.Box3().setFromArray([0, 0, 0, 0.2, 0.2, 0.2])))).toEqual(
-      [0, 1]
-    );
-    expect(sectorIds(scene.getSectorsIntersectingBox(new THREE.Box3().setFromArray([0.6, 0.6, 0.6, 1, 1, 1])))).toEqual(
-      [0, 2]
-    );
+    expect(sectorIds(scene.getSectorsIntersectingBox(new Box3().setFromArray([-10, -10, -10, 10, 10, 10])))).toEqual([
+      0, 1, 2
+    ]);
+    expect(sectorIds(scene.getSectorsIntersectingBox(new Box3().setFromArray([0, 0, 0, 0.2, 0.2, 0.2])))).toEqual([
+      0, 1
+    ]);
+    expect(sectorIds(scene.getSectorsIntersectingBox(new Box3().setFromArray([0.6, 0.6, 0.6, 1, 1, 1])))).toEqual([
+      0, 2
+    ]);
   });
 
   test('getSectorsIntersectingFrustum, some sectors inside', () => {
     // Arrange
     const scene = new SectorSceneImpl(8, 3, 'Meters', root, sectorsById);
-    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10.0);
+    const camera = new PerspectiveCamera(60, 1, 0.1, 10.0);
     camera.position.set(2.0, 0.5, -1);
     camera.lookAt(2.0, 0.5, 0.5);
     camera.updateMatrixWorld();
@@ -67,7 +67,7 @@ describe('SectorSceneImpl', () => {
   test('getSectorsIntersectingFrustum, all sectors inside frustum', () => {
     // Arrange
     const scene = new SectorSceneImpl(8, 3, 'Meters', root, sectorsById);
-    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 10.0);
+    const camera = new PerspectiveCamera(60, 1, 0.1, 10.0);
     camera.position.set(0.5, 0.5, -1);
     camera.lookAt(0.5, 0.5, 0.5);
     camera.updateMatrixWorld();
@@ -94,11 +94,11 @@ describe('SectorSceneImpl', () => {
       [
         0,
         [
-          [1, [], new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.5, 1, 1))],
-          [2, [], new THREE.Box3(new THREE.Vector3(0.5, 0, 0), new THREE.Vector3(1, 1, 1))],
-          [3, [], new THREE.Box3(new THREE.Vector3(1000.5, 1000, 1000), new THREE.Vector3(1001, 1001, 1001))]
+          [1, [], new Box3(new Vector3(0, 0, 0), new Vector3(0.5, 1, 1))],
+          [2, [], new Box3(new Vector3(0.5, 0, 0), new Vector3(1, 1, 1))],
+          [3, [], new Box3(new Vector3(1000.5, 1000, 1000), new Vector3(1001, 1001, 1001))]
         ],
-        new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1001, 1001, 1001))
+        new Box3(new Vector3(0, 0, 0), new Vector3(1001, 1001, 1001))
       ],
       0,
       '0/',
@@ -122,9 +122,9 @@ describe('SectorSceneImpl', () => {
 
   test('getBoundsOfMostGeometry with root with only one child, result is child bounds', () => {
     // Arrange
-    const leafBounds = new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1));
+    const leafBounds = new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
     const root = createV9SectorMetadata(
-      [0, [[1, [], leafBounds]], new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(10, 10, 10))],
+      [0, [[1, [], leafBounds]], new Box3(new Vector3(0, 0, 0), new Vector3(10, 10, 10))],
       0,
       '0/',
       0

--- a/viewer/packages/cad-parsers/src/utilities/SectorScene.ts
+++ b/viewer/packages/cad-parsers/src/utilities/SectorScene.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Vector3 } from 'three';
+import { Box3, Frustum, Matrix4 } from 'three';
 import { traverseDepthFirst } from '@reveal/utilities';
 import type { SectorScene } from './types';
 import type { SectorMetadata } from '../metadata/types';
@@ -14,7 +15,7 @@ export class SectorSceneImpl implements SectorScene {
   readonly root: SectorMetadata;
   readonly unit: string;
   private readonly sectors: Map<number, SectorMetadata>;
-  private _cachedBoundsOfMostGeometry: THREE.Box3 | undefined;
+  private _cachedBoundsOfMostGeometry: Box3 | undefined;
 
   constructor(
     version: number,
@@ -42,7 +43,7 @@ export class SectorSceneImpl implements SectorScene {
     return [...this.sectors.values()];
   }
 
-  getSectorsContainingPoint(p: THREE.Vector3): SectorMetadata[] {
+  getSectorsContainingPoint(p: Vector3): SectorMetadata[] {
     const accepted: SectorMetadata[] = [];
     traverseDepthFirst(this.root, x => {
       if (x.subtreeBoundingBox.containsPoint(p)) {
@@ -54,7 +55,7 @@ export class SectorSceneImpl implements SectorScene {
     return accepted;
   }
 
-  getSectorsIntersectingBox(b: THREE.Box3): SectorMetadata[] {
+  getSectorsIntersectingBox(b: Box3): SectorMetadata[] {
     const accepted: SectorMetadata[] = [];
     traverseDepthFirst(this.root, x => {
       if (x.subtreeBoundingBox.intersectsBox(b)) {
@@ -66,17 +67,14 @@ export class SectorSceneImpl implements SectorScene {
     return accepted;
   }
 
-  getBoundsOfMostGeometry(): THREE.Box3 {
+  getBoundsOfMostGeometry(): Box3 {
     this._cachedBoundsOfMostGeometry = this._cachedBoundsOfMostGeometry ?? this.computeBoundsOfMostGeometry();
     return this._cachedBoundsOfMostGeometry;
   }
 
-  getSectorsIntersectingFrustum(
-    projectionMatrix: THREE.Matrix4,
-    inverseCameraModelMatrix: THREE.Matrix4
-  ): SectorMetadata[] {
-    const frustumMatrix = new THREE.Matrix4().multiplyMatrices(projectionMatrix, inverseCameraModelMatrix);
-    const frustum = new THREE.Frustum().setFromProjectionMatrix(frustumMatrix);
+  getSectorsIntersectingFrustum(projectionMatrix: Matrix4, inverseCameraModelMatrix: Matrix4): SectorMetadata[] {
+    const frustumMatrix = new Matrix4().multiplyMatrices(projectionMatrix, inverseCameraModelMatrix);
+    const frustum = new Frustum().setFromProjectionMatrix(frustumMatrix);
     const accepted: SectorMetadata[] = [];
     traverseDepthFirst(this.root, x => {
       if (frustum.intersectsBox(x.subtreeBoundingBox)) {
@@ -91,9 +89,9 @@ export class SectorSceneImpl implements SectorScene {
   /**
    * Recursive intersection detection.
    */
-  private detectIntersectingBounds(bounds: THREE.Box3, clusters: THREE.Box3[]): THREE.Box3[] {
-    const intersectingClusters: THREE.Box3[] = [];
-    const potentialJunkClusters: THREE.Box3[] = [];
+  private detectIntersectingBounds(bounds: Box3, clusters: Box3[]): Box3[] {
+    const intersectingClusters: Box3[] = [];
+    const potentialJunkClusters: Box3[] = [];
 
     clusters.forEach(cluster => {
       if (bounds !== cluster) {
@@ -120,11 +118,11 @@ export class SectorSceneImpl implements SectorScene {
    * @param inBounds The bounds to be grouped into clusters.
    * @returns Both the list of cluster bounds and the cluster with the highest node count
    */
-  private generateClusters(inBounds: THREE.Box3[]): [THREE.Box3[], THREE.Box3] {
+  private generateClusters(inBounds: Box3[]): [Box3[], Box3] {
     // Store the position of the min and max corners of each bound in 'nodes'
     // Also generate a merged box of all bounds that is used to calculate centroid positions later
     const nodes: number[][] = [];
-    const mergedBounds = new THREE.Box3();
+    const mergedBounds = new Box3();
     inBounds.forEach(x => {
       nodes.push(x.min.toArray(), x.max.toArray());
       mergedBounds.union(x);
@@ -156,7 +154,7 @@ export class SectorSceneImpl implements SectorScene {
     }).idx;
 
     // For each cluster, create the combined bounds of all nodes that belong to it
-    const clusterBounds = clusterCounts.map(_ => new THREE.Box3());
+    const clusterBounds = clusterCounts.map(_ => new Box3());
     result.idxs.forEach((cluster, idx) => {
       clusterBounds[cluster].union(inBounds[Math.floor(idx / 2)]);
     });
@@ -164,12 +162,12 @@ export class SectorSceneImpl implements SectorScene {
     return [clusterBounds, clusterBounds[biggestClusterIndex]];
   }
 
-  private computeBoundsOfMostGeometry(): THREE.Box3 {
+  private computeBoundsOfMostGeometry(): Box3 {
     if (this.root.children.length === 0) {
       return this.root.subtreeBoundingBox;
     }
 
-    const allBounds: THREE.Box3[] = [];
+    const allBounds: Box3[] = [];
     {
       // Find all leaf bounds and count overall render cost
       let allBoundsRenderCost = 0;

--- a/viewer/packages/cad-parsers/src/utilities/computeBoundingBoxFromAttributes.test.ts
+++ b/viewer/packages/cad-parsers/src/utilities/computeBoundingBoxFromAttributes.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Matrix4, Sphere, Vector3 } from 'three';
 import {
   computeBoundingBoxFromCenterAndRadiusAttributes,
   computeBoundingBoxFromEllipseAttributes,
@@ -44,19 +44,19 @@ describe('computeBoundingBoxFromCenterAndRadiusAttributes', () => {
       radiusB_attribute.offset,
       elementSize,
       0,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
-    expect(result).toEqual(new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(2, 2, 2)));
+    expect(result).toEqual(new Box3(new Vector3(0, 0, 0), new Vector3(2, 2, 2)));
   });
 
   test('two spheres, result contains both sphere bounding boxes', () => {
     // Arange
     const valuesAsFloats = new Float32Array(8);
     populateValues([-1, -5, 3], 6, [5, 9, 10], 10, 0, valuesAsFloats);
-    const sphere1 = new THREE.Sphere(new THREE.Vector3(-1, -5, 3), 6);
-    const sphere2 = new THREE.Sphere(new THREE.Vector3(5, 9, 10), 10);
+    const sphere1 = new Sphere(new Vector3(-1, -5, 3), 6);
+    const sphere2 = new Sphere(new Vector3(5, 9, 10), 10);
 
     // Act
     const result = computeBoundingBoxFromCenterAndRadiusAttributes(
@@ -67,20 +67,20 @@ describe('computeBoundingBoxFromCenterAndRadiusAttributes', () => {
       radiusB_attribute.offset,
       elementSize,
       0,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
-    expect(result.containsBox(sphere1.getBoundingBox(new THREE.Box3()))).toBeTruthy();
-    expect(result.containsBox(sphere2.getBoundingBox(new THREE.Box3()))).toBeTruthy();
+    expect(result.containsBox(sphere1.getBoundingBox(new Box3()))).toBeTruthy();
+    expect(result.containsBox(sphere2.getBoundingBox(new Box3()))).toBeTruthy();
   });
 
   test('second element returns correct bounding box', () => {
     // Arange
     const valuesAsFloats = new Float32Array(16);
     populateValues([3, 3, 3], 1, [7, 7, 7], 2, 1, valuesAsFloats);
-    const sphere1 = new THREE.Sphere(new THREE.Vector3(3, 3, 3), 1);
-    const sphere2 = new THREE.Sphere(new THREE.Vector3(7, 7, 7), 2);
+    const sphere1 = new Sphere(new Vector3(3, 3, 3), 1);
+    const sphere2 = new Sphere(new Vector3(7, 7, 7), 2);
 
     // Act
     const result = computeBoundingBoxFromCenterAndRadiusAttributes(
@@ -91,12 +91,12 @@ describe('computeBoundingBoxFromCenterAndRadiusAttributes', () => {
       radiusB_attribute.offset,
       elementSize,
       1,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
-    expect(result.containsBox(sphere1.getBoundingBox(new THREE.Box3()))).toBeTruthy();
-    expect(result.containsBox(sphere2.getBoundingBox(new THREE.Box3()))).toBeTruthy();
+    expect(result.containsBox(sphere1.getBoundingBox(new Box3()))).toBeTruthy();
+    expect(result.containsBox(sphere2.getBoundingBox(new Box3()))).toBeTruthy();
   });
 
   function populateValues(
@@ -148,11 +148,11 @@ describe('computeBoundingBoxFromVertexAttributes', () => {
       valuesAsFloats,
       elementSize,
       0,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
-    expect(result).toEqual(new THREE.Box3(new THREE.Vector3(1, 1, 1), new THREE.Vector3(4, 4, 4)));
+    expect(result).toEqual(new Box3(new Vector3(1, 1, 1), new Vector3(4, 4, 4)));
   });
 
   test('second element returns correct bounding box', () => {
@@ -176,11 +176,11 @@ describe('computeBoundingBoxFromVertexAttributes', () => {
       valuesAsFloats,
       elementSize,
       1,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
-    const box = new THREE.Box3().setFromArray(values.slice(12));
+    const box = new Box3().setFromArray(values.slice(12));
     expect(result).toEqual(box);
   });
 
@@ -219,8 +219,8 @@ describe('computeBoundingBoxFromInstanceMatrixAttributes', () => {
 
   test('unit bbox with identity transform, returns unit bbox', () => {
     // Arange
-    const baseBbox = new THREE.Box3(new THREE.Vector3(-1, -1, -1), new THREE.Vector3(1, 1, 1));
-    const matrix = new THREE.Matrix4().identity();
+    const baseBbox = new Box3(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
+    const matrix = new Matrix4().identity();
     const valuesAsFloats = new Float32Array(matrix.toArray());
     const matrixByteOffset = instanceMatrixAttribute.offset;
 
@@ -231,7 +231,7 @@ describe('computeBoundingBoxFromInstanceMatrixAttributes', () => {
       elementSize,
       0,
       baseBbox,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
@@ -240,10 +240,10 @@ describe('computeBoundingBoxFromInstanceMatrixAttributes', () => {
 
   test('complex bbox with complex transform, returns transformed bbox', () => {
     // Arange
-    const baseBbox = new THREE.Box3(new THREE.Vector3(-2, 3, -5), new THREE.Vector3(2, 7, 3));
-    const matrix = new THREE.Matrix4().multiplyMatrices(
-      new THREE.Matrix4().makeTranslation(10, 11, 12),
-      new THREE.Matrix4().makeScale(1, 2, 3)
+    const baseBbox = new Box3(new Vector3(-2, 3, -5), new Vector3(2, 7, 3));
+    const matrix = new Matrix4().multiplyMatrices(
+      new Matrix4().makeTranslation(10, 11, 12),
+      new Matrix4().makeScale(1, 2, 3)
     );
     const valuesAsFloats = new Float32Array(matrix.toArray());
     const matrixByteOffset = instanceMatrixAttribute.offset;
@@ -255,7 +255,7 @@ describe('computeBoundingBoxFromInstanceMatrixAttributes', () => {
       elementSize,
       0,
       baseBbox,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
@@ -280,7 +280,7 @@ describe('computeBoundingBoxFromEllipseAttributes', () => {
 
   test('unit ellipse, returns unit bbox', () => {
     // Arange
-    const baseBbox = new THREE.Box3(new THREE.Vector3(-1, -1, -1), new THREE.Vector3(1, 1, 1));
+    const baseBbox = new Box3(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
     const valuesAsFloats = new Float32Array([
       // Center
       ...[0, 0, 0],
@@ -299,7 +299,7 @@ describe('computeBoundingBoxFromEllipseAttributes', () => {
       valuesAsFloats,
       elementSize,
       0,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
@@ -320,12 +320,10 @@ describe('computeBoundingBoxFromEllipseAttributes', () => {
       valuesAsFloats,
       elementSize,
       0,
-      new THREE.Box3()
+      new Box3()
     );
 
     // Assert
-    expect(result).toEqual(
-      new THREE.Box3().setFromCenterAndSize(new THREE.Vector3(1, 2, 3), new THREE.Vector3(8, 8, 8))
-    );
+    expect(result).toEqual(new Box3().setFromCenterAndSize(new Vector3(1, 2, 3), new Vector3(8, 8, 8)));
   });
 });

--- a/viewer/packages/cad-parsers/src/utilities/computeBoundingBoxFromAttributes.ts
+++ b/viewer/packages/cad-parsers/src/utilities/computeBoundingBoxFromAttributes.ts
@@ -1,13 +1,13 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Box3, Matrix4, Sphere, Vector3 } from 'three';
 
 const computeBoundingBoxFromCenterAndRadiusAttributesVars = {
-  centerA: new THREE.Vector3(),
-  centerB: new THREE.Vector3(),
-  sphere: new THREE.Sphere(),
-  box: new THREE.Box3()
+  centerA: new Vector3(),
+  centerB: new Vector3(),
+  sphere: new Sphere(),
+  box: new Box3()
 };
 
 type ParsePrimitiveAttribute = {
@@ -23,8 +23,8 @@ export function computeBoundingBoxFromCenterAndRadiusAttributes(
   radiusBByteOffset: number,
   elementSize: number,
   elementIndex: number,
-  out: THREE.Box3
-): THREE.Box3 {
+  out: Box3
+): Box3 {
   const { centerA, centerB, sphere, box } = computeBoundingBoxFromCenterAndRadiusAttributesVars;
 
   function readAttribute(byteOffset: number, idx: number = 0): number {
@@ -57,10 +57,10 @@ export function computeBoundingBoxFromCenterAndRadiusAttributes(
 }
 
 const computeBoundingBoxFromVertexAttributesVars = {
-  vertex1: new THREE.Vector3(),
-  vertex2: new THREE.Vector3(),
-  vertex3: new THREE.Vector3(),
-  vertex4: new THREE.Vector3()
+  vertex1: new Vector3(),
+  vertex2: new Vector3(),
+  vertex3: new Vector3(),
+  vertex4: new Vector3()
 };
 
 export function computeBoundingBoxFromVertexAttributes(
@@ -71,8 +71,8 @@ export function computeBoundingBoxFromVertexAttributes(
   attributeFloatValues: Float32Array,
   elementSize: number,
   elementIndex: number,
-  out: THREE.Box3
-): THREE.Box3 {
+  out: Box3
+): Box3 {
   const { vertex1, vertex2, vertex3, vertex4 } = computeBoundingBoxFromVertexAttributesVars;
 
   function readAttribute(attributeByteOffset: number, idx: number = 0): number {
@@ -106,7 +106,7 @@ export function computeBoundingBoxFromVertexAttributes(
 }
 
 const computeBoundingBoxFromInstanceMatrixAttributesVars = {
-  instanceMatrix: new THREE.Matrix4()
+  instanceMatrix: new Matrix4()
 };
 
 export function computeBoundingBoxFromInstanceMatrixAttributes(
@@ -114,9 +114,9 @@ export function computeBoundingBoxFromInstanceMatrixAttributes(
   byteOffset: number,
   elementSize: number,
   elementIndex: number,
-  baseBoundingBox: THREE.Box3,
-  out: THREE.Box3
-): THREE.Box3 {
+  baseBoundingBox: Box3,
+  out: Box3
+): Box3 {
   const { instanceMatrix } = computeBoundingBoxFromInstanceMatrixAttributesVars;
 
   const offset = (elementIndex * elementSize + byteOffset) / attributeFloatValues.BYTES_PER_ELEMENT;
@@ -147,17 +147,17 @@ export function computeBoundingBoxFromInstanceMatrixAttributes(
 }
 
 const computeBoundingBoxFromEllipseAttributesVars = {
-  center: new THREE.Vector3(),
-  size: new THREE.Vector3()
+  center: new Vector3(),
+  size: new Vector3()
 };
 
 export function computeBoundingBoxFromEllipseValues(
   radius1: number,
   radius2: number,
   height: number,
-  center: THREE.Vector3,
-  out: THREE.Box3
-): THREE.Box3 {
+  center: Vector3,
+  out: Box3
+): Box3 {
   const { size } = computeBoundingBoxFromEllipseAttributesVars;
 
   const extent = 2 * Math.max(radius1, radius2, height);
@@ -174,8 +174,8 @@ export function computeBoundingBoxFromEllipseAttributes(
   attributeFloatValues: Float32Array,
   elementSize: number,
   elementIndex: number,
-  out: THREE.Box3
-): THREE.Box3 {
+  out: Box3
+): Box3 {
   const { center } = computeBoundingBoxFromEllipseAttributesVars;
 
   function readAttribute(attribute: ParsePrimitiveAttribute, idx: number = 0): number {

--- a/viewer/packages/cad-parsers/src/utilities/types.ts
+++ b/viewer/packages/cad-parsers/src/utilities/types.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3, Matrix4, Vector3 } from 'three';
 
 import type { SectorMetadata } from '../metadata/types';
 
@@ -52,15 +52,15 @@ export interface SectorScene {
 
   readonly sectorCount: number;
   getSectorById(sectorId: number): SectorMetadata | undefined;
-  getSectorsContainingPoint(p: THREE.Vector3): SectorMetadata[];
-  getSectorsIntersectingBox(b: THREE.Box3): SectorMetadata[];
+  getSectorsContainingPoint(p: Vector3): SectorMetadata[];
+  getSectorsIntersectingBox(b: Box3): SectorMetadata[];
 
   /**
    * Returns bounds that contains "most geometry". This bounds is an
    * attempt to remove junk geometry from the bounds to allow e.g. setting
    * a good camera position.
    */
-  getBoundsOfMostGeometry(): THREE.Box3;
+  getBoundsOfMostGeometry(): Box3;
 
   /**
    * Gets the sectors intersecting the frustum provided from the projection and inverse
@@ -73,7 +73,7 @@ export interface SectorScene {
    * const cameraProjectionMatrix = camera.projectionMatrix;
    *
    * const transformedCameraMatrixWorldInverse =
-   *  new THREE.Matrix4().multiplyMatrices(cameraMatrixWorldInverse, model.modelMatrix)
+   *  new Matrix4().multiplyMatrices(cameraMatrixWorldInverse, model.modelMatrix)
    *
    * const intersectingSectors = model.scene.getSectorsIntersectingFrustum(
    *   cameraProjectionMatrix,
@@ -83,10 +83,7 @@ export interface SectorScene {
    * @param projectionMatrix
    * @param inverseCameraModelMatrix
    */
-  getSectorsIntersectingFrustum(
-    projectionMatrix: THREE.Matrix4,
-    inverseCameraModelMatrix: THREE.Matrix4
-  ): SectorMetadata[];
+  getSectorsIntersectingFrustum(projectionMatrix: Matrix4, inverseCameraModelMatrix: Matrix4): SectorMetadata[];
   getAllSectors(): SectorMetadata[];
 
   // Available, but not supported:

--- a/viewer/packages/cad-styling/src/AssetNodeCollection.ts
+++ b/viewer/packages/cad-styling/src/AssetNodeCollection.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
 import { PopulateIndexSetFromPagedResponseHelper } from './PopulateIndexSetFromPagedResponseHelper';
 import { NodeCollection } from './NodeCollection';
@@ -32,7 +32,7 @@ export class AssetNodeCollection extends NodeCollection {
   private _areas: AreaCollection = EmptyAreaCollection.instance();
   private readonly _modelMetadataProvider: CdfModelNodeCollectionDataProvider;
   private _fetchResultHelper: PopulateIndexSetFromPagedResponseHelper<AssetMapping3D> | undefined;
-  private _filter: { assetId?: number; boundingBox?: THREE.Box3 } | undefined;
+  private _filter: { assetId?: number; boundingBox?: Box3 } | undefined;
 
   constructor(client: CogniteClient, modelMetadataProvider: CdfModelNodeCollectionDataProvider) {
     super(AssetNodeCollection.classToken);
@@ -52,7 +52,7 @@ export class AssetNodeCollection extends NodeCollection {
    * @param filter.assetId      ID of a single [asset]{@link https://docs.cognite.com/dev/concepts/resource_types/assets.html} (optional)
    * @param filter.boundingBox  When provided, only assets within the provided bounds will be included in the filter.
    */
-  async executeFilter(filter: { assetId?: number; boundingBox?: THREE.Box3 }): Promise<void> {
+  async executeFilter(filter: { assetId?: number; boundingBox?: Box3 }): Promise<void> {
     const model = this._modelMetadataProvider;
 
     if (this._fetchResultHelper !== undefined) {
@@ -75,12 +75,12 @@ export class AssetNodeCollection extends NodeCollection {
       .multiply(model.getCdfToDefaultModelTransformation())
       .invert();
 
-    function mapBoundingBoxToCdf(box?: THREE.Box3) {
+    function mapBoundingBoxToCdf(box?: Box3) {
       if (box === undefined) {
         return undefined;
       }
 
-      const result = new THREE.Box3().copy(box);
+      const result = new Box3().copy(box);
       result.applyMatrix4(totalInverseModelTransform);
       return { min: [result.min.x, result.min.y, result.min.z], max: [result.max.x, result.max.y, result.max.z] };
     }
@@ -128,7 +128,7 @@ export class AssetNodeCollection extends NodeCollection {
       .map(node => {
         const bmin = node.boundingBox!.min;
         const bmax = node.boundingBox!.max;
-        const bounds = new THREE.Box3().setFromArray([bmin[0], bmin[1], bmin[2], bmax[0], bmax[1], bmax[2]]);
+        const bounds = new Box3().setFromArray([bmin[0], bmin[1], bmin[2], bmax[0], bmax[1], bmax[2]]);
         bounds.applyMatrix4(totalModelTransformation);
         return bounds;
       });
@@ -136,7 +136,7 @@ export class AssetNodeCollection extends NodeCollection {
     return boundingBoxes;
   }
 
-  getFilter(): { assetId?: number | undefined; boundingBox?: THREE.Box3 | undefined } | undefined {
+  getFilter(): { assetId?: number | undefined; boundingBox?: Box3 | undefined } | undefined {
     return this._filter;
   }
 

--- a/viewer/packages/cad-styling/src/CdfModelNodeCollectionDataProvider.ts
+++ b/viewer/packages/cad-styling/src/CdfModelNodeCollectionDataProvider.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Matrix4 } from 'three';
 
 /**
  * Provides metadata needed to get asset mappings for a CDF 3D model
@@ -11,14 +11,14 @@ export interface CdfModelNodeCollectionDataProvider {
   /**
    * Gets the transformation of the model in ThreeJS space
    */
-  getModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
+  getModelTransformation(out?: Matrix4): Matrix4;
 
   /**
    * Gets the default transformation of the model from CDF space.
    * The current total transformation of the model from the backend to its transform in ThreeJS space
    * is thus `model.getCdfToDefaultModelTransformation() * model.getModelTransformation()`.
    */
-  getCdfToDefaultModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
+  getCdfToDefaultModelTransformation(out?: Matrix4): Matrix4;
 
   /**
    * Total count of nodes in the model

--- a/viewer/packages/cad-styling/src/CdfNodeCollectionBase.ts
+++ b/viewer/packages/cad-styling/src/CdfNodeCollectionBase.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Box3 } from 'three';
 import type { ListResponse, Node3D } from '@cognite/sdk';
 import { PopulateIndexSetFromPagedResponseHelper } from './PopulateIndexSetFromPagedResponseHelper';
 import type { AreaCollection } from './prioritized/AreaCollection';
@@ -41,7 +41,7 @@ export abstract class CdfNodeCollectionBase extends NodeCollection {
       nodes => nodes.map(node => new NumericRange(node.treeIndex, node.subtreeSize)),
       async nodes =>
         nodes.map(node => {
-          const bounds = new THREE.Box3();
+          const bounds = new Box3();
           if (node.boundingBox !== undefined) {
             toThreeBox3(node.boundingBox, bounds);
             bounds.applyMatrix4(totalModelTransformation);

--- a/viewer/packages/cad-styling/src/NodeAppearanceTextureBuilder.test.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceTextureBuilder.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { DataTexture } from 'three';
 
 import { NodeAppearanceTextureBuilder } from './NodeAppearanceTextureBuilder';
 
@@ -273,7 +273,7 @@ describe('NodeAppearanceTextureBuilder', () => {
   });
 });
 
-function texelsOf(texture: THREE.DataTexture): number[] | undefined {
+function texelsOf(texture: DataTexture): number[] | undefined {
   const data = texture.image.data;
   assert(data !== null);
   return Array.from(createUint8View(data));

--- a/viewer/packages/cad-styling/src/NodeAppearanceTextureBuilder.ts
+++ b/viewer/packages/cad-styling/src/NodeAppearanceTextureBuilder.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { DataTexture } from 'three';
 
 import { IndexSet, determinePowerOfTwoDimensions, NumericRange, createUint8View } from '@reveal/utilities';
 import { DefaultNodeAppearance, type NodeAppearance } from './NodeAppearance';
@@ -16,7 +16,7 @@ export class NodeAppearanceTextureBuilder {
   private _needsUpdate = true;
   private readonly _allTreeIndices: IndexSet;
   private readonly _overrideColorDefaultAppearanceRgba: Uint8ClampedArray;
-  private readonly _overrideColorPerTreeIndexTexture: THREE.DataTexture;
+  private readonly _overrideColorPerTreeIndexTexture: DataTexture;
   private readonly _regularNodesTreeIndices: IndexSet;
   private readonly _ghostedNodesTreeIndices: IndexSet;
   private readonly _infrontNodesTreeIndices: IndexSet;
@@ -94,7 +94,7 @@ export class NodeAppearanceTextureBuilder {
    * Note that in-front and ghost information also is available from
    * the {@see inFrontTreeIndices} and {@see ghostedTreeIndices} collections.
    */
-  get overrideColorPerTreeIndexTexture(): THREE.DataTexture {
+  get overrideColorPerTreeIndexTexture(): DataTexture {
     return this._overrideColorPerTreeIndexTexture;
   }
 
@@ -212,12 +212,12 @@ export class NodeAppearanceTextureBuilder {
   }
 }
 
-function allocateOverrideColorPerTreeIndexTexture(treeIndexCount: number): THREE.DataTexture {
+function allocateOverrideColorPerTreeIndexTexture(treeIndexCount: number): DataTexture {
   const { width, height } = determinePowerOfTwoDimensions(treeIndexCount);
   const textureElementCount = width * height;
 
   // Color and style override texture
-  const overrideColorPerTreeIndexTexture = new THREE.DataTexture(
+  const overrideColorPerTreeIndexTexture = new DataTexture(
     new Uint8ClampedArray(4 * textureElementCount),
     width,
     height

--- a/viewer/packages/cad-styling/src/NodeCollectionDeserializer.ts
+++ b/viewer/packages/cad-styling/src/NodeCollectionDeserializer.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 import { assert } from '@reveal/utilities/assert';
 import type { CogniteClient } from '@cognite/sdk';
 import { NumericRange, IndexSet } from '@reveal/utilities';
@@ -109,9 +109,9 @@ export class NodeCollectionDeserializer {
           max: { x: number; y: number; z: number };
         }[];
         const areaBoxes = areas.map(area => {
-          const min = new THREE.Vector3(area.min.x, area.min.y, area.min.z);
-          const max = new THREE.Vector3(area.max.x, area.max.y, area.max.z);
-          return new THREE.Box3(min, max);
+          const min = new Vector3(area.min.x, area.min.y, area.min.z);
+          const max = new Vector3(area.max.x, area.max.y, area.max.z);
+          return new Box3(min, max);
         });
         nodeCollection.addAreas(areaBoxes);
       }

--- a/viewer/packages/cad-styling/src/NodeIdNodeCollection.test.ts
+++ b/viewer/packages/cad-styling/src/NodeIdNodeCollection.test.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 
 import type { BoundingBox3D, CogniteClient, InternalId, Node3D, Revisions3DAPI } from '@cognite/sdk';
 import { NodeIdNodeCollection } from './NodeIdNodeCollection';
@@ -29,8 +29,8 @@ describe(NodeIdNodeCollection.name, () => {
     mockClient.setup(x => x.revisions3D).returns(mockRevisions3DAPI.object());
 
     mockModel = new Mock<CdfModelNodeCollectionDataProvider>();
-    mockModel.setup(x => x.getModelTransformation()).returns(new THREE.Matrix4());
-    mockModel.setup(x => x.getCdfToDefaultModelTransformation()).returns(new THREE.Matrix4());
+    mockModel.setup(x => x.getModelTransformation()).returns(new Matrix4());
+    mockModel.setup(x => x.getCdfToDefaultModelTransformation()).returns(new Matrix4());
   });
 
   test('executeFilter with 1001 nodeIds, splits into two chunks', async () => {

--- a/viewer/packages/cad-styling/src/PopulateIndexSetFromPagedResponseHelper.test.ts
+++ b/viewer/packages/cad-styling/src/PopulateIndexSetFromPagedResponseHelper.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
 import { PopulateIndexSetFromPagedResponseHelper } from './PopulateIndexSetFromPagedResponseHelper';
 
@@ -21,7 +21,7 @@ describe('PopulateIndexSetFromPagedResponseHelper', () => {
     notifyChangedCallback = vi.fn();
     helper = new PopulateIndexSetFromPagedResponseHelper<number>(
       xs => xs.map(x => new NumericRange(x, 1)),
-      async xs => xs.map(x => new THREE.Box3().setFromArray([x, x, x, x + 1, x + 1, x + 1])),
+      async xs => xs.map(x => new Box3().setFromArray([x, x, x, x + 1, x + 1, x + 1])),
       notifyChangedCallback
     );
   });

--- a/viewer/packages/cad-styling/src/PopulateIndexSetFromPagedResponseHelper.ts
+++ b/viewer/packages/cad-styling/src/PopulateIndexSetFromPagedResponseHelper.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3 } from 'three';
 
 import type { ListResponse } from '@cognite/sdk';
 import type { NumericRange } from '@reveal/utilities';
@@ -15,7 +15,7 @@ import { ClusteredAreaCollection } from './prioritized/ClusteredAreaCollection';
  */
 export class PopulateIndexSetFromPagedResponseHelper<T> {
   private readonly _itemsToTreeIndexRangesCallback: (item: T[]) => NumericRange[];
-  private readonly _itemsToAreasCallback: (item: T[]) => Promise<THREE.Box3[]>;
+  private readonly _itemsToAreasCallback: (item: T[]) => Promise<Box3[]>;
   private readonly _notifyChangedCallback: () => void;
 
   private _ongoingOperations = 0;
@@ -25,7 +25,7 @@ export class PopulateIndexSetFromPagedResponseHelper<T> {
 
   constructor(
     itemsToTreeIndexRangesCallback: (items: T[]) => NumericRange[],
-    itemsToAreasCallback: (items: T[]) => Promise<THREE.Box3[]>,
+    itemsToAreasCallback: (items: T[]) => Promise<Box3[]>,
     notifySetChangedCallback: () => void
   ) {
     this._itemsToTreeIndexRangesCallback = itemsToTreeIndexRangesCallback;

--- a/viewer/packages/cad-styling/src/SinglePropertyFilterNodeCollection.test.ts
+++ b/viewer/packages/cad-styling/src/SinglePropertyFilterNodeCollection.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 
 import type { CogniteClient } from '@cognite/sdk';
 
@@ -24,8 +24,8 @@ describe('SinglePropertyFilterNodeCollection', () => {
     mockClient.setup(x => x.getBaseUrl()).returns('https://mycdf');
 
     mockModel = new Mock<CdfModelNodeCollectionDataProvider>();
-    mockModel.setup(x => x.getCdfToDefaultModelTransformation()).returns(new THREE.Matrix4());
-    mockModel.setup(x => x.getModelTransformation()).returns(new THREE.Matrix4());
+    mockModel.setup(x => x.getCdfToDefaultModelTransformation()).returns(new Matrix4());
+    mockModel.setup(x => x.getModelTransformation()).returns(new Matrix4());
 
     set = new SinglePropertyFilterNodeCollection(mockClient.object(), mockModel.object());
   });

--- a/viewer/packages/cad-styling/src/TreeIndexNodeCollection.ts
+++ b/viewer/packages/cad-styling/src/TreeIndexNodeCollection.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 
 import { EmptyAreaCollection } from './prioritized/EmptyAreaCollection';
 import type { AreaCollection } from './prioritized/AreaCollection';
@@ -81,7 +81,7 @@ export class TreeIndexNodeCollection extends NodeCollection {
    * Nearby areas may be clustered and merged together to keep
    * the number of areas in the set small.
    */
-  addAreas(areas: THREE.Box3[]): void {
+  addAreas(areas: Box3[]): void {
     if (!this._areaCollection) {
       this._areaCollection = new ClusteredAreaCollection();
     }
@@ -93,12 +93,12 @@ export class TreeIndexNodeCollection extends NodeCollection {
    * Add points to this node collection's area set.
    * This effectively adds boxes of size 1x1x1 meter with the points as their centers.
    */
-  addAreaPoints(points: THREE.Vector3[]): void {
+  addAreaPoints(points: Vector3[]): void {
     if (!this._areaCollection) {
       this._areaCollection = new ClusteredAreaCollection();
     }
 
-    const areas = points.map(p => new THREE.Box3().setFromCenterAndSize(p, new THREE.Vector3(1, 1, 1)));
+    const areas = points.map(p => new Box3().setFromCenterAndSize(p, new Vector3(1, 1, 1)));
 
     this._areaCollection.addAreas(areas);
   }

--- a/viewer/packages/cad-styling/src/prioritized/ClusteredAreaCollection.test.ts
+++ b/viewer/packages/cad-styling/src/prioritized/ClusteredAreaCollection.test.ts
@@ -8,7 +8,7 @@ import { createRandomBoxes } from '../../../../test-utilities/src/createBoxes';
 
 import SeededRandom from 'random-seed';
 
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
 describe('ClusteredAreaCollection', () => {
   test('empty set is empty', () => {
@@ -16,7 +16,7 @@ describe('ClusteredAreaCollection', () => {
 
     expect(areaCollection.isEmpty).toBeTruthy();
 
-    areaCollection.addAreas([new THREE.Box3().setFromArray([1, 2, 3, 4, 5, 6])]);
+    areaCollection.addAreas([new Box3().setFromArray([1, 2, 3, 4, 5, 6])]);
 
     expect(areaCollection.isEmpty).toBeFalsy();
   });

--- a/viewer/packages/cad-styling/src/prioritized/EmptyAreaCollection.test.ts
+++ b/viewer/packages/cad-styling/src/prioritized/EmptyAreaCollection.test.ts
@@ -4,7 +4,7 @@
 
 import { EmptyAreaCollection } from './EmptyAreaCollection';
 
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
 describe('EmptyAreaCollection', () => {
   test('empty area collection does empty area collection stuff', () => {
@@ -12,8 +12,8 @@ describe('EmptyAreaCollection', () => {
 
     expect(areaCollection).toBeTruthy();
 
-    expect(() => areaCollection.addAreas([new THREE.Box3()])).toThrow();
-    expect(() => areaCollection.intersectWith([new THREE.Box3()])).not.toThrow();
+    expect(() => areaCollection.addAreas([new Box3()])).toThrow();
+    expect(() => areaCollection.intersectWith([new Box3()])).not.toThrow();
 
     expect(areaCollection.isEmpty).toBeTruthy();
   });

--- a/viewer/packages/cad-styling/src/transform/NodeTransformTextureBuilder.test.ts
+++ b/viewer/packages/cad-styling/src/transform/NodeTransformTextureBuilder.test.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { DataTexture } from 'three';
+import { Matrix4 } from 'three';
 import { NumericRange, createUint8View } from '@reveal/utilities';
 import { NodeTransformProvider } from './NodeTransformProvider';
 import { NodeTransformTextureBuilder } from './NodeTransformTextureBuilder';
@@ -26,7 +27,7 @@ describe('NodeTransformTextureBuilder', () => {
     const originalLookupTexels = texelsOf(builder.transformLookupTexture);
     const originalIndexTexels = texelsOf(builder.overrideTransformIndexTexture);
 
-    const matrix = new THREE.Matrix4().makeTranslation(10, 20, 30);
+    const matrix = new Matrix4().makeTranslation(10, 20, 30);
     transformProvider.setNodeTransform(new NumericRange(0, 16), matrix);
     builder.build();
 
@@ -37,7 +38,7 @@ describe('NodeTransformTextureBuilder', () => {
   test('reset transform in provider, restores index', () => {
     const originalIndexTexels = texelsOf(builder.overrideTransformIndexTexture);
 
-    const matrix = new THREE.Matrix4().makeTranslation(10, 20, 30);
+    const matrix = new Matrix4().makeTranslation(10, 20, 30);
     transformProvider.setNodeTransform(new NumericRange(0, 16), matrix);
     transformProvider.resetNodeTransform(new NumericRange(0, 16));
     builder.build();
@@ -46,7 +47,7 @@ describe('NodeTransformTextureBuilder', () => {
   });
 });
 
-function texelsOf(texture: THREE.DataTexture): number[] {
+function texelsOf(texture: DataTexture): number[] {
   const data = texture.image.data;
   assert(data !== null);
   return Array.from(createUint8View(data));

--- a/viewer/packages/cad-styling/src/transform/NodeTransformTextureBuilder.ts
+++ b/viewer/packages/cad-styling/src/transform/NodeTransformTextureBuilder.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { Matrix4 } from 'three';
+import { DataTexture, FloatType, RedFormat } from 'three';
 
 import { TransformOverrideBuffer } from './TransformOverrideBuffer';
 
@@ -12,7 +13,7 @@ import type { NodeTransformProvider } from './NodeTransformProvider';
 export class NodeTransformTextureBuilder {
   private readonly _transformProvider: NodeTransformProvider;
   private readonly _transformOverrideBuffer: TransformOverrideBuffer;
-  private readonly _transformOverrideIndexTexture: THREE.DataTexture;
+  private readonly _transformOverrideIndexTexture: DataTexture;
   private _needsUpdate = false;
   private readonly _handleTransformChangedBound = this.handleTransformChanged.bind(this);
   private readonly _transformOverrideIndexBufferView: Float32Array;
@@ -37,11 +38,11 @@ export class NodeTransformTextureBuilder {
     return this._needsUpdate;
   }
 
-  get overrideTransformIndexTexture(): THREE.DataTexture {
+  get overrideTransformIndexTexture(): DataTexture {
     return this._transformOverrideIndexTexture;
   }
 
-  get transformLookupTexture(): THREE.DataTexture {
+  get transformLookupTexture(): DataTexture {
     return this._transformOverrideBuffer.dataTexture;
   }
 
@@ -49,7 +50,7 @@ export class NodeTransformTextureBuilder {
     this._needsUpdate = false;
   }
 
-  private setNodeTransform(treeIndices: NumericRange, transform: THREE.Matrix4) {
+  private setNodeTransform(treeIndices: NumericRange, transform: Matrix4) {
     const transformIndex = this._transformOverrideBuffer.addOverrideTransform(treeIndices.from, transform);
     treeIndices.forEach(treeIndex => this.setOverrideIndex(treeIndex, transformIndex));
     this._needsUpdate = true;
@@ -70,7 +71,7 @@ export class NodeTransformTextureBuilder {
     this._needsUpdate = true;
   }
 
-  private handleTransformChanged(change: 'set' | 'reset', treeIndices: NumericRange, transform: THREE.Matrix4) {
+  private handleTransformChanged(change: 'set' | 'reset', treeIndices: NumericRange, transform: Matrix4) {
     switch (change) {
       case 'set':
         this.setNodeTransform(treeIndices, transform);
@@ -85,19 +86,19 @@ export class NodeTransformTextureBuilder {
 }
 
 function allocateTransformOverrideIndexTexture(treeIndexCount: number): {
-  dataTexture: THREE.DataTexture;
+  dataTexture: DataTexture;
   bufferView: Float32Array;
 } {
   const { width, height } = determinePowerOfTwoDimensions(treeIndexCount);
   const textureElementCount = width * height;
 
   const transformOverrideIndexBuffer = new Float32Array(textureElementCount);
-  const transformOverrideIndexTexture = new THREE.DataTexture(
+  const transformOverrideIndexTexture = new DataTexture(
     transformOverrideIndexBuffer,
     width,
     height,
-    THREE.RedFormat,
-    THREE.FloatType
+    RedFormat,
+    FloatType
   );
 
   return { dataTexture: transformOverrideIndexTexture, bufferView: transformOverrideIndexBuffer };

--- a/viewer/packages/cad-styling/src/transform/TransformOverrideBuffer.test.ts
+++ b/viewer/packages/cad-styling/src/transform/TransformOverrideBuffer.test.ts
@@ -1,13 +1,14 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { DataTexture } from 'three';
+import { Matrix4 } from 'three';
 import { TransformOverrideBuffer } from './TransformOverrideBuffer';
 
 import { vi } from 'vitest';
 
 describe('TransformOverrideBuffer', () => {
-  const onGenerateNewTextureCb: (texture: THREE.DataTexture) => void = vi.fn();
+  const onGenerateNewTextureCb: (texture: DataTexture) => void = vi.fn();
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -27,7 +28,7 @@ describe('TransformOverrideBuffer', () => {
   test('addOverrideTransform called many times, triggers reallocation', () => {
     const buffer = new TransformOverrideBuffer(onGenerateNewTextureCb);
     for (let i = 0; i < 1000; i++) {
-      buffer.addOverrideTransform(i, new THREE.Matrix4());
+      buffer.addOverrideTransform(i, new Matrix4());
     }
     expect(onGenerateNewTextureCb).toHaveBeenCalled();
   });
@@ -35,7 +36,7 @@ describe('TransformOverrideBuffer', () => {
   test('consecutive add/removeOverrideTransform doesnt allocate new texture', () => {
     const buffer = new TransformOverrideBuffer(onGenerateNewTextureCb);
     for (let i = 0; i < 1000; i++) {
-      buffer.addOverrideTransform(i, new THREE.Matrix4());
+      buffer.addOverrideTransform(i, new Matrix4());
       buffer.removeOverrideTransform(i);
     }
     expect(onGenerateNewTextureCb).not.toHaveBeenCalled();

--- a/viewer/packages/cad-styling/src/transform/TransformOverrideBuffer.ts
+++ b/viewer/packages/cad-styling/src/transform/TransformOverrideBuffer.ts
@@ -2,23 +2,24 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Matrix4 } from 'three';
+import { DataTexture, FloatType, RedFormat } from 'three';
 
 export class TransformOverrideBuffer {
   private static readonly MIN_NUMBER_OF_TREE_INDICES = 16;
   private static readonly NUMBER_OF_ELEMENTS_PER_MATRIX = 16;
   private static readonly NUMBER_OF_ROWS_PER_MATRIX = 4;
 
-  private _dataTexture: THREE.DataTexture;
+  private _dataTexture: DataTexture;
   private _textureBuffer: Float32Array;
 
   private readonly _unusedIndices: number[];
 
   private readonly _treeIndexToOverrideIndex: Map<number, number>;
 
-  private readonly _onGenerateNewDataTextureCallback: (datatexture: THREE.DataTexture) => void;
+  private readonly _onGenerateNewDataTextureCallback: (datatexture: DataTexture) => void;
 
-  get dataTexture(): THREE.DataTexture {
+  get dataTexture(): DataTexture {
     return this._dataTexture;
   }
 
@@ -26,18 +27,12 @@ export class TransformOverrideBuffer {
     return this._treeIndexToOverrideIndex;
   }
 
-  constructor(onGenerateNewDataTexture: (datatexture: THREE.DataTexture) => void) {
+  constructor(onGenerateNewDataTexture: (datatexture: DataTexture) => void) {
     this._textureBuffer = new Float32Array(
       TransformOverrideBuffer.MIN_NUMBER_OF_TREE_INDICES * TransformOverrideBuffer.NUMBER_OF_ELEMENTS_PER_MATRIX
     );
 
-    this._dataTexture = new THREE.DataTexture(
-      this._textureBuffer,
-      this._textureBuffer.length,
-      1,
-      THREE.RedFormat,
-      THREE.FloatType
-    );
+    this._dataTexture = new DataTexture(this._textureBuffer, this._textureBuffer.length, 1, RedFormat, FloatType);
 
     this._onGenerateNewDataTextureCallback = onGenerateNewDataTexture;
 
@@ -52,7 +47,7 @@ export class TransformOverrideBuffer {
     delete this._dataTexture.image;
   }
 
-  public addOverrideTransform(treeIndex: number, transform: THREE.Matrix4): number {
+  public addOverrideTransform(treeIndex: number, transform: Matrix4): number {
     const transformBuffer = transform.toArray();
 
     let matrixIndex: number | undefined;
@@ -99,13 +94,7 @@ export class TransformOverrideBuffer {
 
     newTextureBuffer.set(this._textureBuffer);
 
-    const newDataTexture = new THREE.DataTexture(
-      newTextureBuffer,
-      newTextureBuffer.length,
-      1,
-      THREE.RedFormat,
-      THREE.FloatType
-    );
+    const newDataTexture = new DataTexture(newTextureBuffer, newTextureBuffer.length, 1, RedFormat, FloatType);
 
     const currentLastMatrixIndex = currentTextureBufferLength / TransformOverrideBuffer.NUMBER_OF_ELEMENTS_PER_MATRIX;
 

--- a/viewer/packages/cad-styling/visual-tests/CustomWithStyling.VisualTest.ts
+++ b/viewer/packages/cad-styling/visual-tests/CustomWithStyling.VisualTest.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Mesh, MeshBasicMaterial, SphereGeometry } from 'three';
 import { DefaultNodeAppearance, TreeIndexNodeCollection } from '..';
 
 import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
@@ -26,8 +26,8 @@ export default class CustomWithStylingVisualTest extends StreamingVisualTestFixt
       .getModelNodeAppearanceProvider(modelIdentifier)
       .assignStyledNodeCollection(ghostedNodes, DefaultNodeAppearance.Ghosted);
 
-    const sphere = new THREE.SphereGeometry(5, 32, 16);
-    const sphereMesh = new THREE.Mesh(sphere, new THREE.MeshBasicMaterial({ color: 'red' }));
+    const sphere = new SphereGeometry(5, 32, 16);
+    const sphereMesh = new Mesh(sphere, new MeshBasicMaterial({ color: 'red' }));
     sphereMesh.position.set(12, -3, -2);
     sceneHandler.addObject3D(sphereMesh);
 

--- a/viewer/packages/camera-manager/app/index.ts
+++ b/viewer/packages/camera-manager/app/index.ts
@@ -1,44 +1,55 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import {
+  BoxGeometry,
+  GridHelper,
+  Mesh,
+  MeshBasicMaterial,
+  MeshNormalMaterial,
+  PerspectiveCamera,
+  Scene,
+  SphereGeometry,
+  Vector3,
+  WebGLRenderer
+} from 'three';
 import { ComboControls } from '../src/ComboControls';
 import Keyboard from '../src/Keyboard';
 
-let renderer: THREE.WebGLRenderer;
-let camera: THREE.PerspectiveCamera;
-let scene: THREE.Scene;
+let renderer: WebGLRenderer;
+let camera: PerspectiveCamera;
+let scene: Scene;
 let controls: ComboControls;
-let sphere: THREE.Mesh;
+let sphere: Mesh;
 let keyboard: Keyboard;
 let currentControlsState: {
-  position: THREE.Vector3;
-  target: THREE.Vector3;
+  position: Vector3;
+  target: Vector3;
 };
 
 init();
 
 function init() {
-  camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 1000000);
+  camera = new PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 1000000);
 
-  scene = new THREE.Scene();
+  scene = new Scene();
 
-  const grid = new THREE.GridHelper(40, 40);
+  const grid = new GridHelper(40, 40);
   scene.add(grid);
 
-  const geometry = new THREE.BoxGeometry(10, 10, 10);
-  const material = new THREE.MeshNormalMaterial();
+  const geometry = new BoxGeometry(10, 10, 10);
+  const material = new MeshNormalMaterial();
 
-  const sphereGeometry = new THREE.SphereGeometry(1);
-  const sphereMaterial = new THREE.MeshBasicMaterial({ color: 'green' });
-  sphere = new THREE.Mesh(sphereGeometry, sphereMaterial);
+  const sphereGeometry = new SphereGeometry(1);
+  const sphereMaterial = new MeshBasicMaterial({ color: 'green' });
+  sphere = new Mesh(sphereGeometry, sphereMaterial);
   scene.add(sphere);
 
-  const mesh = new THREE.Mesh(geometry, material);
+  const mesh = new Mesh(geometry, material);
   mesh.position.set(0, 5, 0);
   scene.add(mesh);
 
-  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer = new WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setAnimationLoop(render);
 
@@ -55,7 +66,7 @@ function init() {
   };
   controls.enabled = true;
 
-  controls.setState(new THREE.Vector3(0, 20, 20), new THREE.Vector3());
+  controls.setState(new Vector3(0, 20, 20), new Vector3());
 
   sphere.position.copy(controls.getState().target);
 
@@ -66,13 +77,13 @@ function render(deltaTimeS: number) {
   currentControlsState = controls.getState();
 
   if (keyboard.isPressed('KeyC')) {
-    controls.setState(currentControlsState.position, currentControlsState.target.add(new THREE.Vector3(-0.1, 0, 0)));
+    controls.setState(currentControlsState.position, currentControlsState.target.add(new Vector3(-0.1, 0, 0)));
   }
   if (keyboard.isPressed('KeyB')) {
-    controls.setState(currentControlsState.position, currentControlsState.target.add(new THREE.Vector3(0.1, 0, 0)));
+    controls.setState(currentControlsState.position, currentControlsState.target.add(new Vector3(0.1, 0, 0)));
   }
   if (keyboard.isPressed('KeyF')) {
-    controls.setState(currentControlsState.position, currentControlsState.target.copy(new THREE.Vector3(3, 2, 0)));
+    controls.setState(currentControlsState.position, currentControlsState.target.copy(new Vector3(3, 2, 0)));
   }
 
   controls.update(deltaTimeS);

--- a/viewer/packages/camera-manager/src/DefaultCameraManager.ts
+++ b/viewer/packages/camera-manager/src/DefaultCameraManager.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, PerspectiveCamera, Quaternion, Raycaster, Vector2, Vector3 } from 'three';
 import TWEEN, { type Tween } from '@tweenjs/tween.js';
 import { clamp } from 'lodash-es';
 
@@ -46,10 +46,10 @@ export class DefaultCameraManager implements CameraManager {
 
   private readonly _stopEventTrigger: DebouncedCameraStopEventTrigger;
   private readonly _controls: ComboControls;
-  private readonly _camera: THREE.PerspectiveCamera;
+  private readonly _camera: PerspectiveCamera;
   private readonly _domElement: HTMLElement;
   private readonly _inputHandler: InputHandler;
-  private readonly _raycaster = new THREE.Raycaster();
+  private readonly _raycaster = new Raycaster();
 
   private _isDisposed = false;
   private _nearAndFarNeedsUpdate = false;
@@ -82,7 +82,7 @@ export class DefaultCameraManager implements CameraManager {
   private _cameraControlsOptions: Required<CameraControlsOptions> = {
     ...DefaultCameraManager.DefaultCameraControlsOptions
   };
-  private readonly _currentBoundingBox: THREE.Box3 = new THREE.Box3();
+  private readonly _currentBoundingBox: Box3 = new Box3();
   /**
    * When false, camera near and far planes will not be updated automatically (defaults to true).
    * This can be useful when you have custom content in the 3D view and need to better
@@ -114,9 +114,9 @@ export class DefaultCameraManager implements CameraManager {
     domElement: HTMLElement,
     inputHandler: InputHandler,
     raycastCallback: RaycastCallback,
-    camera?: THREE.PerspectiveCamera
+    camera?: PerspectiveCamera
   ) {
-    this._camera = camera ?? new THREE.PerspectiveCamera(60, undefined, 0.1, 10000);
+    this._camera = camera ?? new PerspectiveCamera(60, undefined, 0.1, 10000);
 
     this._domElement = domElement;
     this._inputHandler = inputHandler;
@@ -161,7 +161,7 @@ export class DefaultCameraManager implements CameraManager {
     }
   }
 
-  fitCameraToBoundingBox(box: THREE.Box3, duration?: number, radiusFactor: number = 2): void {
+  fitCameraToBoundingBox(box: Box3, duration?: number, radiusFactor: number = 2): void {
     const { position, target } = fitCameraToBoundingBox(this._camera, box, radiusFactor);
     this.moveCameraTo(position, target, duration);
   }
@@ -195,7 +195,7 @@ export class DefaultCameraManager implements CameraManager {
     return this.getComboControlsOptions().enableKeyboardNavigation;
   }
 
-  getCamera(): THREE.PerspectiveCamera {
+  getCamera(): PerspectiveCamera {
     return this._camera;
   }
 
@@ -210,7 +210,7 @@ export class DefaultCameraManager implements CameraManager {
       throw new Error(`Rotation and target can't be set at the same time`);
     }
     const newPosition = state.position ?? this._camera.position;
-    const newRotation = (state.target ? new THREE.Quaternion() : state.rotation) ?? new THREE.Quaternion();
+    const newRotation = (state.target ? new Quaternion() : state.rotation) ?? new Quaternion();
     const newTarget =
       state.target ??
       (state.rotation
@@ -277,7 +277,7 @@ export class DefaultCameraManager implements CameraManager {
     }
   }
 
-  update(deltaTime: number, boundingBox: THREE.Box3): void {
+  update(deltaTime: number, boundingBox: Box3): void {
     if (this._nearAndFarNeedsUpdate || !boundingBox.equals(this._currentBoundingBox)) {
       this.updateCameraNearAndFar(this._camera, boundingBox);
       this._nearAndFarNeedsUpdate = false;
@@ -301,12 +301,7 @@ export class DefaultCameraManager implements CameraManager {
    * @param target Desired look-at target in world space.
    * @param duration Duration of the animation in milliseconds. If omitted, a default is derived from distance.
    */
-  moveCameraTo(
-    position: THREE.Vector3,
-    target: THREE.Vector3,
-    duration?: number,
-    keyboardNavigationEnabled = true
-  ): void {
+  moveCameraTo(position: Vector3, target: Vector3, duration?: number, keyboardNavigationEnabled = true): void {
     if (this._isDisposed) {
       return;
     }
@@ -330,8 +325,8 @@ export class DefaultCameraManager implements CameraManager {
       targetZ: target.z
     };
 
-    const tempTarget = new THREE.Vector3();
-    const tempPosition = new THREE.Vector3();
+    const tempTarget = new Vector3();
+    const tempPosition = new Vector3();
 
     const { tween, stopTween } = this.createTweenAnimation(from, to, duration);
 
@@ -363,7 +358,7 @@ export class DefaultCameraManager implements CameraManager {
     tween.update(TWEEN.now());
   }
 
-  private moveCameraTargetTo(target: THREE.Vector3, duration?: number, keyboardNavigationEnabled = true): void {
+  private moveCameraTargetTo(target: Vector3, duration?: number, keyboardNavigationEnabled = true): void {
     if (this._isDisposed) {
       return;
     }
@@ -385,7 +380,7 @@ export class DefaultCameraManager implements CameraManager {
       targetZ: target.z
     };
 
-    const tempTarget = new THREE.Vector3();
+    const tempTarget = new Vector3();
 
     const { tween, stopTween } = this.createTweenAnimation(from, to, duration);
 
@@ -426,7 +421,7 @@ export class DefaultCameraManager implements CameraManager {
     tween.update(TWEEN.now());
   }
 
-  private updateCameraNearAndFar(camera: THREE.PerspectiveCamera, boundingBox: THREE.Box3): void {
+  private updateCameraNearAndFar(camera: PerspectiveCamera, boundingBox: Box3): void {
     // See https://stackoverflow.com/questions/8101119/how-do-i-methodically-choose-the-near-clip-plane-distance-for-a-perspective-proj
     if (this._isDisposed) {
       return;
@@ -449,8 +444,8 @@ export class DefaultCameraManager implements CameraManager {
     }
   }
 
-  private calculateAnimationStartTarget(newTarget: THREE.Vector3): THREE.Vector3 {
-    this._raycaster.setFromCamera(new THREE.Vector2(), this._camera);
+  private calculateAnimationStartTarget(newTarget: Vector3): Vector3 {
+    this._raycaster.setFromCamera(new Vector2(), this._camera);
     const distanceToTarget = newTarget.distanceTo(this._camera.position);
     const scaledDirection = this._raycaster.ray.direction.clone().multiplyScalar(distanceToTarget);
 
@@ -493,14 +488,14 @@ export class DefaultCameraManager implements CameraManager {
    * @param cursorPosition.x
    * @param cursorPosition.y
    */
-  private calculateNewTargetWithoutModel(cursorPosition: THREE.Vector2, modelsBoundingBox: THREE.Box3): THREE.Vector3 {
+  private calculateNewTargetWithoutModel(cursorPosition: Vector2, modelsBoundingBox: Box3): Vector3 {
     const modelSize = modelsBoundingBox.min.distanceTo(modelsBoundingBox.max);
 
     const lastScrollTargetDistance = this._controls.getScrollTarget().distanceTo(this._camera.position);
 
     const newTargetDistance =
       lastScrollTargetDistance <= this.getComboControlsOptions().minDistance
-        ? Math.min(this._camera.position.distanceTo(modelsBoundingBox.getCenter(new THREE.Vector3())), modelSize) / 2
+        ? Math.min(this._camera.position.distanceTo(modelsBoundingBox.getCenter(new Vector3())), modelSize) / 2
         : lastScrollTargetDistance;
 
     this._raycaster.setFromCamera(cursorPosition, this._camera);
@@ -518,7 +513,7 @@ export class DefaultCameraManager implements CameraManager {
    * Calculates new camera target based on cursor position.
    * @param event PointerEvent that contains pointer location data.
    */
-  private async calculateNewTarget(event: PointerEventData): Promise<THREE.Vector3> {
+  private async calculateNewTarget(event: PointerEventData): Promise<Vector3> {
     const pixelCoordinates = getNormalizedPixelCoordinates(this._domElement, event.offsetX, event.offsetY);
     const raycastResult = await this._raycastCallback(event.offsetX, event.offsetY, false);
 
@@ -576,7 +571,7 @@ export class DefaultCameraManager implements CameraManager {
     let wasLastScrollZoomOut = false;
     let lastWheelEventTime = 0;
 
-    const lastMousePosition = new THREE.Vector2();
+    const lastMousePosition = new Vector2();
 
     const onWheel = async (event: WheelEvent) => {
       // Added because cameraControls are disabled when doing picking, so
@@ -664,7 +659,7 @@ export class DefaultCameraManager implements CameraManager {
       modelRaycastData.intersection?.point ??
       this.calculateNewTargetWithoutModel(pixelCoordinates, modelRaycastData.modelsBoundingBox);
 
-    const newPosition = new THREE.Vector3().subVectors(newTarget, this._camera.position);
+    const newPosition = new Vector3().subVectors(newTarget, this._camera.position);
     newPosition.divideScalar(2);
     newPosition.add(this._camera.position);
     this.moveCameraTo(newPosition, newTarget, DefaultCameraManager.AnimationDuration, keyboardNavigationEnabled);

--- a/viewer/packages/camera-manager/src/ProxyCameraManager.test.ts
+++ b/viewer/packages/camera-manager/src/ProxyCameraManager.test.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import type { PerspectiveCamera } from 'three';
+import { Vector3 } from 'three';
 
 import { It, Mock } from 'moq.ts';
 import { ProxyCameraManager } from './ProxyCameraManager';
@@ -11,8 +12,8 @@ import type { CameraChangeDelegate } from './types';
 describe(ProxyCameraManager.name, () => {
   test('Switching camera manager should also switch event handling', () => {
     const cameraOneEventHandlers = new Set<CameraChangeDelegate>();
-    const cameraOnePositionResult = new THREE.Vector3().random();
-    const cameraOneTargetResult = new THREE.Vector3().random();
+    const cameraOnePositionResult = new Vector3().random();
+    const cameraOneTargetResult = new Vector3().random();
     const cameraManagerOne = new Mock<CameraManager>()
       .setup(p => p.activate())
       .returns()
@@ -31,11 +32,11 @@ describe(ProxyCameraManager.name, () => {
         cameraOneEventHandlers.delete(eventHandler);
       })
       .setup(p => p.getCamera())
-      .returns({ aspect: 70 } as THREE.PerspectiveCamera)
+      .returns({ aspect: 70 } as PerspectiveCamera)
       .object();
 
-    const cameraTwoPositionResult = new THREE.Vector3().random();
-    const cameraTwoTargetResult = new THREE.Vector3().random();
+    const cameraTwoPositionResult = new Vector3().random();
+    const cameraTwoTargetResult = new Vector3().random();
     let cameraTwoEventHandler: CameraChangeDelegate;
     const cameraManagerTwo = new Mock<CameraManager>()
       .setup(p => p.activate())
@@ -51,12 +52,12 @@ describe(ProxyCameraManager.name, () => {
         cameraTwoEventHandler(cameraTwoPositionResult, cameraTwoTargetResult);
       })
       .setup(p => p.getCamera())
-      .returns({ aspect: 70 } as THREE.PerspectiveCamera)
+      .returns({ aspect: 70 } as PerspectiveCamera)
       .object();
 
     const activeCameraManager = new ProxyCameraManager(cameraManagerOne);
 
-    const cameraChangedResults: [THREE.Vector3, THREE.Vector3][] = [];
+    const cameraChangedResults: [Vector3, Vector3][] = [];
     activeCameraManager.on('cameraChange', (position, target) => {
       cameraChangedResults.push([position, target]);
     });

--- a/viewer/packages/camera-manager/tests/CameraManagerHelper.test.ts
+++ b/viewer/packages/camera-manager/tests/CameraManagerHelper.test.ts
@@ -2,11 +2,11 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { PerspectiveCamera, Quaternion, Vector3 } from 'three';
 import { CameraManagerHelper } from '../src/CameraManagerHelper';
 
 describe(CameraManagerHelper.name, () => {
-  const camera = new THREE.PerspectiveCamera();
+  const camera = new PerspectiveCamera();
 
   beforeEach(() => {
     // Reset camera position and rotation for each test
@@ -16,9 +16,9 @@ describe(CameraManagerHelper.name, () => {
 
   test('calculateNewTargetFromRotation rotates the target 180 degrees by corresponding rotation', () => {
     // default camera target when camera has "identity" rotation
-    const target = new THREE.Vector3(0, 0, -1);
+    const target = new Vector3(0, 0, -1);
     // creates rotation around Y axis of 180 degrees.
-    const rotation = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI);
+    const rotation = new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), Math.PI);
 
     const newTarget = CameraManagerHelper.calculateNewTargetFromRotation(camera, rotation, target, camera.position);
 

--- a/viewer/packages/camera-manager/tests/ComboControls.test.ts
+++ b/viewer/packages/camera-manager/tests/ComboControls.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { PerspectiveCamera, Vector3 } from 'three';
 import { ComboControls } from '../src/ComboControls';
 import { It, Mock } from 'moq.ts';
 
@@ -10,14 +10,14 @@ describe('Combo Controls', () => {
   let controls: ComboControls;
 
   beforeEach(() => {
-    const camera = new THREE.PerspectiveCamera();
+    const camera = new PerspectiveCamera();
     const domElementMock = new Mock<HTMLDivElement>().setup(p => p.addEventListener(It.IsAny(), It.IsAny())).returns();
     controls = new ComboControls(camera, domElementMock.object());
   });
 
   test('should return the same as the state that was set', () => {
-    const position = new THREE.Vector3(0, 1, 2);
-    const target = new THREE.Vector3(3, 4, 5);
+    const position = new Vector3(0, 1, 2);
+    const target = new Vector3(3, 4, 5);
 
     const tolerance = 0.000001;
 

--- a/viewer/packages/camera-manager/tests/DefaultCameraManager.test.ts
+++ b/viewer/packages/camera-manager/tests/DefaultCameraManager.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, PerspectiveCamera, Vector3 } from 'three';
 import { DefaultCameraManager } from '../src/DefaultCameraManager';
 import { InputHandler } from '@reveal/utilities';
 
@@ -11,7 +11,7 @@ import { vi } from 'vitest';
 describe(DefaultCameraManager.name, () => {
   const domElement = document.createElement('canvas');
   const mockRaycastFunction = async (_1: number, _2: number, _: boolean) => {
-    return { intersection: null, modelsBoundingBox: new THREE.Box3(), pickedBoundingBox: undefined };
+    return { intersection: null, modelsBoundingBox: new Box3(), pickedBoundingBox: undefined };
   };
   let cameraManager: DefaultCameraManager;
 
@@ -20,7 +20,7 @@ describe(DefaultCameraManager.name, () => {
       domElement,
       new InputHandler(domElement),
       mockRaycastFunction,
-      new THREE.PerspectiveCamera()
+      new PerspectiveCamera()
     );
 
     vi.useFakeTimers();
@@ -34,7 +34,7 @@ describe(DefaultCameraManager.name, () => {
     const callback = vi.fn();
     cameraManager.on('cameraStop', callback);
 
-    cameraManager.setCameraState({ position: new THREE.Vector3(1, 0, 0), target: new THREE.Vector3(0, 0, 0) });
+    cameraManager.setCameraState({ position: new Vector3(1, 0, 0), target: new Vector3(0, 0, 0) });
 
     expect(callback).not.toHaveBeenCalled();
 

--- a/viewer/packages/data-providers/src/ModelMetadataProvider.ts
+++ b/viewer/packages/data-providers/src/ModelMetadataProvider.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import type * as THREE from 'three';
+import type { Matrix4, Vector3 } from 'three';
 import type { ModelIdentifier } from './ModelIdentifier';
 import type { BlobOutputMetadata, File3dFormat } from './types';
 
@@ -11,6 +11,6 @@ import type { BlobOutputMetadata, File3dFormat } from './types';
 export interface ModelMetadataProvider {
   getModelOutputs(modelIdentifier: ModelIdentifier): Promise<BlobOutputMetadata[]>;
   getModelUri(identifier: ModelIdentifier, formatMetadata: BlobOutputMetadata): Promise<string>;
-  getModelCamera(identifier: ModelIdentifier): Promise<{ position: THREE.Vector3; target: THREE.Vector3 } | undefined>;
-  getModelMatrix(identifier: ModelIdentifier, format: File3dFormat | string): Promise<THREE.Matrix4>;
+  getModelCamera(identifier: ModelIdentifier): Promise<{ position: Vector3; target: Vector3 } | undefined>;
+  getModelMatrix(identifier: ModelIdentifier, format: File3dFormat | string): Promise<Matrix4>;
 }

--- a/viewer/packages/data-providers/src/image-360-data-providers/Local360ImageProvider.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/Local360ImageProvider.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Euler, Matrix4 } from 'three';
 import type { Image360Provider } from '../Image360Provider';
 import type {
   Historical360ImageSet,
@@ -60,13 +60,13 @@ export class Local360ImageProvider implements Image360Provider<ClassicDataSource
     const local360ImagesDescriptor: Local360ImagesDescriptor[] = await response.json();
 
     return local360ImagesDescriptor.map((localDescriptor, index) => {
-      const translation = new THREE.Matrix4().makeTranslation(
+      const translation = new Matrix4().makeTranslation(
         localDescriptor.translation.x,
         localDescriptor.translation.y,
         localDescriptor.translation.z
       );
-      const rotation = new THREE.Matrix4().makeRotationFromEuler(
-        new THREE.Euler(localDescriptor.rotation.x, localDescriptor.rotation.y, localDescriptor.rotation.z)
+      const rotation = new Matrix4().makeRotationFromEuler(
+        new Euler(localDescriptor.rotation.x, localDescriptor.rotation.y, localDescriptor.rotation.z)
       );
 
       const historicalImage360Descriptor = {

--- a/viewer/packages/data-providers/src/metadata-providers/CdfModelMetadataProvider.ts
+++ b/viewer/packages/data-providers/src/metadata-providers/CdfModelMetadataProvider.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Euler, Matrix4, Vector3 } from 'three';
 import type { BlobOutputMetadata } from '../types';
 import { File3dFormat } from '../types';
 import type { ModelMetadataProvider } from '../ModelMetadataProvider';
@@ -21,7 +21,7 @@ export class CdfModelMetadataProvider implements ModelMetadataProvider {
     this._client = client;
   }
 
-  public async getModelMatrix(modelIdentifier: ModelIdentifier, format: File3dFormat): Promise<THREE.Matrix4> {
+  public async getModelMatrix(modelIdentifier: ModelIdentifier, format: File3dFormat): Promise<Matrix4> {
     if (!(modelIdentifier instanceof CdfModelIdentifier)) {
       throw new Error(`Model must be a ${CdfModelIdentifier.name}, but got ${modelIdentifier.toString()}`);
     }
@@ -29,19 +29,19 @@ export class CdfModelMetadataProvider implements ModelMetadataProvider {
     const { modelId, revisionId } = modelIdentifier;
     const model = await this._client.revisions3D.retrieve(modelId, revisionId);
 
-    const modelMatrix = new THREE.Matrix4();
+    const modelMatrix = new Matrix4();
 
     if (model.rotation) {
-      modelMatrix.makeRotationFromEuler(new THREE.Euler(...model.rotation));
+      modelMatrix.makeRotationFromEuler(new Euler(...model.rotation));
     }
     if (model.scale) {
-      const scale = new THREE.Vector3().fromArray(model.scale);
-      const scaleMatrix = new THREE.Matrix4().makeScale(...scale.toArray());
+      const scale = new Vector3().fromArray(model.scale);
+      const scaleMatrix = new Matrix4().makeScale(...scale.toArray());
       modelMatrix.multiply(scaleMatrix);
     }
     if (model.translation) {
-      const translation = new THREE.Vector3().fromArray(model.translation);
-      const translationMatrix = new THREE.Matrix4().makeTranslation(...translation.toArray());
+      const translation = new Vector3().fromArray(model.translation);
+      const translationMatrix = new Matrix4().makeTranslation(...translation.toArray());
       modelMatrix.premultiply(translationMatrix);
     }
 
@@ -51,7 +51,7 @@ export class CdfModelMetadataProvider implements ModelMetadataProvider {
 
   public async getModelCamera(
     modelIdentifier: ModelIdentifier
-  ): Promise<{ position: THREE.Vector3; target: THREE.Vector3 } | undefined> {
+  ): Promise<{ position: Vector3; target: Vector3 } | undefined> {
     if (!(modelIdentifier instanceof CdfModelIdentifier)) {
       throw new Error(`Model must be a ${CdfModelIdentifier.name}, but got ${modelIdentifier.toString()}`);
     }
@@ -61,8 +61,8 @@ export class CdfModelMetadataProvider implements ModelMetadataProvider {
     if (model.camera && model.camera.position && model.camera.target) {
       const { position, target } = model.camera;
       return {
-        position: new THREE.Vector3(position[0], position[1], position[2]),
-        target: new THREE.Vector3(target[0], target[1], target[2])
+        position: new Vector3(position[0], position[1], position[2]),
+        target: new Vector3(target[0], target[1], target[2])
       };
     }
     return undefined;

--- a/viewer/packages/data-providers/src/metadata-providers/LocalModelMetadataProvider.ts
+++ b/viewer/packages/data-providers/src/metadata-providers/LocalModelMetadataProvider.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { Vector3 } from 'three';
+import { Matrix4 } from 'three';
 
 import { applyDefaultModelTransformation } from '../utilities/applyDefaultModelTransformation';
 import type { ModelIdentifier } from '../ModelIdentifier';
@@ -22,19 +23,17 @@ export class LocalModelMetadataProvider implements ModelMetadataProvider {
     return Promise.resolve(`${location.origin}/${modelIdentifier.localPath}`);
   }
 
-  async getModelMatrix(modelIdentifier: ModelIdentifier, format: File3dFormat): Promise<THREE.Matrix4> {
+  async getModelMatrix(modelIdentifier: ModelIdentifier, format: File3dFormat): Promise<Matrix4> {
     if (!(modelIdentifier instanceof LocalModelIdentifier)) {
       throw new Error(`Model must be a ${LocalModelIdentifier.name}, but got ${modelIdentifier.toString()}`);
     }
 
-    const matrix = new THREE.Matrix4();
+    const matrix = new Matrix4();
     applyDefaultModelTransformation(matrix, format);
     return matrix;
   }
 
-  getModelCamera(
-    modelIdentifier: ModelIdentifier
-  ): Promise<{ position: THREE.Vector3; target: THREE.Vector3 } | undefined> {
+  getModelCamera(modelIdentifier: ModelIdentifier): Promise<{ position: Vector3; target: Vector3 } | undefined> {
     if (!(modelIdentifier instanceof LocalModelIdentifier)) {
       throw new Error(`Model must be a ${LocalModelIdentifier.name}, but got ${modelIdentifier.toString()}`);
     }

--- a/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/CdfPointCloudStylableObjectProvider.ts
+++ b/viewer/packages/data-providers/src/pointcloud-stylable-object-providers/CdfPointCloudStylableObjectProvider.ts
@@ -14,7 +14,7 @@ import { assert } from '@reveal/utilities/assert';
 import type { CdfPointCloudObjectAnnotation, PointCloudObject } from './types';
 import type { PointCloudStylableObjectProvider } from '../PointCloudStylableObjectProvider';
 
-import * as THREE from 'three';
+import { Matrix4, Vector3 } from 'three';
 import { cdfAnnotationsToObjects } from './cdfAnnotationsToObjects';
 import type { ClassicDataSourceType, ClassicModelIdentifierType } from '../DataSourceType';
 
@@ -31,13 +31,13 @@ export class CdfPointCloudStylableObjectProvider implements PointCloudStylableOb
 
   private annotationGeometryToRevealShapes(geometry: AnnotationsGeometry): IShape {
     if (geometry.box) {
-      return new Box(new THREE.Matrix4().fromArray(geometry.box.matrix).transpose());
+      return new Box(new Matrix4().fromArray(geometry.box.matrix).transpose());
     }
 
     if (geometry.cylinder) {
       return new Cylinder(
-        new THREE.Vector3().fromArray(geometry.cylinder.centerA),
-        new THREE.Vector3().fromArray(geometry.cylinder.centerB),
+        new Vector3().fromArray(geometry.cylinder.centerA),
+        new Vector3().fromArray(geometry.cylinder.centerB),
         geometry.cylinder.radius
       );
     }

--- a/viewer/packages/data-providers/src/types.ts
+++ b/viewer/packages/data-providers/src/types.ts
@@ -7,7 +7,7 @@ import type {
   AnnotationsTypesImagesInstanceLink,
   IdEither
 } from '@cognite/sdk';
-import type * as THREE from 'three';
+import type { Matrix4, Texture } from 'three';
 import type { ClassicDataSourceType, DataSourceType, DMDataSourceType } from './DataSourceType';
 import type {
   AssetAnnotationImage360Info,
@@ -155,7 +155,7 @@ export type Image360RevisionDescriptor<T extends DataSourceType> = {
   label: string | undefined;
   collectionId: string;
   collectionLabel: string | undefined;
-  transform: THREE.Matrix4;
+  transform: Matrix4;
 };
 
 export type FaceName = 'front' | 'back' | 'left' | 'right' | 'top' | 'bottom';
@@ -170,7 +170,7 @@ export type Image360Face = {
 
 export type Image360Texture = {
   face: FaceName;
-  texture: THREE.Texture;
+  texture: Texture;
 };
 
 export type Image360FileDescriptor = {

--- a/viewer/packages/data-providers/src/utilities/applyDefaultModelTransformation.ts
+++ b/viewer/packages/data-providers/src/utilities/applyDefaultModelTransformation.ts
@@ -2,12 +2,12 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Matrix4 } from 'three';
 
 import { File3dFormat } from '../types';
 import { CDF_TO_VIEWER_TRANSFORMATION } from '@reveal/utilities';
 
-export function applyDefaultModelTransformation(matrix: THREE.Matrix4, format: File3dFormat | string): void {
+export function applyDefaultModelTransformation(matrix: Matrix4, format: File3dFormat | string): void {
   switch (format) {
     case File3dFormat.GltfCadModel:
     case File3dFormat.GltfPrioritizedNodes:

--- a/viewer/packages/metrics/src/MetricsLogger.ts
+++ b/viewer/packages/metrics/src/MetricsLogger.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Matrix4 } from 'three';
+import { Quaternion, Vector3 } from 'three';
 import mixpanel from 'mixpanel-browser';
 import { Log } from '@reveal/logger';
 import pkg from '../../../package.json' with { type: 'json' };
@@ -127,13 +128,13 @@ export class MetricsLogger {
   }
 
   private static readonly trackCadNodeTransformOverriddenVars = {
-    zeroVector: new THREE.Vector3(0, 0, 0),
-    oneVector: new THREE.Vector3(1, 1, 1),
-    identityRotation: new THREE.Quaternion().identity(),
+    zeroVector: new Vector3(0, 0, 0),
+    oneVector: new Vector3(1, 1, 1),
+    identityRotation: new Quaternion().identity(),
 
-    translation: new THREE.Vector3(),
-    scale: new THREE.Vector3(),
-    rotation: new THREE.Quaternion()
+    translation: new Vector3(),
+    scale: new Vector3(),
+    rotation: new Quaternion()
   };
 
   /**
@@ -143,11 +144,11 @@ export class MetricsLogger {
    * @param matrix  Matrix used to override the node transform
    */
   static readonly trackCadNodeTransformOverridden = throttle(
-    (nodeCount: number, matrix: THREE.Matrix4) => MetricsLogger.trackCadNodeTransformOverriddenImpl(nodeCount, matrix),
+    (nodeCount: number, matrix: Matrix4) => MetricsLogger.trackCadNodeTransformOverriddenImpl(nodeCount, matrix),
     MetricsLogger.TrackCadNodeTransformOverriddenThrottleDelay
   );
 
-  private static trackCadNodeTransformOverriddenImpl(nodeCount: number, matrix: THREE.Matrix4): void {
+  private static trackCadNodeTransformOverriddenImpl(nodeCount: number, matrix: Matrix4): void {
     const { zeroVector, oneVector, identityRotation, translation, scale, rotation } =
       MetricsLogger.trackCadNodeTransformOverriddenVars;
     matrix.decompose(translation, rotation, scale);

--- a/viewer/packages/model-base/src/types.ts
+++ b/viewer/packages/model-base/src/types.ts
@@ -2,13 +2,13 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { PerspectiveCamera, Plane, Vector2, WebGLRenderer } from 'three';
 
 export interface IntersectInput {
-  normalizedCoords: THREE.Vector2;
-  camera: THREE.PerspectiveCamera;
-  clippingPlanes: THREE.Plane[];
-  renderer: THREE.WebGLRenderer;
+  normalizedCoords: Vector2;
+  camera: PerspectiveCamera;
+  clippingPlanes: Plane[];
+  renderer: WebGLRenderer;
   domElement: HTMLElement;
 }
 

--- a/viewer/packages/nodes-api/src/NodesApiClient.ts
+++ b/viewer/packages/nodes-api/src/NodesApiClient.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3 } from 'three';
 
 import type { CogniteInternalId } from '@cognite/sdk';
 
@@ -68,5 +68,5 @@ export interface NodesApiClient {
     modelId: CogniteInternalId,
     revisionId: CogniteInternalId,
     nodeIds: CogniteInternalId[]
-  ): Promise<THREE.Box3[]>;
+  ): Promise<Box3[]>;
 }

--- a/viewer/packages/nodes-api/src/NodesCdfClient.ts
+++ b/viewer/packages/nodes-api/src/NodesCdfClient.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3 } from 'three';
 
 import type { CogniteClient, CogniteInternalId } from '@cognite/sdk';
 import { HttpError } from '@cognite/sdk';
@@ -84,7 +84,7 @@ export class NodesCdfClient implements NodesApiClient {
     modelId: CogniteInternalId,
     revisionId: CogniteInternalId,
     nodeIds: CogniteInternalId[]
-  ): Promise<THREE.Box3[]> {
+  ): Promise<Box3[]> {
     const chunks = chunkInputItems(nodeIds, NodesCdfClient.MaxItemsPerRequest);
     const mappedBoundingBoxPromises = [...chunks].map(async chunk => {
       return this._client.revisions3D.retrieve3DNodes(

--- a/viewer/packages/nodes-api/src/NodesLocalClient.ts
+++ b/viewer/packages/nodes-api/src/NodesLocalClient.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Box3 } from 'three';
 
 import type { NodesApiClient } from './NodesApiClient';
 
@@ -58,7 +58,7 @@ export class NodesLocalClient implements NodesApiClient {
     _modelId: CogniteInternalId,
     _revisionId: CogniteInternalId,
     _nodeIds: CogniteInternalId[]
-  ): Promise<THREE.Box3[]> {
+  ): Promise<Box3[]> {
     throw new Error('Not supported for local models');
   }
 }

--- a/viewer/packages/pointclouds/src/CognitePointCloudModel.ts
+++ b/viewer/packages/pointclouds/src/CognitePointCloudModel.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Color, Matrix4, Plane } from 'three';
+import { Box3, Vector3 } from 'three';
 import type { CameraConfiguration } from '@reveal/utilities';
 import type { WellKnownAsprsPointClassCodes } from './types';
 import type { PointCloudNode } from './PointCloudNode';
@@ -73,7 +74,7 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * @returns Model's bounding box.
    * @example
    * ```js
-   * const boundingBox = new THREE.Box3()
+   * const boundingBox = new Box3()
    * model.getModelBoundingBox(boundingBox);
    * // boundingBox now has the bounding box
    *```
@@ -82,7 +83,7 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * const boundingBox = model.getModelBoundingBox();
    * ```
    */
-  getModelBoundingBox(outBoundingBox?: THREE.Box3): THREE.Box3 {
+  getModelBoundingBox(outBoundingBox?: Box3): Box3 {
     return this.pointCloudNode.getBoundingBox(outBoundingBox);
   }
 
@@ -99,16 +100,16 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * Sets transformation matrix of the model. This overrides the current transformation.
    * @param transformationMatrix The new transformation matrix
    */
-  setModelTransformation(transformationMatrix: THREE.Matrix4): void {
+  setModelTransformation(transformationMatrix: Matrix4): void {
     this.pointCloudNode.setModelTransformation(transformationMatrix);
   }
 
   /**
    * Gets transformation matrix that has previously been
    * set with {@link CognitePointCloudModel.setModelTransformation}.
-   * @param out Preallocated `THREE.Matrix4` (optional).
+   * @param out Preallocated `Matrix4` (optional).
    */
-  getModelTransformation(out?: THREE.Matrix4): THREE.Matrix4 {
+  getModelTransformation(out?: Matrix4): Matrix4 {
     return this.pointCloudNode.getModelTransformation(out);
   }
 
@@ -116,25 +117,25 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * Gets transformation from CDF space to ThreeJS space,
    * which includes any additional "default" transformations assigned to this model.
    * Does not include any custom transformations set by {@link CognitePointCloudModel.setModelTransformation}
-   * @param out Preallocated `THREE.Matrix4` (optional)
+   * @param out Preallocated `Matrix4` (optional)
    */
-  getCdfToDefaultModelTransformation(out?: THREE.Matrix4): THREE.Matrix4 {
+  getCdfToDefaultModelTransformation(out?: Matrix4): Matrix4 {
     return this.pointCloudNode.getCdfToDefaultModelTransformation(out);
   }
 
   /**
    * Retrieves all points from the point cloud that are contained within the specified bounding box.
-   * @param box The THREE.Box3 bounding box used to filter points, defined in local model coordinates.
-   * @returns Array of THREE.Vector3 points that are located within the provided bounding box in local model coordinates.
+   * @param box The Box3 bounding box used to filter points, defined in local model coordinates.
+   * @returns Array of Vector3 points that are located within the provided bounding box in local model coordinates.
    * @example
    * ```js
-   * const boundingBox = new THREE.Box3(new THREE.Vector3(-10, -10, -10), new THREE.Vector3(10, 10, 10));
+   * const boundingBox = new Box3(new Vector3(-10, -10, -10), new Vector3(10, 10, 10));
    * const pointsInBox = model.getPointsByBoundingBox(boundingBox);
    * console.log(`Found ${pointsInBox.length} points in the bounding box`);
    * ```
    */
 
-  getPointsByBoundingBox(box: THREE.Box3): THREE.Vector3[] {
+  getPointsByBoundingBox(box: Box3): Vector3[] {
     return this.pointCloudNode.getSubtreePointsByBox(box);
   }
 
@@ -143,7 +144,7 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * @param point Point to compute transformation from
    * @param out Optional pre-allocated point
    */
-  mapPointFromCdfToModelCoordinates(point: THREE.Vector3, out: THREE.Vector3 = new THREE.Vector3()): THREE.Vector3 {
+  mapPointFromCdfToModelCoordinates(point: Vector3, out: Vector3 = new Vector3()): Vector3 {
     const cdfToModelTransformation = this.getModelTransformation().multiply(this.getCdfToDefaultModelTransformation());
     return out.copy(point).applyMatrix4(cdfToModelTransformation);
   }
@@ -153,7 +154,7 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * @param box Box to compute transformation from
    * @param out Optional pre-allocated box
    */
-  mapBoxFromCdfToModelCoordinates(box: THREE.Box3, out: THREE.Box3 = new THREE.Box3()): THREE.Box3 {
+  mapBoxFromCdfToModelCoordinates(box: Box3, out: Box3 = new Box3()): Box3 {
     const cdfToModelTransformation = this.getModelTransformation().multiply(this.getCdfToDefaultModelTransformation());
     return out.copy(box).applyMatrix4(cdfToModelTransformation);
   }
@@ -195,7 +196,7 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * Names will be the custom names provided by the user, or a default one if none have been provided.
    * @returns A sorted list of classification codes and names from the model.
    */
-  getClasses(): Array<{ name: string; code: number | WellKnownAsprsPointClassCodes; color: THREE.Color }> {
+  getClasses(): Array<{ name: string; code: number | WellKnownAsprsPointClassCodes; color: Color }> {
     return this.pointCloudNode.getClasses();
   }
 
@@ -295,14 +296,14 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
    * Sets the clipping planes for this model. They will be combined with the
    * global clipping planes.
    */
-  setModelClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+  setModelClippingPlanes(clippingPlanes: Plane[]): void {
     this.pointCloudNode.clippingPlanes = clippingPlanes;
   }
 
   /**
    * Get the clipping planes for this model.
    */
-  getModelClippingPlanes(): THREE.Plane[] {
+  getModelClippingPlanes(): Plane[] {
     return [...this.pointCloudNode.clippingPlanes];
   }
 

--- a/viewer/packages/pointclouds/src/PointCloudLoadingStateHandler.ts
+++ b/viewer/packages/pointclouds/src/PointCloudLoadingStateHandler.ts
@@ -7,7 +7,8 @@ import type { LoadingState } from '@reveal/model-base';
 import type { Observable } from 'rxjs';
 import { combineLatest, interval, of, pipe, Subject } from 'rxjs';
 import { delay, distinctUntilChanged, map, share, startWith, switchMap } from 'rxjs/operators';
-import * as THREE from 'three';
+import type { BufferGeometry, Object3D } from 'three';
+import { Points } from 'three';
 
 import type { PointCloudNode } from './PointCloudNode';
 import { numPointCloudNodesLoading } from './potree-three-loader';
@@ -94,11 +95,11 @@ export class PointCloudLoadingStateHandler {
   private getPointBuffersHash(pointCloudNodes: PointCloudNode<DataSourceType>[]) {
     let pointHash = 0xbaadf00d; // Kind of random bit pattern
     for (const pointCloud of pointCloudNodes) {
-      pointCloud.octree.traverseVisible((x: THREE.Object3D) => {
-        // Note! We pretend everything in the scene graph is THREE.Points,
+      pointCloud.octree.traverseVisible((x: Object3D) => {
+        // Note! We pretend everything in the scene graph is Points,
         // but verify that we only visit Points nodes here.
-        if (x instanceof THREE.Points) {
-          const geometry = x.geometry as THREE.BufferGeometry;
+        if (x instanceof Points) {
+          const geometry = x.geometry as BufferGeometry;
           pointHash ^= geometry.getAttribute('position').count;
         }
       });

--- a/viewer/packages/pointclouds/src/PointCloudManager.ts
+++ b/viewer/packages/pointclouds/src/PointCloudManager.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { PerspectiveCamera, Plane, Scene, WebGLRenderer } from 'three';
+import { BufferGeometry, Mesh } from 'three';
 
 import { assertNever } from '@reveal/utilities';
 import type { LoadingState } from '@reveal/model-base';
@@ -21,8 +22,6 @@ import { MetricsLogger } from '@reveal/metrics';
 import type { SupportedModelTypes } from '@reveal/model-base';
 import type { PointCloudMaterialManager } from '@reveal/rendering';
 
-import type { Mesh } from 'three';
-
 export class PointCloudManager {
   private readonly _pointCloudMetadataRepository: PointCloudMetadataRepository;
   private readonly _pointCloudFactory: PointCloudFactory;
@@ -30,14 +29,14 @@ export class PointCloudManager {
   private readonly _loadingStateHandler: PointCloudLoadingStateHandler;
   private readonly _potreeInstance: Potree;
   private readonly _pointCloudNodes: PointCloudNode[] = [];
-  private _globalClippingPlanes: THREE.Plane[] = [];
+  private _globalClippingPlanes: Plane[] = [];
 
-  private readonly _cameraSubject: Subject<THREE.PerspectiveCamera> = new Subject();
+  private readonly _cameraSubject: Subject<PerspectiveCamera> = new Subject();
   private readonly _modelSubject: Subject<{ modelIdentifier: ModelIdentifier; operation: 'add' | 'remove' }> =
     new Subject();
   private readonly _budgetSubject: Subject<number> = new Subject();
 
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
 
   private _needsRedraw: boolean = false;
 
@@ -46,8 +45,8 @@ export class PointCloudManager {
     materialManager: PointCloudMaterialManager,
     modelFactory: PointCloudFactory,
     potreeInstance: Potree,
-    scene: THREE.Scene,
-    renderer: THREE.WebGLRenderer
+    scene: Scene,
+    renderer: WebGLRenderer
   ) {
     this._pointCloudMetadataRepository = metadataRepository;
     this._pointCloudFactory = modelFactory;
@@ -59,7 +58,7 @@ export class PointCloudManager {
 
     combineLatest([this._cameraSubject, this.loadedModelsObservable(), this._budgetSubject])
       .pipe(throttleTime(500, asyncScheduler, { leading: true, trailing: true }))
-      .subscribe(([cam, _models, _budget]: [THREE.PerspectiveCamera, ModelIdentifier[], number]) => {
+      .subscribe(([cam, _models, _budget]: [PerspectiveCamera, ModelIdentifier[], number]) => {
         this.updatePointClouds(cam);
       });
 
@@ -95,7 +94,7 @@ export class PointCloudManager {
     );
   }
 
-  set clippingPlanes(planes: THREE.Plane[]) {
+  set clippingPlanes(planes: Plane[]) {
     this._globalClippingPlanes = planes;
     this._pointCloudNodes.forEach(node => node.octree.setGlobalClippingPlane(planes));
     this.requestRedraw();
@@ -105,12 +104,12 @@ export class PointCloudManager {
     return this._loadingStateHandler.getLoadingStateObserver();
   }
 
-  updatePointClouds(camera: THREE.PerspectiveCamera): void {
+  updatePointClouds(camera: PerspectiveCamera): void {
     const octrees = this._pointCloudNodes.filter(node => node.visible).map(node => node.octree);
     this._potreeInstance.updatePointClouds(octrees, camera, this._renderer);
   }
 
-  updateCamera(camera: THREE.PerspectiveCamera): void {
+  updateCamera(camera: PerspectiveCamera): void {
     this._cameraSubject.next(camera);
     this.requestRedraw();
   }
@@ -185,7 +184,7 @@ export class PointCloudManager {
   }
 
   createDrawResetTrigger(): Mesh {
-    const drawResetTriggerMesh = new THREE.Mesh(new THREE.BufferGeometry());
+    const drawResetTriggerMesh = new Mesh(new BufferGeometry());
     drawResetTriggerMesh.name = 'onAfterRender trigger (no geometry)';
     drawResetTriggerMesh.frustumCulled = false;
     drawResetTriggerMesh.onAfterRender = () => {

--- a/viewer/packages/pointclouds/src/PointCloudMetadata.ts
+++ b/viewer/packages/pointclouds/src/PointCloudMetadata.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Matrix4 } from 'three';
 import type { CameraConfiguration } from '@reveal/utilities';
 import type { File3dFormat, ModelIdentifier } from '@reveal/data-providers';
 
@@ -12,7 +12,7 @@ export interface PointCloudMetadata {
 
   readonly modelBaseUrl: string;
   readonly modelIdentifier: ModelIdentifier;
-  readonly modelMatrix: THREE.Matrix4;
+  readonly modelMatrix: Matrix4;
   readonly cameraConfiguration?: CameraConfiguration;
   readonly scene: any;
 }

--- a/viewer/packages/pointclouds/src/PointCloudNode.test.ts
+++ b/viewer/packages/pointclouds/src/PointCloudNode.test.ts
@@ -5,7 +5,8 @@
 import { PointCloudNode } from './PointCloudNode';
 import { createPointCloudNode } from '../../../test-utilities';
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { Box3, BufferAttribute, BufferGeometry, Euler, Matrix4, PerspectiveCamera, Points, Ray, Vector3 } from 'three';
 import { PointCloudOctree, PointCloudOctreeNode } from './potree-three-loader';
 import { Mock } from 'moq.ts';
 import type { IPointCloudTreeGeometryNode } from './potree-three-loader/geometry/IPointCloudTreeGeometryNode';
@@ -24,7 +25,7 @@ describe(PointCloudNode.name, () => {
     const node = createPointCloudNode();
     vi.spyOn(PointCloudOctree.prototype, 'pick').mockResolvedValue(null);
 
-    const result = node.pick(new Mock<THREE.WebGLRenderer>().object(), new THREE.PerspectiveCamera(), new THREE.Ray());
+    const result = node.pick(new Mock<WebGLRenderer>().object(), new PerspectiveCamera(), new Ray());
 
     expect(result).toBeInstanceOf(Promise);
     await result;
@@ -32,9 +33,7 @@ describe(PointCloudNode.name, () => {
 
   test('getModelTransformation returns transformation set by setModelTransformation', () => {
     const node = createPointCloudNode();
-    const transform = new THREE.Matrix4()
-      .makeRotationFromEuler(new THREE.Euler(190, 35, 230))
-      .setPosition(new THREE.Vector3(12, 34, 12));
+    const transform = new Matrix4().makeRotationFromEuler(new Euler(190, 35, 230)).setPosition(new Vector3(12, 34, 12));
 
     node.setModelTransformation(transform.clone());
     const receivedTransform = node.getModelTransformation();
@@ -49,7 +48,7 @@ describe(PointCloudNode.name, () => {
     });
 
     test('returns volume objects from annotation list', () => {
-      const shape = new Cylinder(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1), 1);
+      const shape = new Cylinder(new Vector3(0, 0, 0), new Vector3(1, 1, 1), 1);
       const boundingBox = shape.createBoundingBox();
       const annotations = [
         {
@@ -87,7 +86,7 @@ describe(PointCloudNode.name, () => {
         get: vi.fn().mockReturnValue(undefined)
       });
 
-      const box = new THREE.Box3(new THREE.Vector3(-10, -10, -10), new THREE.Vector3(10, 10, 10));
+      const box = new Box3(new Vector3(-10, -10, -10), new Vector3(10, 10, 10));
 
       const result = node.getSubtreePointsByBox(box);
 
@@ -112,28 +111,28 @@ describe(PointCloudNode.name, () => {
               .setup(p => p.children)
               .returns([])
               .setup(p => p.boundingBox)
-              .returns(new THREE.Box3(new THREE.Vector3(1, 1, 1), new THREE.Vector3(15, 15, 15)))
+              .returns(new Box3(new Vector3(1, 1, 1), new Vector3(15, 15, 15)))
               .object(),
-            new THREE.Points(
-              new THREE.BufferGeometry().setAttribute(
+            new Points(
+              new BufferGeometry().setAttribute(
                 'position',
-                new THREE.BufferAttribute(new Float32Array([1, 1, 1, 15, 15, 15, 5, 5, 5]), 3)
+                new BufferAttribute(new Float32Array([1, 1, 1, 15, 15, 15, 5, 5, 5]), 3)
               )
             )
           )
         )
         .object();
 
-      const sourceMatrix = new THREE.Matrix4().identity();
+      const sourceMatrix = new Matrix4().identity();
       const node = new PointCloudNode(Symbol(), sourceMatrix, pointCloudOctree, [], { classificationSets: [] });
 
-      const box = new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(10, 10, 10));
+      const box = new Box3(new Vector3(0, 0, 0), new Vector3(10, 10, 10));
 
       const result = node.getSubtreePointsByBox(box);
 
       expect(result.length).toBe(2);
-      expect(result[0].equals(new THREE.Vector3(1, 1, 1))).toBeTruthy();
-      expect(result[1].equals(new THREE.Vector3(5, 5, 5))).toBeTruthy();
+      expect(result[0].equals(new Vector3(1, 1, 1))).toBeTruthy();
+      expect(result[1].equals(new Vector3(5, 5, 5))).toBeTruthy();
     });
   });
 });

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.test.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.test.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2024 Cognite AS
  */
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { PerspectiveCamera, Plane, Vector2, Vector3 } from 'three';
 import { Mock } from 'moq.ts';
 import { vi } from 'vitest';
 
@@ -16,10 +17,10 @@ import { assert } from '@reveal/utilities/assert';
 
 function createMockIntersectInput(): IntersectInput {
   return {
-    normalizedCoords: new THREE.Vector2(0, 0),
-    camera: new THREE.PerspectiveCamera(),
+    normalizedCoords: new Vector2(0, 0),
+    camera: new PerspectiveCamera(),
     clippingPlanes: [],
-    renderer: new Mock<THREE.WebGLRenderer>().object(),
+    renderer: new Mock<WebGLRenderer>().object(),
     domElement: document.createElement('div')
   };
 }
@@ -28,7 +29,7 @@ describe(PointCloudPickingHandler.name, () => {
   let handler: PointCloudPickingHandler;
 
   beforeEach(() => {
-    const renderer = new Mock<THREE.WebGLRenderer>().object();
+    const renderer = new Mock<WebGLRenderer>().object();
     handler = new PointCloudPickingHandler(renderer);
     vi.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue(null);
   });
@@ -61,7 +62,7 @@ describe(PointCloudPickingHandler.name, () => {
   });
 
   test('intersectPointClouds returns Classic volume metadata when annotation has annotationId', async () => {
-    const shape = new Cylinder(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1), 1);
+    const shape = new Cylinder(new Vector3(0, 0, 0), new Vector3(1, 1, 1), 1);
     const annotationId = 42;
     const objectId = 1;
     const annotation: PointCloudObject<ClassicDataSourceType> = {
@@ -75,7 +76,7 @@ describe(PointCloudPickingHandler.name, () => {
     vi.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue({
       pointIndex: 0,
       object: node.octree,
-      position: new THREE.Vector3(1, 2, 3),
+      position: new Vector3(1, 2, 3),
       objectId
     });
 
@@ -87,7 +88,7 @@ describe(PointCloudPickingHandler.name, () => {
   });
 
   test('intersectPointClouds returns DM volume metadata when annotation has volumeInstanceRef', async () => {
-    const shape = new Cylinder(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1), 1);
+    const shape = new Cylinder(new Vector3(0, 0, 0), new Vector3(1, 1, 1), 1);
     const objectId = 2;
     const volumeInstanceRef = { externalId: 'vol-ext', space: 'vol-space' };
     const annotation: PointCloudObject<DMDataSourceType> = {
@@ -100,7 +101,7 @@ describe(PointCloudPickingHandler.name, () => {
     vi.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue({
       pointIndex: 0,
       object: node.octree,
-      position: new THREE.Vector3(1, 2, 3),
+      position: new Vector3(1, 2, 3),
       objectId
     });
 
@@ -117,43 +118,43 @@ describe(PointCloudPickingHandler.name, () => {
     const input = createMockIntersectInput();
     // Camera is at origin; node1 octree is at distance 5, node2 octree is at distance 1
     vi.spyOn(PointCloudOctreePicker.prototype, 'pick')
-      .mockResolvedValueOnce({ pointIndex: 0, object: node1.octree, position: new THREE.Vector3(5, 0, 0), objectId: 0 })
+      .mockResolvedValueOnce({ pointIndex: 0, object: node1.octree, position: new Vector3(5, 0, 0), objectId: 0 })
       .mockResolvedValueOnce({
         pointIndex: 0,
         object: node2.octree,
-        position: new THREE.Vector3(1, 0, 0),
+        position: new Vector3(1, 0, 0),
         objectId: 0
       });
 
     const result = await handler.intersectPointClouds([node1, node2], input);
 
     expect(result).toHaveLength(2);
-    expect(result[0].point).toEqual(new THREE.Vector3(1, 0, 0));
-    expect(result[1].point).toEqual(new THREE.Vector3(5, 0, 0));
+    expect(result[0].point).toEqual(new Vector3(1, 0, 0));
+    expect(result[1].point).toEqual(new Vector3(5, 0, 0));
   });
 
   test('intersectPointClouds filters out intersections clipped by clipping planes', async () => {
     const node1 = createPointCloudNode();
     const node2 = createPointCloudNode();
     // Clipping plane: normal (-1,0,0) + constant 5 → clips all points with x > 5
-    const clippingPlane = new THREE.Plane(new THREE.Vector3(-1, 0, 0), 5);
+    const clippingPlane = new Plane(new Vector3(-1, 0, 0), 5);
     const input: IntersectInput = {
       ...createMockIntersectInput(),
       clippingPlanes: [clippingPlane]
     };
     vi.spyOn(PointCloudOctreePicker.prototype, 'pick')
-      .mockResolvedValueOnce({ pointIndex: 0, object: node1.octree, position: new THREE.Vector3(1, 0, 0), objectId: 0 })
+      .mockResolvedValueOnce({ pointIndex: 0, object: node1.octree, position: new Vector3(1, 0, 0), objectId: 0 })
       .mockResolvedValueOnce({
         pointIndex: 0,
         object: node2.octree,
-        position: new THREE.Vector3(10, 0, 0),
+        position: new Vector3(10, 0, 0),
         objectId: 0
       });
 
     const result = await handler.intersectPointClouds([node1, node2], input);
 
     expect(result).toHaveLength(1);
-    expect(result[0].point).toEqual(new THREE.Vector3(1, 0, 0));
+    expect(result[0].point).toEqual(new Vector3(1, 0, 0));
   });
 
   test('intersectPointClouds serializes concurrent picks', async () => {

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { Raycaster, Vector2 } from 'three';
 
 import type { IntersectInput } from '@reveal/model-base';
 import type { PointCloudNode } from './PointCloudNode';
@@ -16,15 +17,15 @@ import { isClassicPointCloudVolume, isDMPointCloudVolume } from '@reveal/data-pr
 import type { IntersectPointCloudNodeResult } from './types';
 
 export class PointCloudPickingHandler {
-  private readonly _normalized = new THREE.Vector2();
-  private readonly _raycaster = new THREE.Raycaster();
+  private readonly _normalized = new Vector2();
+  private readonly _raycaster = new Raycaster();
   private readonly _picker: PointCloudOctreePicker;
   private readonly _mutex = new Mutex();
 
   // To solve https://cognitedata.atlassian.net/browse/REV-523
   private static readonly PickingWindowSize = 5;
 
-  constructor(renderer: THREE.WebGLRenderer) {
+  constructor(renderer: WebGLRenderer) {
     this._picker = new PointCloudOctreePicker(renderer);
   }
 

--- a/viewer/packages/pointclouds/src/createPointCloudManager.ts
+++ b/viewer/packages/pointclouds/src/createPointCloudManager.ts
@@ -5,7 +5,7 @@
 import { PointCloudManager } from './PointCloudManager';
 import { PointCloudMetadataRepository } from './PointCloudMetadataRepository';
 
-import type * as THREE from 'three';
+import type { Scene, WebGLRenderer } from 'three';
 
 import type {
   DMDataSourceType,
@@ -26,8 +26,8 @@ export function createPointCloudManager(
   pointCloudDMProvider: PointCloudStylableObjectProvider<DMDataSourceType>,
   pointCloudMaterialManager: PointCloudMaterialManager,
   cachedProvider: CachedModelDataProvider,
-  scene: THREE.Scene,
-  renderer: THREE.WebGLRenderer
+  scene: Scene,
+  renderer: WebGLRenderer
 ): PointCloudManager {
   const metadataRepository = new PointCloudMetadataRepository(modelMetadataProvider, cachedProvider);
 

--- a/viewer/packages/pointclouds/src/potree-three-loader/geometry/IPointCloudTreeGeometry.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/geometry/IPointCloudTreeGeometry.ts
@@ -1,14 +1,14 @@
 import type { IPointCloudTreeNodeBase } from '../tree/IPointCloudTreeNodeBase';
 
-import type * as THREE from 'three';
+import type { Box3, Vector3 } from 'three';
 
 export interface IPointCloudTreeGeometry {
   root: IPointCloudTreeNodeBase | undefined;
 
-  boundingBox: THREE.Box3;
-  tightBoundingBox: THREE.Box3;
+  boundingBox: Box3;
+  tightBoundingBox: Box3;
 
-  offset: THREE.Vector3;
+  offset: Vector3;
   spacing: number;
 
   dispose(): void;

--- a/viewer/packages/pointclouds/src/potree-three-loader/geometry/IPointCloudTreeGeometryNode.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/geometry/IPointCloudTreeGeometryNode.ts
@@ -1,18 +1,13 @@
 import type { IPointCloudTreeNodeBase } from '../tree/IPointCloudTreeNodeBase';
-import type * as THREE from 'three';
+import type { Box3, BufferGeometry, Vector3 } from 'three';
 
 export interface IPointCloudTreeGeometryNode extends IPointCloudTreeNodeBase {
-  geometry: THREE.BufferGeometry | undefined;
+  geometry: BufferGeometry | undefined;
   failed: boolean;
   load: () => Promise<void>;
   baseUrl: () => string;
   fileName: () => string;
   oneTimeDisposeHandlers: (() => void)[];
 
-  doneLoading: (
-    bufferGeometry: THREE.BufferGeometry,
-    _tightBoundingBox: THREE.Box3,
-    np: number,
-    _mean: THREE.Vector3
-  ) => void;
+  doneLoading: (bufferGeometry: BufferGeometry, _tightBoundingBox: Box3, np: number, _mean: Vector3) => void;
 }

--- a/viewer/packages/pointclouds/src/potree-three-loader/geometry/PointCloudEptGeometry.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/geometry/PointCloudEptGeometry.ts
@@ -4,7 +4,7 @@
  * License in LICENSE.potree
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 
 import { EptBinaryLoader } from '../loading/EptBinaryLoader';
 import type { EptJson, EptSchemaEntry } from '../loading/EptJson';
@@ -22,15 +22,15 @@ function findDim(schema: EptSchemaEntry[], name: string): EptSchemaEntry {
 }
 
 export class PointCloudEptGeometry implements IPointCloudTreeGeometry {
-  private readonly _eptScale: THREE.Vector3;
-  private readonly _eptOffset: THREE.Vector3;
+  private readonly _eptScale: Vector3;
+  private readonly _eptOffset: Vector3;
 
   private readonly _url: string;
 
-  private readonly _boundingBox: THREE.Box3;
-  private readonly _tightBoundingBox: THREE.Box3;
+  private readonly _boundingBox: Box3;
+  private readonly _tightBoundingBox: Box3;
 
-  private readonly _offset: THREE.Vector3;
+  private readonly _offset: Vector3;
 
   private readonly _loader: EptBinaryLoader;
 
@@ -53,15 +53,15 @@ export class PointCloudEptGeometry implements IPointCloudTreeGeometry {
     this._root = r;
   }
 
-  get boundingBox(): THREE.Box3 {
+  get boundingBox(): Box3 {
     return this._boundingBox;
   }
 
-  get tightBoundingBox(): THREE.Box3 {
+  get tightBoundingBox(): Box3 {
     return this._tightBoundingBox;
   }
 
-  get offset(): THREE.Vector3 {
+  get offset(): Vector3 {
     return this._offset;
   }
 
@@ -77,11 +77,11 @@ export class PointCloudEptGeometry implements IPointCloudTreeGeometry {
     return this._schema;
   }
 
-  get eptScale(): THREE.Vector3 {
+  get eptScale(): Vector3 {
     return this._eptScale;
   }
 
-  get eptOffset(): THREE.Vector3 {
+  get eptOffset(): Vector3 {
     return this._eptOffset;
   }
 
@@ -121,10 +121,10 @@ export class EptKey {
   readonly x: number;
   readonly y: number;
   readonly z: number;
-  readonly b: THREE.Box3;
+  readonly b: Box3;
   readonly d: number;
 
-  constructor(ept: PointCloudEptGeometry, b: THREE.Box3, d: number, x?: number, y?: number, z?: number) {
+  constructor(ept: PointCloudEptGeometry, b: Box3, d: number, x?: number, y?: number, z?: number) {
     this.ept = ept;
     this.b = b;
     this.d = d;
@@ -140,7 +140,7 @@ export class EptKey {
   step(a: number, b: number, c: number): EptKey {
     const min = this.b.min.clone();
     const max = this.b.max.clone();
-    const dst = new THREE.Vector3().subVectors(max, min);
+    const dst = new Vector3().subVectors(max, min);
 
     if (a) min.x += dst.x / 2;
     else max.x -= dst.x / 2;
@@ -151,7 +151,7 @@ export class EptKey {
     if (c) min.z += dst.z / 2;
     else max.z -= dst.z / 2;
 
-    return new EptKey(this.ept, new THREE.Box3(min, max), this.d + 1, this.x * 2 + a, this.y * 2 + b, this.z * 2 + c);
+    return new EptKey(this.ept, new Box3(min, max), this.d + 1, this.x * 2 + a, this.y * 2 + b, this.z * 2 + c);
   }
 
   children(): string[] {

--- a/viewer/packages/pointclouds/src/potree-three-loader/geometry/PointCloudEptGeometryNode.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/geometry/PointCloudEptGeometryNode.ts
@@ -6,7 +6,7 @@
 
 import type { IPointCloudTreeGeometryNode } from './IPointCloudTreeGeometryNode';
 import type { IPointCloudTreeNodeBase } from '../tree/IPointCloudTreeNodeBase';
-import type * as THREE from 'three';
+import type { Box3, BufferGeometry, Sphere, Vector3 } from 'three';
 import type { PointCloudEptGeometry } from './PointCloudEptGeometry';
 import { EptKey } from './PointCloudEptGeometry';
 import { sphereFrom } from './translationUtils';
@@ -26,9 +26,9 @@ export class PointCloudEptGeometryNode implements IPointCloudTreeGeometryNode {
 
   private readonly _dataLoader: ModelDataProvider;
 
-  private readonly _boundingBox: THREE.Box3;
+  private readonly _boundingBox: Box3;
 
-  private readonly _boundingSphere: THREE.Sphere;
+  private readonly _boundingSphere: Sphere;
   private readonly _spacing: number;
   private _level: number;
   private _numPoints: number;
@@ -44,7 +44,7 @@ export class PointCloudEptGeometryNode implements IPointCloudTreeGeometryNode {
 
   private _isLeafNode: boolean;
 
-  private _geometry: THREE.BufferGeometry | undefined;
+  private _geometry: BufferGeometry | undefined;
 
   private _oneTimeDisposeHandlers: (() => void)[];
 
@@ -66,11 +66,11 @@ export class PointCloudEptGeometryNode implements IPointCloudTreeGeometryNode {
     return this._spacing;
   }
 
-  get boundingBox(): THREE.Box3 {
+  get boundingBox(): Box3 {
     return this._boundingBox;
   }
 
-  get boundingSphere(): THREE.Sphere {
+  get boundingSphere(): Sphere {
     return this._boundingSphere;
   }
 
@@ -103,7 +103,7 @@ export class PointCloudEptGeometryNode implements IPointCloudTreeGeometryNode {
     return this._isLeafNode;
   }
 
-  get geometry(): THREE.BufferGeometry | undefined {
+  get geometry(): BufferGeometry | undefined {
     return this._geometry!;
   }
 
@@ -126,7 +126,7 @@ export class PointCloudEptGeometryNode implements IPointCloudTreeGeometryNode {
   constructor(
     ept: PointCloudEptGeometry,
     modelDataProvider: ModelDataProvider,
-    b?: THREE.Box3,
+    b?: Box3,
     d?: number,
     x?: number,
     y?: number,
@@ -173,11 +173,11 @@ export class PointCloudEptGeometryNode implements IPointCloudTreeGeometryNode {
     return this._loaded;
   }
 
-  getBoundingSphere(): THREE.Sphere {
+  getBoundingSphere(): Sphere {
     return this._boundingSphere;
   }
 
-  getBoundingBox(): THREE.Box3 {
+  getBoundingBox(): Box3 {
     return this._boundingBox;
   }
 
@@ -289,12 +289,7 @@ export class PointCloudEptGeometryNode implements IPointCloudTreeGeometryNode {
     });
   }
 
-  doneLoading(
-    bufferGeometry: THREE.BufferGeometry,
-    _tightBoundingBox: THREE.Box3,
-    np: number,
-    _mean: THREE.Vector3
-  ): void {
+  doneLoading(bufferGeometry: BufferGeometry, _tightBoundingBox: Box3, np: number, _mean: Vector3): void {
     bufferGeometry.boundingBox = this._boundingBox;
     this._geometry = bufferGeometry;
     this._numPoints = np;

--- a/viewer/packages/pointclouds/src/potree-three-loader/geometry/translationUtils.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/geometry/translationUtils.ts
@@ -2,16 +2,16 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Sphere, Vector3 } from 'three';
 
-export function toVector3(v: number[], offset?: number): THREE.Vector3 {
-  return new THREE.Vector3().fromArray(v, offset || 0);
+export function toVector3(v: number[], offset?: number): Vector3 {
+  return new Vector3().fromArray(v, offset || 0);
 }
 
-export function toBox3(b: number[]): THREE.Box3 {
-  return new THREE.Box3(toVector3(b), toVector3(b, 3));
+export function toBox3(b: number[]): Box3 {
+  return new Box3(toVector3(b), toVector3(b, 3));
 }
 
-export function sphereFrom(b: THREE.Box3): THREE.Sphere {
-  return b.getBoundingSphere(new THREE.Sphere());
+export function sphereFrom(b: Box3): Sphere {
+  return b.getBoundingSphere(new Sphere());
 }

--- a/viewer/packages/pointclouds/src/potree-three-loader/loading/EptBinaryLoader.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/loading/EptBinaryLoader.ts
@@ -4,7 +4,8 @@
  * License in LICENSE.potree
  */
 
-import * as THREE from 'three';
+import type { TypedArray } from 'three';
+import { Box3, BufferAttribute, BufferGeometry, Vector3 } from 'three';
 
 import { WorkerPool } from '../utils/WorkerPool';
 import type { ILoader } from './ILoader';
@@ -24,7 +25,7 @@ import type { EptBinaryDecoderWorker } from '../workers/eptBinaryDecoder.worker'
 
 export class EptBinaryLoader implements ILoader {
   private readonly _dataLoader: ModelDataProvider;
-  private readonly _stylableObjectsWithBox: [SerializableStylableObject, THREE.Box3][];
+  private readonly _stylableObjectsWithBox: [SerializableStylableObject, Box3][];
 
   static readonly WORKER_POOL = new WorkerPool(8, EptDecoderWorker);
 
@@ -80,7 +81,7 @@ export class EptBinaryLoader implements ILoader {
     const tightBoundingBox = createTightBoundingBox(parsedData);
 
     const numPoints = parsedData.numPoints;
-    node.doneLoading(geometry, tightBoundingBox, numPoints, new THREE.Vector3(...parsedData.mean));
+    node.doneLoading(geometry, tightBoundingBox, numPoints, new Vector3(...parsedData.mean));
   }
 
   async parse(node: PointCloudEptGeometryNode, data: ArrayBuffer): Promise<ParsedEptData | Error> {
@@ -113,18 +114,18 @@ export class EptBinaryLoader implements ILoader {
   }
 }
 
-function createTightBoundingBox(data: ParsedEptData): THREE.Box3 {
-  return new THREE.Box3(
-    new THREE.Vector3().fromArray(data.tightBoundingBox.min),
-    new THREE.Vector3().fromArray(data.tightBoundingBox.max)
+function createTightBoundingBox(data: ParsedEptData): Box3 {
+  return new Box3(
+    new Vector3().fromArray(data.tightBoundingBox.min),
+    new Vector3().fromArray(data.tightBoundingBox.max)
   );
 }
 
-function createGeometryFromEptData(data: ParsedEptData): THREE.BufferGeometry {
-  const geometry = new THREE.BufferGeometry();
+function createGeometryFromEptData(data: ParsedEptData): BufferGeometry {
+  const geometry = new BufferGeometry();
 
   function addAttributeIfPresent(
-    typedArrayConstructor: { new (data: ArrayBuffer): THREE.TypedArray },
+    typedArrayConstructor: { new (data: ArrayBuffer): TypedArray },
     name: string,
     componentCount: number,
     data?: ArrayBuffer | undefined,
@@ -132,7 +133,7 @@ function createGeometryFromEptData(data: ParsedEptData): THREE.BufferGeometry {
   ): void {
     if (data) {
       const typedArray = new typedArrayConstructor(data);
-      geometry.setAttribute(name, new THREE.BufferAttribute(typedArray, componentCount, normalized));
+      geometry.setAttribute(name, new BufferAttribute(typedArray, componentCount, normalized));
     }
   }
 
@@ -143,7 +144,7 @@ function createGeometryFromEptData(data: ParsedEptData): THREE.BufferGeometry {
   addAttributeIfPresent(Uint8Array, 'classification', 1, data.classification);
   addAttributeIfPresent(Uint16Array, 'objectId', 1, data.objectId);
 
-  (geometry.attributes.indices as THREE.BufferAttribute).normalized = true;
+  (geometry.attributes.indices as BufferAttribute).normalized = true;
 
   return geometry;
 }

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/IPointCloudTreeNode.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/IPointCloudTreeNode.ts
@@ -1,9 +1,9 @@
 import type { IPointCloudTreeNodeBase } from './IPointCloudTreeNodeBase';
 import type { IPointCloudTreeGeometryNode } from '../geometry/IPointCloudTreeGeometryNode';
 
-import type * as THREE from 'three';
+import type { Points } from 'three';
 
 export interface IPointCloudTreeNode extends IPointCloudTreeNodeBase {
-  sceneNode: THREE.Points;
+  sceneNode: Points;
   geometryNode: IPointCloudTreeGeometryNode;
 }

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/IPointCloudTreeNodeBase.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/IPointCloudTreeNodeBase.ts
@@ -1,4 +1,4 @@
-import type * as THREE from 'three';
+import type { Box3, Sphere } from 'three';
 
 export interface IPointCloudTreeNodeBase {
   id: number;
@@ -6,8 +6,8 @@ export interface IPointCloudTreeNodeBase {
   level: number;
   index: number;
   spacing: number;
-  boundingBox: THREE.Box3;
-  boundingSphere: THREE.Sphere;
+  boundingBox: Box3;
+  boundingSphere: Sphere;
   loaded: boolean;
   numPoints: number;
   isTreeNode: boolean;

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePicker.test.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePicker.test.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2024 Cognite AS
  */
-import * as THREE from 'three';
+import type { WebGLRenderTarget, WebGLRenderer } from 'three';
+import { PerspectiveCamera, Ray, Scene, Vector2 } from 'three';
 import { Mock, It } from 'moq.ts';
 import { vi } from 'vitest';
 
@@ -17,16 +18,16 @@ const MINIMAL_PIXEL_BUFFER_SIZE = 4;
 
 function createMockPickState(): IPickState {
   return {
-    renderTarget: new Mock<THREE.WebGLRenderTarget>().object(),
+    renderTarget: new Mock<WebGLRenderTarget>().object(),
     material: new Mock<PointCloudMaterial>().object(),
-    scene: new THREE.Scene()
+    scene: new Scene()
   };
 }
 
-function createMockRenderer(): THREE.WebGLRenderer {
-  return new Mock<THREE.WebGLRenderer>()
+function createMockRenderer(): WebGLRenderer {
+  return new Mock<WebGLRenderer>()
     .setup(r => r.getDrawingBufferSize(It.IsAny()))
-    .returns(new THREE.Vector2(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT))
+    .returns(new Vector2(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT))
     .object();
 }
 
@@ -37,8 +38,8 @@ describe(PointCloudOctreePicker.name, () => {
 
   test('picking returns null immediately for empty octrees array', async () => {
     const picker = new PointCloudOctreePicker(createMockRenderer());
-    const camera = new THREE.PerspectiveCamera();
-    const ray = new THREE.Ray();
+    const camera = new PerspectiveCamera();
+    const ray = new Ray();
 
     const result = await picker.pick(camera, ray, []);
 
@@ -66,8 +67,8 @@ describe(PointCloudOctreePicker.name, () => {
 
     const picker = new PointCloudOctreePicker(createMockRenderer());
     const octree = new Mock<PointCloudOctree>().object();
-    const camera = new THREE.PerspectiveCamera();
-    const ray = new THREE.Ray();
+    const camera = new PerspectiveCamera();
+    const ray = new Ray();
 
     // Starting pick() runs the function synchronously up to the first `await readPixelsPromise`.
     // resetState() and readPixelsAsync() are both called before that await.

--- a/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.test.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/tree/PointCloudOctreePickerHelper.test.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import type { WebGLRenderTarget, WebGLRenderer } from 'three';
+import { PerspectiveCamera, Vector3 } from 'three';
 import type { RenderedNode } from './PointCloudOctreePickerHelper';
 import { PointCloudOctreePickerHelper } from './PointCloudOctreePickerHelper';
 
@@ -16,11 +17,11 @@ describe('PointCloudOctreePickerHelper', () => {
     const pickWindowSize = 2;
     // 2x2 pixel buffer with 1 non-zero value and two "kinds" of zero values (with 0 and 1 alpha)
     const dummyPixels: Uint8Array = new Uint8Array([15, 0, 0, 2, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 0]);
-    const dummyCamera = new THREE.PerspectiveCamera();
+    const dummyCamera = new PerspectiveCamera();
     dummyCamera.position.set(1, 0, 0);
 
     vi.spyOn(PointCloudOctreePickerHelper, 'getPointPosition').mockImplementation(() => {
-      return new THREE.Vector3();
+      return new Vector3();
     });
 
     expect(PointCloudOctreePickerHelper.findHit(dummyPixels, pickWindowSize, [dummyNode], dummyCamera)).toStrictEqual({
@@ -37,11 +38,11 @@ describe('PointCloudOctreePickerHelper', () => {
       1, 0, 0, 22, 0, 0, 0, 255, 0, 0, 0, 255, 3, 0, 0, 22, 2, 0, 0, 22, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0,
       0, 255
     ]);
-    const dummyCamera = new THREE.PerspectiveCamera();
+    const dummyCamera = new PerspectiveCamera();
     dummyCamera.position.set(1, 0, 0);
 
     vi.spyOn(PointCloudOctreePickerHelper, 'getPointPosition').mockImplementation((_nodes, _pcIndex, pIndex) => {
-      const result = new THREE.Vector3();
+      const result = new Vector3();
       switch (pIndex) {
         case 1:
           result.set(-3, 0, 0);
@@ -68,8 +69,8 @@ describe('PointCloudOctreePickerHelper', () => {
     const pickX = 5;
     const pickY = 10;
     const pickWndSize = 3;
-    const rendererMock = new Mock<THREE.WebGLRenderer>();
-    const renderTargetMock = new Mock<THREE.WebGLRenderTarget>();
+    const rendererMock = new Mock<WebGLRenderer>();
+    const renderTargetMock = new Mock<WebGLRenderTarget>();
     const expectedPixelCount = 4 * pickWndSize * pickWndSize;
 
     rendererMock

--- a/viewer/packages/pointclouds/visual-tests/EdlPointCloud.VisualTest.ts
+++ b/viewer/packages/pointclouds/visual-tests/EdlPointCloud.VisualTest.ts
@@ -10,15 +10,15 @@ import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-
 import { StreamingVisualTestFixture } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
 import type { SceneHandler } from '@reveal/utilities';
 
-import * as THREE from 'three';
+import { PerspectiveCamera } from 'three';
 
 export default class EdlPointCloudVisualTest extends StreamingVisualTestFixture {
   constructor() {
     super('pointcloud-bunny');
   }
 
-  override createCamera(): THREE.PerspectiveCamera {
-    return new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 1.5);
+  override createCamera(): PerspectiveCamera {
+    return new PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 1.5);
   }
 
   createDefaultRenderPipelineProvider(

--- a/viewer/packages/pointclouds/visual-tests/PointCloudColorStyling.VisualTest.ts
+++ b/viewer/packages/pointclouds/visual-tests/PointCloudColorStyling.VisualTest.ts
@@ -24,17 +24,15 @@ import {
 } from '../../pointcloud-styling';
 
 import { assert } from '@reveal/utilities/assert';
-import * as THREE from 'three';
+import { Color, PerspectiveCamera, Vector3 } from 'three';
 import { LocalPointClassificationsProvider } from '../src/classificationsProviders/LocalPointClassificationsProvider';
 import { PointColorType } from '@reveal/rendering';
-import { Color } from 'three';
-
 class CustomAnnotationProvider implements PointCloudStylableObjectProvider<ClassicDataSourceType> {
   async getPointCloudObjects(_modelIdentifier: ClassicModelIdentifierType): Promise<PointCloudObject[]> {
     const cdfAnnotations = [
       {
         volumeMetadata: { annotationId: 123 },
-        region: [new Cylinder(new THREE.Vector3(-0.03, 0.1, -1000), new THREE.Vector3(-0.03, 0.1, 1000), 0.03478)]
+        region: [new Cylinder(new Vector3(-0.03, 0.1, -1000), new Vector3(-0.03, 0.1, 1000), 0.03478)]
       }
     ];
 
@@ -49,7 +47,7 @@ class CustomDMProvider implements PointCloudStylableObjectProvider<DMDataSourceT
     const cdfAnnotations = [
       {
         volumeMetadata: { instanceRef: { externalId: '123', space: 'space' } },
-        region: [new Cylinder(new THREE.Vector3(-0.03, 0.1, -1000), new THREE.Vector3(-0.03, 0.1, 1000), 0.03478)]
+        region: [new Cylinder(new Vector3(-0.03, 0.1, -1000), new Vector3(-0.03, 0.1, 1000), 0.03478)]
       }
     ];
 
@@ -72,8 +70,8 @@ export default class PointCloudColorStylingVisualTest extends StreamingVisualTes
     );
   }
 
-  override createCamera(): THREE.PerspectiveCamera {
-    return new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 1.5);
+  override createCamera(): PerspectiveCamera {
+    return new PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 1.5);
   }
 
   public setup(testFixtureComponents: StreamingTestFixtureComponents): Promise<void> {

--- a/viewer/packages/rendering/src/CadMaterialManager.test.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.test.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { RawShaderMaterial } from 'three';
+import { Matrix4, Plane, Texture } from 'three';
 
 import { CadMaterialManager, createCadMaterial } from './CadMaterialManager';
 import type { Materials } from './rendering/materials';
@@ -44,7 +45,7 @@ describe('CadMaterialManager', () => {
     const cadMaterial = createCadMaterial(16);
 
     manager.addModelMaterials(modelIdentifier1, cadMaterial);
-    manager.clippingPlanes = [new THREE.Plane()];
+    manager.clippingPlanes = [new Plane()];
 
     expect(cadMaterial.materials.box.clippingPlanes).toEqual(manager.clippingPlanes);
   });
@@ -87,7 +88,7 @@ describe('CadMaterialManager', () => {
     const provider = manager.getModelNodeTransformProvider(modelIdentifier);
     provider.on('changed', listener);
 
-    provider.setNodeTransform(new NumericRange(0, 2), new THREE.Matrix4().makeRotationY(Math.PI / 4.0));
+    provider.setNodeTransform(new NumericRange(0, 2), new Matrix4().makeRotationY(Math.PI / 4.0));
 
     expect(listener).toHaveBeenCalled();
   });
@@ -95,7 +96,7 @@ describe('CadMaterialManager', () => {
   test('per-model clipping planes are combined with global clipping planes', () => {
     // Arrange
 
-    const globalClipPlanes = [new THREE.Plane(), new THREE.Plane()];
+    const globalClipPlanes = [new Plane(), new Plane()];
     manager.clippingPlanes = globalClipPlanes;
 
     const cadMaterial1 = createCadMaterial(16);
@@ -104,8 +105,8 @@ describe('CadMaterialManager', () => {
     manager.addModelMaterials(modelIdentifier2, cadMaterial2);
 
     // Act
-    cadMaterial1.clippingPlanesProvider.setClippingPlanes([new THREE.Plane(), new THREE.Plane()]);
-    cadMaterial2.clippingPlanesProvider.setClippingPlanes([new THREE.Plane()]);
+    cadMaterial1.clippingPlanesProvider.setClippingPlanes([new Plane(), new Plane()]);
+    cadMaterial2.clippingPlanesProvider.setClippingPlanes([new Plane()]);
 
     // Assert
     for (const material of iterateMaterials(manager.getModelMaterials(modelIdentifier1))) {
@@ -123,7 +124,7 @@ describe('CadMaterialManager', () => {
   test('addTexturedMeshMaterial creates textured material successfully', () => {
     // Arrange
     manager.addModelMaterials(modelIdentifier1, createCadMaterial(16));
-    const texture = new THREE.Texture();
+    const texture = new Texture();
     const sectorId = 123;
     // Act
     const texturedMaterial = manager.addTexturedMeshMaterial(modelIdentifier1, sectorId, texture);
@@ -140,7 +141,7 @@ describe('CadMaterialManager', () => {
   test('addTexturedMeshMaterial throws error when model identifier not found', () => {
     // Arrange
     const nonExistentModelId = Symbol('nonExistent');
-    const texture = new THREE.Texture();
+    const texture = new Texture();
     const sectorId = 123;
     // Act & Assert
     expect(() => {
@@ -151,8 +152,8 @@ describe('CadMaterialManager', () => {
   test('addTexturedMeshMaterial disposes existing textured material when replacing', () => {
     // Arrange
     manager.addModelMaterials(modelIdentifier1, createCadMaterial(16));
-    const texture1 = new THREE.Texture();
-    const texture2 = new THREE.Texture();
+    const texture1 = new Texture();
+    const texture2 = new Texture();
     const sectorId = 123;
     // Create first textured material
     const firstMaterial = manager.addTexturedMeshMaterial(modelIdentifier1, sectorId, texture1);
@@ -170,7 +171,7 @@ describe('CadMaterialManager', () => {
   test('addTexturedMeshMaterial clones original triangle mesh material properties', () => {
     // Arrange
     manager.addModelMaterials(modelIdentifier1, createCadMaterial(16));
-    const texture = new THREE.Texture();
+    const texture = new Texture();
     const sectorId = 123;
 
     const originalMaterial = manager.getModelMaterials(modelIdentifier1).triangleMesh;
@@ -189,6 +190,6 @@ describe('CadMaterialManager', () => {
   });
 });
 
-function* iterateMaterials(materials: Materials): Generator<THREE.RawShaderMaterial> {
-  return Object.values(materials).map(x => x as THREE.RawShaderMaterial);
+function* iterateMaterials(materials: Materials): Generator<RawShaderMaterial> {
+  return Object.values(materials).map(x => x as RawShaderMaterial);
 }

--- a/viewer/packages/rendering/src/CadMaterialManager.ts
+++ b/viewer/packages/rendering/src/CadMaterialManager.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Plane, RawShaderMaterial } from 'three';
+import { SRGBColorSpace, Texture, Vector2, Vector4 } from 'three';
 
 import type { Materials } from './rendering/materials';
 import { createMaterials, initializeDefinesAndUniforms, forEachMaterial } from './rendering/materials';
@@ -28,7 +29,7 @@ export type CadMaterial = {
   nodeTransformProvider: NodeTransformProvider;
   nodeAppearanceTextureBuilder: NodeAppearanceTextureBuilder;
   nodeTransformTextureBuilder: NodeTransformTextureBuilder;
-  matCapTexture: THREE.Texture;
+  matCapTexture: Texture;
   clippingPlanesProvider: ClippingPlanesProvider;
 };
 
@@ -37,11 +38,11 @@ type MaterialsWrapper = CadMaterial & {
 };
 
 export class CadMaterialManager {
-  get clippingPlanes(): THREE.Plane[] {
+  get clippingPlanes(): Plane[] {
     return this._clippingPlanes;
   }
 
-  set clippingPlanes(clippingPlanes: THREE.Plane[]) {
+  set clippingPlanes(clippingPlanes: Plane[]) {
     this._clippingPlanes = clippingPlanes;
     for (const modelIdentifier of this.materialsMap.keys()) {
       this.updateClippingPlanesForModel(modelIdentifier);
@@ -56,7 +57,7 @@ export class CadMaterialManager {
   private _renderMode: RenderMode = RenderMode.Color;
   private readonly materialsMap: Map<symbol, MaterialsWrapper> = new Map();
   // TODO: j-bjorne 29-04-2020: Move into separate cliping manager?
-  private _clippingPlanes: THREE.Plane[] = [];
+  private _clippingPlanes: Plane[] = [];
   private _needsRedraw: boolean = false;
 
   addModelMaterials(modelIdentifier: symbol, cadMaterial: CadMaterial): void {
@@ -113,7 +114,7 @@ export class CadMaterialManager {
     modelData.nodeAppearanceTextureBuilder.dispose();
   }
 
-  addTexturedMeshMaterial(modelIdentifier: symbol, sectorId: number, texture: THREE.Texture): THREE.RawShaderMaterial {
+  addTexturedMeshMaterial(modelIdentifier: symbol, sectorId: number, texture: Texture): RawShaderMaterial {
     const modelData = this.materialsMap.get(modelIdentifier);
 
     if (modelData === undefined) {
@@ -121,7 +122,7 @@ export class CadMaterialManager {
     }
 
     // Refer https://threejs.org/docs/#examples/en/loaders/GLTFLoader under Textures for details on GLTF model texture color information.
-    texture.colorSpace = THREE.SRGBColorSpace;
+    texture.colorSpace = SRGBColorSpace;
     texture.flipY = false;
 
     const newMaterial = modelData.materials.triangleMesh.clone();
@@ -163,7 +164,7 @@ export class CadMaterialManager {
     return wrapper.nodeAppearanceTextureBuilder.getDefaultAppearance();
   }
 
-  getModelClippingPlanes(modelIdentifier: symbol): THREE.Plane[] {
+  getModelClippingPlanes(modelIdentifier: symbol): Plane[] {
     const materialWrapper = this.materialsMap.get(modelIdentifier);
     if (materialWrapper === undefined) {
       throw new Error(
@@ -235,7 +236,7 @@ export class CadMaterialManager {
 
     const clippingPlanes = [...materialWrapper.clippingPlanesProvider.getClippingPlanes(), ...this.clippingPlanes];
     const clippingPlanesAsUniform = clippingPlanes.map(
-      p => new THREE.Vector4(p.normal.x, p.normal.y, p.normal.z, -p.constant)
+      p => new Vector4(p.normal.x, p.normal.y, p.normal.z, -p.constant)
     );
 
     forEachMaterial(materialWrapper.materials, m => {
@@ -267,7 +268,7 @@ export class CadMaterialManager {
       nodeTransformTextureBuilder.build();
 
       const transformsLookupTexture = nodeTransformTextureBuilder.transformLookupTexture;
-      const transformsLookupTextureSize = new THREE.Vector2(
+      const transformsLookupTextureSize = new Vector2(
         transformsLookupTexture.image.width,
         transformsLookupTexture.image.height
       );
@@ -291,14 +292,14 @@ export class CadMaterialManager {
     return wrapper;
   }
 
-  private applyToAllMaterials(callback: (material: THREE.RawShaderMaterial) => void) {
+  private applyToAllMaterials(callback: (material: RawShaderMaterial) => void) {
     for (const materialWrapper of this.materialsMap.values()) {
       const materials = materialWrapper.materials;
       forEachMaterial(materials, callback);
     }
   }
 
-  private initializeDefinesAndUniforms(modelIdentifier: symbol, material: THREE.RawShaderMaterial) {
+  private initializeDefinesAndUniforms(modelIdentifier: symbol, material: RawShaderMaterial) {
     const materialData = this.materialsMap.get(modelIdentifier);
 
     assert(materialData !== undefined);
@@ -327,7 +328,7 @@ export function createCadMaterial(maxTreeIndex: number): CadMaterial {
   const nodeTransformTextureBuilder = new NodeTransformTextureBuilder(maxTreeIndex + 1, nodeTransformProvider);
   nodeTransformTextureBuilder.build();
 
-  const matCapTexture = new THREE.Texture(getMatCapTextureData());
+  const matCapTexture = new Texture(getMatCapTextureData());
   matCapTexture.needsUpdate = true;
 
   const clippingPlanesProvider = new ClippingPlanesProvider();

--- a/viewer/packages/rendering/src/PointCloudMaterialManager.test.ts
+++ b/viewer/packages/rendering/src/PointCloudMaterialManager.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { AdditiveBlending } from 'three';
 import type { PointCloudObjectIdMaps } from './pointcloud-rendering/PointCloudObjectIdMaps';
 import { PointCloudMaterialManager } from './PointCloudMaterialManager';
 
@@ -43,7 +43,7 @@ describe('PointCloudMaterialManager', () => {
     const material1 = materialManager.getModelMaterial(modelIdentifier1);
     const material2 = materialManager.getModelMaterial(modelIdentifier2);
 
-    const materialParameters = { weighted: true, blending: THREE.AdditiveBlending };
+    const materialParameters = { weighted: true, blending: AdditiveBlending };
     materialManager.setModelsMaterialParameters(materialParameters);
 
     expect(material1.weighted).toBe(materialParameters.weighted);

--- a/viewer/packages/rendering/src/RenderPass.ts
+++ b/viewer/packages/rendering/src/RenderPass.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Camera, WebGLRenderer } from 'three';
 
 /**
  * The RenderPass interface describes some render pass
@@ -13,5 +13,5 @@ import type * as THREE from 'three';
  * some RenderPipelineProvider that defines the rendering job.
  */
 export interface RenderPass {
-  render(renderer: THREE.WebGLRenderer, camera: THREE.Camera): void;
+  render(renderer: WebGLRenderer, camera: Camera): void;
 }

--- a/viewer/packages/rendering/src/RenderPipelineExecutor.ts
+++ b/viewer/packages/rendering/src/RenderPipelineExecutor.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Camera } from 'three';
 import type { RenderPipelineProvider } from './RenderPipelineProvider';
 
 /**
@@ -10,6 +10,6 @@ import type { RenderPipelineProvider } from './RenderPipelineProvider';
  * a given pipeline from a RenderPipelineProvider.
  */
 export interface RenderPipelineExecutor {
-  render(renderPipeline: RenderPipelineProvider, camera: THREE.Camera): void;
+  render(renderPipeline: RenderPipelineProvider, camera: Camera): void;
   dispose(): void;
 }

--- a/viewer/packages/rendering/src/pipeline-executors/BasicPipelineExecutor.test.ts
+++ b/viewer/packages/rendering/src/pipeline-executors/BasicPipelineExecutor.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { PerspectiveCamera, WebGLRenderer } from 'three';
 import { It, Mock, Times } from 'moq.ts';
 import { BasicPipelineExecutor } from './BasicPipelineExecutor';
 import type { RenderPass } from '../RenderPass';
@@ -11,7 +11,7 @@ import type { RenderPipelineProvider } from '../RenderPipelineProvider';
 describe(BasicPipelineExecutor.name, () => {
   let basicPipelineExecutor: BasicPipelineExecutor;
   beforeEach(() => {
-    const rendererMock = new Mock<THREE.WebGLRenderer>()
+    const rendererMock = new Mock<WebGLRenderer>()
       .setup(p => (p.info.autoReset = It.IsAny()))
       .callback(() => true)
       .setup(p => p.info.reset())
@@ -20,7 +20,7 @@ describe(BasicPipelineExecutor.name, () => {
   });
 
   test('Basic pipeline executor can succsessfully execute a render pipeline', () => {
-    const mockCamera = new Mock<THREE.PerspectiveCamera>();
+    const mockCamera = new Mock<PerspectiveCamera>();
 
     const firstRenderPassMock = new Mock<RenderPass>().setup(p => p.render(It.IsAny(), It.IsAny())).returns();
     const secondRenderPassMock = new Mock<RenderPass>().setup(p => p.render(It.IsAny(), It.IsAny())).returns();

--- a/viewer/packages/rendering/src/pipeline-executors/BasicPipelineExecutor.ts
+++ b/viewer/packages/rendering/src/pipeline-executors/BasicPipelineExecutor.ts
@@ -2,20 +2,20 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { PerspectiveCamera, WebGLRenderer } from 'three';
 import type { RenderPipelineExecutor } from '../RenderPipelineExecutor';
 import type { RenderPipelineProvider } from '../RenderPipelineProvider';
 
 export class BasicPipelineExecutor implements RenderPipelineExecutor {
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
 
-  constructor(renderer: THREE.WebGLRenderer) {
+  constructor(renderer: WebGLRenderer) {
     this._renderer = renderer;
 
     renderer.info.autoReset = false;
   }
 
-  public render(renderPipeline: RenderPipelineProvider, camera: THREE.PerspectiveCamera): void {
+  public render(renderPipeline: RenderPipelineProvider, camera: PerspectiveCamera): void {
     this._renderer.info.reset();
     for (const renderPass of renderPipeline.pipeline(this._renderer)) {
       renderPass.render(this._renderer, camera);

--- a/viewer/packages/rendering/src/pipeline-executors/StepPipelineExecutor.test.ts
+++ b/viewer/packages/rendering/src/pipeline-executors/StepPipelineExecutor.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { PerspectiveCamera, WebGLRenderer } from 'three';
 import { It, Mock, Times } from 'moq.ts';
 import type { RenderPass } from '../RenderPass';
 import { StepPipelineExecutor } from './StepPipelineExecutor';
@@ -11,7 +11,7 @@ import type { RenderPipelineProvider } from '../RenderPipelineProvider';
 describe(StepPipelineExecutor.name, () => {
   let stepPipelineExecutor: StepPipelineExecutor;
   beforeEach(() => {
-    const rendererMock = new Mock<THREE.WebGLRenderer>()
+    const rendererMock = new Mock<WebGLRenderer>()
       .setup(p => (p.info.autoReset = It.IsAny()))
       .callback(() => true)
       .setup(p => p.info.reset())
@@ -29,7 +29,7 @@ describe(StepPipelineExecutor.name, () => {
   });
 
   test('StepPipelineExecutor pipeline executor can succsessfully execute a render pipeline', () => {
-    const mockCamera = new Mock<THREE.PerspectiveCamera>();
+    const mockCamera = new Mock<PerspectiveCamera>();
 
     const firstRenderPassMock = new Mock<RenderPass>().setup(p => p.render(It.IsAny(), It.IsAny())).returns();
     const secondRenderPassMock = new Mock<RenderPass>().setup(p => p.render(It.IsAny(), It.IsAny())).returns();
@@ -50,7 +50,7 @@ describe(StepPipelineExecutor.name, () => {
   });
 
   test('StepPipelineExecutor pipeline executor can succsessfully partially execute a render pipeline', () => {
-    const mockCamera = new Mock<THREE.PerspectiveCamera>();
+    const mockCamera = new Mock<PerspectiveCamera>();
 
     const firstRenderPassMock = new Mock<RenderPass>().setup(p => p.render(It.IsAny(), It.IsAny())).returns();
     const secondRenderPassMock = new Mock<RenderPass>().setup(p => p.render(It.IsAny(), It.IsAny())).returns();

--- a/viewer/packages/rendering/src/pipeline-executors/StepPipelineExecutor.ts
+++ b/viewer/packages/rendering/src/pipeline-executors/StepPipelineExecutor.ts
@@ -2,13 +2,13 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Camera, WebGLRenderer } from 'three';
 import type { RenderPipelineExecutor } from '../RenderPipelineExecutor';
 import type { RenderPipelineProvider } from '../RenderPipelineProvider';
 import { GpuTimer } from '../utilities/GpuTimer';
 
 export class StepPipelineExecutor implements RenderPipelineExecutor {
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
   private _numSteps: number | undefined;
   private readonly _gpuTimer: GpuTimer;
 
@@ -20,13 +20,13 @@ export class StepPipelineExecutor implements RenderPipelineExecutor {
     return this._gpuTimer.timings;
   }
 
-  constructor(renderer: THREE.WebGLRenderer) {
+  constructor(renderer: WebGLRenderer) {
     this._renderer = renderer;
     renderer.info.autoReset = false;
     this._gpuTimer = new GpuTimer(renderer.getContext() as WebGL2RenderingContext);
   }
 
-  public render(renderPipeline: RenderPipelineProvider, camera: THREE.Camera): void {
+  public render(renderPipeline: RenderPipelineProvider, camera: Camera): void {
     this._renderer.info.reset();
     let count = 0;
 

--- a/viewer/packages/rendering/src/pointcloud-rendering/PointCloudObjectAppearanceTexture.ts
+++ b/viewer/packages/rendering/src/pointcloud-rendering/PointCloudObjectAppearanceTexture.ts
@@ -4,7 +4,8 @@
 
 import { generateDataTexture } from './texture-generation';
 
-import * as THREE from 'three';
+import type { DataTexture } from 'three';
+import { Color } from 'three';
 import type { CompletePointCloudAppearance, StyledPointCloudVolumeCollection } from '@reveal/pointcloud-styling';
 import { DefaultPointCloudAppearance, isPointCloudObjectCollection } from '@reveal/pointcloud-styling';
 import type { PointCloudObjectIdMaps } from './PointCloudObjectIdMaps';
@@ -14,7 +15,7 @@ import { dmInstanceRefToKey, createUint8View } from '@reveal/utilities';
 import { sortBy } from 'lodash-es';
 
 export class PointCloudObjectAppearanceTexture {
-  private readonly _objectStyleTexture: THREE.DataTexture;
+  private readonly _objectStyleTexture: DataTexture;
   private _needsReconstruction: boolean = true;
 
   private readonly _styledObjectSets: StyledPointCloudVolumeCollection<DataSourceType>[] = [];
@@ -27,7 +28,7 @@ export class PointCloudObjectAppearanceTexture {
   private _annotationIdsToObjectId: Map<number | DMInstanceKey, number> | undefined;
 
   constructor(width: number, height: number) {
-    this._objectStyleTexture = generateDataTexture(width, height, new THREE.Color(0x0), 0x01); // Initialize with visibility bit set
+    this._objectStyleTexture = generateDataTexture(width, height, new Color(0x0), 0x01); // Initialize with visibility bit set
 
     this._width = width;
     this._height = height;
@@ -142,7 +143,7 @@ export class PointCloudObjectAppearanceTexture {
     return this._defaultAppearance;
   }
 
-  get objectStyleTexture(): THREE.DataTexture {
+  get objectStyleTexture(): DataTexture {
     return this._objectStyleTexture;
   }
 }

--- a/viewer/packages/rendering/src/render-passes/GeometryPass.ts
+++ b/viewer/packages/rendering/src/render-passes/GeometryPass.ts
@@ -2,21 +2,21 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Camera, Object3D, WebGLRenderer } from 'three';
 import type { CadMaterialManager } from '../CadMaterialManager';
 import { RenderMode } from '../rendering/RenderMode';
 import type { RenderPass } from '../RenderPass';
 import { getLayerMask } from '../utilities/renderUtilities';
 
 export class GeometryPass implements RenderPass {
-  private readonly _geometryScene: THREE.Object3D;
+  private readonly _geometryScene: Object3D;
   private readonly _materialManager: CadMaterialManager;
   private readonly _renderMode: RenderMode;
   private readonly _overrideRenderLayer: number | undefined;
   private readonly _renderLayer: number;
 
   constructor(
-    scene: THREE.Object3D,
+    scene: Object3D,
     materialManager: CadMaterialManager,
     renderMode = RenderMode.Color,
     overrideLayerMask?: number
@@ -28,7 +28,7 @@ export class GeometryPass implements RenderPass {
     this._renderLayer = this._overrideRenderLayer ?? getLayerMask(this._renderMode);
   }
 
-  public render(renderer: THREE.WebGLRenderer, camera: THREE.Camera): void {
+  public render(renderer: WebGLRenderer, camera: Camera): void {
     const currentCameraMask = camera.layers.mask;
     let renderMode: RenderMode = this._renderMode;
     try {

--- a/viewer/packages/rendering/src/render-passes/PointCloudEffectsPass.ts
+++ b/viewer/packages/rendering/src/render-passes/PointCloudEffectsPass.ts
@@ -2,19 +2,19 @@
  * Copyright 2022 Cognite AS
  */
 import { WebGLRendererStateHelper } from '@reveal/utilities';
-import type * as THREE from 'three';
+import type { Camera, Object3D, WebGLRenderer } from 'three';
 import type { RenderPass } from '../RenderPass';
 import { getLayerMask, RenderLayer, setRendererParameters } from '../utilities/renderUtilities';
 import type { PointCloudPassParameters } from './types';
 import type { PointCloudMaterialManager } from '../PointCloudMaterialManager';
 
 export class PointCloudEffectsPass implements RenderPass {
-  private readonly _viewerScene: THREE.Object3D;
+  private readonly _viewerScene: Object3D;
   private readonly _pointCloudMaterialManager: PointCloudMaterialManager;
   private readonly _passMaterialParameters: PointCloudPassParameters;
 
   constructor(
-    scene: THREE.Object3D,
+    scene: Object3D,
     pointCloudMaterialManager: PointCloudMaterialManager,
     materialParameters?: PointCloudPassParameters
   ) {
@@ -23,7 +23,7 @@ export class PointCloudEffectsPass implements RenderPass {
     this._passMaterialParameters = materialParameters ?? {};
   }
 
-  public render(renderer: THREE.WebGLRenderer, camera: THREE.Camera): void {
+  public render(renderer: WebGLRenderer, camera: Camera): void {
     const currentCameraMask = camera.layers.mask;
     const rendererStateHelper = new WebGLRendererStateHelper(renderer);
     try {

--- a/viewer/packages/rendering/src/render-passes/PostProcessingPass.ts
+++ b/viewer/packages/rendering/src/render-passes/PostProcessingPass.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Camera, Material, Mesh, Scene, ShaderMaterial, WebGLRenderer } from 'three';
 import type { PostProcessingObjectsVisibilityParameters } from './types';
 import { transparentBlendOptions } from './types';
 import type { RenderPass } from '../RenderPass';
@@ -24,9 +24,9 @@ import { shouldApplyEdl } from '../render-pipeline-providers/pointCloudParameter
  * triangles in a specific render order.
  */
 export class PostProcessingPass implements RenderPass {
-  private readonly _scene: THREE.Scene;
-  private readonly _postProcessingObjects: THREE.Mesh[];
-  private readonly _pointcloudBlitMaterial: THREE.ShaderMaterial;
+  private readonly _scene: Scene;
+  private readonly _postProcessingObjects: Mesh[];
+  private readonly _pointcloudBlitMaterial: ShaderMaterial;
   private readonly _postProcessingOptions: PostProcessingPipelineOptions;
   private readonly setBlendFactorByBackVisibility: () => void;
 
@@ -39,7 +39,7 @@ export class PostProcessingPass implements RenderPass {
     this.setBlendFactorByBackVisibility();
   }
 
-  constructor(scene: THREE.Scene, postProcessingPipelineOptions: PostProcessingPipelineOptions) {
+  constructor(scene: Scene, postProcessingPipelineOptions: PostProcessingPipelineOptions) {
     this._scene = scene;
     this._postProcessingOptions = postProcessingPipelineOptions;
 
@@ -113,7 +113,7 @@ export class PostProcessingPass implements RenderPass {
     this._postProcessingObjects = [backBlitObject, ghostBlitObject, inFrontBlitObject, pointcloudBlitObject];
   }
 
-  public render(renderer: THREE.WebGLRenderer, camera: THREE.Camera): void {
+  public render(renderer: WebGLRenderer, camera: Camera): void {
     if (shouldApplyEdl(this._postProcessingOptions.edlOptions)) {
       this._pointcloudBlitMaterial.uniforms.screenWidth = { value: this._postProcessingOptions.pointCloud.width };
       this._pointcloudBlitMaterial.uniforms.screenHeight = { value: this._postProcessingOptions.pointCloud.height };
@@ -127,7 +127,7 @@ export class PostProcessingPass implements RenderPass {
   public dispose(): void {
     this._postProcessingObjects.forEach(postProcessingObject => {
       postProcessingObject.geometry.dispose();
-      (postProcessingObject.material as THREE.Material).dispose();
+      (postProcessingObject.material as Material).dispose();
       this._scene.remove(postProcessingObject);
     });
   }

--- a/viewer/packages/rendering/src/render-passes/SSAOPass.ts
+++ b/viewer/packages/rendering/src/render-passes/SSAOPass.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Camera, Mesh, Texture, WebGLRenderer } from 'three';
+import { GLSL3, Matrix4, RawShaderMaterial, Vector3 } from 'three';
 import { ssaoShaders } from '../rendering/shaders';
 import type { SsaoParameters } from '../rendering/types';
 import type { RenderPass } from '../RenderPass';
@@ -11,8 +12,8 @@ import { createFullScreenTriangleMesh, unitOrthographicCamera } from '../utiliti
 import SeededRandom from 'random-seed';
 
 export class SSAOPass implements RenderPass {
-  private readonly _fullScreenTriangle: THREE.Mesh;
-  private readonly _ssaoShaderMaterial: THREE.RawShaderMaterial;
+  private readonly _fullScreenTriangle: Mesh;
+  private readonly _ssaoShaderMaterial: RawShaderMaterial;
 
   set ssaoParameters(ssaoParameters: SsaoParameters) {
     const { sampleSize, depthCheckBias, sampleRadius } = ssaoParameters;
@@ -29,26 +30,26 @@ export class SSAOPass implements RenderPass {
     this._fullScreenTriangle.visible = sampleSize > 0;
   }
 
-  constructor(depthTexture: THREE.Texture | null, ssaoParameters: SsaoParameters) {
+  constructor(depthTexture: Texture | null, ssaoParameters: SsaoParameters) {
     const { sampleSize, depthCheckBias, sampleRadius } = ssaoParameters;
 
     const uniforms = {
       tDepth: { value: depthTexture },
-      projMatrix: { value: new THREE.Matrix4() },
-      inverseProjectionMatrix: { value: new THREE.Matrix4() },
+      projMatrix: { value: new Matrix4() },
+      inverseProjectionMatrix: { value: new Matrix4() },
       sampleRadius: { value: sampleRadius },
       bias: { value: depthCheckBias },
       kernel: { value: this.createKernel(sampleSize) }
     };
 
-    this._ssaoShaderMaterial = new THREE.RawShaderMaterial({
+    this._ssaoShaderMaterial = new RawShaderMaterial({
       vertexShader: ssaoShaders.vertex,
       fragmentShader: ssaoShaders.fragment,
       uniforms,
       defines: {
         MAX_KERNEL_SIZE: sampleSize
       },
-      glslVersion: THREE.GLSL3,
+      glslVersion: GLSL3,
       depthTest: false,
       depthWrite: false
     });
@@ -57,18 +58,18 @@ export class SSAOPass implements RenderPass {
     this._fullScreenTriangle.visible = sampleSize > 0;
   }
 
-  public render(renderer: THREE.WebGLRenderer, camera: THREE.Camera): void {
+  public render(renderer: WebGLRenderer, camera: Camera): void {
     this._ssaoShaderMaterial.uniforms.inverseProjectionMatrix.value = camera.projectionMatrixInverse;
     this._ssaoShaderMaterial.uniforms.projMatrix.value = camera.projectionMatrix;
 
     renderer.render(this._fullScreenTriangle, unitOrthographicCamera);
   }
 
-  private createKernel(kernelSize: number): THREE.Vector3[] {
+  private createKernel(kernelSize: number): Vector3[] {
     const random = SeededRandom.create('some_seed');
-    const result: THREE.Vector3[] = [];
+    const result: Vector3[] = [];
     for (let i = 0; i < kernelSize; i++) {
-      const sample = new THREE.Vector3(1, 1, 1);
+      const sample = new Vector3(1, 1, 1);
       while (sample.length() > 1.0) {
         // Ensure some distance in samples
         sample.x = random.random() * 2 - 1;

--- a/viewer/packages/rendering/src/render-passes/types.ts
+++ b/viewer/packages/rendering/src/render-passes/types.ts
@@ -3,14 +3,15 @@
  */
 
 import type { PointShape } from '../pointcloud-rendering';
-import * as THREE from 'three';
+import type { Blending, BlendingDstFactor, BlendingSrcFactor, DepthTexture, IUniform, Texture } from 'three';
+import { OneFactor, OneMinusDstAlphaFactor, OneMinusSrcAlphaFactor, SrcAlphaFactor } from 'three';
 import type { EdlOptions } from '../rendering/types';
 
 export type BlendOptions = {
-  blendDestination: THREE.BlendingDstFactor;
-  blendSource: THREE.BlendingDstFactor | THREE.BlendingSrcFactor;
-  blendDestinationAlpha?: THREE.BlendingDstFactor;
-  blendSourceAlpha?: THREE.BlendingDstFactor | THREE.BlendingSrcFactor;
+  blendDestination: BlendingDstFactor;
+  blendSource: BlendingDstFactor | BlendingSrcFactor;
+  blendDestinationAlpha?: BlendingDstFactor;
+  blendSourceAlpha?: BlendingDstFactor | BlendingSrcFactor;
 };
 
 export enum BlitEffect {
@@ -20,10 +21,10 @@ export enum BlitEffect {
 }
 
 export type BlitOptions = {
-  texture: THREE.Texture;
+  texture: Texture;
   effect?: BlitEffect;
-  depthTexture: THREE.DepthTexture | null;
-  ssaoTexture?: THREE.Texture;
+  depthTexture: DepthTexture | null;
+  ssaoTexture?: Texture;
   blendOptions?: BlendOptions;
   overrideAlpha?: number;
   edges?: boolean;
@@ -31,32 +32,32 @@ export type BlitOptions = {
 };
 
 export type DepthBlendBlitOptions = {
-  texture: THREE.Texture;
-  depthTexture: THREE.DepthTexture | null;
-  blendTexture: THREE.Texture;
-  blendDepthTexture: THREE.Texture | null;
+  texture: Texture;
+  depthTexture: DepthTexture | null;
+  blendTexture: Texture;
+  blendDepthTexture: Texture | null;
   blendFactor: number;
   overrideAlpha?: number;
   outline?: boolean;
 };
 
 export type PointCloudPostProcessingOptions = {
-  logDepthTexture: THREE.Texture;
-  texture: THREE.Texture;
-  depthTexture: THREE.DepthTexture | null;
+  logDepthTexture: Texture;
+  texture: Texture;
+  depthTexture: DepthTexture | null;
   pointBlending: boolean;
   edlOptions: EdlOptions;
 };
 
 export const transparentBlendOptions: BlendOptions = {
-  blendDestination: THREE.OneMinusSrcAlphaFactor,
-  blendSource: THREE.SrcAlphaFactor,
-  blendDestinationAlpha: THREE.OneFactor,
-  blendSourceAlpha: THREE.OneMinusDstAlphaFactor
+  blendDestination: OneMinusSrcAlphaFactor,
+  blendSource: SrcAlphaFactor,
+  blendDestinationAlpha: OneFactor,
+  blendSourceAlpha: OneMinusDstAlphaFactor
 };
 
 export type ThreeUniforms = {
-  [uniform: string]: THREE.IUniform<any>;
+  [uniform: string]: IUniform<any>;
 };
 
 export type PointCloudMaterialParameters = {
@@ -65,9 +66,9 @@ export type PointCloudMaterialParameters = {
   useEDL?: boolean;
   hqDepthPass?: boolean;
   depthWrite?: boolean;
-  blending?: THREE.Blending;
-  blendSrc?: THREE.BlendingDstFactor | THREE.BlendingSrcFactor;
-  blendDst?: THREE.BlendingDstFactor;
+  blending?: Blending;
+  blendSrc?: BlendingDstFactor | BlendingSrcFactor;
+  blendDst?: BlendingDstFactor;
   colorWrite?: boolean;
 };
 

--- a/viewer/packages/rendering/src/render-pipeline-providers/CadGeometryRenderModePipelineProvider.ts
+++ b/viewer/packages/rendering/src/render-pipeline-providers/CadGeometryRenderModePipelineProvider.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Scene, WebGLRenderTarget, WebGLRenderer } from 'three';
+import { Vector2 } from 'three';
 import type { CadMaterialManager } from '../CadMaterialManager';
 import { GeometryPass } from '../render-passes/GeometryPass';
 import type { RenderPass } from '../RenderPass';
@@ -13,29 +14,29 @@ import type { SceneHandler } from '@reveal/utilities';
 import type { SettableRenderTarget } from '../rendering/SettableRenderTarget';
 
 export class CadGeometryRenderModePipelineProvider implements RenderPipelineProvider, SettableRenderTarget {
-  private readonly _renderTargetData: { currentRenderSize: THREE.Vector2 };
+  private readonly _renderTargetData: { currentRenderSize: Vector2 };
   private readonly _geometryPass: GeometryPass;
-  private _outputRenderTarget: THREE.WebGLRenderTarget | null = null;
+  private _outputRenderTarget: WebGLRenderTarget | null = null;
   private _autoSizeRenderTarget = false;
 
-  public readonly scene: THREE.Scene;
+  public readonly scene: Scene;
 
   constructor(renderMode: RenderMode, materialManager: CadMaterialManager, sceneHandler: SceneHandler) {
     this.scene = sceneHandler.scene;
     this._renderTargetData = {
-      currentRenderSize: new THREE.Vector2(1, 1)
+      currentRenderSize: new Vector2(1, 1)
     };
 
     const layerMask = getLayerMask(RenderLayer.InFront) | getLayerMask(RenderLayer.Back);
     this._geometryPass = new GeometryPass(sceneHandler.scene, materialManager, renderMode, layerMask);
   }
 
-  public setOutputRenderTarget(target: THREE.WebGLRenderTarget | null, autoSizeRenderTarget = true): void {
+  public setOutputRenderTarget(target: WebGLRenderTarget | null, autoSizeRenderTarget = true): void {
     this._outputRenderTarget = target;
     this._autoSizeRenderTarget = autoSizeRenderTarget;
   }
 
-  public *pipeline(renderer: THREE.WebGLRenderer): Generator<RenderPass> {
+  public *pipeline(renderer: WebGLRenderer): Generator<RenderPass> {
     this.updateRenderTargetSizes(renderer);
     renderer.setRenderTarget(this._outputRenderTarget);
     yield this._geometryPass;
@@ -43,8 +44,8 @@ export class CadGeometryRenderModePipelineProvider implements RenderPipelineProv
 
   public dispose(): void {}
 
-  private updateRenderTargetSizes(renderer: THREE.WebGLRenderer): void {
-    const renderSize = new THREE.Vector2();
+  private updateRenderTargetSizes(renderer: WebGLRenderer): void {
+    const renderSize = new Vector2();
     renderer.getDrawingBufferSize(renderSize);
 
     const { x: width, y: height } = renderSize;

--- a/viewer/packages/rendering/src/render-pipeline-providers/CadGeometryRenderPipelineProvider.ts
+++ b/viewer/packages/rendering/src/render-pipeline-providers/CadGeometryRenderPipelineProvider.ts
@@ -4,7 +4,8 @@
 
 import type { SceneHandler } from '@reveal/utilities';
 import { WebGLRendererStateHelper } from '@reveal/utilities';
-import * as THREE from 'three';
+import type { Object3D, WebGLRenderer } from 'three';
+import { Color, Vector2 } from 'three';
 import type { CadMaterialManager } from '../CadMaterialManager';
 import { GeometryPass } from '../render-passes/GeometryPass';
 import { RenderMode } from '../rendering/RenderMode';
@@ -24,7 +25,7 @@ export class CadGeometryRenderPipelineProvider implements RenderPipelineProvider
   private readonly _cadGeometryRenderTargets: CadGeometryRenderTargets;
   private readonly _cadGeometryRenderPasses: CadGeometryRenderPasses;
   private readonly _cadModels: {
-    cadNode: THREE.Object3D;
+    cadNode: Object3D;
     modelIdentifier: symbol;
   }[];
   private readonly _materialManager: CadMaterialManager;
@@ -43,7 +44,7 @@ export class CadGeometryRenderPipelineProvider implements RenderPipelineProvider
     this._cadGeometryRenderPasses = this.initializeRenderPasses(sceneHandler);
   }
 
-  public *pipeline(renderer: THREE.WebGLRenderer): Generator<RenderPass> {
+  public *pipeline(renderer: WebGLRenderer): Generator<RenderPass> {
     this.pipelineSetup(renderer);
 
     try {
@@ -81,17 +82,17 @@ export class CadGeometryRenderPipelineProvider implements RenderPipelineProvider
     this._cadGeometryRenderTargets.inFront.dispose();
   }
 
-  private pipelineSetup(renderer: THREE.WebGLRenderer) {
+  private pipelineSetup(renderer: WebGLRenderer) {
     this._rendererStateHelper = new WebGLRendererStateHelper(renderer);
     this._rendererStateHelper.autoClear = true;
-    this._rendererStateHelper.setClearColor(renderer.getClearColor(new THREE.Color()), 0);
+    this._rendererStateHelper.setClearColor(renderer.getClearColor(new Color()), 0);
 
     this.updateRenderTargetSizes(renderer);
   }
 
   private initializeRenderTargets(multisampleCount: number): CadGeometryRenderTargets {
     return {
-      currentRenderSize: new THREE.Vector2(1, 1),
+      currentRenderSize: new Vector2(1, 1),
       back: createRenderTarget(1, 1, multisampleCount),
       ghost: createRenderTarget(1, 1, multisampleCount),
       inFront: createRenderTarget(1, 1, multisampleCount)
@@ -106,8 +107,8 @@ export class CadGeometryRenderPipelineProvider implements RenderPipelineProvider
     };
   }
 
-  private updateRenderTargetSizes(renderer: THREE.WebGLRenderer): void {
-    const renderSize = new THREE.Vector2();
+  private updateRenderTargetSizes(renderer: WebGLRenderer): void {
+    const renderSize = new Vector2();
     renderer.getDrawingBufferSize(renderSize);
 
     const { x: width, y: height } = renderSize;

--- a/viewer/packages/rendering/src/render-pipeline-providers/DefaultRenderPipelineProvider.test.ts
+++ b/viewer/packages/rendering/src/render-pipeline-providers/DefaultRenderPipelineProvider.test.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { Color, Object3D, Vector2 } from 'three';
 import type { IMock } from 'moq.ts';
 import { It, Mock } from 'moq.ts';
 import { DefaultRenderPipelineProvider } from './DefaultRenderPipelineProvider';
@@ -14,26 +15,26 @@ import { createCadModel, createPointCloudModel } from '../../../../test-utilitie
 import type { PointCloudMaterialManager } from '../PointCloudMaterialManager';
 
 describe(DefaultRenderPipelineProvider.name, () => {
-  let rendererMock: IMock<THREE.WebGLRenderer>;
+  let rendererMock: IMock<WebGLRenderer>;
   let cadNodeMock: CadNode;
-  let pointCloudNodeMock: THREE.Object3D & { modelIdentifier: symbol };
+  let pointCloudNodeMock: Object3D & { modelIdentifier: symbol };
 
   const modelIdentifierSymbol = Symbol('0');
 
   beforeEach(() => {
-    rendererMock = new Mock<THREE.WebGLRenderer>()
+    rendererMock = new Mock<WebGLRenderer>()
       .setup(p => (p.info.autoReset = It.IsAny()))
       .callback(() => true)
       .setup(p => p.info.reset())
       .returns()
       .setup(p => p.getClearColor(It.IsAny()))
-      .returns(new THREE.Color())
+      .returns(new Color())
       .setup(p => p.getClearAlpha())
       .returns(0)
       .setup(p => p.setClearColor(It.IsAny(), It.IsAny()))
       .returns()
       .setup(p => p.getDrawingBufferSize(It.IsAny()))
-      .returns(new THREE.Vector2())
+      .returns(new Vector2())
       .setup(p => p.setRenderTarget(It.IsAny()))
       .returns()
       .setup(p => p.clear())
@@ -127,7 +128,7 @@ describe(DefaultRenderPipelineProvider.name, () => {
 
     const sceneHandler = new SceneHandler();
 
-    sceneHandler.addObject3D(new THREE.Object3D());
+    sceneHandler.addObject3D(new Object3D());
 
     const defaultRenderPipelineProvider = new DefaultRenderPipelineProvider(
       materialManagerMock.object(),

--- a/viewer/packages/rendering/src/render-pipeline-providers/DefaultRenderPipelineProvider.ts
+++ b/viewer/packages/rendering/src/render-pipeline-providers/DefaultRenderPipelineProvider.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Material, Mesh, Object3D, Scene, WebGLRenderTarget, WebGLRenderer } from 'three';
+import { Color, GLSL3, RawShaderMaterial, Vector2 } from 'three';
 import { cloneDeep } from 'lodash-es';
 import type { CadMaterialManager } from '../CadMaterialManager';
 import type { RenderPass } from '../RenderPass';
@@ -22,25 +23,25 @@ import type { PointCloudMaterialManager } from '../PointCloudMaterialManager';
 import type { SettableRenderTarget } from '../rendering/SettableRenderTarget';
 
 export class DefaultRenderPipelineProvider implements RenderPipelineProvider, SettableRenderTarget {
-  private readonly _viewerScene: THREE.Scene;
+  private readonly _viewerScene: Scene;
   private readonly _renderTargetData: RenderTargetData;
   private readonly _cadModels: {
-    cadNode: THREE.Object3D;
+    cadNode: Object3D;
     modelIdentifier: symbol;
   }[];
   private readonly _pointCloudModels: {
-    pointCloudNode: THREE.Object3D;
+    pointCloudNode: Object3D;
     modelIdentifier: symbol;
   }[];
   private readonly _customObjects: ICustomObject[];
   private _autoResizeOutputTarget: boolean;
-  private _outputRenderTarget: THREE.WebGLRenderTarget | null;
+  private _outputRenderTarget: WebGLRenderTarget | null;
   private readonly _cadGeometryRenderPipeline: CadGeometryRenderPipelineProvider;
   private readonly _pointCloudRenderPipeline: PointCloudRenderPipelineProvider;
   private readonly _postProcessingPass: PostProcessingPass;
   private readonly _ssaoPass: SSAOPass;
-  private readonly _blitToScreenMaterial: THREE.RawShaderMaterial;
-  private readonly _blitToScreenMesh: THREE.Mesh;
+  private readonly _blitToScreenMaterial: RawShaderMaterial;
+  private readonly _blitToScreenMesh: Mesh;
   private readonly _materialManager: CadMaterialManager;
   private _rendererStateHelper: WebGLRendererStateHelper | undefined;
 
@@ -71,7 +72,7 @@ export class DefaultRenderPipelineProvider implements RenderPipelineProvider, Se
     sceneHandler: SceneHandler,
     renderOptions: RenderOptions,
     outputRenderTarget?: {
-      target: THREE.WebGLRenderTarget;
+      target: WebGLRenderTarget;
       autoSize?: boolean;
     }
   ) {
@@ -81,7 +82,7 @@ export class DefaultRenderPipelineProvider implements RenderPipelineProvider, Se
     this._outputRenderTarget = outputRenderTarget?.target ?? null;
 
     this._renderTargetData = {
-      currentRenderSize: new THREE.Vector2(1, 1),
+      currentRenderSize: new Vector2(1, 1),
       ssaoRenderTarget: createRenderTarget(),
       postProcessingRenderTarget: createRenderTarget()
     };
@@ -118,14 +119,14 @@ export class DefaultRenderPipelineProvider implements RenderPipelineProvider, Se
       ...this._cadGeometryRenderPipeline.cadGeometryRenderTargets
     });
 
-    this._blitToScreenMaterial = new THREE.RawShaderMaterial({
+    this._blitToScreenMaterial = new RawShaderMaterial({
       vertexShader: blitShaders.vertex,
       fragmentShader: blitShaders.fragment,
       uniforms: {
         tDiffuse: { value: this._renderTargetData.postProcessingRenderTarget.texture },
         tDepth: { value: this._renderTargetData.postProcessingRenderTarget.depthTexture }
       },
-      glslVersion: THREE.GLSL3,
+      glslVersion: GLSL3,
       defines: {
         DEPTH_WRITE: true,
         FXAA: true
@@ -137,12 +138,12 @@ export class DefaultRenderPipelineProvider implements RenderPipelineProvider, Se
     this.renderOptions = cloneDeep(renderOptions);
   }
 
-  public setOutputRenderTarget(target: THREE.WebGLRenderTarget | null, autoSizeRenderTarget?: boolean): void {
+  public setOutputRenderTarget(target: WebGLRenderTarget | null, autoSizeRenderTarget?: boolean): void {
     this._outputRenderTarget = target;
     if (autoSizeRenderTarget) this._autoResizeOutputTarget = autoSizeRenderTarget;
   }
 
-  public *pipeline(renderer: THREE.WebGLRenderer): Generator<RenderPass> {
+  public *pipeline(renderer: WebGLRenderer): Generator<RenderPass> {
     this.pipelineSetup(renderer);
 
     const modelIdentifiers = this._cadModels.map(cadModel => cadModel.modelIdentifier);
@@ -192,13 +193,13 @@ export class DefaultRenderPipelineProvider implements RenderPipelineProvider, Se
     this._renderTargetData.postProcessingRenderTarget.dispose();
 
     this._blitToScreenMesh.geometry.dispose();
-    (this._blitToScreenMesh.material as THREE.Material).dispose();
+    (this._blitToScreenMesh.material as Material).dispose();
   }
 
-  private pipelineSetup(renderer: THREE.WebGLRenderer) {
+  private pipelineSetup(renderer: WebGLRenderer) {
     this._rendererStateHelper = new WebGLRendererStateHelper(renderer);
     this._rendererStateHelper.autoClear = true;
-    this._rendererStateHelper.setClearColor(renderer.getClearColor(new THREE.Color()), 0);
+    this._rendererStateHelper.setClearColor(renderer.getClearColor(new Color()), 0);
 
     this._cadModels.forEach(cadModel => {
       cadModel.cadNode.matrixAutoUpdate = false;
@@ -211,8 +212,8 @@ export class DefaultRenderPipelineProvider implements RenderPipelineProvider, Se
     this.updateRenderTargetSizes(renderer);
   }
 
-  private updateRenderTargetSizes(renderer: THREE.WebGLRenderer): void {
-    const renderSize = new THREE.Vector2();
+  private updateRenderTargetSizes(renderer: WebGLRenderer): void {
+    const renderSize = new Vector2();
     renderer.getDrawingBufferSize(renderSize);
 
     const { x: width, y: height } = renderSize;

--- a/viewer/packages/rendering/src/render-pipeline-providers/PointCloudRenderPipelineProvider.ts
+++ b/viewer/packages/rendering/src/render-pipeline-providers/PointCloudRenderPipelineProvider.ts
@@ -2,7 +2,20 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import {
+  CustomBlending,
+  DepthTexture,
+  FloatType,
+  NearestFilter,
+  NoBlending,
+  OneFactor,
+  RGBAFormat,
+  SrcAlphaFactor,
+  UnsignedIntType,
+  Vector2,
+  WebGLRenderTarget
+} from 'three';
 import type { RenderPass } from '../RenderPass';
 import type { RenderPipelineProvider } from '../RenderPipelineProvider';
 import type { SceneHandler } from '@reveal/utilities';
@@ -16,9 +29,9 @@ import { shouldApplyEdl } from './pointCloudParameterUtils';
 
 export class PointCloudRenderPipelineProvider implements RenderPipelineProvider {
   private readonly _renderTargetData: {
-    currentRenderSize: THREE.Vector2;
-    logDepthAndDepthOutput: THREE.WebGLRenderTarget;
-    output: THREE.WebGLRenderTarget;
+    currentRenderSize: Vector2;
+    logDepthAndDepthOutput: WebGLRenderTarget;
+    output: WebGLRenderTarget;
   };
   private readonly _renderParameters: PointCloudParameters;
   private readonly _depthPass: PointCloudEffectsPass;
@@ -32,7 +45,7 @@ export class PointCloudRenderPipelineProvider implements RenderPipelineProvider 
       shape: PointShape.Circle,
       hqDepthPass: true,
       depthWrite: true,
-      blending: THREE.NoBlending,
+      blending: NoBlending,
       colorWrite: true
     }
   };
@@ -42,9 +55,9 @@ export class PointCloudRenderPipelineProvider implements RenderPipelineProvider 
       shape: PointShape.Circle,
       hqDepthPass: false,
       depthWrite: false,
-      blending: THREE.CustomBlending,
-      blendSrc: THREE.SrcAlphaFactor,
-      blendDst: THREE.OneFactor,
+      blending: CustomBlending,
+      blendSrc: SrcAlphaFactor,
+      blendDst: OneFactor,
       colorWrite: true
     },
     renderer: {
@@ -57,21 +70,21 @@ export class PointCloudRenderPipelineProvider implements RenderPipelineProvider 
     pointCloudMaterialManager: PointCloudMaterialManager,
     renderParameters: PointCloudParameters
   ) {
-    const depthTexture = new THREE.DepthTexture(1, 1, THREE.UnsignedIntType);
+    const depthTexture = new DepthTexture(1, 1, UnsignedIntType);
     this._renderTargetData = {
-      currentRenderSize: new THREE.Vector2(1, 1),
-      logDepthAndDepthOutput: new THREE.WebGLRenderTarget(1, 1, {
-        minFilter: THREE.NearestFilter,
-        magFilter: THREE.NearestFilter,
-        format: THREE.RGBAFormat,
-        type: THREE.FloatType,
+      currentRenderSize: new Vector2(1, 1),
+      logDepthAndDepthOutput: new WebGLRenderTarget(1, 1, {
+        minFilter: NearestFilter,
+        magFilter: NearestFilter,
+        format: RGBAFormat,
+        type: FloatType,
         depthTexture: depthTexture
       }),
-      output: new THREE.WebGLRenderTarget(1, 1, {
-        minFilter: THREE.NearestFilter,
-        magFilter: THREE.NearestFilter,
-        format: THREE.RGBAFormat,
-        type: THREE.FloatType,
+      output: new WebGLRenderTarget(1, 1, {
+        minFilter: NearestFilter,
+        magFilter: NearestFilter,
+        format: RGBAFormat,
+        type: FloatType,
         depthTexture: depthTexture
       })
     };
@@ -111,7 +124,7 @@ export class PointCloudRenderPipelineProvider implements RenderPipelineProvider 
     };
   }
 
-  public *pipeline(renderer: THREE.WebGLRenderer): Generator<RenderPass> {
+  public *pipeline(renderer: WebGLRenderer): Generator<RenderPass> {
     this.updateRenderTargetSizes(renderer);
 
     // Needs to be updated manually since automatic update is disabled because of CAD pipeline.
@@ -140,8 +153,8 @@ export class PointCloudRenderPipelineProvider implements RenderPipelineProvider 
     this._renderTargetData.output.dispose();
   }
 
-  private updateRenderTargetSizes(renderer: THREE.WebGLRenderer): void {
-    const renderSize = new THREE.Vector2();
+  private updateRenderTargetSizes(renderer: WebGLRenderer): void {
+    const renderSize = new Vector2();
     renderer.getDrawingBufferSize(renderSize);
 
     const { x: width, y: height } = renderSize;

--- a/viewer/packages/rendering/src/render-pipeline-providers/types.ts
+++ b/viewer/packages/rendering/src/render-pipeline-providers/types.ts
@@ -2,30 +2,30 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Texture, Vector2, WebGLRenderTarget } from 'three';
 import type { EdlOptions } from '../rendering/types';
 
 export type RenderTargetData = {
-  currentRenderSize: THREE.Vector2;
-  ssaoRenderTarget: THREE.WebGLRenderTarget;
-  postProcessingRenderTarget: THREE.WebGLRenderTarget;
+  currentRenderSize: Vector2;
+  ssaoRenderTarget: WebGLRenderTarget;
+  postProcessingRenderTarget: WebGLRenderTarget;
 };
 
 export type CadGeometryRenderTargets = {
-  currentRenderSize: THREE.Vector2;
-  back: THREE.WebGLRenderTarget;
-  ghost: THREE.WebGLRenderTarget;
-  inFront: THREE.WebGLRenderTarget;
+  currentRenderSize: Vector2;
+  back: WebGLRenderTarget;
+  ghost: WebGLRenderTarget;
+  inFront: WebGLRenderTarget;
 };
 
 export type PointCloudRenderTargets = {
-  pointCloudLogDepth: THREE.WebGLRenderTarget;
-  pointCloud: THREE.WebGLRenderTarget;
+  pointCloudLogDepth: WebGLRenderTarget;
+  pointCloud: WebGLRenderTarget;
 };
 
 export type PostProcessingPipelineOptions = CadGeometryRenderTargets &
   PointCloudRenderTargets & {
-    ssaoTexture: THREE.Texture;
+    ssaoTexture: Texture;
     edges: boolean;
     pointBlending?: boolean;
     edlOptions: EdlOptions;

--- a/viewer/packages/rendering/src/rendering/materials.ts
+++ b/viewer/packages/rendering/src/rendering/materials.ts
@@ -2,34 +2,35 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { DataTexture, Texture } from 'three';
+import { DoubleSide, GLSL3, Matrix4, RawShaderMaterial, Vector2, Vector3 } from 'three';
 import { sectorShaders } from './shaders';
 import { RenderMode } from './RenderMode';
 
 export interface Materials {
   // Materials
-  box: THREE.RawShaderMaterial;
-  circle: THREE.RawShaderMaterial;
-  generalRing: THREE.RawShaderMaterial;
-  nut: THREE.RawShaderMaterial;
-  quad: THREE.RawShaderMaterial;
-  cone: THREE.RawShaderMaterial;
-  eccentricCone: THREE.RawShaderMaterial;
-  torusSegment: THREE.RawShaderMaterial;
-  generalCylinder: THREE.RawShaderMaterial;
-  trapezium: THREE.RawShaderMaterial;
-  ellipsoidSegment: THREE.RawShaderMaterial;
-  instancedMesh: THREE.RawShaderMaterial;
-  triangleMesh: THREE.RawShaderMaterial;
-  texturedMaterials: { [key: string]: THREE.RawShaderMaterial };
+  box: RawShaderMaterial;
+  circle: RawShaderMaterial;
+  generalRing: RawShaderMaterial;
+  nut: RawShaderMaterial;
+  quad: RawShaderMaterial;
+  cone: RawShaderMaterial;
+  eccentricCone: RawShaderMaterial;
+  torusSegment: RawShaderMaterial;
+  generalCylinder: RawShaderMaterial;
+  trapezium: RawShaderMaterial;
+  ellipsoidSegment: RawShaderMaterial;
+  instancedMesh: RawShaderMaterial;
+  triangleMesh: RawShaderMaterial;
+  texturedMaterials: { [key: string]: RawShaderMaterial };
 }
 
-export function forEachMaterial(materials: Materials, callback: (material: THREE.RawShaderMaterial) => void): void {
+export function forEachMaterial(materials: Materials, callback: (material: RawShaderMaterial) => void): void {
   for (const materialOrMaterialSet of Object.values(materials)) {
     if (materialOrMaterialSet.isMaterial === true) {
-      callback(materialOrMaterialSet as THREE.RawShaderMaterial);
+      callback(materialOrMaterialSet as RawShaderMaterial);
     } else {
-      const materialSet = materialOrMaterialSet as { [key: string]: THREE.RawShaderMaterial };
+      const materialSet = materialOrMaterialSet as { [key: string]: RawShaderMaterial };
 
       Object.values(materialSet).forEach(material => callback(material));
     }
@@ -37,27 +38,27 @@ export function forEachMaterial(materials: Materials, callback: (material: THREE
 }
 
 export function createMaterials(
-  overrideColorPerTreeIndex: THREE.DataTexture,
-  transformOverrideIndexTexture: THREE.DataTexture,
-  transformOverrideLookupTexture: THREE.DataTexture,
-  matCapTexture: THREE.Texture
+  overrideColorPerTreeIndex: DataTexture,
+  transformOverrideIndexTexture: DataTexture,
+  transformOverrideLookupTexture: DataTexture,
+  matCapTexture: Texture
 ): Materials {
-  const boxMaterial = new THREE.RawShaderMaterial({
+  const boxMaterial = new RawShaderMaterial({
     name: 'Primitives (Box)',
     clipping: true,
     clippingPlanes: [],
     vertexShader: sectorShaders.boxPrimitive.vertex,
     fragmentShader: sectorShaders.boxPrimitive.fragment,
-    side: THREE.DoubleSide,
+    side: DoubleSide,
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
-    glslVersion: THREE.GLSL3
+    glslVersion: GLSL3
   });
 
-  const circleMaterial = new THREE.RawShaderMaterial({
+  const circleMaterial = new RawShaderMaterial({
     name: 'Primitives (Circle)',
     clipping: true,
     clippingPlanes: [],
@@ -65,164 +66,164 @@ export function createMaterials(
     fragmentShader: sectorShaders.circlePrimitive.fragment,
     // TODO double side is not necessary for all,
     // we should indicate this in the data from Rust
-    side: THREE.DoubleSide,
+    side: DoubleSide,
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
-    glslVersion: THREE.GLSL3
+    glslVersion: GLSL3
   });
 
-  const nutMaterial = new THREE.RawShaderMaterial({
+  const nutMaterial = new RawShaderMaterial({
     name: 'Primitives (Nuts)',
     clipping: true,
     clippingPlanes: [],
     vertexShader: sectorShaders.nutPrimitive.vertex,
     fragmentShader: sectorShaders.nutPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const quadMaterial = new THREE.RawShaderMaterial({
+  const quadMaterial = new RawShaderMaterial({
     name: 'Primitives (Quads)',
     clipping: true,
     clippingPlanes: [],
     vertexShader: sectorShaders.quadPrimitive.vertex,
     fragmentShader: sectorShaders.quadPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const generalRingMaterial = new THREE.RawShaderMaterial({
+  const generalRingMaterial = new RawShaderMaterial({
     name: 'Primitives (General rings)',
     clipping: true,
     clippingPlanes: [],
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
     vertexShader: sectorShaders.generalRingPrimitive.vertex,
     fragmentShader: sectorShaders.generalRingPrimitive.fragment,
     // TODO we can avoid drawing DoubleSide if we flip the ring in Rust and adjust the angle and
     // arc_angle accordingly
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const coneMaterial = new THREE.RawShaderMaterial({
+  const coneMaterial = new RawShaderMaterial({
     name: 'Primitives (Cone)',
     clipping: true,
     clippingPlanes: [],
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
     vertexShader: sectorShaders.conePrimitive.vertex,
     fragmentShader: sectorShaders.conePrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const eccentricConeMaterial = new THREE.RawShaderMaterial({
+  const eccentricConeMaterial = new RawShaderMaterial({
     name: 'Primitives (Eccentric cone)',
     clipping: true,
     clippingPlanes: [],
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
     vertexShader: sectorShaders.eccentricConePrimitive.vertex,
     fragmentShader: sectorShaders.eccentricConePrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const ellipsoidSegmentMaterial = new THREE.RawShaderMaterial({
+  const ellipsoidSegmentMaterial = new RawShaderMaterial({
     name: 'Primitives (Ellipsoid segments)',
     clipping: true,
     clippingPlanes: [],
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
 
     vertexShader: sectorShaders.ellipsoidSegmentPrimitive.vertex,
     fragmentShader: sectorShaders.ellipsoidSegmentPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const generalCylinderMaterial = new THREE.RawShaderMaterial({
+  const generalCylinderMaterial = new RawShaderMaterial({
     name: 'Primitives (General cylinder)',
     clipping: true,
     clippingPlanes: [],
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       },
       cameraPosition: {
-        value: new THREE.Vector3()
+        value: new Vector3()
       }
     },
     vertexShader: sectorShaders.generalCylinderPrimitive.vertex,
     fragmentShader: sectorShaders.generalCylinderPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const trapeziumMaterial = new THREE.RawShaderMaterial({
+  const trapeziumMaterial = new RawShaderMaterial({
     name: 'Primitives (Trapezium)',
     clipping: true,
     clippingPlanes: [],
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
     vertexShader: sectorShaders.trapeziumPrimitive.vertex,
     fragmentShader: sectorShaders.trapeziumPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const torusSegmentMaterial = new THREE.RawShaderMaterial({
+  const torusSegmentMaterial = new RawShaderMaterial({
     name: 'Primitives (Torus segment)',
     clipping: true,
     clippingPlanes: [],
     uniforms: {
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       }
     },
     vertexShader: sectorShaders.torusSegmentPrimitive.vertex,
     fragmentShader: sectorShaders.torusSegmentPrimitive.fragment,
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3
+    side: DoubleSide,
+    glslVersion: GLSL3
   });
 
-  const triangleMeshMaterial = new THREE.RawShaderMaterial({
+  const triangleMeshMaterial = new RawShaderMaterial({
     name: 'Triangle meshes',
     clipping: true,
     clippingPlanes: [],
-    side: THREE.DoubleSide,
+    side: DoubleSide,
     fragmentShader: sectorShaders.detailedMesh.fragment,
     vertexShader: sectorShaders.detailedMesh.vertex,
-    glslVersion: THREE.GLSL3
+    glslVersion: GLSL3
   });
 
-  const instancedMeshMaterial = new THREE.RawShaderMaterial({
+  const instancedMeshMaterial = new RawShaderMaterial({
     name: 'Instanced meshes',
     clipping: true,
     clippingPlanes: [],
-    side: THREE.DoubleSide,
+    side: DoubleSide,
     fragmentShader: sectorShaders.instancedMesh.fragment,
     vertexShader: sectorShaders.instancedMesh.vertex,
-    glslVersion: THREE.GLSL3
+    glslVersion: GLSL3
   });
 
   const allMaterials = {
@@ -259,18 +260,18 @@ export function createMaterials(
 }
 
 export function initializeDefinesAndUniforms(
-  material: THREE.RawShaderMaterial,
-  overrideColorPerTreeIndex: THREE.DataTexture,
-  transformOverrideIndexTexture: THREE.DataTexture,
-  transformOverrideTexture: THREE.DataTexture,
-  matCapTexture: THREE.Texture,
+  material: RawShaderMaterial,
+  overrideColorPerTreeIndex: DataTexture,
+  transformOverrideIndexTexture: DataTexture,
+  transformOverrideTexture: DataTexture,
+  matCapTexture: Texture,
   renderMode: RenderMode
 ): void {
-  const treeIndexTextureSize = new THREE.Vector2(
+  const treeIndexTextureSize = new Vector2(
     overrideColorPerTreeIndex.image.width,
     overrideColorPerTreeIndex.image.height
   );
-  const transformOverrideTextureSize = new THREE.Vector2(
+  const transformOverrideTextureSize = new Vector2(
     transformOverrideTexture.image.width,
     transformOverrideTexture.image.height
   );

--- a/viewer/packages/rendering/src/utilities/renderUtilities.ts
+++ b/viewer/packages/rendering/src/utilities/renderUtilities.ts
@@ -2,7 +2,23 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Color, Object3D } from 'three';
+import {
+  AlwaysDepth,
+  CustomBlending,
+  DataTexture,
+  DepthFormat,
+  DepthTexture,
+  GLSL3,
+  Mesh,
+  NormalBlending,
+  OneMinusSrcAlphaFactor,
+  OrthographicCamera,
+  RawShaderMaterial,
+  SrcAlphaFactor,
+  UnsignedIntType,
+  WebGLRenderTarget
+} from 'three';
 import type { WebGLRendererStateHelper } from '@reveal/utilities';
 import { createRenderTriangle, createUint8View } from '@reveal/utilities';
 import type { CadMaterialManager } from '../CadMaterialManager';
@@ -23,27 +39,27 @@ import { NodeOutlineColor } from '@reveal/cad-styling';
 import { DEFAULT_EDL_NEIGHBOURS_COUNT } from '../pointcloud-rendering/constants';
 import { shouldApplyEdl } from '../render-pipeline-providers/pointCloudParameterUtils';
 
-export const unitOrthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, -1, 1);
+export const unitOrthographicCamera = new OrthographicCamera(-1, 1, 1, -1, -1, 1);
 
-export function createFullScreenTriangleMesh(shaderMaterial: THREE.RawShaderMaterial): THREE.Mesh {
+export function createFullScreenTriangleMesh(shaderMaterial: RawShaderMaterial): Mesh {
   const renderTriangle = createRenderTriangle();
-  const mesh = new THREE.Mesh(renderTriangle, shaderMaterial);
+  const mesh = new Mesh(renderTriangle, shaderMaterial);
   mesh.frustumCulled = false;
   return mesh;
 }
 
-export function createRenderTarget(width = 1, height = 1, multiSampleCount = 1): THREE.WebGLRenderTarget {
-  const renderTarget = new THREE.WebGLRenderTarget(width, height);
+export function createRenderTarget(width = 1, height = 1, multiSampleCount = 1): WebGLRenderTarget {
+  const renderTarget = new WebGLRenderTarget(width, height);
   renderTarget.samples = multiSampleCount > 1 ? multiSampleCount : 0;
 
-  renderTarget.depthTexture = new THREE.DepthTexture(width, height);
-  renderTarget.depthTexture.format = THREE.DepthFormat;
-  renderTarget.depthTexture.type = THREE.UnsignedIntType;
+  renderTarget.depthTexture = new DepthTexture(width, height);
+  renderTarget.depthTexture.format = DepthFormat;
+  renderTarget.depthTexture.type = UnsignedIntType;
 
   return renderTarget;
 }
 
-export function getDepthBlendBlitMaterial(options: DepthBlendBlitOptions): THREE.RawShaderMaterial {
+export function getDepthBlendBlitMaterial(options: DepthBlendBlitOptions): RawShaderMaterial {
   const { texture, depthTexture, blendTexture, blendDepthTexture, blendFactor, outline, overrideAlpha } = options;
 
   const uniforms: ThreeUniforms = {
@@ -62,17 +78,17 @@ export function getDepthBlendBlitMaterial(options: DepthBlendBlitOptions): THREE
     uniforms['tOutlineColors'] = { value: createOutlineColorTexture() };
   }
 
-  return new THREE.RawShaderMaterial({
+  return new RawShaderMaterial({
     vertexShader: depthBlendBlitShaders.vertex,
     fragmentShader: depthBlendBlitShaders.fragment,
     uniforms,
-    glslVersion: THREE.GLSL3,
+    glslVersion: GLSL3,
     defines,
-    depthFunc: THREE.AlwaysDepth
+    depthFunc: AlwaysDepth
   });
 }
 
-export function getBlitMaterial(options: BlitOptions): THREE.RawShaderMaterial {
+export function getBlitMaterial(options: BlitOptions): RawShaderMaterial {
   const { texture, effect, depthTexture, blendOptions, overrideAlpha, ssaoTexture, edges, outline } = options;
 
   const uniforms: ThreeUniforms = {
@@ -100,18 +116,18 @@ export function getBlitMaterial(options: BlitOptions): THREE.RawShaderMaterial {
 
   const initializedBlendOptions = initializeBlendingOptions(blendOptions); // Uses blendDst value if null
 
-  return new THREE.RawShaderMaterial({
+  return new RawShaderMaterial({
     vertexShader: blitShaders.vertex,
     fragmentShader: blitShaders.fragment,
     uniforms,
-    glslVersion: THREE.GLSL3,
+    glslVersion: GLSL3,
     defines,
     depthTest,
     ...initializedBlendOptions
   });
 }
 
-export function getPointCloudPostProcessingMaterial(options: PointCloudPostProcessingOptions): THREE.RawShaderMaterial {
+export function getPointCloudPostProcessingMaterial(options: PointCloudPostProcessingOptions): RawShaderMaterial {
   const { logDepthTexture, texture, depthTexture, pointBlending, edlOptions } = options;
 
   let uniforms: ThreeUniforms = {
@@ -140,12 +156,12 @@ export function getPointCloudPostProcessingMaterial(options: PointCloudPostProce
     };
   }
 
-  return new THREE.RawShaderMaterial({
+  return new RawShaderMaterial({
     vertexShader: pointCloudShaders.normalize.vertex,
     fragmentShader: pointCloudShaders.normalize.fragment,
     uniforms,
     defines,
-    glslVersion: THREE.GLSL3
+    glslVersion: GLSL3
   });
 }
 
@@ -158,9 +174,9 @@ function getEDLNeighbourPoints(neighbourCount: number): Float32Array {
   return neighbours;
 }
 
-function createOutlineColorTexture(): THREE.DataTexture {
+function createOutlineColorTexture(): DataTexture {
   const outlineColorBuffer = new Uint8Array(8 * 4);
-  const outlineColorTexture = new THREE.DataTexture(outlineColorBuffer, 8, 1);
+  const outlineColorTexture = new DataTexture(outlineColorBuffer, 8, 1);
   const rawData = outlineColorTexture.image.data;
   if (!rawData) return outlineColorTexture;
   const colorTextureView = createUint8View(rawData);
@@ -175,14 +191,14 @@ function createOutlineColorTexture(): THREE.DataTexture {
   return outlineColorTexture;
 }
 
-function setOutlineColor(outlineTextureData: Uint8Array | Uint8ClampedArray, colorIndex: number, color: THREE.Color) {
+function setOutlineColor(outlineTextureData: Uint8Array | Uint8ClampedArray, colorIndex: number, color: Color) {
   outlineTextureData[4 * colorIndex + 0] = Math.floor(255 * color.r);
   outlineTextureData[4 * colorIndex + 1] = Math.floor(255 * color.g);
   outlineTextureData[4 * colorIndex + 2] = Math.floor(255 * color.b);
   outlineTextureData[4 * colorIndex + 3] = 255;
 }
 
-function setDepthTestOptions(depthTexture: THREE.DepthTexture | null, uniforms: ThreeUniforms, defines: any) {
+function setDepthTestOptions(depthTexture: DepthTexture | null, uniforms: ThreeUniforms, defines: any) {
   if (depthTexture === null) {
     return false;
   }
@@ -211,9 +227,9 @@ function setBlitEffect(effect: BlitEffect | undefined, defines: any) {
 }
 
 function initializeBlendingOptions(blendOptions: BlendOptions | undefined) {
-  const blending = blendOptions !== undefined ? THREE.CustomBlending : THREE.NormalBlending;
-  const blendDst = blendOptions?.blendDestination ?? THREE.OneMinusSrcAlphaFactor;
-  const blendSrc = blendOptions?.blendSource ?? THREE.SrcAlphaFactor;
+  const blending = blendOptions !== undefined ? CustomBlending : NormalBlending;
+  const blendDst = blendOptions?.blendDestination ?? OneMinusSrcAlphaFactor;
+  const blendSrc = blendOptions?.blendSource ?? SrcAlphaFactor;
   const blendSrcAlpha = blendOptions?.blendSourceAlpha ?? null; // Uses blendSrc value if undefined
   const blendDstAlpha = blendOptions?.blendDestinationAlpha ?? null; // Uses blendDst value if undefined
   return {
@@ -259,7 +275,7 @@ export function hasStyledNodes(
   return { back: totalBackIndices > 0, ghost: totalGhostIndices > 0, inFront: totalInFrontIndices > 0 };
 }
 
-export function setModelRenderLayers(rootNode: THREE.Object3D, stylingSets: StyledTreeIndexSets): void {
+export function setModelRenderLayers(rootNode: Object3D, stylingSets: StyledTreeIndexSets): void {
   const { back, ghost, inFront, visible } = stylingSets;
   rootNode.traverse(node => {
     node.layers.disableAll();

--- a/viewer/packages/rendering/src/utilities/types.ts
+++ b/viewer/packages/rendering/src/utilities/types.ts
@@ -3,30 +3,30 @@
  */
 
 import type { IndexSet } from '@reveal/utilities';
-import * as THREE from 'three';
+import { Color } from 'three';
 
 /**
  * Colors from the Cognite theme.
  */
 export class CogniteColors {
-  public static readonly Black = new THREE.Color('rgb(0, 0, 0)');
-  public static readonly White = new THREE.Color('rgb(255, 255, 255)');
-  public static readonly Cyan = new THREE.Color('rgb(102, 213, 234)');
-  public static readonly Blue = new THREE.Color('rgb(77, 106, 242)');
-  public static readonly Purple = new THREE.Color('rgb(186, 82, 212)');
-  public static readonly Pink = new THREE.Color('rgb(232, 64, 117)');
-  public static readonly Orange = new THREE.Color('rgb(238, 113, 53)');
-  public static readonly Yellow = new THREE.Color('rgb(246, 189, 65)');
-  public static readonly VeryLightGray = new THREE.Color('rgb(247, 246, 245)');
-  public static readonly LightGray = new THREE.Color('rgb(242, 241, 240)');
+  public static readonly Black = new Color('rgb(0, 0, 0)');
+  public static readonly White = new Color('rgb(255, 255, 255)');
+  public static readonly Cyan = new Color('rgb(102, 213, 234)');
+  public static readonly Blue = new Color('rgb(77, 106, 242)');
+  public static readonly Purple = new Color('rgb(186, 82, 212)');
+  public static readonly Pink = new Color('rgb(232, 64, 117)');
+  public static readonly Orange = new Color('rgb(238, 113, 53)');
+  public static readonly Yellow = new Color('rgb(246, 189, 65)');
+  public static readonly VeryLightGray = new Color('rgb(247, 246, 245)');
+  public static readonly LightGray = new Color('rgb(242, 241, 240)');
 }
 
 /**
  * Some additional colors to supplement {@link CogniteColors}.
  */
 export class RevealColors {
-  public static readonly Red = new THREE.Color('rgb(235,0,4)');
-  public static readonly Green = new THREE.Color('rgb(46,164,79)');
+  public static readonly Red = new Color('rgb(235,0,4)');
+  public static readonly Green = new Color('rgb(46,164,79)');
 }
 
 export type StyledTreeIndexSets = {

--- a/viewer/packages/rendering/visual-tests/RenderTarget.VisualTest.ts
+++ b/viewer/packages/rendering/visual-tests/RenderTarget.VisualTest.ts
@@ -2,7 +2,20 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import {
+  BufferAttribute,
+  BufferGeometry,
+  DepthFormat,
+  DepthTexture,
+  GLSL3,
+  Mesh,
+  OrthographicCamera,
+  RawShaderMaterial,
+  Scene,
+  UnsignedIntType,
+  WebGLRenderTarget
+} from 'three';
 
 import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
 import { StreamingVisualTestFixture } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
@@ -10,14 +23,14 @@ import { DefaultRenderPipelineProvider } from '../src/render-pipeline-providers/
 import { defaultRenderOptions } from '../src/rendering/types';
 
 export default class RenderTargetVisualTest extends StreamingVisualTestFixture {
-  private readonly _orthographicCamera: THREE.OrthographicCamera;
-  private readonly _testScene: THREE.Scene;
-  private _glRenderer!: THREE.WebGLRenderer;
+  private readonly _orthographicCamera: OrthographicCamera;
+  private readonly _testScene: Scene;
+  private _glRenderer!: WebGLRenderer;
 
   constructor() {
     super();
-    this._orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
-    this._testScene = new THREE.Scene();
+    this._orthographicCamera = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    this._testScene = new Scene();
   }
 
   public setup(testFixtureComponents: StreamingTestFixtureComponents): Promise<void> {
@@ -25,10 +38,10 @@ export default class RenderTargetVisualTest extends StreamingVisualTestFixture {
 
     this._glRenderer = renderer;
 
-    const renderTarget = new THREE.WebGLRenderTarget(300, 300);
-    renderTarget.depthTexture = new THREE.DepthTexture(300, 300);
-    renderTarget.depthTexture.format = THREE.DepthFormat;
-    renderTarget.depthTexture.type = THREE.UnsignedIntType;
+    const renderTarget = new WebGLRenderTarget(300, 300);
+    renderTarget.depthTexture = new DepthTexture(300, 300);
+    renderTarget.depthTexture.format = DepthFormat;
+    renderTarget.depthTexture.type = UnsignedIntType;
 
     this.pipelineProvider = new DefaultRenderPipelineProvider(
       cadMaterialManager,
@@ -77,25 +90,25 @@ export default class RenderTargetVisualTest extends StreamingVisualTestFixture {
       }
     `;
 
-    const geometry = new THREE.BufferGeometry();
+    const geometry = new BufferGeometry();
     const vertices = new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]);
     const uvs = new Float32Array([0, 0, 2, 0, 0, 2]);
 
-    geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
-    geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+    geometry.setAttribute('position', new BufferAttribute(vertices, 3));
+    geometry.setAttribute('uv', new BufferAttribute(uvs, 2));
 
-    const shaderMaterial = new THREE.RawShaderMaterial({
+    const shaderMaterial = new RawShaderMaterial({
       vertexShader: vShader,
       fragmentShader: fShader,
       uniforms: {
         tDiffuse: { value: renderTarget.texture },
         tDepth: { value: renderTarget.depthTexture }
       },
-      glslVersion: THREE.GLSL3,
+      glslVersion: GLSL3,
       depthTest: true
     });
 
-    const mesh = new THREE.Mesh(geometry, shaderMaterial);
+    const mesh = new Mesh(geometry, shaderMaterial);
     this._testScene.add(mesh);
 
     return Promise.resolve();

--- a/viewer/packages/rendering/visual-tests/Rendering.VisualTest.ts
+++ b/viewer/packages/rendering/visual-tests/Rendering.VisualTest.ts
@@ -7,7 +7,7 @@ import type { SceneHandler } from '@reveal/utilities';
 import { DeferredPromise, NumericRange } from '@reveal/utilities';
 import type { Box3, Object3D, PerspectiveCamera, WebGLRenderer } from 'three';
 import { BoxGeometry, Color, GridHelper, Mesh, MeshBasicMaterial, Vector2, Vector3 } from 'three';
-import { TransformControls } from 'three/addons';
+import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import type { PointCloudMaterialManager } from '..';
 import { AntiAliasingMode, defaultRenderOptions, DefaultRenderPipelineProvider } from '..';
 

--- a/viewer/packages/rendering/visual-tests/Rendering.VisualTest.ts
+++ b/viewer/packages/rendering/visual-tests/Rendering.VisualTest.ts
@@ -5,7 +5,8 @@
 import { DefaultNodeAppearance, TreeIndexNodeCollection } from '@reveal/cad-styling';
 import type { SceneHandler } from '@reveal/utilities';
 import { DeferredPromise, NumericRange } from '@reveal/utilities';
-import * as THREE from 'three';
+import type { Box3, Object3D, PerspectiveCamera, WebGLRenderer } from 'three';
+import { BoxGeometry, Color, GridHelper, Mesh, MeshBasicMaterial, Vector2, Vector3 } from 'three';
 import { TransformControls } from 'three/addons';
 import type { PointCloudMaterialManager } from '..';
 import { AntiAliasingMode, defaultRenderOptions, DefaultRenderPipelineProvider } from '..';
@@ -44,7 +45,7 @@ export default class RenderingVisualTestFixture extends StreamingVisualTestFixtu
 
   private setupGui(
     stepPipelineExecutor: StepPipelineExecutor,
-    renderer: THREE.WebGLRenderer,
+    renderer: WebGLRenderer,
     cadMaterialManager: CadMaterialManager,
     pcMaterialManager: PointCloudMaterialManager,
     sceneHandler: SceneHandler
@@ -119,7 +120,7 @@ export default class RenderingVisualTestFixture extends StreamingVisualTestFixtu
     super.render();
   }
 
-  private setupBackgroundColorGUI(renderer: THREE.WebGLRenderer) {
+  private setupBackgroundColorGUI(renderer: WebGLRenderer) {
     const backgroundGuiData: {
       canvasColor: `#${string}`;
       clearColor: `#${string}`;
@@ -130,7 +131,7 @@ export default class RenderingVisualTestFixture extends StreamingVisualTestFixtu
       clearAlpha: 1
     };
 
-    renderer.setClearColor(new THREE.Color(backgroundGuiData.clearColor).convertLinearToSRGB());
+    renderer.setClearColor(new Color(backgroundGuiData.clearColor).convertLinearToSRGB());
     renderer.setClearAlpha(backgroundGuiData.clearAlpha);
     renderer.domElement.style.backgroundColor = backgroundGuiData.canvasColor;
 
@@ -138,13 +139,13 @@ export default class RenderingVisualTestFixture extends StreamingVisualTestFixtu
     renderOptionsGUI.open();
 
     renderOptionsGUI.addColor(backgroundGuiData, 'clearColor').onChange(async () => {
-      renderer.setClearColor(new THREE.Color(backgroundGuiData.clearColor).convertLinearToSRGB());
+      renderer.setClearColor(new Color(backgroundGuiData.clearColor).convertLinearToSRGB());
       renderer.setClearAlpha(backgroundGuiData.clearAlpha);
       this.render();
     });
 
     renderOptionsGUI.add(backgroundGuiData, 'clearAlpha', 0, 1).onChange(async () => {
-      renderer.setClearColor(new THREE.Color(backgroundGuiData.clearColor).convertLinearToSRGB());
+      renderer.setClearColor(new Color(backgroundGuiData.clearColor).convertLinearToSRGB());
       renderer.setClearAlpha(backgroundGuiData.clearAlpha);
       this.render();
     });
@@ -189,42 +190,38 @@ export default class RenderingVisualTestFixture extends StreamingVisualTestFixtu
     }
   }
 
-  private getGridFromBoundingBox(boundingBox: THREE.Box3): THREE.GridHelper {
-    const gridSize = new THREE.Vector2(boundingBox.max.x - boundingBox.min.x, boundingBox.max.z - boundingBox.min.z);
-    const grid = new THREE.GridHelper(
+  private getGridFromBoundingBox(boundingBox: Box3): GridHelper {
+    const gridSize = new Vector2(boundingBox.max.x - boundingBox.min.x, boundingBox.max.z - boundingBox.min.z);
+    const grid = new GridHelper(
       gridSize.x,
       20,
-      new THREE.Color('#444444').convertLinearToSRGB(),
-      new THREE.Color('#888888').convertLinearToSRGB()
+      new Color('#444444').convertLinearToSRGB(),
+      new Color('#888888').convertLinearToSRGB()
     ); //THIS IS WRONG
-    grid.position.copy(boundingBox.getCenter(new THREE.Vector3()));
+    grid.position.copy(boundingBox.getCenter(new Vector3()));
     grid.position.setY(boundingBox.min.y);
 
     return grid;
   }
 
-  private getCustomBoxFromBoundingBox(boundingBox: THREE.Box3): THREE.Mesh {
-    const customBox = new THREE.Mesh(
-      new THREE.BoxGeometry(10, 10, 30),
-      new THREE.MeshBasicMaterial({
-        color: new THREE.Color(1, 0, 0),
+  private getCustomBoxFromBoundingBox(boundingBox: Box3): Mesh {
+    const customBox = new Mesh(
+      new BoxGeometry(10, 10, 30),
+      new MeshBasicMaterial({
+        color: new Color(1, 0, 0),
         transparent: true,
         opacity: 0.5,
         depthTest: false
       })
     );
 
-    const boxCenter = boundingBox.getCenter(new THREE.Vector3());
+    const boxCenter = boundingBox.getCenter(new Vector3());
     customBox.position.copy(boxCenter);
 
     return customBox;
   }
 
-  private attachTransformControlsTo(
-    object: THREE.Object3D,
-    camera: THREE.PerspectiveCamera,
-    canvas: HTMLCanvasElement
-  ) {
+  private attachTransformControlsTo(object: Object3D, camera: PerspectiveCamera, canvas: HTMLCanvasElement) {
     const transformControls = new TransformControls(camera, canvas);
     transformControls.attach(object);
     return transformControls;

--- a/viewer/packages/rendering/visual-tests/Ssao.VisualTest.ts
+++ b/viewer/packages/rendering/visual-tests/Ssao.VisualTest.ts
@@ -3,7 +3,7 @@
  */
 
 import { NumericRange } from '@reveal/utilities';
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 import type { StreamingTestFixtureComponents } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
 import { StreamingVisualTestFixture } from '../../../visual-tests/test-fixtures/StreamingVisualTestFixture';
 import type { DefaultRenderPipelineProvider } from '../src/render-pipeline-providers/DefaultRenderPipelineProvider';
@@ -18,7 +18,7 @@ export default class SsaoVisualTest extends StreamingVisualTestFixture {
     )!;
 
     const transformProvider = cadMaterialManager.getModelNodeTransformProvider(modelIdentifier);
-    transformProvider.setNodeTransform(new NumericRange(1, 1), new THREE.Matrix4().makeTranslation(4, 0, 0));
+    transformProvider.setNodeTransform(new NumericRange(1, 1), new Matrix4().makeTranslation(4, 0, 0));
 
     const renderOptions = defaultRenderOptions;
     renderOptions.ssaoRenderParameters = {
@@ -29,7 +29,7 @@ export default class SsaoVisualTest extends StreamingVisualTestFixture {
 
     (this.pipelineProvider as DefaultRenderPipelineProvider).renderOptions = renderOptions;
 
-    const matrix = new THREE.Matrix4().makeTranslation(10.5, -1, 15);
+    const matrix = new Matrix4().makeTranslation(10.5, -1, 15);
 
     model.geometryNode.setModelTransformation(matrix);
 

--- a/viewer/packages/sector-loader/visual-tests/SectorLoader.VisualTest.ts
+++ b/viewer/packages/sector-loader/visual-tests/SectorLoader.VisualTest.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Camera, Matrix4, RawShaderMaterial, Scene } from 'three';
+import { Box3, CustomBlending, Group, InstancedMesh, OneFactor, Vector3, ZeroFactor } from 'three';
 import { assert } from '@reveal/utilities/assert';
 
 import type { ModelIdentifier } from '@reveal/data-providers';
@@ -34,14 +35,14 @@ export default class SectorLoaderVisualTestFixture extends SimpleVisualTestFixtu
     const sceneJson = (await modelDataProvider.getJsonFile(modelUri, 'scene.json')) as CadSceneRootMetadata;
 
     const box = sceneJson.sectors[0].boundingBox;
-    const rootBoundingBox = new THREE.Box3(
-      new THREE.Vector3(box.min.x, box.min.y, box.min.z),
-      new THREE.Vector3(box.max.x, box.max.y, box.max.z)
+    const rootBoundingBox = new Box3(
+      new Vector3(box.min.x, box.min.y, box.min.z),
+      new Vector3(box.max.x, box.max.y, box.max.z)
     );
 
     this.fitCameraToBoundingBox(rootBoundingBox, 1.3);
 
-    cameraControls.target.copy(rootBoundingBox.getCenter(new THREE.Vector3()));
+    cameraControls.target.copy(rootBoundingBox.getCenter(new Vector3()));
 
     const consumedSectorsGroup = await this.loadSectors(
       sceneJson,
@@ -60,29 +61,24 @@ export default class SectorLoaderVisualTestFixture extends SimpleVisualTestFixtu
     sectorRepository: SectorRepository,
     cadMaterialManager: CadMaterialManager,
     modelUri: string
-  ): Promise<THREE.Group> {
+  ): Promise<Group> {
     const internalId = modelIdentifier.revealInternalId;
 
     const cadMaterial = createCadMaterial(sceneJson.maxTreeIndex);
     cadMaterialManager.addModelMaterials(internalId, cadMaterial);
-    for (const material of Object.values(
-      cadMaterialManager.getModelMaterials(internalId)
-    ) as THREE.RawShaderMaterial[]) {
-      material.blending = THREE.CustomBlending;
-      material.blendDst = THREE.ZeroFactor;
-      material.blendDstAlpha = THREE.OneFactor;
-      material.blendSrc = THREE.OneFactor;
-      material.blendSrcAlpha = THREE.ZeroFactor;
+    for (const material of Object.values(cadMaterialManager.getModelMaterials(internalId)) as RawShaderMaterial[]) {
+      material.blending = CustomBlending;
+      material.blendDst = ZeroFactor;
+      material.blendDstAlpha = OneFactor;
+      material.blendSrc = OneFactor;
+      material.blendSrcAlpha = ZeroFactor;
       material.needsUpdate = true;
     }
 
-    const model = new THREE.Group();
+    const model = new Group();
 
     function toThreeBox(box: BoundingBox) {
-      return new THREE.Box3(
-        new THREE.Vector3(box.min.x, box.min.y, box.min.z),
-        new THREE.Vector3(box.max.x, box.max.y, box.max.z)
-      );
+      return new Box3(new Vector3(box.min.x, box.min.y, box.min.z), new Vector3(box.max.x, box.max.y, box.max.z));
     }
 
     await Promise.all(
@@ -110,8 +106,8 @@ export default class SectorLoaderVisualTestFixture extends SimpleVisualTestFixtu
     return model;
   }
 
-  private initializeGroup(scene: THREE.Scene) {
-    const group = new THREE.Group();
+  private initializeGroup(scene: Scene) {
+    const group = new Group();
     group.frustumCulled = false;
     group.applyMatrix4(this.cadFromCdfToThreeMatrix);
     scene.add(group);
@@ -119,21 +115,21 @@ export default class SectorLoaderVisualTestFixture extends SimpleVisualTestFixtu
   }
 
   private createGltfSectorGroup(consumedSector: ConsumedSector, materials: Materials) {
-    const geometryGroup = new THREE.Group();
+    const geometryGroup = new Group();
 
     for (const parsedGeometry of consumedSector.geometryBatchingQueue!) {
       const material = this.getShaderMaterial(parsedGeometry.type, materials);
 
       const count = parsedGeometry.geometryBuffer.getAttribute('a_treeIndex').count;
 
-      const mesh = new THREE.InstancedMesh(parsedGeometry.geometryBuffer, material, count);
+      const mesh = new InstancedMesh(parsedGeometry.geometryBuffer, material, count);
 
-      mesh.onBeforeRender = (_0, _1, camera: THREE.Camera) => {
+      mesh.onBeforeRender = (_0, _1, camera: Camera) => {
         if (material.uniforms.renderMode) {
           material.uniforms.renderMode.value = 1;
         }
-        (material.uniforms.inverseModelMatrix?.value as THREE.Matrix4)?.copy(mesh.matrixWorld).invert();
-        (material.uniforms.cameraPosition?.value as THREE.Vector3)?.copy(camera.position);
+        (material.uniforms.inverseModelMatrix?.value as Matrix4)?.copy(mesh.matrixWorld).invert();
+        (material.uniforms.cameraPosition?.value as Vector3)?.copy(camera.position);
         material.needsUpdate = true;
       };
 
@@ -145,7 +141,7 @@ export default class SectorLoaderVisualTestFixture extends SimpleVisualTestFixtu
     return geometryGroup;
   }
 
-  private getShaderMaterial(type: RevealGeometryCollectionType, materials: Materials): THREE.RawShaderMaterial {
+  private getShaderMaterial(type: RevealGeometryCollectionType, materials: Materials): RawShaderMaterial {
     assert(type !== RevealGeometryCollectionType.TexturedTriangleMesh);
     switch (type) {
       case RevealGeometryCollectionType.BoxCollection:

--- a/viewer/packages/sector-parser/src/GltfSectorParser.ts
+++ b/viewer/packages/sector-parser/src/GltfSectorParser.ts
@@ -1,7 +1,16 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { TypedArray } from 'three';
+import {
+  BufferAttribute,
+  BufferGeometry,
+  InstancedBufferGeometry,
+  InstancedInterleavedBuffer,
+  InterleavedBuffer,
+  InterleavedBufferAttribute,
+  Texture
+} from 'three';
 import { assert } from '@reveal/utilities/assert';
 
 import { setPrimitiveTopology } from './reveal-glb-parser/primitiveGeometries';
@@ -55,7 +64,7 @@ export class GltfSectorParser {
 
     if (instancingExtension === undefined && meshId === undefined) return undefined;
 
-    const bufferGeometry = instancingExtension ? new THREE.InstancedBufferGeometry() : new THREE.BufferGeometry();
+    const bufferGeometry = instancingExtension ? new InstancedBufferGeometry() : new BufferGeometry();
 
     const geometryType = RevealGeometryCollectionType[node.name as keyof typeof RevealGeometryCollectionType];
 
@@ -119,7 +128,7 @@ export class GltfSectorParser {
     const instanceBufferByteOffset = payload.glbHeaderData.byteOffsetToBinContent + (sharedBufferView.byteOffset ?? 0);
     const { byteLength: instanceBufferByteLength, byteStride: instanceBufferByteStride } = sharedBufferView;
 
-    this.setInterleavedBufferAttributes<THREE.InstancedInterleavedBuffer>(
+    this.setInterleavedBufferAttributes<InstancedInterleavedBuffer>(
       payload.glbHeaderData.json,
       payload.instancingExtension!.attributes,
       payload.data,
@@ -128,7 +137,7 @@ export class GltfSectorParser {
       instanceBufferByteStride,
       primitivesAttributeNameTransformer,
       payload.bufferGeometry,
-      THREE.InstancedInterleavedBuffer
+      InstancedInterleavedBuffer
     );
 
     return {
@@ -153,7 +162,7 @@ export class GltfSectorParser {
     const byteOffset = payload.glbHeaderData.byteOffsetToBinContent + (sharedBufferView.byteOffset ?? 0);
     const { byteLength, byteStride } = sharedBufferView;
 
-    this.setInterleavedBufferAttributes<THREE.InstancedInterleavedBuffer>(
+    this.setInterleavedBufferAttributes<InstancedInterleavedBuffer>(
       payload.glbHeaderData.json,
       payload.instancingExtension!.attributes!,
       payload.data,
@@ -162,7 +171,7 @@ export class GltfSectorParser {
       byteStride,
       primitivesAttributeNameTransformer,
       payload.bufferGeometry,
-      THREE.InstancedInterleavedBuffer
+      InstancedInterleavedBuffer
     );
   }
 
@@ -187,7 +196,7 @@ export class GltfSectorParser {
       bufferGeometry
     );
 
-    this.setInterleavedBufferAttributes<THREE.InterleavedBuffer>(
+    this.setInterleavedBufferAttributes<InterleavedBuffer>(
       json,
       primitive.attributes,
       vertexBuffer,
@@ -196,7 +205,7 @@ export class GltfSectorParser {
       byteStride,
       attributeNameTransformer,
       bufferGeometry,
-      THREE.InterleavedBuffer
+      InterleavedBuffer
     );
 
     payload.texture = await this.getDiffuseTexture(json, glbHeaderData, data, primitive);
@@ -222,7 +231,7 @@ export class GltfSectorParser {
     glbHeaderData: GlbHeaderData,
     data: ArrayBuffer,
     primitive: Primitive
-  ): Promise<THREE.Texture | undefined> {
+  ): Promise<Texture | undefined> {
     if (primitive.material === undefined) {
       return undefined;
     }
@@ -234,7 +243,7 @@ export class GltfSectorParser {
     const byteOffsetInData = offsetToBinChunk + (bufferView.byteOffset ?? 0);
     const newView = data.slice(byteOffsetInData, byteOffsetInData + bufferView.byteLength);
 
-    const texture = new THREE.Texture();
+    const texture = new Texture();
     const blob = new Blob([newView], { type: image.mimeType });
 
     return createImageBitmap(blob).then(bitmap => {
@@ -249,7 +258,7 @@ export class GltfSectorParser {
     glbHeaderData: GlbHeaderData,
     data: ArrayBuffer,
     primitive: Primitive,
-    bufferGeometry: THREE.InstancedBufferGeometry | THREE.BufferGeometry
+    bufferGeometry: InstancedBufferGeometry | BufferGeometry
   ) {
     let vertexBuffer: ArrayBuffer;
     let byteOffset: number;
@@ -278,7 +287,7 @@ export class GltfSectorParser {
     glbHeaderData: GlbHeaderData,
     primitive: Primitive,
     data: ArrayBuffer,
-    bufferGeometry: THREE.InstancedBufferGeometry | THREE.BufferGeometry
+    bufferGeometry: InstancedBufferGeometry | BufferGeometry
   ) {
     const json = glbHeaderData.json;
     const offsetToBinChunk = glbHeaderData.byteOffsetToBinContent;
@@ -297,21 +306,21 @@ export class GltfSectorParser {
 
     const elementSize = COLLECTION_TYPE_SIZES.get(indicesAccessor.type)!;
 
-    bufferGeometry.setIndex(new THREE.BufferAttribute(indicesTypedArray, elementSize));
+    bufferGeometry.setIndex(new BufferAttribute(indicesTypedArray, elementSize));
   }
 
   private setPositionBuffer(
     data: ArrayBuffer,
     byteOffset: number,
     byteLength: number,
-    bufferGeometry: THREE.InstancedBufferGeometry | THREE.BufferGeometry
+    bufferGeometry: InstancedBufferGeometry | BufferGeometry
   ) {
     const positionBytesPerElement = Float32Array.BYTES_PER_ELEMENT;
     const elementSize = 3;
 
     const positionTypedArray = new Float32Array(data, byteOffset, byteLength / positionBytesPerElement);
 
-    bufferGeometry.setAttribute('position', new THREE.BufferAttribute(positionTypedArray, elementSize));
+    bufferGeometry.setAttribute('position', new BufferAttribute(positionTypedArray, elementSize));
   }
 
   private getSharedBufferView(
@@ -333,7 +342,7 @@ export class GltfSectorParser {
     return json.bufferViews[bufferViewId];
   }
 
-  private setInterleavedBufferAttributes<T extends THREE.InterleavedBuffer>(
+  private setInterleavedBufferAttributes<T extends InterleavedBuffer>(
     json: GltfJson,
     attributes: {
       [key: string]: number;
@@ -343,8 +352,8 @@ export class GltfSectorParser {
     byteLength: number,
     stride: number,
     transformAttributeName: (attributeName: string) => string,
-    bufferGeometry: THREE.BufferGeometry | THREE.InstancedBufferGeometry,
-    bufferType: { new (array: THREE.TypedArray, stride: number): T }
+    bufferGeometry: BufferGeometry | InstancedBufferGeometry,
+    bufferType: { new (array: TypedArray, stride: number): T }
   ) {
     const componentTypes = Object.values(attributes).map(accessorId => json.accessors[accessorId].componentType);
 
@@ -360,12 +369,12 @@ export class GltfSectorParser {
     this.setAttributes<T>(attributes, json, typedArrayMap, transformAttributeName, bufferGeometry);
   }
 
-  private setAttributes<T extends THREE.InterleavedBuffer>(
+  private setAttributes<T extends InterleavedBuffer>(
     attributes: { [key: string]: number },
     json: GltfJson,
     typedArrayMap: { [key: string]: T },
     transformAttributeName: (attributeName: string) => string,
-    bufferGeometry: THREE.InstancedBufferGeometry | THREE.BufferGeometry
+    bufferGeometry: InstancedBufferGeometry | BufferGeometry
   ) {
     Object.keys(attributes).forEach(attributeName => {
       const accessor = json.accessors[attributes[attributeName]];
@@ -385,7 +394,7 @@ export class GltfSectorParser {
 
       assert(elementSize !== undefined);
 
-      const interleavedBufferAttribute = new THREE.InterleavedBufferAttribute(
+      const interleavedBufferAttribute = new InterleavedBufferAttribute(
         interleavedBuffer,
         size,
         byteOffset / elementSize
@@ -395,13 +404,13 @@ export class GltfSectorParser {
     });
   }
 
-  private getUniqueComponentViews<T extends THREE.InterleavedBuffer>(
+  private getUniqueComponentViews<T extends InterleavedBuffer>(
     componentTypes: number[],
     data: ArrayBuffer,
     byteOffset: number,
     byteLength: number,
     byteStride: number,
-    bufferType: new (array: THREE.TypedArray, stride: number) => T
+    bufferType: new (array: TypedArray, stride: number) => T
   ) {
     const typedArrays = [...new Set(componentTypes)].map(componentType => {
       const TypedArray = DATA_TYPE_BYTE_SIZES.get(componentType)!;

--- a/viewer/packages/sector-parser/src/reveal-glb-parser/primitiveGeometries.ts
+++ b/viewer/packages/sector-parser/src/reveal-glb-parser/primitiveGeometries.ts
@@ -3,7 +3,17 @@
  */
 
 import { assertNever } from '@reveal/utilities';
-import * as THREE from 'three';
+import type { BufferGeometry, InterleavedBufferAttribute } from 'three';
+import {
+  Box3,
+  BoxGeometry,
+  BufferAttribute,
+  CylinderGeometry,
+  Float32BufferAttribute,
+  Matrix4,
+  PlaneGeometry,
+  Uint16BufferAttribute
+} from 'three';
 import { RevealGeometryCollectionType } from '../types';
 
 /**
@@ -43,13 +53,13 @@ function generatePlane3D(
   }
 
   return {
-    index: new THREE.Uint16BufferAttribute(indices, 1),
-    position: new THREE.Float32BufferAttribute(vertices, 3)
+    index: new Uint16BufferAttribute(indices, 1),
+    position: new Float32BufferAttribute(vertices, 3)
   };
 }
 
-export function setBoxGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
-  const boxGeometry = new THREE.BoxGeometry(1, 1, 1, 1, 1, 1);
+export function setBoxGeometry(geometry: BufferGeometry): Box3 {
+  const boxGeometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
 
   geometry.setIndex(boxGeometry.getIndex());
   geometry.setAttribute('position', boxGeometry.getAttribute('position'));
@@ -60,8 +70,8 @@ export function setBoxGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
   return geometry.boundingBox!;
 }
 
-export function setQuadGeometry(geometry: THREE.BufferGeometry, includeNormal = true): THREE.Box3 {
-  const quadGeometry = new THREE.PlaneGeometry(1, 1, 1, 1);
+export function setQuadGeometry(geometry: BufferGeometry, includeNormal = true): Box3 {
+  const quadGeometry = new PlaneGeometry(1, 1, 1, 1);
 
   geometry.setIndex(quadGeometry.getIndex());
   geometry.setAttribute('position', quadGeometry.getAttribute('position'));
@@ -73,17 +83,17 @@ export function setQuadGeometry(geometry: THREE.BufferGeometry, includeNormal = 
   return geometry.boundingBox!;
 }
 
-export function setTrapeziumGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
+export function setTrapeziumGeometry(geometry: BufferGeometry): Box3 {
   const index = [0, 1, 3, 0, 3, 2];
   const position = [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3];
 
-  geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(index), 1));
-  geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(position), 3));
+  geometry.setIndex(new BufferAttribute(new Uint16Array(index), 1));
+  geometry.setAttribute('position', new BufferAttribute(new Float32Array(position), 3));
 
-  return new THREE.Box3().setFromArray(position);
+  return new Box3().setFromArray(position);
 }
 
-export function setConeGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
+export function setConeGeometry(geometry: BufferGeometry): Box3 {
   const positions = [];
   positions.push(-1, 1, -1);
   positions.push(-1, -1, -1);
@@ -94,12 +104,12 @@ export function setConeGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
 
   const indices = new Uint16Array([1, 2, 0, 1, 3, 2, 3, 4, 2, 3, 5, 4]);
 
-  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
-  geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(positions), 3));
-  return new THREE.Box3().setFromArray(positions);
+  geometry.setIndex(new BufferAttribute(indices, 1));
+  geometry.setAttribute('position', new BufferAttribute(new Float32Array(positions), 3));
+  return new Box3().setFromArray(positions);
 }
 
-export function setTorusGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
+export function setTorusGeometry(geometry: BufferGeometry): Box3 {
   const lods = [
     { tubularSegments: 9, radialSegments: 18 },
     { tubularSegments: 5, radialSegments: 12 },
@@ -112,25 +122,23 @@ export function setTorusGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
   geometry.setIndex(torusGeometry.index);
   geometry.setAttribute('position', torusGeometry.position);
 
-  return new THREE.Box3().setFromArray(torusGeometry.position.array);
+  return new Box3().setFromArray(torusGeometry.position.array);
 }
 
-export function setNutGeometry(geometry: THREE.BufferGeometry): THREE.Box3 {
-  const nutGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, 6);
-  nutGeometry.applyMatrix4(new THREE.Matrix4().makeRotationX(-Math.PI / 2));
+export function setNutGeometry(geometry: BufferGeometry): Box3 {
+  const nutGeometry = new CylinderGeometry(0.5, 0.5, 1, 6);
+  nutGeometry.applyMatrix4(new Matrix4().makeRotationX(-Math.PI / 2));
 
   geometry.setIndex(nutGeometry.getIndex());
   geometry.setAttribute('position', nutGeometry.getAttribute('position'));
   geometry.setAttribute('normal', nutGeometry.getAttribute('normal'));
 
-  return new THREE.Box3().setFromArray(
-    (nutGeometry.getAttribute('position') as THREE.InterleavedBufferAttribute).array
-  );
+  return new Box3().setFromArray((nutGeometry.getAttribute('position') as InterleavedBufferAttribute).array);
 }
 
 export function setPrimitiveTopology(
   primitiveCollectionName: RevealGeometryCollectionType,
-  geometry: THREE.BufferGeometry
+  geometry: BufferGeometry
 ): void {
   switch (primitiveCollectionName) {
     case RevealGeometryCollectionType.BoxCollection:

--- a/viewer/packages/sector-parser/visual-tests/GeneralCylinder.VisualTest.ts
+++ b/viewer/packages/sector-parser/visual-tests/GeneralCylinder.VisualTest.ts
@@ -1,20 +1,20 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import { Vector3, Vector4 } from 'three';
 import type { GeneralCylinder } from '../../../test-utilities/src/primitives';
 import { PrimitiveName } from '../../../test-utilities/src/primitives';
 import { PrimitivesVisualTestFixture } from './PrimitivesVisualTestFixture';
 
 type GeneralCylinderAttributes = {
   treeIndex: number;
-  color: THREE.Vector4;
-  centerA: THREE.Vector3;
-  centerB: THREE.Vector3;
+  color: Vector4;
+  centerA: Vector3;
+  centerB: Vector3;
   radius: number;
-  planeA: THREE.Vector4;
-  planeB: THREE.Vector4;
-  localXAxis: THREE.Vector3;
+  planeA: Vector4;
+  planeB: Vector4;
+  localXAxis: Vector3;
   angle: number;
   arcAngle: number;
 };
@@ -24,37 +24,37 @@ export default class GeneralCylinderVisualTest extends PrimitivesVisualTestFixtu
     const testCylinders: GeneralCylinderAttributes[] = [
       {
         treeIndex: 0,
-        color: new THREE.Vector4(1, 0, 0, 1),
-        centerA: new THREE.Vector3(0, 0.5, 1),
-        centerB: new THREE.Vector3(0, 0, 0.5),
+        color: new Vector4(1, 0, 0, 1),
+        centerA: new Vector3(0, 0.5, 1),
+        centerB: new Vector3(0, 0, 0.5),
         radius: 0.2,
-        planeA: new THREE.Vector4(0.4161, 0.0733, 0.9063, 2),
-        planeB: new THREE.Vector4(0, 0, -1, 0),
-        localXAxis: new THREE.Vector3(1, 0, 0),
+        planeA: new Vector4(0.4161, 0.0733, 0.9063, 2),
+        planeB: new Vector4(0, 0, -1, 0),
+        localXAxis: new Vector3(1, 0, 0),
         angle: 0,
         arcAngle: Math.PI * 2
       },
       {
         treeIndex: 1,
-        color: new THREE.Vector4(255, 0, 0, 1),
-        centerA: new THREE.Vector3(0, 0.5, 1),
-        centerB: new THREE.Vector3(0, 0, 0.5),
+        color: new Vector4(255, 0, 0, 1),
+        centerA: new Vector3(0, 0.5, 1),
+        centerB: new Vector3(0, 0, 0.5),
         radius: 0.6,
-        planeA: new THREE.Vector4(0.4161, 0.0733, 0.9063, 2),
-        planeB: new THREE.Vector4(0, 0, -1, 0),
-        localXAxis: new THREE.Vector3(1, 0, 0),
+        planeA: new Vector4(0.4161, 0.0733, 0.9063, 2),
+        planeB: new Vector4(0, 0, -1, 0),
+        localXAxis: new Vector3(1, 0, 0),
         angle: 0,
         arcAngle: Math.PI * 1.5
       },
       {
         treeIndex: 2,
-        color: new THREE.Vector4(255, 0, 0, 1),
-        centerA: new THREE.Vector3(2, 0, -1),
-        centerB: new THREE.Vector3(-2, 0, -1),
+        color: new Vector4(255, 0, 0, 1),
+        centerA: new Vector3(2, 0, -1),
+        centerB: new Vector3(-2, 0, -1),
         radius: 0.5,
-        planeA: new THREE.Vector4(0.577, 0.577, 0.577, 2),
-        planeB: new THREE.Vector4(0.577, 0.577, -0.577, 0),
-        localXAxis: new THREE.Vector3(0, 1, 0),
+        planeA: new Vector4(0.577, 0.577, 0.577, 2),
+        planeB: new Vector4(0.577, 0.577, -0.577, 0),
+        localXAxis: new Vector3(0, 1, 0),
         angle: Math.PI * 0.3,
         arcAngle: Math.PI * 1.7
       }

--- a/viewer/packages/sector-parser/visual-tests/PrimitivesVisualTestFixture.ts
+++ b/viewer/packages/sector-parser/visual-tests/PrimitivesVisualTestFixture.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import type { Matrix4, Scene, Vector3 } from 'three';
+import { Group, InstancedMesh } from 'three';
 import type { Primitive, PrimitiveName } from '../../../test-utilities/src/primitives';
 import { createPrimitiveInterleavedGeometry, getCollectionType } from '../../../test-utilities/src/primitives';
 import type { SimpleTestFixtureComponents } from '../../../visual-tests';
@@ -26,11 +27,11 @@ export abstract class PrimitivesVisualTestFixture extends SimpleVisualTestFixtur
     const materials = getMaterialsMap(this._primitives.length);
 
     const generalCylinderMaterial = materials.get(getCollectionType(this._primitiveName))!;
-    const mesh = new THREE.InstancedMesh(geometry, generalCylinderMaterial, this._primitives.length);
+    const mesh = new InstancedMesh(geometry, generalCylinderMaterial, this._primitives.length);
     mesh.frustumCulled = false;
     mesh.onBeforeRender = () => {
-      (generalCylinderMaterial.uniforms.inverseModelMatrix?.value as THREE.Matrix4)?.copy(mesh.matrixWorld).invert();
-      (generalCylinderMaterial.uniforms.cameraPosition?.value as THREE.Vector3)?.copy(camera.position);
+      (generalCylinderMaterial.uniforms.inverseModelMatrix?.value as Matrix4)?.copy(mesh.matrixWorld).invert();
+      (generalCylinderMaterial.uniforms.cameraPosition?.value as Vector3)?.copy(camera.position);
     };
 
     group.add(mesh);
@@ -41,8 +42,8 @@ export abstract class PrimitivesVisualTestFixture extends SimpleVisualTestFixtur
     return Promise.resolve();
   }
 
-  private initializeGroup(scene: THREE.Scene) {
-    const group = new THREE.Group();
+  private initializeGroup(scene: Scene) {
+    const group = new Group();
     group.frustumCulled = false;
     group.applyMatrix4(this.cadFromCdfToThreeMatrix);
     scene.add(group);

--- a/viewer/packages/sector-parser/visual-tests/SectorParser.VisualTest.ts
+++ b/viewer/packages/sector-parser/visual-tests/SectorParser.VisualTest.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Matrix4, PerspectiveCamera, RawShaderMaterial, Scene } from 'three';
+import { Box3, Group, Mesh, Vector3 } from 'three';
 
 import type { SimpleTestFixtureComponents } from '../../../visual-tests';
 import { SimpleVisualTestFixture } from '../../../visual-tests';
@@ -37,7 +38,7 @@ export default class SectorParserVisualTestFixture extends SimpleVisualTestFixtu
     const min = sectors[0].boundingBox.min;
     const max = sectors[0].boundingBox.max;
 
-    const boundingBox = new THREE.Box3(new THREE.Vector3(min.x, min.y, min.z), new THREE.Vector3(max.x, max.y, max.z));
+    const boundingBox = new Box3(new Vector3(min.x, min.y, min.z), new Vector3(max.x, max.y, max.z));
     boundingBox.applyMatrix4(this.cadFromCdfToThreeMatrix);
 
     const fileNames = sectors.map(sector => sector.sectorFileName);
@@ -54,20 +55,20 @@ export default class SectorParserVisualTestFixture extends SimpleVisualTestFixtu
   private async loadSectors(
     blobs: ArrayBuffer[],
     loader: GltfSectorParser,
-    materialMap: Map<RevealGeometryCollectionType, THREE.RawShaderMaterial>,
-    camera: THREE.PerspectiveCamera,
-    group: THREE.Group
+    materialMap: Map<RevealGeometryCollectionType, RawShaderMaterial>,
+    camera: PerspectiveCamera,
+    group: Group
   ) {
     return Promise.all(
       blobs.map(async element => {
         const geometries = await loader.parseSector(element);
         geometries.forEach(result => {
           const material = materialMap.get(result.type)!;
-          const mesh = new THREE.Mesh(result.geometryBuffer, material);
+          const mesh = new Mesh(result.geometryBuffer, material);
           mesh.frustumCulled = false;
           mesh.onBeforeRender = () => {
-            (material.uniforms.inverseModelMatrix?.value as THREE.Matrix4)?.copy(mesh.matrixWorld).invert();
-            (material.uniforms.cameraPosition?.value as THREE.Vector3)?.copy(camera.position);
+            (material.uniforms.inverseModelMatrix?.value as Matrix4)?.copy(mesh.matrixWorld).invert();
+            (material.uniforms.cameraPosition?.value as Vector3)?.copy(camera.position);
           };
           group.add(mesh);
         });
@@ -75,8 +76,8 @@ export default class SectorParserVisualTestFixture extends SimpleVisualTestFixtu
     );
   }
 
-  private initializeGroup(scene: THREE.Scene) {
-    const group = new THREE.Group();
+  private initializeGroup(scene: Scene) {
+    const group = new Group();
     group.frustumCulled = false;
     group.applyMatrix4(this.cadFromCdfToThreeMatrix);
     scene.add(group);

--- a/viewer/packages/sector-parser/visual-tests/testMaterials.ts
+++ b/viewer/packages/sector-parser/visual-tests/testMaterials.ts
@@ -1,14 +1,26 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { ShaderMaterialParameters } from 'three';
+import {
+  CustomBlending,
+  DataTexture,
+  DoubleSide,
+  GLSL3,
+  Matrix4,
+  OneFactor,
+  RawShaderMaterial,
+  Texture,
+  Vector2,
+  ZeroFactor
+} from 'three';
 
 // TODO: Fix dependencies such that test app doesn't depend on core internals
 import { getMatCapTextureData } from '../../../packages/rendering/src/rendering/matCapTextureData';
 import { sectorShaders } from '../../../packages/rendering/src/rendering/shaders';
 import { RevealGeometryCollectionType } from '../src/types';
 
-const matCapTexture = new THREE.Texture(getMatCapTextureData());
+const matCapTexture = new Texture(getMatCapTextureData());
 matCapTexture.needsUpdate = true;
 
 function getColorDataTexture(treeIndexCount: number) {
@@ -20,7 +32,7 @@ function getColorDataTexture(treeIndexCount: number) {
     buffer[i * 4 + 3] = 1;
   }
   // Color and style override texture
-  const overrideColorPerTreeIndexTexture = new THREE.DataTexture(buffer, width, height);
+  const overrideColorPerTreeIndexTexture = new DataTexture(buffer, width, height);
 
   return { colorDataTexture: overrideColorPerTreeIndexTexture, width, height };
 
@@ -35,28 +47,28 @@ function getColorDataTexture(treeIndexCount: number) {
   }
 }
 
-export function getMaterialsMap(treeIndexCount: number): Map<RevealGeometryCollectionType, THREE.RawShaderMaterial> {
+export function getMaterialsMap(treeIndexCount: number): Map<RevealGeometryCollectionType, RawShaderMaterial> {
   const { colorDataTexture, width, height } = getColorDataTexture(treeIndexCount);
   colorDataTexture.needsUpdate = true;
 
-  const sharedParams: THREE.ShaderMaterialParameters = {
+  const sharedParams: ShaderMaterialParameters = {
     clipping: false,
     uniforms: {
       renderMode: { value: 1 },
       inverseModelMatrix: {
-        value: new THREE.Matrix4()
+        value: new Matrix4()
       },
       matCapTexture: { value: matCapTexture },
-      treeIndexTextureSize: { value: new THREE.Vector2(width, height) },
+      treeIndexTextureSize: { value: new Vector2(width, height) },
       colorDataTexture: { value: colorDataTexture }
     },
-    side: THREE.DoubleSide,
-    glslVersion: THREE.GLSL3,
-    blending: THREE.CustomBlending,
-    blendDst: THREE.ZeroFactor,
-    blendDstAlpha: THREE.OneFactor,
-    blendSrc: THREE.OneFactor,
-    blendSrcAlpha: THREE.ZeroFactor
+    side: DoubleSide,
+    glslVersion: GLSL3,
+    blending: CustomBlending,
+    blendDst: ZeroFactor,
+    blendDstAlpha: OneFactor,
+    blendSrc: OneFactor,
+    blendSrcAlpha: ZeroFactor
   };
   return new Map([
     [
@@ -183,9 +195,9 @@ function createMaterial(
   name: string,
   vertexShader: string,
   fragmentShader: string,
-  sharedParams: THREE.ShaderMaterialParameters
-): THREE.RawShaderMaterial {
-  return new THREE.RawShaderMaterial({
+  sharedParams: ShaderMaterialParameters
+): RawShaderMaterial {
+  return new RawShaderMaterial({
     ...sharedParams,
     name,
     vertexShader,

--- a/viewer/packages/tools/src/AxisView/AxisViewTool.test.ts
+++ b/viewer/packages/tools/src/AxisView/AxisViewTool.test.ts
@@ -4,7 +4,7 @@
 
 import { CogniteClient } from '@cognite/sdk';
 import { Cognite3DViewer } from '@reveal/api';
-import type * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
 
 import { mockClientAuthentication, autoMockWebGLRenderer } from '../../../../test-utilities';
 
@@ -26,7 +26,7 @@ describe('AxisViewTool', () => {
       getToken: async () => 'dummy'
     });
     mockClientAuthentication(sdk);
-    const renderer = autoMockWebGLRenderer(new Mock<THREE.WebGLRenderer>()).object();
+    const renderer = autoMockWebGLRenderer(new Mock<WebGLRenderer>()).object();
     renderer.render = vi.fn();
 
     domSize = { height: 480, width: 640 };

--- a/viewer/packages/tools/src/AxisView/AxisViewTool.ts
+++ b/viewer/packages/tools/src/AxisView/AxisViewTool.ts
@@ -2,7 +2,22 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import {
+  CanvasTexture,
+  CustomBlending,
+  DoubleSide,
+  GLSL3,
+  Group,
+  Mesh,
+  OneMinusSrcAlphaFactor,
+  PlaneGeometry,
+  RawShaderMaterial,
+  Raycaster,
+  SrcAlphaFactor,
+  Vector2,
+  Vector3
+} from 'three';
 import { cloneDeep, merge } from 'lodash-es';
 
 import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
@@ -19,16 +34,16 @@ import { Corner } from '../utilities/Corner';
 export class AxisViewTool extends Cognite3DViewerToolBase {
   private readonly _layoutConfig: Required<AxisBoxConfig>;
 
-  private readonly _boxFaceGeometry: THREE.PlaneGeometry;
+  private readonly _boxFaceGeometry: PlaneGeometry;
 
   private readonly _viewer: Cognite3DViewer;
 
-  private readonly _axisGroup: THREE.Group;
+  private readonly _axisGroup: Group;
 
-  private readonly _interactiveObjects: THREE.Mesh[];
-  private readonly _raycaster: THREE.Raycaster;
+  private readonly _interactiveObjects: Mesh[];
+  private readonly _raycaster: Raycaster;
 
-  private readonly _screenPosition: THREE.Vector2;
+  private readonly _screenPosition: Vector2;
 
   private readonly _disposeClickDiv: () => void;
 
@@ -38,17 +53,17 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
   constructor(viewer: Cognite3DViewer, config?: AxisBoxConfig) {
     super();
 
-    this._screenPosition = new THREE.Vector2();
-    this._boxFaceGeometry = new THREE.PlaneGeometry(0.9, 0.9, 1, 1);
+    this._screenPosition = new Vector2();
+    this._boxFaceGeometry = new PlaneGeometry(0.9, 0.9, 1, 1);
 
-    this._raycaster = new THREE.Raycaster();
+    this._raycaster = new Raycaster();
     this._raycaster.layers.enableAll();
 
     this._viewer = viewer;
 
     this._layoutConfig = merge(cloneDeep(defaultAxisBoxConfig), config);
 
-    this._axisGroup = new THREE.Group();
+    this._axisGroup = new Group();
     this._axisGroup.name = 'Axis View Tool';
     this._axisGroup.renderOrder = 1;
     this._interactiveObjects = this.createAxisCross(this._axisGroup);
@@ -103,7 +118,7 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
     ];
   }
 
-  private addAxisBoxToViewer(axisGroup: THREE.Group, position: AbsolutePosition | RelativePosition) {
+  private addAxisBoxToViewer(axisGroup: Group, position: AbsolutePosition | RelativePosition) {
     const size = this._layoutConfig.size;
 
     if (isAbsolute(position)) {
@@ -155,8 +170,8 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
   private handleClick(xScreenPos: number, yScreenPos: number, boundingRect: DOMRect): boolean {
     const xNdc = (2 * (xScreenPos - this._screenPosition.x)) / this._layoutConfig.size - 1;
     const yNdc = (2 * (boundingRect.height - yScreenPos - this._screenPosition.y)) / this._layoutConfig.size - 1;
-    const rayOrigin = new THREE.Vector3(xNdc, yNdc, 1);
-    const rayDirection = new THREE.Vector3(0, 0, -1).normalize();
+    const rayOrigin = new Vector3(xNdc, yNdc, 1);
+    const rayDirection = new Vector3(0, 0, -1).normalize();
     this._raycaster.set(rayOrigin, rayDirection);
 
     const intersects = this._raycaster.intersectObjects(this._interactiveObjects);
@@ -164,13 +179,13 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
     if (!(intersects.length > 0)) return false;
 
     const targetAxis = intersects[0].object.position.clone().normalize();
-    const targetUp = (intersects[0].object.userData.upVector as THREE.Vector3).clone();
+    const targetUp = (intersects[0].object.userData.upVector as Vector3).clone();
 
     moveCameraTo(this._viewer.cameraManager, targetAxis, targetUp, this._layoutConfig.animationSpeed);
     return true;
   }
 
-  private createAxisCross(axisGroup: THREE.Group) {
+  private createAxisCross(axisGroup: Group) {
     const compass = this.createCompass();
     axisGroup.add(compass);
 
@@ -182,8 +197,8 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
     return interactiveObjects;
   }
 
-  private setupTransformOnRender(axisGroup: THREE.Group) {
-    axisGroup.children[0].onBeforeRender = (renderer: THREE.WebGLRenderer) => {
+  private setupTransformOnRender(axisGroup: Group) {
+    axisGroup.children[0].onBeforeRender = (renderer: WebGLRenderer) => {
       this._dynamicUpdatePosition();
       axisGroup.quaternion.copy(this._viewer.cameraManager.getCamera().quaternion).invert();
       axisGroup.updateMatrixWorld();
@@ -192,22 +207,22 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
       const cWidth = renderer.domElement.clientWidth;
       const cHeight = renderer.domElement.clientHeight;
 
-      const renderSize = new THREE.Vector2();
+      const renderSize = new Vector2();
       renderer.getSize(renderSize);
 
       const size = this._layoutConfig.size;
 
-      const scale = new THREE.Vector2(size / cWidth, size / cHeight);
-      const offset = new THREE.Vector2(
+      const scale = new Vector2(size / cWidth, size / cHeight);
+      const offset = new Vector2(
         (this._screenPosition.x / cWidth) * 2 + size / cWidth,
         (this._screenPosition.y / cHeight) * 2 + size / cHeight
       );
 
       axisGroup.traverse(node => {
-        if (node instanceof THREE.Mesh) {
-          (node.material as THREE.RawShaderMaterial).uniforms.offset.value = offset;
-          (node.material as THREE.RawShaderMaterial).uniforms.scale.value = scale;
-          (node.material as THREE.RawShaderMaterial).uniformsNeedUpdate = true;
+        if (node instanceof Mesh) {
+          (node.material as RawShaderMaterial).uniforms.offset.value = offset;
+          (node.material as RawShaderMaterial).uniforms.scale.value = scale;
+          (node.material as RawShaderMaterial).uniformsNeedUpdate = true;
         }
       });
     };
@@ -216,44 +231,36 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
   private createBoxFaces() {
     const facesConfig = this._layoutConfig.faces;
 
-    const posXFace = this.createBoxFace(new THREE.Vector3(1, 0, 0), facesConfig.xPositiveFace!);
-    const negXFace = this.createBoxFace(new THREE.Vector3(-1, 0, 0), facesConfig.xNegativeFace!);
+    const posXFace = this.createBoxFace(new Vector3(1, 0, 0), facesConfig.xPositiveFace!);
+    const negXFace = this.createBoxFace(new Vector3(-1, 0, 0), facesConfig.xNegativeFace!);
 
-    const posYFace = this.createBoxFace(
-      new THREE.Vector3(0, 1, 0),
-      facesConfig.yPositiveFace!,
-      new THREE.Vector3(0, 0, -1)
-    );
-    const negYFace = this.createBoxFace(
-      new THREE.Vector3(0, -1, 0),
-      facesConfig.yNegativeFace!,
-      new THREE.Vector3(0, 0, 1)
-    );
+    const posYFace = this.createBoxFace(new Vector3(0, 1, 0), facesConfig.yPositiveFace!, new Vector3(0, 0, -1));
+    const negYFace = this.createBoxFace(new Vector3(0, -1, 0), facesConfig.yNegativeFace!, new Vector3(0, 0, 1));
 
-    const posZFace = this.createBoxFace(new THREE.Vector3(0, 0, 1), facesConfig.zPositiveFace!);
-    const negZFace = this.createBoxFace(new THREE.Vector3(0, 0, -1), facesConfig.zNegativeFace!);
+    const posZFace = this.createBoxFace(new Vector3(0, 0, 1), facesConfig.zPositiveFace!);
+    const negZFace = this.createBoxFace(new Vector3(0, 0, -1), facesConfig.zNegativeFace!);
 
     return [posXFace, negXFace, posYFace, negYFace, posZFace, negZFace];
   }
 
   private createCompass() {
-    const compassPlaneGeometry = new THREE.PlaneGeometry(2, 2, 1, 1);
-    const compass = new THREE.Mesh(
+    const compassPlaneGeometry = new PlaneGeometry(2, 2, 1, 1);
+    const compass = new Mesh(
       compassPlaneGeometry,
-      new THREE.RawShaderMaterial({
+      new RawShaderMaterial({
         vertexShader: vertexShader,
         fragmentShader: fragmentShader,
         uniforms: {
-          offset: { value: new THREE.Vector2() },
-          scale: { value: new THREE.Vector2() },
+          offset: { value: new Vector2() },
+          scale: { value: new Vector2() },
           tex: { value: this.createCompassTexture() }
         },
-        side: THREE.DoubleSide,
-        glslVersion: THREE.GLSL3,
+        side: DoubleSide,
+        glslVersion: GLSL3,
         depthTest: false,
-        blending: THREE.CustomBlending,
-        blendDst: THREE.OneMinusSrcAlphaFactor,
-        blendSrc: THREE.SrcAlphaFactor
+        blending: CustomBlending,
+        blendDst: OneMinusSrcAlphaFactor,
+        blendSrc: SrcAlphaFactor
       })
     );
 
@@ -264,7 +271,7 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
     const z = Math.cos(this._layoutConfig.compass.labelDelta!);
 
     compass.position.y = -0.45;
-    compass.up.copy(new THREE.Vector3(x, 0, z));
+    compass.up.copy(new Vector3(x, 0, z));
     compass.lookAt(0, 0, 0);
 
     return compass;
@@ -299,7 +306,7 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
       context.fillStyle = compassLayout.fontColor!.getStyle();
       context.fillText(compassLayout.ringLabel, halfSize, halfSize * (1 / 4) + fontSize / 3);
     }
-    const canvasTexture = new THREE.CanvasTexture(canvas);
+    const canvasTexture = new CanvasTexture(canvas);
     canvasTexture.anisotropy = 8;
     return canvasTexture;
   }
@@ -327,24 +334,24 @@ export class AxisViewTool extends Cognite3DViewerToolBase {
       context.fillStyle = faceConfig.fontColor!.getStyle();
       context.fillText(faceConfig.label!, textureSize / 2, textureSize / 2 + fontSize / 3);
     }
-    const canvasTexture = new THREE.CanvasTexture(canvas);
+    const canvasTexture = new CanvasTexture(canvas);
     canvasTexture.anisotropy = 8;
     return canvasTexture;
   }
 
-  private createBoxFace(position: THREE.Vector3, faceConfig: AxisBoxFaceConfig, upVector = new THREE.Vector3(0, 1, 0)) {
-    const face = new THREE.Mesh(
+  private createBoxFace(position: Vector3, faceConfig: AxisBoxFaceConfig, upVector = new Vector3(0, 1, 0)) {
+    const face = new Mesh(
       this._boxFaceGeometry,
-      new THREE.RawShaderMaterial({
+      new RawShaderMaterial({
         vertexShader: vertexShader,
         fragmentShader: fragmentShader,
         uniforms: {
-          offset: { value: new THREE.Vector2() },
-          scale: { value: new THREE.Vector2() },
+          offset: { value: new Vector2() },
+          scale: { value: new Vector2() },
           tex: { value: this.getFaceTexture(faceConfig, this._layoutConfig.size) }
         },
         depthTest: false,
-        glslVersion: THREE.GLSL3,
+        glslVersion: GLSL3,
         // Even if this isn't transparent, we want ThreeJS to draw the object
         // after transparent objects so its correctly blended
         transparent: true

--- a/viewer/packages/tools/src/AxisView/types.ts
+++ b/viewer/packages/tools/src/AxisView/types.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Color, Vector2 } from 'three';
 import { AxisViewTool } from './AxisViewTool';
 import { Corner } from '../utilities/Corner';
 
@@ -57,7 +57,7 @@ export type AbsolutePosition = {
  */
 export type RelativePosition = {
   corner: Corner;
-  padding: THREE.Vector2;
+  padding: Vector2;
 };
 
 /**
@@ -69,10 +69,10 @@ export type AxisBoxFaceConfig = {
    */
   label?: string;
   fontSize?: number;
-  fontColor?: THREE.Color;
+  fontColor?: Color;
   outlineSize?: number;
-  outlineColor?: THREE.Color;
-  faceColor?: THREE.Color;
+  outlineColor?: Color;
+  faceColor?: Color;
 };
 
 /**
@@ -89,32 +89,32 @@ export type AxisBoxCompassConfig = {
    */
   labelDelta?: number;
   fontSize?: number;
-  fontColor?: THREE.Color;
-  tickColor?: THREE.Color;
+  fontColor?: Color;
+  tickColor?: Color;
 };
 
 export const defaultAxisBoxCompassConfig: AxisBoxCompassConfig = {
   ringLabel: 'N',
   labelDelta: Math.PI,
   fontSize: undefined,
-  fontColor: new THREE.Color(0xff0000),
-  tickColor: new THREE.Color(0x949494)
+  fontColor: new Color(0xff0000),
+  tickColor: new Color(0x949494)
 };
 
 export const defaultFaceConfig: AxisBoxFaceConfig = {
   label: '',
   fontSize: undefined,
-  fontColor: new THREE.Color(0x333333),
+  fontColor: new Color(0x333333),
   outlineSize: undefined,
-  outlineColor: new THREE.Color(0x333333),
-  faceColor: new THREE.Color(0x949494)
+  outlineColor: new Color(0x333333),
+  faceColor: new Color(0x949494)
 };
 
 export const defaultAxisBoxConfig: Required<AxisBoxConfig> = {
   size: 128,
   position: {
     corner: Corner.BottomRight,
-    padding: new THREE.Vector2()
+    padding: new Vector2()
   },
   animationSpeed: 200,
   faces: {

--- a/viewer/packages/tools/src/DebugCameraTool.ts
+++ b/viewer/packages/tools/src/DebugCameraTool.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { PerspectiveCamera } from 'three';
+import { CameraHelper } from 'three';
 import type { DisposedDelegate } from '@reveal/utilities';
 
 import { Cognite3DViewerToolBase } from './Cognite3DViewerToolBase';
@@ -12,9 +13,9 @@ import type { DataSourceType } from '@reveal/data-providers';
 export class DebugCameraTool extends Cognite3DViewerToolBase {
   private readonly _viewer: Cognite3DViewer<DataSourceType>;
   private readonly _onViewerDisposedHandler: DisposedDelegate;
-  private _cameraHelper?: THREE.CameraHelper;
+  private _cameraHelper?: CameraHelper;
 
-  private get viewerCamera(): THREE.PerspectiveCamera {
+  private get viewerCamera(): PerspectiveCamera {
     return this._viewer.cameraManager.getCamera();
   }
 
@@ -37,7 +38,7 @@ export class DebugCameraTool extends Cognite3DViewerToolBase {
 
   showCameraHelper(): void {
     this.hideCameraHelper();
-    this._cameraHelper = new THREE.CameraHelper(this.viewerCamera.clone() as THREE.PerspectiveCamera);
+    this._cameraHelper = new CameraHelper(this.viewerCamera.clone() as PerspectiveCamera);
     this._viewer.addObject3D(this._cameraHelper);
   }
 

--- a/viewer/packages/tools/src/HtmlOverlay/BucketGrid2D.test.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/BucketGrid2D.test.ts
@@ -1,28 +1,28 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Box2, Vector2 } from 'three';
 import { BucketGrid2D } from './BucketGrid2D';
 
 describe('BucketGrid2D', () => {
   let dimensions: [number, number];
-  let bounds: THREE.Box2;
+  let bounds: Box2;
   let grid: BucketGrid2D<number>;
-  let cellBounds: (i: number, j: number) => THREE.Box2;
+  let cellBounds: (i: number, j: number) => Box2;
 
   beforeEach(() => {
     dimensions = [2, 2];
 
-    bounds = new THREE.Box2(new THREE.Vector2(1, 2), new THREE.Vector2(2, 4));
+    bounds = new Box2(new Vector2(1, 2), new Vector2(2, 4));
     grid = new BucketGrid2D<number>(bounds, dimensions);
 
     cellBounds = (i, j) => {
       // Create box that is just inside the bounds of the cell
-      const boundsSize = bounds.getSize(new THREE.Vector2());
-      const cellSize = new THREE.Vector2(boundsSize.x / dimensions[0], boundsSize.y / dimensions[1]);
-      return new THREE.Box2(
-        new THREE.Vector2(bounds.min.x + cellSize.x * i + 1e-4, bounds.min.y + cellSize.y * j + 1e-4),
-        new THREE.Vector2(bounds.min.x + cellSize.x * (i + 1) - 1e-4, bounds.min.y + cellSize.y * (j + 1) - 1e-4)
+      const boundsSize = bounds.getSize(new Vector2());
+      const cellSize = new Vector2(boundsSize.x / dimensions[0], boundsSize.y / dimensions[1]);
+      return new Box2(
+        new Vector2(bounds.min.x + cellSize.x * i + 1e-4, bounds.min.y + cellSize.y * j + 1e-4),
+        new Vector2(bounds.min.x + cellSize.x * (i + 1) - 1e-4, bounds.min.y + cellSize.y * (j + 1) - 1e-4)
       );
     };
   });
@@ -84,6 +84,6 @@ describe('BucketGrid2D', () => {
   });
 });
 
-function createBounds(min: [x: number, y: number], max: [x: number, y: number]): THREE.Box2 {
-  return new THREE.Box2(new THREE.Vector2(min[0], min[1]), new THREE.Vector2(max[0], max[1]));
+function createBounds(min: [x: number, y: number], max: [x: number, y: number]): Box2 {
+  return new Box2(new Vector2(min[0], min[1]), new Vector2(max[0], max[1]));
 }

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.test.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.test.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { Vector2, Vector3 } from 'three';
 
 import type { HtmlOverlayOptions, HtmlOverlayToolOptions, HtmlOverlayCreateClusterDelegate } from './HtmlOverlayTool';
 import { HtmlOverlayTool } from './HtmlOverlayTool';
@@ -17,7 +18,7 @@ const TIMER_ADVANCE_MS = 50;
 describe(HtmlOverlayTool.name, () => {
   let canvasContainer: HTMLElement;
   let viewer: Cognite3DViewer<DataSourceType>;
-  let renderer: THREE.WebGLRenderer;
+  let renderer: WebGLRenderer;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -33,7 +34,7 @@ describe(HtmlOverlayTool.name, () => {
     const htmlElement = document.createElement('div');
     htmlElement.className = 'overlay';
     htmlElement.style.position = 'relative';
-    const position = new THREE.Vector3();
+    const position = new Vector3();
 
     // Act & Assert
     expect(() => {
@@ -47,7 +48,7 @@ describe(HtmlOverlayTool.name, () => {
     const helper = new HtmlOverlayTool(viewer);
     const htmlElement = document.createElement('div');
     htmlElement.style.cssText = 'position: absolute;';
-    const position = new THREE.Vector3();
+    const position = new Vector3();
 
     // Act & Assert
     expect(() => helper.add(htmlElement, position)).not.toThrow();
@@ -60,7 +61,7 @@ describe(HtmlOverlayTool.name, () => {
     htmlElement.style.position = 'absolute';
     expect(htmlElement.style.top).toHaveLength(0);
     expect(htmlElement.style.left).toHaveLength(0);
-    const position = new THREE.Vector3(0, 0, 0.5);
+    const position = new Vector3(0, 0, 0.5);
 
     // Act
     helper.add(htmlElement, position);
@@ -82,8 +83,8 @@ describe(HtmlOverlayTool.name, () => {
     behindFarPlaneElement.style.position = 'absolute';
 
     // Act
-    helper.add(behindCameraElement, new THREE.Vector3(0, 0, -1));
-    helper.add(behindFarPlaneElement, new THREE.Vector3(0, 0, 10));
+    helper.add(behindCameraElement, new Vector3(0, 0, -1));
+    helper.add(behindFarPlaneElement, new Vector3(0, 0, 10));
     helper.forceUpdate();
 
     // Assert
@@ -95,7 +96,7 @@ describe(HtmlOverlayTool.name, () => {
     const helper = new HtmlOverlayTool(viewer);
     const htmlElement = document.createElement('div');
     htmlElement.style.position = 'absolute';
-    const position = new THREE.Vector3(0, 0, 0.5);
+    const position = new Vector3(0, 0, 0.5);
 
     helper.add(htmlElement, position);
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
@@ -125,11 +126,11 @@ describe(HtmlOverlayTool.name, () => {
     const options: HtmlOverlayOptions = { positionUpdatedCallback: vi.fn() };
 
     // Act
-    helper.add(behindCameraElement, new THREE.Vector3(0, 0, -1), { ...options, userData: 'behindCameraElement' });
+    helper.add(behindCameraElement, new Vector3(0, 0, -1), { ...options, userData: 'behindCameraElement' });
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
-    helper.add(behindFarPlaneElement, new THREE.Vector3(0, 0, 10), { ...options, userData: 'behindFarPlaneElement' });
+    helper.add(behindFarPlaneElement, new Vector3(0, 0, 10), { ...options, userData: 'behindFarPlaneElement' });
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
-    helper.add(withinNearAndFarPlaneElement, new THREE.Vector3(0, 0, 0.5), {
+    helper.add(withinNearAndFarPlaneElement, new Vector3(0, 0, 0.5), {
       ...options,
       userData: 'withinNearAndFarPlaneElement'
     });
@@ -140,22 +141,22 @@ describe(HtmlOverlayTool.name, () => {
     // Assert
     expect(options.positionUpdatedCallback).toHaveBeenCalledWith(
       behindCameraElement,
-      expect.any(THREE.Vector2),
-      expect.any(THREE.Vector3),
+      expect.any(Vector2),
+      expect.any(Vector3),
       expect.anything(),
       'behindCameraElement'
     );
     expect(options.positionUpdatedCallback).toHaveBeenCalledWith(
       behindFarPlaneElement,
-      expect.any(THREE.Vector2),
-      expect.any(THREE.Vector3),
+      expect.any(Vector2),
+      expect.any(Vector3),
       expect.anything(),
       'behindFarPlaneElement'
     );
     expect(options.positionUpdatedCallback).toHaveBeenCalledWith(
       withinNearAndFarPlaneElement,
-      expect.any(THREE.Vector2),
-      expect.any(THREE.Vector3),
+      expect.any(Vector2),
+      expect.any(Vector3),
       expect.anything(),
       'withinNearAndFarPlaneElement'
     );
@@ -168,7 +169,7 @@ describe(HtmlOverlayTool.name, () => {
     for (let i = 0; i < 10; i++) {
       const element = document.createElement('div');
       element.style.position = 'absolute';
-      helper.add(element, new THREE.Vector3(0, 0, 0));
+      helper.add(element, new Vector3(0, 0, 0));
       vi.advanceTimersByTime(TIMER_ADVANCE_MS);
     }
     expect(canvasContainer.children.length).toBe(initialNumberOfElements + 10);
@@ -187,7 +188,7 @@ describe(HtmlOverlayTool.name, () => {
     for (let i = 0; i < 10; i++) {
       const element = document.createElement('div');
       element.style.position = 'absolute';
-      helper.add(element, new THREE.Vector3(0, 0, 0));
+      helper.add(element, new Vector3(0, 0, 0));
       vi.advanceTimersByTime(TIMER_ADVANCE_MS);
     }
 
@@ -216,10 +217,10 @@ describe(HtmlOverlayTool.name, () => {
     fakeGetBoundingClientRect(div2, 0, 0, 64, 18);
 
     // Act
-    helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    helper.add(div1, new Vector3(0, 0, 0.5));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
-    helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    helper.add(div2, new Vector3(0, 0, 0.7));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
     helper.forceUpdate();
@@ -247,10 +248,10 @@ describe(HtmlOverlayTool.name, () => {
     fakeGetBoundingClientRect(div2, 0, 0, 64, 18);
 
     // Act
-    helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    helper.add(div1, new Vector3(0, 0, 0.5));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
-    helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    helper.add(div2, new Vector3(0, 0, 0.7));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
     helper.forceUpdate();
@@ -282,9 +283,9 @@ describe(HtmlOverlayTool.name, () => {
     div2.style.position = 'absolute';
     fakeGetBoundingClientRect(div2, 0, 0, 64, 18);
 
-    helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    helper.add(div1, new Vector3(0, 0, 0.5));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
-    helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    helper.add(div2, new Vector3(0, 0, 0.7));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
     // Act — first update creates the composite
@@ -322,9 +323,9 @@ describe(HtmlOverlayTool.name, () => {
     div3.style.position = 'absolute';
     fakeGetBoundingClientRect(div3, 0, 0, 64, 18);
 
-    helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    helper.add(div1, new Vector3(0, 0, 0.5));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
-    helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    helper.add(div2, new Vector3(0, 0, 0.7));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
     // Act — first cluster composition is {div1, div2}
@@ -332,7 +333,7 @@ describe(HtmlOverlayTool.name, () => {
     expect(createClusterElementCallback).toHaveBeenCalledTimes(1);
 
     // Adding a third overlapping element changes the cluster composition
-    helper.add(div3, new THREE.Vector3(0, 0, 0.6));
+    helper.add(div3, new Vector3(0, 0, 0.6));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
     helper.forceUpdate();
 
@@ -356,9 +357,9 @@ describe(HtmlOverlayTool.name, () => {
     div2.style.position = 'absolute';
     fakeGetBoundingClientRect(div2, 0, 0, 64, 18);
 
-    helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    helper.add(div1, new Vector3(0, 0, 0.5));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
-    helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    helper.add(div2, new Vector3(0, 0, 0.7));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
     helper.forceUpdate();
@@ -387,9 +388,9 @@ describe(HtmlOverlayTool.name, () => {
     div2.style.position = 'absolute';
     fakeGetBoundingClientRect(div2, 0, 0, 64, 18);
 
-    helper.add(div1, new THREE.Vector3(0, 0, 0.5));
+    helper.add(div1, new Vector3(0, 0, 0.5));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
-    helper.add(div2, new THREE.Vector3(0, 0, 0.7));
+    helper.add(div2, new Vector3(0, 0, 0.7));
     vi.advanceTimersByTime(TIMER_ADVANCE_MS);
 
     helper.forceUpdate();

--- a/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
+++ b/viewer/packages/tools/src/HtmlOverlay/HtmlOverlayTool.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { PerspectiveCamera, WebGLRenderer } from 'three';
+import { Box2, Plane, Vector2, Vector3 } from 'three';
 
 import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
 import { BucketGrid2D } from './BucketGrid2D';
@@ -21,8 +22,8 @@ import type { DataSourceType } from '@reveal/data-providers';
  */
 export type HtmlOverlayPositionUpdatedDelegate = (
   element: HTMLElement,
-  position2D: THREE.Vector2,
-  position3D: THREE.Vector3,
+  position2D: Vector2,
+  position3D: Vector3,
   distanceToCamera: number,
   userData: any
 ) => void;
@@ -101,12 +102,12 @@ export type HtmlOverlayToolOptions = {
 };
 
 type HtmlOverlayElement = {
-  position3D: THREE.Vector3;
+  position3D: Vector3;
   options: HtmlOverlayOptions;
 
   state: {
     visible: boolean;
-    position2D: THREE.Vector2;
+    position2D: Vector2;
     width: number;
     height: number;
   };
@@ -139,7 +140,7 @@ type HtmlOverlayElement = {
  * el.innerHtml = '<h1>Overlay</h1>';
  *
  * const overlayTool = new HtmlOverlayTool(viewer);
- * overlayTool.add(el, new THREE.Vector3(10, 10, 10));
+ * overlayTool.add(el, new Vector3(10, 10, 10));
  * // ...
  * overlayTool.remove(el);
  * // or, to remove all attached elements
@@ -169,12 +170,12 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   private readonly _onViewerDisposedHandler: DisposedDelegate;
   // Allocate variables needed for processing once to avoid allocations
   private readonly _preallocatedVariables = {
-    camPos: new THREE.Vector3(),
-    camNormal: new THREE.Vector3(),
-    point: new THREE.Vector3(),
-    nearPlane: new THREE.Plane(),
-    farPlane: new THREE.Plane(),
-    position2D: new THREE.Vector2()
+    camPos: new Vector3(),
+    camNormal: new Vector3(),
+    point: new Vector3(),
+    nearPlane: new Plane(),
+    farPlane: new Plane(),
+    position2D: new Vector2()
   };
 
   private readonly scheduleUpdate: () => void;
@@ -183,7 +184,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
     return this._viewer.domElement;
   }
 
-  private get viewerCamera(): THREE.PerspectiveCamera {
+  private get viewerCamera(): PerspectiveCamera {
     return this._viewer.cameraManager.getCamera();
   }
 
@@ -211,7 +212,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   /**
    * Returns all added HTML elements along with their 3D positions.
    */
-  get elements(): { element: HTMLElement; position3D: THREE.Vector3 }[] {
+  get elements(): { element: HTMLElement; position3D: Vector3 }[] {
     return Array.from(this._htmlOverlays.entries()).map(([element, info]) => {
       return { element, position3D: info.position3D };
     });
@@ -235,7 +236,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
    * @param position3D
    * @param options
    */
-  add(htmlElement: HTMLElement, position3D: THREE.Vector3, options: HtmlOverlayOptions = {}): void {
+  add(htmlElement: HTMLElement, position3D: Vector3, options: HtmlOverlayOptions = {}): void {
     this.ensureNotDisposed();
 
     if (this.viewerDomElement.contains(htmlElement)) {
@@ -257,7 +258,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
         position3D,
         options,
         state: {
-          position2D: new THREE.Vector2(),
+          position2D: new Vector2(),
           width: -1,
           height: -1,
           visible: true
@@ -329,7 +330,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
    * Calling this function often might cause degraded performance.
    * @param customCamera Optional camera to be used in place of viewerCamera when calculating positions
    */
-  forceUpdate(customCamera?: THREE.PerspectiveCamera): void {
+  forceUpdate(customCamera?: PerspectiveCamera): void {
     // Do not update elements if overlay visibility is set to hidden/false.
     if (!this._visible) {
       return;
@@ -497,8 +498,8 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
 
     const canvas = this.viewerCanvas;
     const canvasBounds = domRectToBox2(canvas.getBoundingClientRect());
-    const canvasSize = canvasBounds.getSize(new THREE.Vector2());
-    canvasBounds.set(new THREE.Vector2(0, 0), canvasSize);
+    const canvasSize = canvasBounds.getSize(new Vector2());
+    canvasBounds.set(new Vector2(0, 0), canvasSize);
     // Compute once as updating styles below will cause (unnecessary)
     // recomputation which slows down the process
 
@@ -512,8 +513,8 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
       grid.insert(elementBounds, { htmlElement, ...element });
     }
 
-    const elementBounds = new THREE.Box2();
-    const clusterMidpoint = new THREE.Vector2();
+    const elementBounds = new Box2();
+    const clusterMidpoint = new Vector2();
     for (const element of this._htmlOverlays.values()) {
       const { state } = element;
       createElementBounds(element, elementBounds);
@@ -564,7 +565,7 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
       .join(',');
   }
 
-  private addComposite(htmlElement: HTMLElement, position: THREE.Vector2) {
+  private addComposite(htmlElement: HTMLElement, position: Vector2) {
     const canvas = this.viewerCanvas;
     htmlElement.style.visibility = 'visible';
     htmlElement.style.left = `${position.x + canvas.offsetLeft}px`;
@@ -574,8 +575,8 @@ export class HtmlOverlayTool extends Cognite3DViewerToolBase {
   private onSceneRendered(event: {
     frameNumber: number;
     renderTime: number;
-    renderer: THREE.WebGLRenderer;
-    camera: THREE.PerspectiveCamera;
+    renderer: WebGLRenderer;
+    camera: PerspectiveCamera;
   }): void {
     this.forceUpdate(event.camera);
   }
@@ -605,8 +606,8 @@ function fadeIn(htmlElement: HTMLElement) {
   htmlElement.style.transition = 'opacity 0.2s linear';
 }
 
-function domRectToBox2(rect: DOMRect, out?: THREE.Box2): THREE.Box2 {
-  out = out ?? new THREE.Box2();
+function domRectToBox2(rect: DOMRect, out?: Box2): Box2 {
+  out = out ?? new Box2();
   out.min.set(rect.left, rect.top);
   out.max.set(rect.right, rect.bottom);
   return out;
@@ -616,9 +617,9 @@ function clusterKeyContainsId(key: string, id: number): boolean {
   return key.split(',').includes(`${id}`);
 }
 
-function createElementBounds(element: HtmlOverlayElement, out?: THREE.Box2) {
+function createElementBounds(element: HtmlOverlayElement, out?: Box2) {
   const { state } = element;
-  out = out ?? new THREE.Box2();
+  out = out ?? new Box2();
   out.min.set(state.position2D.x, state.position2D.y);
   out.max.set(state.position2D.x + state.width, state.position2D.y + state.height);
   return out;

--- a/viewer/packages/tools/src/Measurement/MeasurementLine.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementLine.ts
@@ -3,21 +3,22 @@
  */
 
 import { Line2, LineGeometry, LineMaterial, isPointVisibleByPlanes } from '@reveal/utilities';
-import * as THREE from 'three';
+import type { Color, Plane } from 'three';
+import { BufferGeometry, Group, Mesh, Vector2, Vector3 } from 'three';
 
 export class MeasurementLine {
   private readonly _geometry: LineGeometry;
-  private readonly _meshes: THREE.Group;
+  private readonly _meshes: Group;
   private readonly _fixedWidthLineMaterial: LineMaterial;
   private readonly _adaptiveWidthLineMaterial: LineMaterial;
-  private readonly _startPos: THREE.Vector3;
-  private readonly _endpoint: THREE.Vector3;
+  private readonly _startPos: Vector3;
+  private readonly _endpoint: Vector3;
 
-  constructor(lineWidth: number, lineColor: THREE.Color, startPoint: THREE.Vector3) {
+  constructor(lineWidth: number, lineColor: Color, startPoint: Vector3) {
     this._geometry = new LineGeometry();
 
     this._startPos = startPoint;
-    this._endpoint = new THREE.Vector3();
+    this._endpoint = new Vector3();
 
     //Adaptive Line width
     this._adaptiveWidthLineMaterial = new LineMaterial({
@@ -35,13 +36,13 @@ export class MeasurementLine {
       depthTest: false
     });
 
-    this._meshes = new THREE.Group();
+    this._meshes = new Group();
     this._meshes.name = 'Measurement';
 
-    const onBeforeRenderTrigger = new THREE.Mesh(new THREE.BufferGeometry());
+    const onBeforeRenderTrigger = new Mesh(new BufferGeometry());
     onBeforeRenderTrigger.name = 'onBeforeRenderTrigger trigger (no geometry)';
     onBeforeRenderTrigger.frustumCulled = false;
-    const resolution = new THREE.Vector2();
+    const resolution = new Vector2();
     onBeforeRenderTrigger.onBeforeRender = renderer => {
       const { width, height } = renderer.domElement.getBoundingClientRect();
       resolution.set(width, height);
@@ -61,7 +62,7 @@ export class MeasurementLine {
     this._meshes.removeFromParent();
   }
 
-  get meshes(): THREE.Group {
+  get meshes(): Group {
     return this._meshes;
   }
 
@@ -69,7 +70,7 @@ export class MeasurementLine {
    * Update the measuring line end point.
    * @param endPoint Second point of the line to end the measurement.
    */
-  updateLine(endPoint: THREE.Vector3): void {
+  updateLine(endPoint: Vector3): void {
     this._endpoint.copy(endPoint);
     this._meshes.position.copy(this.getMidPointOnLine());
     this._meshes.lookAt(endPoint);
@@ -80,7 +81,7 @@ export class MeasurementLine {
    * Updates the measuring line clipping planes
    * @param clippingPlanes current active global clipping planes.
    */
-  updateLineClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+  updateLineClippingPlanes(clippingPlanes: Plane[]): void {
     const visible =
       !isPointVisibleByPlanes(clippingPlanes, this._startPos) ||
       !isPointVisibleByPlanes(clippingPlanes, this._endpoint);
@@ -99,7 +100,7 @@ export class MeasurementLine {
    * Calculate mid point on the Line.
    * @returns Returns mid point between start and end points.
    */
-  getMidPointOnLine(): THREE.Vector3 {
+  getMidPointOnLine(): Vector3 {
     return this._endpoint.clone().add(this._startPos).multiplyScalar(0.5);
   }
 
@@ -115,7 +116,7 @@ export class MeasurementLine {
    * Update current line color.
    * @param color Color of the measuring line mesh.
    */
-  updateLineColor(color: THREE.Color): void {
+  updateLineColor(color: Color): void {
     this._fixedWidthLineMaterial.color = this._adaptiveWidthLineMaterial.color = color;
   }
 

--- a/viewer/packages/tools/src/Measurement/MeasurementManager.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementManager.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Camera, Color, Group, Plane } from 'three';
+import { Ray, Vector3 } from 'three';
 import type { HtmlOverlayTool } from '../HtmlOverlay/HtmlOverlayTool';
 import { MeasurementLabels } from './MeasurementLabels';
 import { MeasurementLine } from './MeasurementLine';
@@ -14,26 +15,26 @@ export class MeasurementManager {
   private readonly _line: MeasurementLine;
   private readonly _options: Required<MeasurementOptions>;
   private readonly _domElement: HTMLElement;
-  private readonly _camera: THREE.Camera;
-  private readonly _meshGroup: THREE.Group;
+  private readonly _camera: Camera;
+  private readonly _meshGroup: Group;
   private readonly _htmlOverlay: HtmlOverlayTool;
   private _labelElement: HTMLDivElement | undefined;
   private readonly _distanceToCamera: number;
-  private readonly _startPoint: THREE.Vector3;
+  private readonly _startPoint: Vector3;
   private _measurement: Measurement = {
     measurementId: 0,
-    startPoint: new THREE.Vector3(),
-    endPoint: new THREE.Vector3(),
+    startPoint: new Vector3(),
+    endPoint: new Vector3(),
     distanceInMeters: 0
   };
 
   constructor(
     viewerDomElement: HTMLElement,
-    camera: THREE.Camera,
-    meshGroup: THREE.Group,
+    camera: Camera,
+    meshGroup: Group,
     options: Required<MeasurementOptions>,
     overlay: HtmlOverlayTool,
-    startPoint: THREE.Vector3
+    startPoint: Vector3
   ) {
     this._options = options;
     this._measurementLabel = new MeasurementLabels();
@@ -42,7 +43,7 @@ export class MeasurementManager {
     this._camera = camera;
     this._meshGroup = meshGroup;
     this._startPoint = startPoint;
-    this._distanceToCamera = this._camera.getWorldPosition(new THREE.Vector3()).distanceTo(startPoint);
+    this._distanceToCamera = this._camera.getWorldPosition(new Vector3()).distanceTo(startPoint);
     this._line = this.startMeasurement(startPoint);
     this._meshGroup.add(this._line.meshes);
   }
@@ -59,7 +60,7 @@ export class MeasurementManager {
    * End the measurement.
    * @param point World position at which measuring line ends.
    */
-  endMeasurement(point: THREE.Vector3): void {
+  endMeasurement(point: Vector3): void {
     const { distanceToLabelCallback } = this._options;
     //Update the line with final end point.
     this._line.updateLine(point);
@@ -97,7 +98,7 @@ export class MeasurementManager {
    * Updates the measuring line clipping planes
    * @param clippingPlanes current active global clipping planes.
    */
-  updateLineClippingPlanes(clippingPlanes: THREE.Plane[]): void {
+  updateLineClippingPlanes(clippingPlanes: Plane[]): void {
     this._line.updateLineClippingPlanes(clippingPlanes);
     if (this._labelElement) {
       this._labelElement.hidden = !this._line.meshes.visible;
@@ -116,7 +117,7 @@ export class MeasurementManager {
    * Update current line color.
    * @param color Color of the measuring line mesh.
    */
-  updateLineColor(color: THREE.Color): void {
+  updateLineColor(color: Color): void {
     this._line.updateLineColor(color);
   }
 
@@ -134,7 +135,7 @@ export class MeasurementManager {
    * Start the measurement.
    * @param point World position to start measurement operation from.
    */
-  private startMeasurement(point: THREE.Vector3): MeasurementLine {
+  private startMeasurement(point: Vector3): MeasurementLine {
     return new MeasurementLine(this._options.lineWidth, this._options.color, point);
   }
 
@@ -144,28 +145,28 @@ export class MeasurementManager {
    * @param label Label text.
    * @returns HTML element.
    */
-  private addLabel(position: THREE.Vector3, label: string): HTMLDivElement {
+  private addLabel(position: Vector3, label: string): HTMLDivElement {
     const labelElement = this._measurementLabel.createLabel(label);
     this._htmlOverlay.add(labelElement, position);
     return labelElement;
   }
 
-  private pointerTo3DPosition(offsetX: number, offsetY: number): THREE.Vector3 {
+  private pointerTo3DPosition(offsetX: number, offsetY: number): Vector3 {
     const mouse = getNormalizedPixelCoordinates(this._domElement, offsetX, offsetY);
 
     // Set the origin of the Ray to camera.
-    const origin = new THREE.Vector3();
+    const origin = new Vector3();
     origin.setFromMatrixPosition(this._camera.matrixWorld);
 
-    const ray = new THREE.Ray();
+    const ray = new Ray();
     ray.origin.copy(origin);
 
     // Calculate the camera direction.
-    const direction = new THREE.Vector3(mouse.x, mouse.y, 0.5).unproject(this._camera).sub(ray.origin).normalize();
+    const direction = new Vector3(mouse.x, mouse.y, 0.5).unproject(this._camera).sub(ray.origin).normalize();
     ray.direction.copy(direction);
 
     // Note: Using the initial/start point as reference for ray to emit till that distance from camera.
-    const position = new THREE.Vector3();
+    const position = new Vector3();
     ray.at(this._distanceToCamera, position);
     return position;
   }

--- a/viewer/packages/tools/src/Measurement/MeasurementTool.ts
+++ b/viewer/packages/tools/src/Measurement/MeasurementTool.ts
@@ -6,7 +6,8 @@ import type { Cognite3DViewer } from '@reveal/api';
 import { Cognite3DViewerToolBase } from '../Cognite3DViewerToolBase';
 import type { DisposedDelegate } from '@reveal/utilities';
 import { assertNever, EventTrigger } from '@reveal/utilities';
-import * as THREE from 'three';
+import type { Vector3 } from 'three';
+import { Color, Group } from 'three';
 import type {
   MeasurementAddedDelegate,
   MeasurementStartedDelegate,
@@ -62,7 +63,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
 
   private _options: Required<MeasurementOptions>;
   private readonly _viewer: Cognite3DViewer<DataSourceType>;
-  private readonly _geometryGroup = new THREE.Group();
+  private readonly _geometryGroup = new Group();
   private readonly _measurements: MeasurementManager[];
   private _activeMeasurement: MeasurementManager | undefined;
   private readonly _htmlOverlay: HtmlOverlayTool;
@@ -90,7 +91,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
   private static readonly defaultLineOptions: Required<MeasurementOptions> = {
     distanceToLabelCallback: d => MeasurementTool.metersLabelCallback(d),
     lineWidth: 0.01,
-    color: new THREE.Color(0xff8746)
+    color: new Color(0xff8746)
   };
 
   constructor(viewer: Cognite3DViewer<DataSourceType>, options?: MeasurementOptions) {
@@ -288,7 +289,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
   /**
    * Adds a measurement directly. E.g. to restore a previous state programatically
    */
-  addMeasurement(startPoint: THREE.Vector3, endPoint: THREE.Vector3): Measurement {
+  addMeasurement(startPoint: Vector3, endPoint: Vector3): Measurement {
     const measurementManager = new MeasurementManager(
       this._viewer.domElement,
       this._viewer.cameraManager.getCamera(),
@@ -360,7 +361,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
    * @param measurement Measurement to be updated.
    * @param color Color of the measuring line.
    */
-  updateLineColor(measurement: Measurement, color: THREE.Color): void {
+  updateLineColor(measurement: Measurement, color: Color): void {
     const index = this._measurements.findIndex(
       measurementManager => measurementManager.getMeasurement() === measurement
     );

--- a/viewer/packages/tools/src/Overlay3D/Overlay3DTool.ts
+++ b/viewer/packages/tools/src/Overlay3D/Overlay3DTool.ts
@@ -4,7 +4,8 @@
 import type { Cognite3DViewer } from '@reveal/api';
 import type { DisposedDelegate, PointerEventData } from '@reveal/utilities';
 import { assertNever, EventTrigger, getNormalizedPixelCoordinates } from '@reveal/utilities';
-import * as THREE from 'three';
+import type { Texture } from 'three';
+import { Color, Vector3 } from 'three';
 import type {
   Overlay3DIcon,
   OverlayInfo,
@@ -43,7 +44,7 @@ export type Overlay3DToolParameters = {
   /**
    * Sets default overlay color for newly added labels.
    */
-  defaultOverlayColor: THREE.Color;
+  defaultOverlayColor: Color;
 };
 
 /**
@@ -54,13 +55,13 @@ export type OverlayCollectionOptions = {
    * Sets default overlay color for newly added overlays.
    * Default is yellow.
    * */
-  defaultOverlayColor?: THREE.Color;
+  defaultOverlayColor?: Color;
   /**
    * Sets default texture for all overlays of this OverlayCollection.
    * Must be a square texture, recommended size is at least `maxPointSize` for
    * not pixelated overlays.
    */
-  overlayTexture?: THREE.Texture;
+  overlayTexture?: Texture;
   /**
    * Sets default mask for all overlays of this OverlayCollection,
    * denoting where overlay color should be placed compared to texture color.
@@ -68,7 +69,7 @@ export type OverlayCollectionOptions = {
    * Texture should be monochrome. Internally, R channel is used for
    * denoting pixels that should be colored by texture and not by overlay color.
    */
-  overlayTextureMask?: THREE.Texture;
+  overlayTextureMask?: Texture;
 };
 
 /**
@@ -77,7 +78,7 @@ export type OverlayCollectionOptions = {
 export class Overlay3DTool<ContentType = DefaultOverlay3DContentType> extends Cognite3DViewerToolBase {
   private readonly _viewer: Cognite3DViewer;
 
-  private readonly _defaultOverlayColor: THREE.Color = new THREE.Color('#fbe50b');
+  private readonly _defaultOverlayColor: Color = new Color('#fbe50b');
 
   private _overlayCollections: Overlay3DCollection<ContentType>[] = [];
   private _isVisible = true;
@@ -290,9 +291,9 @@ export class Overlay3DTool<ContentType = DefaultOverlay3DContentType> extends Co
       mouseCoords.offsetY
     );
     const camera = _viewer.cameraManager.getCamera();
-    const cameraDirection = camera.getWorldDirection(new THREE.Vector3());
+    const cameraDirection = camera.getWorldDirection(new Vector3());
 
-    const intersections: [Overlay3D<ContentType>, THREE.Vector3][] = [];
+    const intersections: [Overlay3D<ContentType>, Vector3][] = [];
 
     for (const points of this._overlayCollections) {
       const intersection = points.intersectOverlays(normalizedCoordinates, camera);
@@ -302,10 +303,7 @@ export class Overlay3DTool<ContentType = DefaultOverlay3DContentType> extends Co
     }
 
     const sortedIntersections = intersections
-      .map(
-        ([icon, intersection]) =>
-          [icon, intersection.sub(camera.position)] as [Overlay3DIcon<ContentType>, THREE.Vector3]
-      )
+      .map(([icon, intersection]) => [icon, intersection.sub(camera.position)] as [Overlay3DIcon<ContentType>, Vector3])
       .filter(([, intersection]) => intersection.dot(cameraDirection) > 0)
       .sort((a, b) => a[1].length() - b[1].length());
 

--- a/viewer/packages/tools/visual-tests/Overlay3DTool.VisualTest.ts
+++ b/viewer/packages/tools/visual-tests/Overlay3DTool.VisualTest.ts
@@ -3,7 +3,8 @@
  */
 
 import type { DefaultCameraManager } from '../../camera-manager';
-import * as THREE from 'three';
+import type { Texture } from 'three';
+import { CanvasTexture, Color, TextureLoader, Vector3 } from 'three';
 import type { ViewerTestFixtureComponents } from '../../../visual-tests/test-fixtures/ViewerVisualTestFixture';
 import { ViewerVisualTestFixture } from '../../../visual-tests/test-fixtures/ViewerVisualTestFixture';
 import { Overlay3DTool } from '../src/Overlay3D/Overlay3DTool';
@@ -22,7 +23,7 @@ export default class DefaultVisualTest extends ViewerVisualTestFixture {
     smartOverlayTool.on('hover', ({ htmlTextOverlay, targetOverlay }) => {
       const { text, id } = targetOverlay.getContent();
       htmlTextOverlay.innerText = text + ', #' + id + ' hovered';
-      targetOverlay.setColor(new THREE.Color('red'));
+      targetOverlay.setColor(new Color('red'));
       viewer.requestRedraw();
     });
 
@@ -38,10 +39,10 @@ export default class DefaultVisualTest extends ViewerVisualTestFixture {
     const labels: OverlayInfo<{ text: string; id: number }>[] = [];
     const overlays = [];
 
-    const reusableVec = new THREE.Vector3();
+    const reusableVec = new Vector3();
 
     const boxSize = 10;
-    const overlaysOffset = new THREE.Vector3(0, -10, -10);
+    const overlaysOffset = new Vector3(0, -10, -10);
 
     for (let i = boxSize / -2; i < boxSize / 2; i++) {
       for (let x = boxSize / -2; x < boxSize / 2; x++) {
@@ -54,11 +55,7 @@ export default class DefaultVisualTest extends ViewerVisualTestFixture {
                 id: i + x + y
               },
               position: reusableVec.set(x, i, y).multiplyScalar(0.9).clone().add(overlaysOffset),
-              color: new THREE.Color(
-                Math.abs(i / (boxSize / 2)),
-                Math.abs(x / (boxSize / 2)),
-                Math.abs(y / (boxSize / 2))
-              )
+              color: new Color(Math.abs(i / (boxSize / 2)), Math.abs(x / (boxSize / 2)), Math.abs(y / (boxSize / 2)))
             });
           }
         }
@@ -81,8 +78,8 @@ export default class DefaultVisualTest extends ViewerVisualTestFixture {
 }
 
 async function loadTexture(url: string) {
-  return new Promise<THREE.Texture>((resolve, reject) => {
-    new THREE.TextureLoader().load(url, resolve, undefined, reject);
+  return new Promise<Texture>((resolve, reject) => {
+    new TextureLoader().load(url, resolve, undefined, reject);
   });
 }
 
@@ -98,7 +95,7 @@ function createTransparentMask() {
   context.fillStyle = 'rgba(128, 12, 255, 1)';
   context.fillRect(0, 0, textureSize, textureSize);
 
-  return new THREE.CanvasTexture(canvas);
+  return new CanvasTexture(canvas);
 }
 
 const imageTransparent: string = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAEtQTFRFAAAA8cOy67ml4a2YzrGdxaOO2b6v2ZmJxYd18dDDbFlLkYJx5Mm7rpWBW0Q3rnFgRC0if25ejl5M3d/gycG719bVwrevJRcQpJyTeacoOgAAABl0Uk5TAN7e3t7e3t7e3t7e3t3e3t7e3gyRQ1PemNUFp58AAAyDSURBVHic7ZtrY5y4DoYHfIHBGMbAzPD/f+nRK8mGSdrsOUD3fKm3SbNJWz3WzZIwt9vf9Xf9XYfX/HzenvP/RfRzXddlWWNYV/5qeeKb/570GFLqdCX6MqUQl4UU8i/oY4b4kAItEqwI3UCf4jo/+z+oBdrb87U62nzXDQPtmyBS2iGEsN7vfvljOpjnxZHEQNKH4cEIXRoJYiAgYhgIKPZ397r9GQSSH0m87JgIHu/HQAQhJuiDlQC7OBdff8YM86Iah7pJA0TwfsP7xm4CARuDfCNGt/wJgqeHeKggsd+zEh5EQKZnlWRXJDu49fUH5Ef4vPgdSXpgvemD9j5NgxDAFhPCgeLhYvkvG4rbJ9E+LUVg8bAKSOCSpKawXih9nl8uJrEAB8E7L5A84A6ikYf458DxcKUVSP9q+gDtvzeAHcabEYYO/tldS/DsLUf7Jv/xKAYQuQ8BYYNAHRwOl8UCy+/YtAPks8KHbT22BQz8mWEigIvcYGYDcK5LvDsWSjxTXmr4R46MATkKKep1SSxQAiQH4Cjr8I9DGkkdabXbGkcKAYGQT2yxawhWPn2QZ9jJ6MssvXHO5NVkCDUG/kJKywXyl5DEACqfxJNs1zSNMXVd6arrmiCadpyyOZigO0/wosMf8hmANg/5zvHWIb3v+43B1KyIiSG6QMmrOx0KTzr/Ob1QisMJjO07Zy3Ek/D+fr9X1U4NrAgYQwimcDYbvAAwcM3RUYJL40jSaXkv0u/9niAbg2yBw4FOxuROAixcABECDtwYSP0Q7ot8XlX1VQ+kBhgs+HjWBvAAaB8AIZLvO/9NvphhY6jhDiahaIounivRFlKi1L500EY3tlalf4hnhPuHCoiAnLZL1p07mZfsgggqF7H/nuV/AyiaUIDatDBCtOfy4RqKC6TgohPn+7A//ypffqqAcqaj4uQ4wVNdkMIAlVa0/hvA1+3v/LBFQg4unNDASzyA8j9FlKX99/4HA1TVXgMUjBMylzuTj5coCkCZ56zL2/9igq86qOuckZAQqX08rgJpAVFiRZezDwlnAPz2CVBlL1D5FIqwwYnK5BmlAKcUFFn+poGchr9s/yMMjIkCfxhgCZ2exHGXAL9ZYR8Peyc0xk3dOQBpPcUDIN3/ygt+4wRcJdA5MoXjB5IAoPeHCSB7r4Kq+h2AnMyGbYAAtkcBVpQi3GypBvp+r4HqhzhAuQAAmV0cBxAFKEC/A/ilAUouLCZw9C+EMRx1gkW7ke8Av5b/4YRMYANX80dT0RIYIHEa2Jv/N/K3UMy5iFo6BNF6UAXP0BWAfwyAD4wCgF5mSkfbtGfgbgAAUgfkTPij9D2BQ0VLYXzQBs+gE6gQ91mI5fwMkd3AoadK0fbHAOYwSEUenChAEbxHXUq1uaXaWGiqb8EoBCM1Vel11AmfMvegSHK7POg9HYyUmkJEc2RYdLVlA2kUau1VABAOTy+XIcnwJepBIMnQk/wRvokaVfqTrICezC5di1EN0N8/3iUvOvFICsBagO6pPp/QHrexAOjiJhGtG1EwwHAGYOVyCKdxBsD2beR2mDtk2OCjQ6RCDD3qmAlOA/AoILmyf+jfcicMAiA0rOwiv2nlB40QjMR/+DB85QGg+CB5AOvfOt4kxgHcKTvVAZeB+BErpmk4SOJjSIcV8MJkkMOQq0HdvoUQ+H878aiAAHT/on4ZX6B5N9YSwOMUADf71OZqFkD8N+NobSvqnx4wt4QiAZD8rqP/hxlaIBDA8AgnABL7QBIAMYGdRhtlVN0xAXFYLg9rNj+8gkS3TGC9Gx6HqwFoQObyAOA0SB5A/Tl6/3cXBx8m6sIB4FGeGJY/YT4D6fRhKGcNJ4LABg2CrAFvSPdt11Gh9X6kwfcQiImBvwvACPlvyl7T1IwC0HWHARYbBgXIKcAhAURKRDwYv3vSNPmjZROQC5AKRtIZBY+fhpYcsfYupeMlaTspgOYhxD/Jt6ZxnOoo1DjtsQLuyAHjGJG5hs66YaJAqb1Nx2viFcMmPo4ZACkAhSZyvaTbRmeEtuYKQGd1gHaeHBJeWNsTRfk6jU7bAgJgP+xrPmy28SQPC21NxzFrgKnGGPEVfjUEcLQcu83N6MjP+bGQAJCzc8KBs/FqeVhoDfsgNNCW+Sl+wBpIh33w2Y4kk+vifBb1fd2zqEZFGBLB31eAphAQmjRnJwCalqIIo+gUc2NqJOPkqh/HUJ4Y0XebLwTkMfWJ6QAAKMwUQBqz+qPmxTRMDknBkpmxRAbKBJJfx8NNyW1eG09xtdOA932p+CoWX5sqT+wkDFg3ddYOERxvyygPNJ6zOzVGPvfmn0UvVp7ZFYB6B1DXx10AmdCzRb3VKNSGoNqK3mo3qmAAU8BqqUuP50GygWeAtuc0tNs/G7ziMugu3aJ6BvZe5Iuh2jPD6h4+MDqpRPb635lgm9qyCupP+fTHzgAsVHhAAwqQO5AMgHxgtrEt10QNq35fpZ4BeJLxG6q4NAvtFaAVoC0T+7smCET/rk6vq1PD8sUa2/ucBu8yl6m1AkXWMdIKSVcuvvlJcBJgpgpEeqHSFdaVxho/IDI4nbxxJQNgRt3uWpX65DOjxWf50hP08HQ4O22UT2M+fjjt8ofhyrhtcpleVScB5qX3e4DykA7yUPkjUQ0TF8JNg5IQz61ys4J19qnZ7LMGuCV3pmHpGYDCRDtBeXY5NhAKHeScdPr58bIREAAVY43oGp+cTAmkVWz5eyJVz2qcCmflkxGyDSDNSCEoEzh+euZika8nNFrkNv+hCwCeXuOQxTVlWVmkgDjy8au2kRgpmOcB5sW6jUClt6x+rwh4hJwVoEaATzLCaYAbZ2SINzABso/4fxmbcd2Rx3IlRhTAXwFAbsAAIMDeHOQ7eXzBGbkcfYUBVRF/cQnA7XlnAwDAk4ujMSAb+GIQ2W6jz9MlRLkoM+aKx/d8h0RdwJKAJjcmWpq37f4ug9TKWKyNiy6yPL04nIMN0JiN0/v9pgxIqUfuUmSOEXlxpN2L/KsAbt7mZSjKSeUj7qmMVDXTrwYHAp8NYzPhDokEo7kSYNkApA6hen3A3b32fm/oRG4Mfq/qu8dsYBcSV93keal0jgP805SUxyn0dyND40YfWN37x9SYWluX+iIfvHFthPEYItFwMYKTsRmt7aRMGrgy8pXH3LDOD/Dr5rLLVPPiLI9giYIDnlMjOcNAbudp3z3Ec69s8sQOPnCVfHIC52QGTDbYCDzyUoup0dS2Mh00G4BpLrPAB4DVvgynpIb8LhVpRc4eeJ0FCgAfwR4CtEhigtwFGS6E8tCSauYLb3Yu9hOg0iKl5gTMYlX+TgEXWgCJoAAIgbhBsQHXQ9oSqgccfl76W4CYVdB7BajNjoBLgSo3DcZderE1a8DpNQI5ewWAh0GIutIVXh0CAvBBwCqovdZhpRxiXxQAd+3dYgGIexXsRkVSD3NhIm5wtQGKBmJUL9BiKI9DShuQj6Hm4ovF82ILgc3VWJkR7GUrwNkrbD8BiBF6VkGVhzG5ZVaAqw2gADsCbtf3j+uqvQLctRFw45qsACgBj0w+IdQc3jaXRQDfAptfa7R+AxAEpzOLqt4DkC+ihb0UYFnT0NlPArnWhJS4zaNkgkrfdddVYjfcJsNl2s4XgEzgcpkup49OrYzHU4ULC5FX4LvknfefGhA7oEPQE0CCkapGfnJ9kfR5Vvnv8A0gKEOeBMjCzy/piTPA2sm7BDF3RhtACMzQllqISDhKkRuv8oEldfIGgcsAFudBJsBLNV9umAfLmrjq3YJVAR62yHdOEQCQpqTX3OXTNDrpibrjj2v3C/cpGSAHQSHIKpj2V/y7KaJ1YIATj0t3C/eY3nsfLDWBGiGlgtDR9pEdZGA5PM6M6Yv8qABDLK2h+0rAovnGAoIiT0yHx/EHtmU9LZQMgBQ3+d+UoOLxQNdm+aZ7dMefFRUF8At95AODXCi1340AApkOyPFg8xyZAM6/2+AYYHjzFQ4lcBtCyYiIQ6nV6D/VAF70OXiRc+Ylr7bxK418gUFU4L67QTmZ+G6J0+dVDW6VH7rNO29rZfn5Xcrck+wBtqNZtSODEUzy+CWbsB546072P+PdwgIgKmAV7+SrFhzHPuYGLsuXG9XyWl58/Y/XuFg4RUCRzyqYghYh1mUPKAB8YwnnkCkA7SAAuJee/pun509eXPwQAEm3oQshE/AT/JCP3++rNGZFAaO+ZpTkYn5yyz+oQcYsCsDxn7oiX7yAj75fA7QfADVbIAMkvYcUl5/c4T9Q2wTBd9ywcAAAAABJRU5ErkJggg==`;

--- a/viewer/packages/utilities/src/RandomColors.ts
+++ b/viewer/packages/utilities/src/RandomColors.ts
@@ -1,21 +1,21 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Color } from 'three';
 
 /**
  * Utility class for creating reasonable visible colors. Mainly meant for use
  * in debugging.
  */
 export class RandomColors {
-  private static readonly _colors: Map<number, THREE.Color> = new Map();
+  private static readonly _colors: Map<number, Color> = new Map();
 
   /**
-   * Returns a color as a THREE.Color.
+   * Returns a color as a Color.
    * @param colorIndex
    * @returns
    */
-  static color(colorIndex: number): THREE.Color {
+  static color(colorIndex: number): Color {
     const color = RandomColors._colors.get(colorIndex);
     if (color !== undefined) {
       return color;
@@ -50,10 +50,10 @@ export class RandomColors {
    * Returns a random color with reasonable lightness and saturation
    * to make the color easily distinguishable from other colors.
    */
-  static generateRandomColor(): THREE.Color {
+  static generateRandomColor(): Color {
     const hue = Math.random();
     const saturation = 0.4 + Math.random() * 0.6;
     const lightness = 0.3 + 0.4 * Math.random();
-    return new THREE.Color().setHSL(hue, saturation, lightness);
+    return new Color().setHSL(hue, saturation, lightness);
   }
 }

--- a/viewer/packages/utilities/src/SceneHandler.test.ts
+++ b/viewer/packages/utilities/src/SceneHandler.test.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { BoxGeometry, Mesh, MeshBasicMaterial } from 'three';
 import { SceneHandler } from '..';
 
 import { createCadModel } from '../../../test-utilities';
@@ -10,9 +10,9 @@ import { vi } from 'vitest';
 
 describe(SceneHandler.name, () => {
   test('Calling dispose correctly disposes all objects within the scene', () => {
-    const box = new THREE.BoxGeometry(1, 1);
-    const material = new THREE.MeshBasicMaterial();
-    const customObjectMesh = new THREE.Mesh(box, material);
+    const box = new BoxGeometry(1, 1);
+    const material = new MeshBasicMaterial();
+    const customObjectMesh = new Mesh(box, material);
 
     const disposeCustomObjectMeshGeometry = vi.spyOn(customObjectMesh.geometry, 'dispose');
     const disposeCustomObjectMeshMaterial = vi.spyOn(customObjectMesh.material, 'dispose');

--- a/viewer/packages/utilities/src/SceneHandler.ts
+++ b/viewer/packages/utilities/src/SceneHandler.ts
@@ -2,26 +2,27 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Object3D } from 'three';
+import { Line, Mesh, Points, Scene } from 'three';
 import { remove } from 'lodash-es';
 import type { ICustomObject } from './customObject/ICustomObject';
 import { CustomObject } from './customObject/CustomObject';
 
 export class SceneHandler {
-  private readonly _scene: THREE.Scene;
-  private readonly _cadModels: { cadNode: THREE.Object3D; modelIdentifier: symbol }[];
-  private readonly _pointCloudModels: { pointCloudNode: THREE.Object3D; modelIdentifier: symbol }[];
+  private readonly _scene: Scene;
+  private readonly _cadModels: { cadNode: Object3D; modelIdentifier: symbol }[];
+  private readonly _pointCloudModels: { pointCloudNode: Object3D; modelIdentifier: symbol }[];
   private readonly _customObjects: ICustomObject[];
 
-  get scene(): THREE.Scene {
+  get scene(): Scene {
     return this._scene;
   }
 
-  get cadModels(): { cadNode: THREE.Object3D; modelIdentifier: symbol }[] {
+  get cadModels(): { cadNode: Object3D; modelIdentifier: symbol }[] {
     return this._cadModels;
   }
 
-  get pointCloudModels(): { pointCloudNode: THREE.Object3D; modelIdentifier: symbol }[] {
+  get pointCloudModels(): { pointCloudNode: Object3D; modelIdentifier: symbol }[] {
     return this._pointCloudModels;
   }
 
@@ -33,32 +34,32 @@ export class SceneHandler {
     this._cadModels = [];
     this._pointCloudModels = [];
     this._customObjects = [];
-    this._scene = new THREE.Scene();
+    this._scene = new Scene();
 
     this._scene.matrixWorldAutoUpdate = false;
   }
 
-  public addCadModel(cadNode: THREE.Object3D, modelIdentifier: symbol): void {
+  public addCadModel(cadNode: Object3D, modelIdentifier: symbol): void {
     this._cadModels.push({ cadNode, modelIdentifier });
     this._scene.add(cadNode);
   }
 
-  public addPointCloudModel(pointCloudNode: THREE.Object3D, modelIdentifier: symbol): void {
+  public addPointCloudModel(pointCloudNode: Object3D, modelIdentifier: symbol): void {
     this._pointCloudModels.push({ pointCloudNode, modelIdentifier });
     this._scene.add(pointCloudNode);
   }
 
-  public removePointCloudModel(pointCloudNode: THREE.Object3D): void {
+  public removePointCloudModel(pointCloudNode: Object3D): void {
     this.scene.remove(pointCloudNode);
     remove(this._pointCloudModels, { pointCloudNode });
   }
 
-  public removeCadModel(cadNode: THREE.Object3D): void {
+  public removeCadModel(cadNode: Object3D): void {
     this.scene.remove(cadNode);
     remove(this._cadModels, { cadNode });
   }
 
-  public addObject3D(object: THREE.Object3D): void {
+  public addObject3D(object: Object3D): void {
     this.addCustomObject(new CustomObject(object));
   }
 
@@ -67,7 +68,7 @@ export class SceneHandler {
     this._scene.add(customObject.object);
   }
 
-  public removeObject3D(object: THREE.Object3D): void {
+  public removeObject3D(object: Object3D): void {
     const customObject = this._customObjects.find(customObject => customObject.object === object);
     if (customObject) {
       this.removeCustomObject(customObject);
@@ -85,8 +86,7 @@ export class SceneHandler {
     this._customObjects.splice(0);
 
     this.scene.traverse(object => {
-      const hasGeometry =
-        object instanceof THREE.Mesh || object instanceof THREE.Points || object instanceof THREE.Line;
+      const hasGeometry = object instanceof Mesh || object instanceof Points || object instanceof Line;
 
       if (!hasGeometry) {
         return;

--- a/viewer/packages/utilities/src/WebGLRendererStateHelper.test.ts
+++ b/viewer/packages/utilities/src/WebGLRendererStateHelper.test.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { WebGLRenderer } from 'three';
+import { Color, Vector2, Vector4, WebGLRenderTarget } from 'three';
 import { WebGLRendererStateHelper } from './WebGLRendererStateHelper';
 
 import type { Mock as ViMock } from 'vitest';
@@ -18,11 +19,11 @@ describe('WebGLRendererStateHelper', () => {
     const setClearColorSpy = vi.fn();
     const renderer = mockedWebGLRenderer(setClearColorSpy).object();
     renderer.setClearColor('#AABBCC', 0.5);
-    const originalColor = renderer.getClearColor(new THREE.Color());
+    const originalColor = renderer.getClearColor(new Color());
     const originalAlpha = renderer.getClearAlpha();
 
     const helper = new WebGLRendererStateHelper(renderer);
-    const color = new THREE.Color('#112233');
+    const color = new Color('#112233');
 
     helper.setClearColor(color, 0.8);
     expect(setClearColorSpy).toHaveBeenCalledWith(color, 0.8);
@@ -30,16 +31,16 @@ describe('WebGLRendererStateHelper', () => {
     helper.resetState();
     expect(setClearColorSpy).toHaveBeenCalledWith(originalColor, originalAlpha);
 
-    function mockedWebGLRenderer(setClearColorSpy: THREE.WebGLRenderer['setClearColor']): Mock<THREE.WebGLRenderer> {
-      const rendererMock = new Mock<THREE.WebGLRenderer>();
+    function mockedWebGLRenderer(setClearColorSpy: WebGLRenderer['setClearColor']): Mock<WebGLRenderer> {
+      const rendererMock = new Mock<WebGLRenderer>();
       const state = {
-        clearColor: new THREE.Color(),
+        clearColor: new Color(),
         clearAlpha: 0
       };
       rendererMock
         .setup(instance =>
           instance.setClearColor(
-            It.Is<THREE.Color>(value => {
+            It.Is<Color>(value => {
               state.clearColor.copy(value);
               return true;
             }),
@@ -74,8 +75,8 @@ describe('WebGLRendererStateHelper', () => {
     helper.resetState();
     expect(setSizeSpy).toHaveBeenCalledWith(128, 256);
 
-    function mockedWebGLRenderer(setSizeSpy: THREE.WebGLRenderer['setSize']): Mock<THREE.WebGLRenderer> {
-      const rendererMock = new Mock<THREE.WebGLRenderer>();
+    function mockedWebGLRenderer(setSizeSpy: WebGLRenderer['setSize']): Mock<WebGLRenderer> {
+      const rendererMock = new Mock<WebGLRenderer>();
       const state = {
         width: 0,
         height: 0
@@ -95,7 +96,7 @@ describe('WebGLRendererStateHelper', () => {
         )
         .returns()
         .setup(instance => instance.getSize(It.IsAny()))
-        .callback(() => new THREE.Vector2(state.width, state.height))
+        .callback(() => new Vector2(state.width, state.height))
         .setup(instance => instance.setSize)
         .returns(setSizeSpy);
 
@@ -106,8 +107,8 @@ describe('WebGLRendererStateHelper', () => {
   test('setRenderTarget()', () => {
     const setRenderTargetSpy = vi.fn();
     const renderer = mockedWebGLRenderer(setRenderTargetSpy).object();
-    const originalTarget = new THREE.WebGLRenderTarget(64, 64);
-    const newTarget = new THREE.WebGLRenderTarget(64, 64);
+    const originalTarget = new WebGLRenderTarget(64, 64);
+    const newTarget = new WebGLRenderTarget(64, 64);
     renderer.setRenderTarget(originalTarget);
 
     const helper = new WebGLRendererStateHelper(renderer);
@@ -118,17 +119,15 @@ describe('WebGLRendererStateHelper', () => {
     helper.resetState();
     expect(setRenderTargetSpy).toHaveBeenCalledWith(originalTarget);
 
-    function mockedWebGLRenderer(
-      setRenderTargetSpy: THREE.WebGLRenderer['setRenderTarget']
-    ): Mock<THREE.WebGLRenderer> {
-      const rendererMock = new Mock<THREE.WebGLRenderer>();
-      const state: { renderTarget: THREE.WebGLRenderTarget | null } = {
+    function mockedWebGLRenderer(setRenderTargetSpy: WebGLRenderer['setRenderTarget']): Mock<WebGLRenderer> {
+      const rendererMock = new Mock<WebGLRenderer>();
+      const state: { renderTarget: WebGLRenderTarget | null } = {
         renderTarget: null
       };
       rendererMock
         .setup(instance =>
           instance.setRenderTarget(
-            It.Is<THREE.WebGLRenderTarget>(value => {
+            It.Is<WebGLRenderTarget>(value => {
               state.renderTarget = value;
               return true;
             })
@@ -156,8 +155,8 @@ describe('WebGLRendererStateHelper', () => {
     helper.resetState();
     expect(renderer.localClippingEnabled).toBeTruthy();
 
-    function mockedWebGLRenderer(): Mock<THREE.WebGLRenderer> {
-      const rendererMock = new Mock<THREE.WebGLRenderer>();
+    function mockedWebGLRenderer(): Mock<WebGLRenderer> {
+      const rendererMock = new Mock<WebGLRenderer>();
       const state = {
         localClippingEnabled: false
       };
@@ -188,8 +187,8 @@ describe('WebGLRendererStateHelper', () => {
     helper.resetState();
     expect(renderer.autoClear).toBeTruthy();
 
-    function mockedWebGLRenderer(): Mock<THREE.WebGLRenderer> {
-      const rendererMock = new Mock<THREE.WebGLRenderer>();
+    function mockedWebGLRenderer(): Mock<WebGLRenderer> {
+      const rendererMock = new Mock<WebGLRenderer>();
       const state = {
         autoClear: false
       };
@@ -211,7 +210,7 @@ describe('WebGLRendererStateHelper', () => {
 
   test('setScissorTest()', () => {
     const setScissorTestSpy = vi.fn();
-    const renderer = autoMockWebGLRenderer(new Mock<THREE.WebGLRenderer>())
+    const renderer = autoMockWebGLRenderer(new Mock<WebGLRenderer>())
       .setup(p => p.setScissorTest)
       .returns(setScissorTestSpy)
       .object();
@@ -236,10 +235,10 @@ describe('WebGLRendererStateHelper', () => {
     expect(setScissorSpy).toHaveBeenCalledWith(0, 0, 128, 128);
 
     helper.resetState();
-    expect(setScissorSpy).toHaveBeenCalledWith(new THREE.Vector4(0, 0, 64, 64));
+    expect(setScissorSpy).toHaveBeenCalledWith(new Vector4(0, 0, 64, 64));
 
-    function mockedWebGLRenderer(setScissorSpy: ViMock<THREE.WebGLRenderer['setScissor']>): Mock<THREE.WebGLRenderer> {
-      const rendererMock = new Mock<THREE.WebGLRenderer>();
+    function mockedWebGLRenderer(setScissorSpy: ViMock<WebGLRenderer['setScissor']>): Mock<WebGLRenderer> {
+      const rendererMock = new Mock<WebGLRenderer>();
       const state = {
         x: 0,
         y: 0,
@@ -265,7 +264,7 @@ describe('WebGLRendererStateHelper', () => {
           })
         )
         .setup(instance => instance.getScissor(It.IsAny()))
-        .callback(() => new THREE.Vector4(state.x, state.y, state.width, state.height));
+        .callback(() => new Vector4(state.x, state.y, state.width, state.height));
 
       return rendererMock;
     }
@@ -274,7 +273,7 @@ describe('WebGLRendererStateHelper', () => {
   test('setWebGLState', () => {
     const depthSetTestSpy = vi.fn();
     const depthSetMaskSpy = vi.fn();
-    const renderer = autoMockWebGLRenderer(new Mock<THREE.WebGLRenderer>())
+    const renderer = autoMockWebGLRenderer(new Mock<WebGLRenderer>())
       .setup(instance => instance.state.buffers.depth.setTest)
       .returns(depthSetTestSpy)
       .setup(instance => instance.state.buffers.depth.setMask)

--- a/viewer/packages/utilities/src/WebGLRendererStateHelper.ts
+++ b/viewer/packages/utilities/src/WebGLRendererStateHelper.ts
@@ -1,18 +1,17 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
-import { Vector4 } from 'three';
-
+import type { WebGLRenderTarget, WebGLRenderer } from 'three';
+import { Color, Vector2, Vector4 } from 'three';
 type WebGLRendererState = {
   autoClear?: boolean;
   autoClearDepth?: boolean;
-  clearColor?: THREE.Color | number;
+  clearColor?: Color | number;
   clearAlpha?: number;
-  size?: THREE.Vector2;
+  size?: Vector2;
   localClippingEnabled?: boolean;
-  renderTarget?: THREE.WebGLRenderTarget | null;
-  scissorData?: THREE.Vector4;
+  renderTarget?: WebGLRenderTarget | null;
+  scissorData?: Vector4;
   scissorTest?: boolean;
   webGLState?: WebGLState;
 };
@@ -28,7 +27,7 @@ type WebGLState = {
 
 export class WebGLRendererStateHelper {
   private _originalState: WebGLRendererState = {};
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
 
   private static readonly DefaultWebGLState: WebGLState = {
     buffers: {
@@ -39,7 +38,7 @@ export class WebGLRendererStateHelper {
     }
   };
 
-  constructor(renderer: THREE.WebGLRenderer) {
+  constructor(renderer: WebGLRenderer) {
     this._renderer = renderer;
     this._originalState = {};
   }
@@ -55,9 +54,9 @@ export class WebGLRendererStateHelper {
     this._renderer.setScissorTest(enabled);
   }
 
-  setClearColor(color: THREE.Color | number, alpha?: number): void {
+  setClearColor(color: Color | number, alpha?: number): void {
     this._originalState = {
-      clearColor: this._renderer.getClearColor(new THREE.Color()),
+      clearColor: this._renderer.getClearColor(new Color()),
       clearAlpha: this._renderer.getClearAlpha(),
       ...this._originalState
     };
@@ -87,7 +86,7 @@ export class WebGLRendererStateHelper {
   }
 
   setSize(width: number, height: number): void {
-    this._originalState = { size: this._renderer.getSize(new THREE.Vector2()), ...this._originalState };
+    this._originalState = { size: this._renderer.getSize(new Vector2()), ...this._originalState };
     this._renderer.setSize(width, height);
   }
 
@@ -106,7 +105,7 @@ export class WebGLRendererStateHelper {
     this._renderer.autoClearDepth = enabled;
   }
 
-  setRenderTarget(renderTarget: THREE.WebGLRenderTarget | null): void {
+  setRenderTarget(renderTarget: WebGLRenderTarget | null): void {
     this._originalState = { renderTarget: this._renderer.getRenderTarget(), ...this._originalState };
     this._renderer.setRenderTarget(renderTarget);
   }

--- a/viewer/packages/utilities/src/calculateVolumeOfMesh.test.ts
+++ b/viewer/packages/utilities/src/calculateVolumeOfMesh.test.ts
@@ -2,14 +2,15 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { BufferAttribute } from 'three';
+import { BoxGeometry, ConeGeometry, CylinderGeometry, SphereGeometry } from 'three';
 import { calculateVolumeOfMesh } from './calculateVolumeOfMesh';
 
 describe(calculateVolumeOfMesh.name, () => {
   test('Volume of unit box should be 1', () => {
-    const testBox = new THREE.BoxGeometry(1, 1, 1, 1, 1, 1);
+    const testBox = new BoxGeometry(1, 1, 1, 1, 1, 1);
     const volume = calculateVolumeOfMesh(
-      Float32Array.from((testBox.getAttribute('position') as THREE.BufferAttribute).array),
+      Float32Array.from((testBox.getAttribute('position') as BufferAttribute).array),
       Uint32Array.from(testBox.getIndex()!.array)
     );
 
@@ -17,9 +18,9 @@ describe(calculateVolumeOfMesh.name, () => {
   });
 
   test('Volume of unit sphere should be (4 / 3) * PI', () => {
-    const testSphere = new THREE.SphereGeometry(1, 200, 200);
+    const testSphere = new SphereGeometry(1, 200, 200);
     const calculatedVolume = calculateVolumeOfMesh(
-      Float32Array.from((testSphere.getAttribute('position') as THREE.BufferAttribute).array),
+      Float32Array.from((testSphere.getAttribute('position') as BufferAttribute).array),
       Uint32Array.from(testSphere.getIndex()!.array)
     );
 
@@ -29,10 +30,10 @@ describe(calculateVolumeOfMesh.name, () => {
   });
 
   test('Volume of unit cylinder should be PI', () => {
-    const testCylinder = new THREE.CylinderGeometry(1, 1, 1, 200, 200);
+    const testCylinder = new CylinderGeometry(1, 1, 1, 200, 200);
 
     const calculatedVolume = calculateVolumeOfMesh(
-      Float32Array.from((testCylinder.getAttribute('position') as THREE.BufferAttribute).array),
+      Float32Array.from((testCylinder.getAttribute('position') as BufferAttribute).array),
       Uint32Array.from(testCylinder.getIndex()!.array)
     );
 
@@ -42,10 +43,10 @@ describe(calculateVolumeOfMesh.name, () => {
   });
 
   test('Volume of unit cone should be PI / 3', () => {
-    const testCylinder = new THREE.ConeGeometry(1, 1, 200, 200);
+    const testCylinder = new ConeGeometry(1, 1, 200, 200);
 
     const calculatedVolume = calculateVolumeOfMesh(
-      Float32Array.from((testCylinder.getAttribute('position') as THREE.BufferAttribute).array),
+      Float32Array.from((testCylinder.getAttribute('position') as BufferAttribute).array),
       Uint32Array.from(testCylinder.getIndex()!.array)
     );
 

--- a/viewer/packages/utilities/src/calculateVolumeOfMesh.ts
+++ b/viewer/packages/utilities/src/calculateVolumeOfMesh.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Vector3 } from 'three';
 import { chunk, map } from 'lodash-es';
 import { assert } from '@reveal/utilities/assert';
 
@@ -10,7 +10,7 @@ export function calculateVolumeOfMesh(vertexBuffer: Float32Array, indexBuffer: U
   assert(vertexBuffer.length % 3 === 0);
   assert(indexBuffer.length % 3 === 0);
 
-  const vertices = chunk(vertexBuffer, 3).map(vertices => new THREE.Vector3(vertices[0], vertices[1], vertices[2]));
+  const vertices = chunk(vertexBuffer, 3).map(vertices => new Vector3(vertices[0], vertices[1], vertices[2]));
 
   const triangles = chunk(
     map(indexBuffer, index => vertices[index]),

--- a/viewer/packages/utilities/src/three/createDistinctColors.test.ts
+++ b/viewer/packages/utilities/src/three/createDistinctColors.test.ts
@@ -4,7 +4,7 @@
 
 import { createDistinctColors } from './createDistinctColors';
 
-import * as THREE from 'three';
+import { Vector3 } from 'three';
 
 describe('createDistinctColors', () => {
   test('creates somewhat distinct colors', () => {
@@ -22,9 +22,7 @@ describe('createDistinctColors', () => {
           return;
         }
 
-        const dist = new THREE.Vector3()
-          .fromArray(c0.toArray())
-          .distanceTo(new THREE.Vector3().fromArray(c1.toArray()));
+        const dist = new Vector3().fromArray(c0.toArray()).distanceTo(new Vector3().fromArray(c1.toArray()));
 
         expect(dist).toBeGreaterThan(minDifference);
       });

--- a/viewer/packages/utilities/src/three/createDistinctColors.ts
+++ b/viewer/packages/utilities/src/three/createDistinctColors.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Color } from 'three';
 
 /**
  * Expects h,s,v to be between 0 and 1.
@@ -34,14 +34,14 @@ function hsvToRgb(h: number, s: number, v: number): [number, number, number] {
   }
 }
 
-export function createDistinctColors(count: number): THREE.Color[] {
-  const result: THREE.Color[] = [];
+export function createDistinctColors(count: number): Color[] {
+  const result: Color[] = [];
 
   const hue_partition_size = 1.0 / count;
   for (let i = 0; i < count; i++) {
     const rgb = hsvToRgb(hue_partition_size * i, 1.0 - (i % 2) * 0.5, 1.0 - (i % 3) * 0.1);
 
-    result.push(new THREE.Color(...rgb));
+    result.push(new Color(...rgb));
   }
 
   return result;

--- a/viewer/packages/utilities/src/three/createFullScreenTriangleGeometry.ts
+++ b/viewer/packages/utilities/src/three/createFullScreenTriangleGeometry.ts
@@ -2,15 +2,15 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { BufferAttribute, BufferGeometry } from 'three';
 
-export function createRenderTriangle(): THREE.BufferGeometry {
-  const geometry = new THREE.BufferGeometry();
+export function createRenderTriangle(): BufferGeometry {
+  const geometry = new BufferGeometry();
   const vertices = new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]);
   const uvs = new Float32Array([0, 0, 2, 0, 0, 2]);
 
-  geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
-  geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+  geometry.setAttribute('position', new BufferAttribute(vertices, 3));
+  geometry.setAttribute('uv', new BufferAttribute(uvs, 2));
 
   return geometry;
 }

--- a/viewer/packages/utilities/src/three/fitCameraToBoundingBox.ts
+++ b/viewer/packages/utilities/src/three/fitCameraToBoundingBox.ts
@@ -2,7 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Box3, PerspectiveCamera } from 'three';
+import { Sphere, Vector3 } from 'three';
 
 /**
  * Calculates camera position and target that allows to see the content of provided bounding box.
@@ -12,15 +13,15 @@ import * as THREE from 'three';
  * @returns
  */
 export function fitCameraToBoundingBox(
-  camera: THREE.PerspectiveCamera,
-  boundingBox: THREE.Box3,
+  camera: PerspectiveCamera,
+  boundingBox: Box3,
   radiusFactor: number = 2
-): { position: THREE.Vector3; target: THREE.Vector3 } {
-  const boundingSphere = boundingBox.getBoundingSphere(new THREE.Sphere());
+): { position: Vector3; target: Vector3 } {
+  const boundingSphere = boundingBox.getBoundingSphere(new Sphere());
 
   const target = boundingSphere.center;
   const distance = boundingSphere.radius * radiusFactor;
-  const direction = new THREE.Vector3(0, 0, -1);
+  const direction = new Vector3(0, 0, -1);
   direction.applyQuaternion(camera.quaternion);
 
   const position = direction.clone().multiplyScalar(-distance).add(target);

--- a/viewer/packages/utilities/src/three/fromThreeVector3.ts
+++ b/viewer/packages/utilities/src/three/fromThreeVector3.ts
@@ -2,8 +2,8 @@
  * Copyright 2022 Cognite AS
  */
 
-import type * as THREE from 'three';
+import type { Vector3 } from 'three';
 
-export function fromThreeVector3(vec: THREE.Vector3): [number, number, number] {
+export function fromThreeVector3(vec: Vector3): [number, number, number] {
   return [vec.x, vec.y, vec.z];
 }

--- a/viewer/packages/utilities/src/three/isBox3OnPositiveSideOfPlane.test.ts
+++ b/viewer/packages/utilities/src/three/isBox3OnPositiveSideOfPlane.test.ts
@@ -2,37 +2,28 @@
  * Copyright 2021 Cognite AS
  */
 import { isBox3OnPositiveSideOfPlane } from './isBox3OnPositiveSideOfPlane';
-import * as THREE from 'three';
+import { Box3, Plane, Vector3 } from 'three';
 
 describe('isBox3OnPositiveSideOfPlane', () => {
   test('All box-corners are on positive side of plane', () => {
     const box = createBox([0, 0, 0], [1, 1, 1]);
-    const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, -5, 0)
-    );
+    const plane = new Plane().setFromNormalAndCoplanarPoint(new Vector3(0, 1, 0), new Vector3(0, -5, 0));
     expect(isBox3OnPositiveSideOfPlane(box, plane)).toBeTruthy();
   });
 
   test('All box-corners are on the negative side of plane', () => {
     const box = createBox([0, 0, 0], [1, 1, 1]);
-    const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, 5, 0)
-    );
+    const plane = new Plane().setFromNormalAndCoplanarPoint(new Vector3(0, 1, 0), new Vector3(0, 5, 0));
     expect(isBox3OnPositiveSideOfPlane(box, plane)).toBeFalsy();
   });
 
   test('Plane slices box', () => {
     const box = createBox([0, 0, 0], [1, 1, 1]);
-    const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(
-      new THREE.Vector3(0, 1, 0),
-      new THREE.Vector3(0, 0.5, 0)
-    );
+    const plane = new Plane().setFromNormalAndCoplanarPoint(new Vector3(0, 1, 0), new Vector3(0, 0.5, 0));
     expect(isBox3OnPositiveSideOfPlane(box, plane)).toBeTruthy();
   });
 });
 
-function createBox(min: [number, number, number], max: [number, number, number]): THREE.Box3 {
-  return new THREE.Box3().setFromArray([...min, ...max]);
+function createBox(min: [number, number, number], max: [number, number, number]): Box3 {
+  return new Box3().setFromArray([...min, ...max]);
 }

--- a/viewer/packages/utilities/src/three/isBox3OnPositiveSideOfPlane.ts
+++ b/viewer/packages/utilities/src/three/isBox3OnPositiveSideOfPlane.ts
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import type * as THREE from 'three';
+import type { Box3, Plane } from 'three';
 import { visitBox3CornerPoints } from './visitBox3CornerPoints';
 
 /**
@@ -9,7 +9,7 @@ import { visitBox3CornerPoints } from './visitBox3CornerPoints';
  * of the plane provided (i.e. the corner point has a non-negative signed distance to the
  * plane)
  */
-export function isBox3OnPositiveSideOfPlane(box: THREE.Box3, plane: THREE.Plane): boolean {
+export function isBox3OnPositiveSideOfPlane(box: Box3, plane: Plane): boolean {
   let planeAccepts = false;
   visitBox3CornerPoints(box, boundCorner => {
     planeAccepts = planeAccepts || plane.distanceToPoint(boundCorner) >= 0;

--- a/viewer/packages/utilities/src/three/toThreeBox3.ts
+++ b/viewer/packages/utilities/src/three/toThreeBox3.ts
@@ -1,11 +1,11 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import { Box3 } from 'three';
 import type { BoundingBox3D } from '@cognite/sdk';
 
-export function toThreeBox3(boundingBox: BoundingBox3D, out?: THREE.Box3): THREE.Box3 {
-  out = out ?? new THREE.Box3();
+export function toThreeBox3(boundingBox: BoundingBox3D, out?: Box3): Box3 {
+  out = out ?? new Box3();
   out.min.set(boundingBox.min[0], boundingBox.min[1], boundingBox.min[2]);
   out.max.set(boundingBox.max[0], boundingBox.max[1], boundingBox.max[2]);
   return out;

--- a/viewer/packages/utilities/src/three/unionBoxes.test.ts
+++ b/viewer/packages/utilities/src/three/unionBoxes.test.ts
@@ -7,19 +7,19 @@ import { createRandomBox } from '../../../../test-utilities/src/createBoxes';
 import SeededRandom from 'random-seed';
 import { unionBoxes } from './unionBoxes';
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 
 describe('computeSceneBoundingBox', () => {
-  let boxes: THREE.Box3[];
+  let boxes: Box3[];
 
   beforeEach(() => {
     const rand = SeededRandom.create('some_seed');
 
     const numSectors = 30;
-    boxes = new Array<THREE.Box3>(numSectors);
+    boxes = new Array<Box3>(numSectors);
 
     for (let i = 0; i < numSectors; i++) {
-      const box: THREE.Box3 = createRandomBox(20, 100, rand);
+      const box: Box3 = createRandomBox(20, 100, rand);
       boxes[i] = box;
     }
   });
@@ -43,7 +43,7 @@ describe('computeSceneBoundingBox', () => {
       maxX = Math.max(maxX, box.max.x);
     }
 
-    const boxOutside = new THREE.Box3(new THREE.Vector3(maxX, 0, 0), new THREE.Vector3(maxX + 1, 1, 1));
+    const boxOutside = new Box3(new Vector3(maxX, 0, 0), new Vector3(maxX + 1, 1, 1));
 
     expect(fullBoundingBox.containsBox(boxOutside)).toBeFalsy();
   });

--- a/viewer/packages/utilities/src/three/unionBoxes.ts
+++ b/viewer/packages/utilities/src/three/unionBoxes.ts
@@ -2,10 +2,10 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3 } from 'three';
 
-export function unionBoxes(boxes: THREE.Box3[], out?: THREE.Box3): THREE.Box3 {
-  out = out ?? new THREE.Box3();
+export function unionBoxes(boxes: Box3[], out?: Box3): Box3 {
+  out = out ?? new Box3();
   out.makeEmpty();
 
   boxes.forEach(inputBox => {

--- a/viewer/packages/utilities/src/three/visitBox3CornerPoints.ts
+++ b/viewer/packages/utilities/src/three/visitBox3CornerPoints.ts
@@ -1,10 +1,11 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import * as THREE from 'three';
+import type { Box3 } from 'three';
+import { Vector3, Vector4 } from 'three';
 
 const visitBox3CornerPointsVars = {
-  tmpVector: new THREE.Vector3()
+  tmpVector: new Vector3()
 };
 
 /**
@@ -14,7 +15,7 @@ const visitBox3CornerPointsVars = {
  * that will be changed later, so if this is to be stored
  * it must be cloned first.
  */
-export function visitBox3CornerPoints(box: THREE.Box3, callback: (corner: THREE.Vector3) => void): void {
+export function visitBox3CornerPoints(box: Box3, callback: (corner: Vector3) => void): void {
   const { tmpVector } = visitBox3CornerPointsVars;
   tmpVector.set(box.min.x, box.min.y, box.min.z); // 000
   callback(tmpVector);
@@ -34,15 +35,15 @@ export function visitBox3CornerPoints(box: THREE.Box3, callback: (corner: THREE.
   callback(tmpVector);
 }
 
-export function getBox3CornerPoints(box: THREE.Box3): THREE.Vector4[] {
+export function getBox3CornerPoints(box: Box3): Vector4[] {
   return [
-    new THREE.Vector4(box.min.x, box.min.y, box.min.z),
-    new THREE.Vector4(box.min.x, box.min.y, box.max.z),
-    new THREE.Vector4(box.min.x, box.max.y, box.min.z),
-    new THREE.Vector4(box.min.x, box.max.y, box.max.z),
-    new THREE.Vector4(box.max.x, box.min.y, box.min.z),
-    new THREE.Vector4(box.max.x, box.min.y, box.max.z),
-    new THREE.Vector4(box.max.x, box.max.y, box.min.z),
-    new THREE.Vector4(box.max.x, box.max.y, box.max.z)
+    new Vector4(box.min.x, box.min.y, box.min.z),
+    new Vector4(box.min.x, box.min.y, box.max.z),
+    new Vector4(box.min.x, box.max.y, box.min.z),
+    new Vector4(box.min.x, box.max.y, box.max.z),
+    new Vector4(box.max.x, box.min.y, box.min.z),
+    new Vector4(box.max.x, box.min.y, box.max.z),
+    new Vector4(box.max.x, box.max.y, box.min.z),
+    new Vector4(box.max.x, box.max.y, box.max.z)
   ];
 }

--- a/viewer/packages/utilities/src/transformCameraConfiguration.ts
+++ b/viewer/packages/utilities/src/transformCameraConfiguration.ts
@@ -1,13 +1,13 @@
 /*!
  * Copyright 2021 Cognite AS
  */
-import type * as THREE from 'three';
+import type { Matrix4 } from 'three';
 
 import type { CameraConfiguration } from './CameraConfiguration';
 
 export function transformCameraConfiguration(
   cameraConfiguration: CameraConfiguration | undefined,
-  modelMatrix: THREE.Matrix4
+  modelMatrix: Matrix4
 ): CameraConfiguration | undefined {
   if (cameraConfiguration === undefined) {
     return undefined;

--- a/viewer/packages/utilities/src/worldToViewport.test.ts
+++ b/viewer/packages/utilities/src/worldToViewport.test.ts
@@ -2,7 +2,8 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Camera, WebGLRenderer } from 'three';
+import { PerspectiveCamera, Vector2, Vector3, Vector4 } from 'three';
 
 import {
   worldToNormalizedViewportCoordinates,
@@ -37,8 +38,8 @@ expect.extend({
 });
 
 describe('worldToViewport', () => {
-  let renderer: THREE.WebGLRenderer;
-  let camera: THREE.PerspectiveCamera;
+  let renderer: WebGLRenderer;
+  let camera: PerspectiveCamera;
   let canvasRect: DOMRect;
 
   beforeEach(async () => {
@@ -47,7 +48,7 @@ describe('worldToViewport', () => {
       height: 64
     } as DOMRect;
 
-    camera = new THREE.PerspectiveCamera();
+    camera = new PerspectiveCamera();
     camera.near = 1;
     camera.far = 10;
     camera.position.set(0, 0, 0);
@@ -58,12 +59,12 @@ describe('worldToViewport', () => {
     const canvas = document.createElement('canvas');
     vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue(canvasRect);
 
-    renderer = autoMockWebGLRenderer(new Mock<THREE.WebGLRenderer>(), { canvas }).object();
+    renderer = autoMockWebGLRenderer(new Mock<WebGLRenderer>(), { canvas }).object();
     renderer.setSize(64, 64);
   });
 
   test('coordinate outside viewport', () => {
-    const p = new THREE.Vector3(100, 100, 100);
+    const p = new Vector3(100, 100, 100);
     const absolute = worldToViewportCoordinates(renderer.domElement, camera, p);
     const normalized = worldToNormalizedViewportCoordinates(camera, p);
 
@@ -77,7 +78,7 @@ describe('worldToViewport', () => {
   });
 
   test('coordinate behind far plane', () => {
-    const p = new THREE.Vector3(0, 0, 11);
+    const p = new Vector3(0, 0, 11);
     const absolute = worldToViewportCoordinates(renderer.domElement, camera, p);
     const normalized = worldToNormalizedViewportCoordinates(camera, p);
 
@@ -91,7 +92,7 @@ describe('worldToViewport', () => {
   });
 
   test('coordinate in front of near plane', () => {
-    const p = new THREE.Vector3(0, 0, -2);
+    const p = new Vector3(0, 0, -2);
     const absolute = worldToViewportCoordinates(renderer.domElement, camera, p);
     const normalized = worldToNormalizedViewportCoordinates(camera, p);
 
@@ -105,25 +106,25 @@ describe('worldToViewport', () => {
   });
 
   test('pixel ratio is not 1', () => {
-    const p = new THREE.Vector3(0.25, 1.25, 5);
+    const p = new Vector3(0.25, 1.25, 5);
 
     renderer.setPixelRatio(1.0);
-    const absoluteWithPixelRatio1 = worldToViewportCoordinates(renderer.domElement, camera, p, new THREE.Vector3());
-    const normalizedWithPixelRatio1 = worldToNormalizedViewportCoordinates(camera, p, new THREE.Vector3());
+    const absoluteWithPixelRatio1 = worldToViewportCoordinates(renderer.domElement, camera, p, new Vector3());
+    const normalizedWithPixelRatio1 = worldToNormalizedViewportCoordinates(camera, p, new Vector3());
 
     const pixelRatio = 2.5;
     renderer.setPixelRatio(pixelRatio);
-    const scaledRenderer = renderer.getSize(new THREE.Vector2()).multiplyScalar(pixelRatio);
+    const scaledRenderer = renderer.getSize(new Vector2()).multiplyScalar(pixelRatio);
     renderer.setSize(scaledRenderer.x, scaledRenderer.y);
-    const absoluteWithPixelRatio2 = worldToViewportCoordinates(renderer.domElement, camera, p, new THREE.Vector3());
-    const normalizedWithPixelRatio2 = worldToNormalizedViewportCoordinates(camera, p, new THREE.Vector3());
+    const absoluteWithPixelRatio2 = worldToViewportCoordinates(renderer.domElement, camera, p, new Vector3());
+    const normalizedWithPixelRatio2 = worldToNormalizedViewportCoordinates(camera, p, new Vector3());
 
     expect(absoluteWithPixelRatio2).toEqual(absoluteWithPixelRatio1);
     expect(normalizedWithPixelRatio2).toEqual(normalizedWithPixelRatio1);
   });
 
   test('far top-left corner of view frustum, returns top-left corner of canvas', () => {
-    const p = ndcToWorld(new THREE.Vector3(-1, 1, 1), camera);
+    const p = ndcToWorld(new Vector3(-1, 1, 1), camera);
     const absolute = worldToViewportCoordinates(renderer.domElement, camera, p);
     const normalized = worldToNormalizedViewportCoordinates(camera, p);
 
@@ -137,7 +138,7 @@ describe('worldToViewport', () => {
   });
 
   test('near top-left corner of view frustum, returns top-left corner of canvas', () => {
-    const p = ndcToWorld(new THREE.Vector3(-1, 1, -1), camera);
+    const p = ndcToWorld(new Vector3(-1, 1, -1), camera);
     const absolute = worldToViewportCoordinates(renderer.domElement, camera, p);
     const normalized = worldToNormalizedViewportCoordinates(camera, p);
 
@@ -151,7 +152,7 @@ describe('worldToViewport', () => {
   });
 
   test('far bottom-right corner of view frustum, returns bottom-right corner of canvas', () => {
-    const p = ndcToWorld(new THREE.Vector3(1, -1, 1), camera);
+    const p = ndcToWorld(new Vector3(1, -1, 1), camera);
     const absolute = worldToViewportCoordinates(renderer.domElement, camera, p);
     const normalized = worldToNormalizedViewportCoordinates(camera, p);
 
@@ -165,7 +166,7 @@ describe('worldToViewport', () => {
   });
 
   test('near bottom-right corner of view frustum, returns bottom-right corner of canvas', () => {
-    const p = ndcToWorld(new THREE.Vector3(1, -1, -1), camera);
+    const p = ndcToWorld(new Vector3(1, -1, -1), camera);
     const absolute = worldToViewportCoordinates(renderer.domElement, camera, p);
     const normalized = worldToNormalizedViewportCoordinates(camera, p);
 
@@ -179,12 +180,12 @@ describe('worldToViewport', () => {
   });
 });
 
-function ndcToWorld(ndcPoint: THREE.Vector3, camera: THREE.Camera): THREE.Vector3 {
-  const p = new THREE.Vector4(ndcPoint.x, ndcPoint.y, ndcPoint.z, 1.0);
+function ndcToWorld(ndcPoint: Vector3, camera: Camera): Vector3 {
+  const p = new Vector4(ndcPoint.x, ndcPoint.y, ndcPoint.z, 1.0);
   p.applyMatrix4(camera.projectionMatrixInverse);
   p.divideScalar(p.w);
   p.applyMatrix4(camera.matrixWorldInverse);
-  return new THREE.Vector3(p.x, p.y, p.z);
+  return new Vector3(p.x, p.y, p.z);
 }
 
 describe(getNormalizedPixelCoordinates.name, () => {

--- a/viewer/packages/utilities/src/worldToViewport.ts
+++ b/viewer/packages/utilities/src/worldToViewport.ts
@@ -2,11 +2,12 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { PerspectiveCamera } from 'three';
+import { Vector2, Vector3 } from 'three';
 
 const worldToViewportVars = {
-  renderSize: new THREE.Vector2(),
-  position: new THREE.Vector3()
+  renderSize: new Vector2(),
+  position: new Vector3()
 };
 
 /**
@@ -16,16 +17,16 @@ const worldToViewportVars = {
  * is inside the camera near and far planes.
  * @param camera      Camera used to project point from 3D to NDC coordinates
  * @param position3D  World position in 3D
- * @param out         Optionally pre-allocated THREE.Vector3
+ * @param out         Optionally pre-allocated Vector3
  * @returns           Relative screen coordinates in X, Y and Z in range [-1, 1] if point
  * is within near/far of camera.
  */
 
 export function worldToNormalizedViewportCoordinates(
-  camera: THREE.PerspectiveCamera,
-  position3D: THREE.Vector3,
-  out: THREE.Vector3 = new THREE.Vector3()
-): THREE.Vector3 {
+  camera: PerspectiveCamera,
+  position3D: Vector3,
+  out: Vector3 = new Vector3()
+): Vector3 {
   const { position } = worldToViewportVars;
 
   // map to normalized device coordinate (NDC) space
@@ -48,16 +49,16 @@ export function worldToNormalizedViewportCoordinates(
  * @param canvas      Renderer canvas used to render the "world"
  * @param camera      Camera used to project point from 3D to NDC coordinates
  * @param position3D  World position in 3D
- * @param out         Optionally pre-allocated THREE.Vector3
+ * @param out         Optionally pre-allocated Vector3
  * @returns           Relative screen coordinates in X, Y and Z in range [-1, 1] if point
  * is within near/far of camera.
  */
 export function worldToViewportCoordinates(
   canvas: HTMLCanvasElement,
-  camera: THREE.PerspectiveCamera,
-  position3D: THREE.Vector3,
-  out: THREE.Vector3 = new THREE.Vector3()
-): THREE.Vector3 {
+  camera: PerspectiveCamera,
+  position3D: Vector3,
+  out: Vector3 = new Vector3()
+): Vector3 {
   worldToNormalizedViewportCoordinates(camera, position3D, out);
 
   const { width: canvasWidth, height: canvasHeight } = canvas.getBoundingClientRect();
@@ -75,14 +76,14 @@ export function getNormalizedPixelCoordinatesBySize(
   pixelY: number,
   width: number,
   height: number
-): THREE.Vector2 {
-  return new THREE.Vector2((pixelX / width) * 2 - 1, -(pixelY / height) * 2 + 1);
+): Vector2 {
+  return new Vector2((pixelX / width) * 2 - 1, -(pixelY / height) * 2 + 1);
 }
 
-export function getNormalizedPixelCoordinates(domElement: HTMLElement, pixelX: number, pixelY: number): THREE.Vector2 {
+export function getNormalizedPixelCoordinates(domElement: HTMLElement, pixelX: number, pixelY: number): Vector2 {
   const { width, height } = domElement.getBoundingClientRect();
   if (width === 0 || height === 0) {
-    return new THREE.Vector2();
+    return new Vector2();
   }
   return getNormalizedPixelCoordinatesBySize(pixelX, pixelY, width, height);
 }

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -26,7 +26,6 @@ import { Plane } from 'three';
 import { Quaternion } from 'three';
 import { Raycaster } from 'three';
 import { Texture } from 'three';
-import * as THREE from 'three';
 import { Vector2 } from 'three';
 import { Vector3 } from 'three';
 import { WebGLRenderer } from 'three';
@@ -93,14 +92,14 @@ export class AssetNodeCollection extends NodeCollection {
     clear(): void;
     executeFilter(filter: {
         assetId?: number;
-        boundingBox?: THREE.Box3;
+        boundingBox?: Box3;
     }): Promise<void>;
     // (undocumented)
     getAreas(): AreaCollection;
     // (undocumented)
     getFilter(): {
         assetId?: number | undefined;
-        boundingBox?: THREE.Box3 | undefined;
+        boundingBox?: Box3 | undefined;
     } | undefined;
     // (undocumented)
     getIndexSet(): IndexSet;
@@ -115,8 +114,8 @@ export type AxisBoxCompassConfig = {
     ringLabel?: string;
     labelDelta?: number;
     fontSize?: number;
-    fontColor?: THREE.Color;
-    tickColor?: THREE.Color;
+    fontColor?: Color;
+    tickColor?: Color;
 };
 
 // @public
@@ -139,10 +138,10 @@ export type AxisBoxConfig = {
 export type AxisBoxFaceConfig = {
     label?: string;
     fontSize?: number;
-    fontColor?: THREE.Color;
+    fontColor?: Color;
     outlineSize?: number;
-    outlineColor?: THREE.Color;
-    faceColor?: THREE.Color;
+    outlineColor?: Color;
+    faceColor?: Color;
 };
 
 // @beta
@@ -238,9 +237,9 @@ export interface BlobOutputMetadata {
 
 // @public (undocumented)
 export class BoundingBoxClipper {
-    constructor(box?: THREE.Box3);
+    constructor(box?: Box3);
     // (undocumented)
-    get clippingPlanes(): THREE.Plane[];
+    get clippingPlanes(): Plane[];
     set maxX(x: number);
     // (undocumented)
     get maxX(): number;
@@ -368,8 +367,8 @@ export class CdfModelIdentifier implements ModelIdentifier {
 
 // @public
 export interface CdfModelNodeCollectionDataProvider {
-    getCdfToDefaultModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
-    getModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
+    getCdfToDefaultModelTransformation(out?: Matrix4): Matrix4;
+    getModelTransformation(out?: Matrix4): Matrix4;
     modelId: number;
     nodeCount: number;
     // (undocumented)
@@ -461,7 +460,7 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     // @beta
     addCustomObject(customObject: ICustomObject): void;
     addModel(options: AddModelOptions<DataSourceT>): Promise<CogniteModel<DataSourceT>>;
-    addObject3D(object: THREE.Object3D): void;
+    addObject3D(object: Object3D): void;
     addPointCloudModel(options: AddModelOptions<DataSourceT>): Promise<CognitePointCloudModel<DataSourceT>>;
     get cadBudget(): CadModelBudget;
     set cadBudget(budget: CadModelBudget);
@@ -471,14 +470,14 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     canDoImage360Action(action: Image360Action): boolean;
     get canvas(): HTMLCanvasElement;
     // @beta
-    createCustomObjectIntersectInput(pixelCoords: THREE.Vector2): CustomObjectIntersectInput;
+    createCustomObjectIntersectInput(pixelCoords: Vector2): CustomObjectIntersectInput;
     determineModelType(modelId: number, revisionId: number): Promise<SupportedModelTypes | ''>;
     dispose(): void;
     get domElement(): HTMLElement;
     enter360Image(image360: Image360<DataSourceT>, revision?: Image360Revision<DataSourceT>): Promise<void>;
     exit360Image(): void;
-    findBestNext360ImageEntity(clickedWorldPosition: THREE.Vector3): Image360WithCollection<DataSourceT> | undefined;
-    fitCameraToBoundingBox(boundingBox: THREE.Box3, duration?: number, radiusFactor?: number): void;
+    findBestNext360ImageEntity(clickedWorldPosition: Vector3): Image360WithCollection<DataSourceT> | undefined;
+    fitCameraToBoundingBox(boundingBox: Box3, duration?: number, radiusFactor?: number): void;
     fitCameraToModel(model: CogniteModel<DataSourceT>, duration?: number): void;
     fitCameraToModels(models?: CogniteModel<DataSourceT>[], duration?: number, restrictToMostGeometry?: boolean): void;
     fitCameraToVisualSceneBoundingBox(duration?: number): void;
@@ -486,24 +485,24 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     get360ImageCollections(): Image360Collection<DataSourceT>[];
     getActive360ImageInfo(): Image360WithCollection<DataSourceT> | undefined;
     // @beta
-    getAnyIntersectionFromPixel(pixelCoords: THREE.Vector2, options?: {
+    getAnyIntersectionFromPixel(pixelCoords: Vector2, options?: {
         stopOnHitting360Icon?: boolean;
         predicate?: (customObject: ICustomObject) => boolean;
     }): Promise<AnyIntersection<DataSourceT> | undefined>;
     // @deprecated
-    getClippingPlanes(): THREE.Plane[];
-    getGlobalClippingPlanes(): THREE.Plane[];
+    getClippingPlanes(): Plane[];
+    getGlobalClippingPlanes(): Plane[];
     getIntersectionFromPixel(offsetX: number, offsetY: number): Promise<null | Intersection<DataSourceT>>;
-    getNormalizedPixelCoordinates(pixelCoords: THREE.Vector2): THREE.Vector2;
-    getPixelCoordinatesFromEvent(event: PointerEvent | WheelEvent): THREE.Vector2;
+    getNormalizedPixelCoordinates(pixelCoords: Vector2): Vector2;
+    getPixelCoordinatesFromEvent(event: PointerEvent | WheelEvent): Vector2;
     getResolutionOptions(): ResolutionOptions;
     // @beta
-    getSceneBoundingBox(): THREE.Box3;
+    getSceneBoundingBox(): Box3;
     getScreenshot(width?: number, height?: number, includeUI?: boolean): Promise<string>;
     getVersion(): string;
     getViewState(): ViewerState;
     // @beta
-    getVisualSceneBoundingBox(): THREE.Box3;
+    getVisualSceneBoundingBox(): Box3;
     // @beta
     image360Action(action: Image360Action): Promise<void>;
     loadCameraFromModel(model: CogniteModel<DataSourceT>): void;
@@ -540,21 +539,21 @@ export class Cognite3DViewer<DataSourceT extends DataSourceType = ClassicDataSou
     // @beta
     removeCustomObject(customObject: ICustomObject): void;
     removeModel(model: CogniteModel<DataSourceT>): void;
-    removeObject3D(object: THREE.Object3D): void;
+    removeObject3D(object: Object3D): void;
     get renderParameters(): RenderParameters;
     requestRedraw(): void;
     setBackgroundColor(backgroundColor: {
-        color?: THREE.Color;
+        color?: Color;
         alpha?: number;
     }): void;
     setCameraManager(cameraManager: CameraManager): void;
     // @deprecated
-    setClippingPlanes(clippingPlanes: THREE.Plane[]): void;
-    setGlobalClippingPlanes(clippingPlanes: THREE.Plane[]): void;
+    setClippingPlanes(clippingPlanes: Plane[]): void;
+    setGlobalClippingPlanes(clippingPlanes: Plane[]): void;
     setLogLevel(level: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent' | 'none'): void;
     setResolutionOptions(options: ResolutionOptions): void;
     setViewState(state: ViewerState): Promise<void>;
-    worldToScreen(point: THREE.Vector3, normalize?: boolean): THREE.Vector2 | null;
+    worldToScreen(point: Vector3, normalize?: boolean): Vector2 | null;
 }
 
 // @public
@@ -605,23 +604,23 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
     assignStyledNodeCollection(nodeCollection: NodeCollection, appearance: NodeAppearance, importance?: number): void;
     dispose(): void;
     getAncestorTreeIndices(treeIndex: number, generation: number): Promise<NumericRange>;
-    getBoundingBoxByNodeId(nodeId: number, box?: THREE.Box3): Promise<THREE.Box3>;
-    getBoundingBoxByTreeIndex(treeIndex: number, box?: THREE.Box3): Promise<THREE.Box3>;
-    getBoundingBoxesByNodeIds(nodeIds: number[]): Promise<THREE.Box3[]>;
+    getBoundingBoxByNodeId(nodeId: number, box?: Box3): Promise<Box3>;
+    getBoundingBoxByTreeIndex(treeIndex: number, box?: Box3): Promise<Box3>;
+    getBoundingBoxesByNodeIds(nodeIds: number[]): Promise<Box3[]>;
     getCameraConfiguration(): CameraConfiguration | undefined;
-    getCdfToDefaultModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
+    getCdfToDefaultModelTransformation(out?: Matrix4): Matrix4;
     getDefaultNodeAppearance(): NodeAppearance;
-    getModelBoundingBox(outBoundingBox?: THREE.Box3, restrictToMostGeometry?: boolean): THREE.Box3;
-    getModelClippingPlanes(): THREE.Plane[];
-    getModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
+    getModelBoundingBox(outBoundingBox?: Box3, restrictToMostGeometry?: boolean): Box3;
+    getModelClippingPlanes(): Plane[];
+    getModelTransformation(out?: Matrix4): Matrix4;
     getSubtreeTreeIndices(treeIndex: number): Promise<NumericRange>;
     iterateNodesByTreeIndex(action: (treeIndex: number) => void): Promise<void>;
     iterateSubtreeByTreeIndex(treeIndex: number, action: (treeIndex: number) => void): Promise<void>;
     lockTreeIndices(treeIndices: number[]): void;
-    mapBoxFromCdfToModelCoordinates(box: THREE.Box3, out?: THREE.Box3): THREE.Box3;
+    mapBoxFromCdfToModelCoordinates(box: Box3, out?: Box3): Box3;
     mapNodeIdsToTreeIndices(nodeIds: CogniteInternalId[]): Promise<number[]>;
     mapNodeIdToTreeIndex(nodeId: CogniteInternalId): Promise<number>;
-    mapPointFromCdfToModelCoordinates(point: THREE.Vector3, out?: THREE.Vector3): THREE.Vector3;
+    mapPointFromCdfToModelCoordinates(point: Vector3, out?: Vector3): Vector3;
     mapTreeIndexToNodeId(treeIndex: number): Promise<CogniteInternalId>;
     mapTreeIndicesToNodeIds(treeIndices: number[]): Promise<CogniteInternalId[]>;
     readonly modelId: number;
@@ -633,10 +632,10 @@ export class CogniteCadModel implements CdfModelNodeCollectionDataProvider {
     resetNodeTransformByTreeIndex(treeIndex: number, applyToChildren?: boolean): Promise<number>;
     readonly revisionId: number;
     setDefaultNodeAppearance(appearance: NodeAppearance): void;
-    setModelClippingPlanes(clippingPlanes: THREE.Plane[]): void;
-    setModelTransformation(matrix: THREE.Matrix4): void;
-    setNodeTransform(treeIndices: NumericRange, transformMatrix: THREE.Matrix4, boundingBox?: THREE.Box3, space?: 'model' | 'world'): void;
-    setNodeTransformByTreeIndex(treeIndex: number, transform: THREE.Matrix4, applyToChildren?: boolean, space?: 'model' | 'world'): Promise<number>;
+    setModelClippingPlanes(clippingPlanes: Plane[]): void;
+    setModelTransformation(matrix: Matrix4): void;
+    setNodeTransform(treeIndices: NumericRange, transformMatrix: Matrix4, boundingBox?: Box3, space?: 'model' | 'world'): void;
+    setNodeTransformByTreeIndex(treeIndex: number, transform: Matrix4, applyToChildren?: boolean, space?: 'model' | 'world'): Promise<number>;
     get styledNodeCollections(): {
         nodeCollection: NodeCollection;
         appearance: NodeAppearance;
@@ -658,22 +657,22 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
     assignStyledObjectCollection(objectCollection: T['pointCloudCollectionType'], appearance: PointCloudAppearance, importance?: number): void;
     dispose(): void;
     getCameraConfiguration(): CameraConfiguration | undefined;
-    getCdfToDefaultModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
+    getCdfToDefaultModelTransformation(out?: Matrix4): Matrix4;
     getClasses(): Array<{
         name: string;
         code: number | WellKnownAsprsPointClassCodes;
-        color: THREE.Color;
+        color: Color;
     }>;
     getDefaultPointCloudAppearance(): PointCloudAppearance;
     // (undocumented)
-    getModelBoundingBox(outBoundingBox?: THREE.Box3): THREE.Box3;
-    getModelClippingPlanes(): THREE.Plane[];
-    getModelTransformation(out?: THREE.Matrix4): THREE.Matrix4;
-    getPointsByBoundingBox(box: THREE.Box3): THREE.Vector3[];
+    getModelBoundingBox(outBoundingBox?: Box3): Box3;
+    getModelClippingPlanes(): Plane[];
+    getModelTransformation(out?: Matrix4): Matrix4;
+    getPointsByBoundingBox(box: Box3): Vector3[];
     hasClass(pointClass: number | WellKnownAsprsPointClassCodes): boolean;
     isClassVisible(pointClass: number | WellKnownAsprsPointClassCodes): boolean;
-    mapBoxFromCdfToModelCoordinates(box: THREE.Box3, out?: THREE.Box3): THREE.Box3;
-    mapPointFromCdfToModelCoordinates(point: THREE.Vector3, out?: THREE.Vector3): THREE.Vector3;
+    mapBoxFromCdfToModelCoordinates(box: Box3, out?: Box3): Box3;
+    mapPointFromCdfToModelCoordinates(point: Vector3, out?: Vector3): Vector3;
     // @deprecated
     readonly modelId: number;
     readonly modelIdentifier: T['modelIdentifier'];
@@ -690,8 +689,8 @@ export class CognitePointCloudModel<T extends DataSourceType = ClassicDataSource
     readonly revisionId: number;
     setClassVisible(pointClass: number | WellKnownAsprsPointClassCodes, visible: boolean): void;
     setDefaultPointCloudAppearance(appearance: PointCloudAppearance): void;
-    setModelClippingPlanes(clippingPlanes: THREE.Plane[]): void;
-    setModelTransformation(transformationMatrix: THREE.Matrix4): void;
+    setModelClippingPlanes(clippingPlanes: Plane[]): void;
+    setModelTransformation(transformationMatrix: Matrix4): void;
     // (undocumented)
     get stylableObjectCount(): number;
     get stylableObjects(): PointCloudObjectMetadata<T>[];
@@ -921,16 +920,16 @@ export class DefaultCameraManager implements CameraManager {
     // (undocumented)
     dispose(): void;
     // (undocumented)
-    fitCameraToBoundingBox(box: THREE.Box3, duration?: number, radiusFactor?: number): void;
+    fitCameraToBoundingBox(box: Box3, duration?: number, radiusFactor?: number): void;
     // (undocumented)
-    getCamera(): THREE.PerspectiveCamera;
+    getCamera(): PerspectiveCamera;
     getCameraControlsOptions(): CameraControlsOptions;
     // (undocumented)
     getCameraState(): Required<CameraState>;
     getComboControlsOptions(): Readonly<ComboControlsOptions>;
     set keyboardNavigationEnabled(enabled: boolean);
     get keyboardNavigationEnabled(): boolean;
-    moveCameraTo(position: THREE.Vector3, target: THREE.Vector3, duration?: number, keyboardNavigationEnabled?: boolean): void;
+    moveCameraTo(position: Vector3, target: Vector3, duration?: number, keyboardNavigationEnabled?: boolean): void;
     // (undocumented)
     off(event: CameraManagerEventType, callback: CameraEventDelegate): void;
     // (undocumented)
@@ -939,7 +938,7 @@ export class DefaultCameraManager implements CameraManager {
     setCameraState(state: CameraState): void;
     setComboControlsOptions(options: Partial<ComboControlsOptions>): void;
     // (undocumented)
-    update(deltaTime: number, boundingBox: THREE.Box3): void;
+    update(deltaTime: number, boundingBox: Box3): void;
 }
 
 // @public
@@ -1173,10 +1172,10 @@ export type GeometryFilter = {
 };
 
 // @public (undocumented)
-export function getNormalizedPixelCoordinates(domElement: HTMLElement, pixelX: number, pixelY: number): THREE.Vector2;
+export function getNormalizedPixelCoordinates(domElement: HTMLElement, pixelX: number, pixelY: number): Vector2;
 
 // @public
-export function getNormalizedPixelCoordinatesBySize(pixelX: number, pixelY: number, width: number, height: number): THREE.Vector2;
+export function getNormalizedPixelCoordinatesBySize(pixelX: number, pixelY: number, width: number, height: number): Vector2;
 
 // @beta
 export function getWheelEventDelta(event: WheelEvent): number;
@@ -1202,20 +1201,20 @@ export type HtmlOverlayOptions = {
 };
 
 // @public
-export type HtmlOverlayPositionUpdatedDelegate = (element: HTMLElement, position2D: THREE.Vector2, position3D: THREE.Vector3, distanceToCamera: number, userData: any) => void;
+export type HtmlOverlayPositionUpdatedDelegate = (element: HTMLElement, position2D: Vector2, position3D: Vector3, distanceToCamera: number, userData: any) => void;
 
 // @public
 export class HtmlOverlayTool extends Cognite3DViewerToolBase {
     constructor(viewer: Cognite3DViewer<DataSourceType>, options?: HtmlOverlayToolOptions);
-    add(htmlElement: HTMLElement, position3D: THREE.Vector3, options?: HtmlOverlayOptions): void;
+    add(htmlElement: HTMLElement, position3D: Vector3, options?: HtmlOverlayOptions): void;
     clear(): void;
     // @override
     dispose(): void;
     get elements(): {
         element: HTMLElement;
-        position3D: THREE.Vector3;
+        position3D: Vector3;
     }[];
-    forceUpdate(customCamera?: THREE.PerspectiveCamera): void;
+    forceUpdate(customCamera?: PerspectiveCamera): void;
     remove(htmlElement: HTMLElement): void;
     visible(enable: boolean): void;
 }
@@ -1598,7 +1597,7 @@ export type MeasurementStartedDelegate = () => void;
 // @public
 export class MeasurementTool extends Cognite3DViewerToolBase {
     constructor(viewer: Cognite3DViewer<DataSourceType>, options?: MeasurementOptions);
-    addMeasurement(startPoint: THREE.Vector3, endPoint: THREE.Vector3): Measurement;
+    addMeasurement(startPoint: Vector3, endPoint: Vector3): Measurement;
     dispose(): void;
     enterMeasurementMode(): void;
     exitMeasurementMode(): void;
@@ -1620,7 +1619,7 @@ export class MeasurementTool extends Cognite3DViewerToolBase {
     removeMeasurement(measurement: Measurement): void;
     setLineOptions(options: MeasurementOptions): void;
     setMeasurementLabelsVisible(enable: boolean): void;
-    updateLineColor(measurement: Measurement, color: THREE.Color): void;
+    updateLineColor(measurement: Measurement, color: Color): void;
     updateLineWidth(measurement: Measurement, lineWidth: number): void;
     visible(enable: boolean): void;
 }
@@ -1641,11 +1640,11 @@ export interface ModelIdentifier {
 export interface ModelMetadataProvider {
     // (undocumented)
     getModelCamera(identifier: ModelIdentifier): Promise<{
-        position: THREE.Vector3;
-        target: THREE.Vector3;
+        position: Vector3;
+        target: Vector3;
     } | undefined>;
     // (undocumented)
-    getModelMatrix(identifier: ModelIdentifier, format: File3dFormat | string): Promise<THREE.Matrix4>;
+    getModelMatrix(identifier: ModelIdentifier, format: File3dFormat | string): Promise<Matrix4>;
     // (undocumented)
     getModelOutputs(modelIdentifier: ModelIdentifier): Promise<BlobOutputMetadata[]>;
     // (undocumented)
@@ -1744,7 +1743,7 @@ export interface NodesApiClient {
         treeIndex: number;
         subtreeSize: number;
     }[]>;
-    getBoundingBoxesByNodeIds(modelId: CogniteInternalId, revisionId: CogniteInternalId, nodeIds: CogniteInternalId[]): Promise<THREE.Box3[]>;
+    getBoundingBoxesByNodeIds(modelId: CogniteInternalId, revisionId: CogniteInternalId, nodeIds: CogniteInternalId[]): Promise<Box3[]>;
     mapNodeIdsToTreeIndices(modelId: CogniteInternalId, revisionId: CogniteInternalId, nodeIds: CogniteInternalId[]): Promise<number[]>;
     mapTreeIndicesToNodeIds(modelId: CogniteInternalId, revisionId: CogniteInternalId, treeIndices: number[]): Promise<CogniteInternalId[]>;
 }
@@ -1847,7 +1846,7 @@ export class Overlay3DTool<ContentType = DefaultOverlay3DContentType> extends Co
 // @public
 export type Overlay3DToolParameters = {
     maxPointSize?: number;
-    defaultOverlayColor: THREE.Color;
+    defaultOverlayColor: Color;
 };
 
 // @public
@@ -1861,9 +1860,9 @@ export interface OverlayCollection<ContentType> {
 
 // @public
 export type OverlayCollectionOptions = {
-    defaultOverlayColor?: THREE.Color;
-    overlayTexture?: THREE.Texture;
-    overlayTextureMask?: THREE.Texture;
+    defaultOverlayColor?: Color;
+    overlayTexture?: Texture;
+    overlayTextureMask?: Texture;
 };
 
 // @public
@@ -2038,7 +2037,7 @@ export function registerNodeCollectionType<T extends NodeCollection>(nodeCollect
 // @public
 export type RelativePosition = {
     corner: Corner;
-    padding: THREE.Vector2;
+    padding: Vector2;
 };
 
 // @public
@@ -2141,8 +2140,8 @@ export class TreeIndexNodeCollection extends NodeCollection {
     constructor(treeIndexSet?: IndexSet);
     constructor(treeIndices?: Iterable<number>);
     constructor(treeIndexRange?: NumericRange);
-    addAreaPoints(points: THREE.Vector3[]): void;
-    addAreas(areas: THREE.Box3[]): void;
+    addAreaPoints(points: Vector3[]): void;
+    addAreas(areas: Box3[]): void;
     // (undocumented)
     static readonly classToken = "TreeIndexNodeCollection";
     clear(): void;

--- a/viewer/test-utilities/src/createCadModelMetadata.ts
+++ b/viewer/test-utilities/src/createCadModelMetadata.ts
@@ -2,7 +2,7 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Matrix4 } from 'three';
 
 import { File3dFormat, LocalModelIdentifier } from '../../packages/data-providers';
 import type { SectorMetadata, CadModelMetadata } from '../../packages/cad-parsers';
@@ -19,8 +19,8 @@ export function createCadModelMetadata(sceneVersion: number, root: SectorMetadat
     format: File3dFormat.GltfCadModel,
     formatVersion: sceneVersion,
     modelBaseUrl: `https://localhost/${modelId}`,
-    modelMatrix: new THREE.Matrix4().identity(),
-    inverseModelMatrix: new THREE.Matrix4().identity(),
+    modelMatrix: new Matrix4().identity(),
+    inverseModelMatrix: new Matrix4().identity(),
     scene,
     geometryClipBox: null
   };

--- a/viewer/test-utilities/src/createPointCloudModel.ts
+++ b/viewer/test-utilities/src/createPointCloudModel.ts
@@ -8,7 +8,7 @@ import { CognitePointCloudModel, PointCloudNode } from '../../packages/pointclou
 import type { Potree } from '../../packages/pointclouds/src/potree-three-loader';
 import { PointCloudOctree } from '../../packages/pointclouds/src/potree-three-loader';
 
-import * as THREE from 'three';
+import { Box3, Matrix4, Vector3 } from 'three';
 
 import type { IPointCloudTreeGeometry } from '../../packages/pointclouds/src/potree-three-loader/geometry/IPointCloudTreeGeometry';
 import type { PointCloudMaterial } from '../../packages/rendering';
@@ -33,11 +33,11 @@ export function createPointCloudNode<T extends DataSourceType>(params?: {
     new Mock<Potree>().object(),
     new Mock<IPointCloudTreeGeometry>()
       .setup(p => p.boundingBox)
-      .returns(new THREE.Box3())
+      .returns(new Box3())
       .setup(p => p.offset)
-      .returns(new THREE.Vector3())
+      .returns(new Vector3())
       .setup(p => p.tightBoundingBox)
-      .returns(new THREE.Box3())
+      .returns(new Box3())
       .object(),
     new Mock<PointCloudMaterial>()
       .setup(p => p.classification)
@@ -47,7 +47,7 @@ export function createPointCloudNode<T extends DataSourceType>(params?: {
       .object()
   );
 
-  return new PointCloudNode(Symbol(), new THREE.Matrix4(), pointCloudOctree, params?.annotations ?? [], {
+  return new PointCloudNode(Symbol(), new Matrix4(), pointCloudOctree, params?.annotations ?? [], {
     classificationSets: []
   });
 }

--- a/viewer/test-utilities/src/createSectorMetadata.ts
+++ b/viewer/test-utilities/src/createSectorMetadata.ts
@@ -2,12 +2,12 @@
  * Copyright 2021 Cognite AS
  */
 
-import * as THREE from 'three';
+import { Box3, Vector3 } from 'three';
 import type { SectorMetadata } from '../../packages/cad-parsers/src/metadata/types';
 
-export type SectorTree = [id: number, subtree: SectorTree[], bounds?: THREE.Box3];
+export type SectorTree = [id: number, subtree: SectorTree[], bounds?: Box3];
 
-const unitBox = new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1));
+const unitBox = new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
 
 export function createV9SectorMetadata(
   tree: SectorTree,
@@ -50,7 +50,7 @@ export function generateV9SectorTree(depth: number, childrenPerLevel: number = 4
 
 function generateSectorTreeChildren(
   depth: number,
-  bounds: THREE.Box3,
+  bounds: Box3,
   childCount: number,
   firstId: number
 ): { children: SectorTree[]; nextId: number } {

--- a/viewer/test-utilities/src/primitives/internal/read.ts
+++ b/viewer/test-utilities/src/primitives/internal/read.ts
@@ -8,7 +8,8 @@ import type { AttributeDesc } from './attributes';
 import { commonAttributeTypeMap } from './attributes';
 import type { Primitive, PrimitiveComponent } from './types';
 
-import * as THREE from 'three';
+import type { BufferGeometry } from 'three';
+import { InterleavedBufferAttribute } from 'three';
 
 function readBufferValues(array: TypedArray, count: number): number[] {
   const resultArray: number[] = [];
@@ -19,11 +20,11 @@ function readBufferValues(array: TypedArray, count: number): number[] {
 }
 
 function readAttributeValue(
-  geometryBuffer: THREE.BufferGeometry,
+  geometryBuffer: BufferGeometry,
   attributeDescription: AttributeDesc,
   byteOffset: number
 ): PrimitiveComponent {
-  const threeAttribute = geometryBuffer.getAttribute(attributeDescription.name) as THREE.InterleavedBufferAttribute;
+  const threeAttribute = geometryBuffer.getAttribute(attributeDescription.name) as InterleavedBufferAttribute;
   const underlyingTypedArray = threeAttribute.data.array as TypedArray;
   const rawBuffer = underlyingTypedArray.buffer;
 
@@ -50,11 +51,11 @@ function readAttributeValue(
   }
 }
 
-function getInterleavedAttributeDescriptionsFromBufferGeometry(geometryBuffer: THREE.BufferGeometry): AttributeDesc[] {
+function getInterleavedAttributeDescriptionsFromBufferGeometry(geometryBuffer: BufferGeometry): AttributeDesc[] {
   const descs: AttributeDesc[] = [];
   for (const attributeName in geometryBuffer.attributes) {
     const attribute = geometryBuffer.attributes[attributeName];
-    if (!(attribute instanceof THREE.InterleavedBufferAttribute)) continue;
+    if (!(attribute instanceof InterleavedBufferAttribute)) continue;
 
     const format = commonAttributeTypeMap.get(attributeName);
 
@@ -75,7 +76,7 @@ function getInterleavedAttributeDescriptionsFromBufferGeometry(geometryBuffer: T
 /**
  * Reads and returns a single primitive from the provided geometry buffer, at the given byte offset
  */
-export function readPrimitiveFromBuffer(geometryBuffer: THREE.BufferGeometry, byteOffset: number): Primitive {
+export function readPrimitiveFromBuffer(geometryBuffer: BufferGeometry, byteOffset: number): Primitive {
   const attributeDescriptions = getInterleavedAttributeDescriptionsFromBufferGeometry(geometryBuffer);
 
   const obj: Record<string, PrimitiveComponent> = {};

--- a/viewer/test-utilities/src/primitives/internal/threeTranslation.ts
+++ b/viewer/test-utilities/src/primitives/internal/threeTranslation.ts
@@ -12,7 +12,7 @@ import { writePrimitiveToBuffer } from './write';
 import { readPrimitiveFromBuffer } from './read';
 import type { PrimitiveName, Primitive } from './types';
 
-import * as THREE from 'three';
+import { BufferGeometry, InstancedInterleavedBuffer, InterleavedBufferAttribute } from 'three';
 import type { TypedArray } from '../../../../packages/utilities';
 import { assert } from '../../../../packages/utilities/src/assert';
 
@@ -30,11 +30,11 @@ function createInstancedInterleavedBuffers(
   types: PrimitiveName[],
   primitiveDescs: Primitive[][],
   elementSizes: number[]
-): THREE.InstancedInterleavedBuffer[] {
+): InstancedInterleavedBuffer[] {
   let currentByteOffset = 0;
   let lastByteOffset = 0;
 
-  const interleavedBuffers: THREE.InstancedInterleavedBuffer[] = [];
+  const interleavedBuffers: InstancedInterleavedBuffer[] = [];
 
   for (let i = 0; i < types.length; i++) {
     for (const primitiveDesc of primitiveDescs[i]) {
@@ -48,9 +48,7 @@ function createInstancedInterleavedBuffers(
     );
     lastByteOffset = currentByteOffset;
 
-    interleavedBuffers.push(
-      new THREE.InstancedInterleavedBuffer(floatView, elementSizes[i] / floatView.BYTES_PER_ELEMENT)
-    );
+    interleavedBuffers.push(new InstancedInterleavedBuffer(floatView, elementSizes[i] / floatView.BYTES_PER_ELEMENT));
   }
 
   return interleavedBuffers;
@@ -58,14 +56,14 @@ function createInstancedInterleavedBuffers(
 
 function createBufferGeometries(
   types: PrimitiveName[],
-  interleavedBuffers: THREE.InstancedInterleavedBuffer[]
-): THREE.BufferGeometry[] {
-  const geometries: THREE.BufferGeometry[] = [];
+  interleavedBuffers: InstancedInterleavedBuffer[]
+): BufferGeometry[] {
+  const geometries: BufferGeometry[] = [];
 
   for (let i = 0; i < types.length; i++) {
     const attributeDescriptions = createAttributeDescriptionsForPrimitive(types[i]);
 
-    const geometry = new THREE.BufferGeometry();
+    const geometry = new BufferGeometry();
 
     for (const attributeDescription of attributeDescriptions) {
       const itemSize =
@@ -78,7 +76,7 @@ function createBufferGeometries(
 
       const shouldNormalize = getShouldNormalize(attributeDescription.format.componentType);
 
-      const bufferAttribute = new THREE.InterleavedBufferAttribute(
+      const bufferAttribute = new InterleavedBufferAttribute(
         interleavedBuffers[i],
         itemSize,
         attributeDescription.byteOffset / Float32Array.BYTES_PER_ELEMENT,
@@ -96,13 +94,13 @@ function createBufferGeometries(
 /**
  * Takes a list of primitive names and a list of lists containing
  * instances of the corresponding primitives.
- * Returns a list of THREE.BufferGeometry objects describing the primitives
+ * Returns a list of BufferGeometry objects describing the primitives
  * written to a single shared underlying buffer.
  */
 export function createPrimitiveInterleavedGeometriesSharingBuffer(
   types: PrimitiveName[],
   primitiveDescs: Primitive[][]
-): THREE.BufferGeometry[] {
+): BufferGeometry[] {
   assert(types.length == primitiveDescs.length);
 
   const elementSizes = types.map(computeTotalAttributeByteSize);
@@ -115,23 +113,20 @@ export function createPrimitiveInterleavedGeometriesSharingBuffer(
 
 /**
  * Takes a primitive name and a list of primitive instances of that type
- * Returns a THREE.BufferGeometry containing the primitives
+ * Returns a BufferGeometry containing the primitives
  */
-export function createPrimitiveInterleavedGeometry(
-  name: PrimitiveName,
-  primitiveDescs: Primitive[]
-): THREE.BufferGeometry {
+export function createPrimitiveInterleavedGeometry(name: PrimitiveName, primitiveDescs: Primitive[]): BufferGeometry {
   return createPrimitiveInterleavedGeometriesSharingBuffer([name], [primitiveDescs])[0];
 }
 
 /* NB: Assumes BufferGeometry only uses one underlying buffer for interleaved attributes */
-function getBufferByteSize(geometryBuffer: THREE.BufferGeometry): [number, number] {
+function getBufferByteSize(geometryBuffer: BufferGeometry): [number, number] {
   let underlyingByteBufferLength: number | undefined = undefined;
   let underlyingByteBufferOffset: number | undefined = undefined;
   for (const attr of Object.entries(geometryBuffer.attributes)) {
-    if (attr[1] instanceof THREE.InterleavedBufferAttribute) {
-      underlyingByteBufferLength = ((attr[1] as THREE.InterleavedBufferAttribute).array as TypedArray).byteLength;
-      underlyingByteBufferOffset = ((attr[1] as THREE.InterleavedBufferAttribute).array as TypedArray).byteOffset;
+    if (attr[1] instanceof InterleavedBufferAttribute) {
+      underlyingByteBufferLength = ((attr[1] as InterleavedBufferAttribute).array as TypedArray).byteLength;
+      underlyingByteBufferOffset = ((attr[1] as InterleavedBufferAttribute).array as TypedArray).byteOffset;
     }
   }
 
@@ -143,10 +138,10 @@ function getBufferByteSize(geometryBuffer: THREE.BufferGeometry): [number, numbe
 }
 
 /**
- * Reads primitives of the specified type out of the provided THREE.BufferGeometry object
+ * Reads primitives of the specified type out of the provided BufferGeometry object
  * Returns list of records containing the resulting primitives
  */
-export function parseInterleavedGeometry(name: PrimitiveName, geometryBuffer: THREE.BufferGeometry): Primitive[] {
+export function parseInterleavedGeometry(name: PrimitiveName, geometryBuffer: BufferGeometry): Primitive[] {
   const singleElementSize = computeTotalAttributeByteSize(name);
 
   const [byteLength, byteOffset] = getBufferByteSize(geometryBuffer);

--- a/viewer/visual-tests/test-fixtures/SimpleVisualTestFixture.ts
+++ b/viewer/visual-tests/test-fixtures/SimpleVisualTestFixture.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import type { Box3 } from 'three';
+import { Matrix4, PerspectiveCamera, Scene, Sphere, Vector3, WebGLRenderer } from 'three';
 import { OrbitControls } from 'three/addons';
 
 import type { ModelMetadataProvider, ModelDataProvider, ModelIdentifier } from '../../packages/data-providers';
@@ -9,9 +10,9 @@ import { createDataProviders } from './utilities/createDataProviders';
 import type { VisualTestFixture } from './VisualTestFixture';
 
 export type SimpleTestFixtureComponents = {
-  renderer: THREE.WebGLRenderer;
-  scene: THREE.Scene;
-  camera: THREE.PerspectiveCamera;
+  renderer: WebGLRenderer;
+  scene: Scene;
+  camera: PerspectiveCamera;
   cameraControls: OrbitControls;
   dataProviders: {
     modelMetadataProvider: ModelMetadataProvider;
@@ -21,19 +22,19 @@ export type SimpleTestFixtureComponents = {
 };
 
 export abstract class SimpleVisualTestFixture implements VisualTestFixture {
-  public readonly cadFromCdfToThreeMatrix = new THREE.Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
+  public readonly cadFromCdfToThreeMatrix = new Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
 
-  private readonly _perspectiveCamera: THREE.PerspectiveCamera;
-  private readonly _scene: THREE.Scene;
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _perspectiveCamera: PerspectiveCamera;
+  private readonly _scene: Scene;
+  private readonly _renderer: WebGLRenderer;
   private readonly _controls: OrbitControls;
 
   constructor() {
-    this._perspectiveCamera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.1, 10000);
+    this._perspectiveCamera = new PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.1, 10000);
 
-    this._scene = new THREE.Scene();
+    this._scene = new Scene();
 
-    this._renderer = new THREE.WebGLRenderer();
+    this._renderer = new WebGLRenderer();
 
     this._controls = new OrbitControls(this._perspectiveCamera, this._renderer.domElement);
 
@@ -66,17 +67,17 @@ export abstract class SimpleVisualTestFixture implements VisualTestFixture {
     this._renderer.render(this._scene, this._perspectiveCamera);
   }
 
-  public fitCameraToBoundingBox(box: THREE.Box3, radiusFactor: number = 2): void {
-    const center = new THREE.Vector3().lerpVectors(box.min, box.max, 0.5);
-    const radius = 0.5 * new THREE.Vector3().subVectors(box.max, box.min).length();
-    const boundingSphere = new THREE.Sphere(center, radius);
+  public fitCameraToBoundingBox(box: Box3, radiusFactor: number = 2): void {
+    const center = new Vector3().lerpVectors(box.min, box.max, 0.5);
+    const radius = 0.5 * new Vector3().subVectors(box.max, box.min).length();
+    const boundingSphere = new Sphere(center, radius);
 
     const target = boundingSphere.center;
     const distance = boundingSphere.radius * radiusFactor;
-    const direction = new THREE.Vector3(0, 0, -1);
+    const direction = new Vector3(0, 0, -1);
     direction.applyQuaternion(this._perspectiveCamera.quaternion);
 
-    const position = new THREE.Vector3();
+    const position = new Vector3();
     position.copy(direction).multiplyScalar(-distance).add(target);
 
     this._perspectiveCamera.position.copy(position);

--- a/viewer/visual-tests/test-fixtures/SimpleVisualTestFixture.ts
+++ b/viewer/visual-tests/test-fixtures/SimpleVisualTestFixture.ts
@@ -3,7 +3,7 @@
  */
 import type { Box3 } from 'three';
 import { Matrix4, PerspectiveCamera, Scene, Sphere, Vector3, WebGLRenderer } from 'three';
-import { OrbitControls } from 'three/addons';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 import type { ModelMetadataProvider, ModelDataProvider, ModelIdentifier } from '../../packages/data-providers';
 import { createDataProviders } from './utilities/createDataProviders';

--- a/viewer/visual-tests/test-fixtures/StreamingVisualTestFixture.ts
+++ b/viewer/visual-tests/test-fixtures/StreamingVisualTestFixture.ts
@@ -3,7 +3,7 @@
  */
 import type { Box3 } from 'three';
 import { Matrix4, PerspectiveCamera, WebGLRenderer } from 'three';
-import { OrbitControls } from 'three/addons';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import TWEEN from '@tweenjs/tween.js';
 
 import { CadManager, CadModelUpdateHandler } from '../../packages/cad-geometry-loaders';

--- a/viewer/visual-tests/test-fixtures/StreamingVisualTestFixture.ts
+++ b/viewer/visual-tests/test-fixtures/StreamingVisualTestFixture.ts
@@ -1,7 +1,8 @@
 /*!
  * Copyright 2022 Cognite AS
  */
-import * as THREE from 'three';
+import type { Box3 } from 'three';
+import { Matrix4, PerspectiveCamera, WebGLRenderer } from 'three';
 import { OrbitControls } from 'three/addons';
 import TWEEN from '@tweenjs/tween.js';
 
@@ -48,13 +49,13 @@ import type { CogniteClient } from '@cognite/sdk';
 import { getDistanceToMeterConversionFactor } from '../../packages/cad-parsers';
 
 export type StreamingTestFixtureComponents = {
-  renderer: THREE.WebGLRenderer;
+  renderer: WebGLRenderer;
   sceneHandler: SceneHandler;
   model: {
     geometryNode: CadNode | PointCloudNode;
-    boundingBox: THREE.Box3;
+    boundingBox: Box3;
   };
-  camera: THREE.PerspectiveCamera;
+  camera: PerspectiveCamera;
   cameraControls: OrbitControls;
   cadMaterialManager: CadMaterialManager;
   pcMaterialManager: PointCloudMaterialManager;
@@ -65,9 +66,9 @@ export type StreamingTestFixtureComponents = {
 };
 
 export abstract class StreamingVisualTestFixture implements VisualTestFixture {
-  private readonly _perspectiveCamera: THREE.PerspectiveCamera;
+  private readonly _perspectiveCamera: PerspectiveCamera;
   private readonly _sceneHandler: SceneHandler;
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
   private readonly _controls: OrbitControls;
   private readonly _materialManager: CadMaterialManager;
   protected readonly _pcMaterialManager: PointCloudMaterialManager;
@@ -138,8 +139,8 @@ export abstract class StreamingVisualTestFixture implements VisualTestFixture {
     );
   }
 
-  createCamera(): THREE.PerspectiveCamera {
-    return new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 1, 1000);
+  createCamera(): PerspectiveCamera {
+    return new PerspectiveCamera(70, window.innerWidth / window.innerHeight, 1, 1000);
   }
 
   createDefaultRenderPipelineProvider(
@@ -161,7 +162,7 @@ export abstract class StreamingVisualTestFixture implements VisualTestFixture {
     this._cadNodes = new Array<CadNode>();
     this._sceneHandler = new SceneHandler();
 
-    this._renderer = new THREE.WebGLRenderer();
+    this._renderer = new WebGLRenderer();
     this._renderer.setPixelRatio(window.devicePixelRatio);
     this._renderer.localClippingEnabled = true;
 
@@ -355,10 +356,10 @@ export abstract class StreamingVisualTestFixture implements VisualTestFixture {
     }
   }
 
-  private getModelBoundingBox(model: CadNode | PointCloudNode): THREE.Box3 {
+  private getModelBoundingBox(model: CadNode | PointCloudNode): Box3 {
     if (model instanceof CadNode) {
       const boundingBox = model.sectorScene.getBoundsOfMostGeometry();
-      const cadFromCdfToThreeMatrix = new THREE.Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
+      const cadFromCdfToThreeMatrix = new Matrix4().set(1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1);
       boundingBox.applyMatrix4(cadFromCdfToThreeMatrix);
       const unit = model.cadModelMetadata.scene.unit;
       const scaleFactor = getDistanceToMeterConversionFactor(unit);

--- a/viewer/visual-tests/test-fixtures/ViewerVisualTestFixture.ts
+++ b/viewer/visual-tests/test-fixtures/ViewerVisualTestFixture.ts
@@ -7,7 +7,7 @@ import { addModels, createCognite3DViewer } from './utilities/cognite3DViewerHel
 import { DeferredPromise } from '../../packages/utilities';
 import { CognitePointCloudModel } from '../../packages/pointclouds';
 import { AxisViewTool } from '../../packages/tools';
-import * as THREE from 'three';
+import { WebGLRenderer } from 'three';
 
 export type ViewerTestFixtureComponents = {
   viewer: Cognite3DViewer;
@@ -17,11 +17,11 @@ export type ViewerTestFixtureComponents = {
 export abstract class ViewerVisualTestFixture implements VisualTestFixture {
   private readonly _localModelUrls: string[];
   private _viewer!: Cognite3DViewer;
-  private readonly _renderer: THREE.WebGLRenderer;
+  private readonly _renderer: WebGLRenderer;
 
   constructor(...localModelUrls: string[]) {
     this._localModelUrls = localModelUrls.length > 0 ? localModelUrls : ['primitives'];
-    this._renderer = new THREE.WebGLRenderer({ powerPreference: 'high-performance' });
+    this._renderer = new WebGLRenderer({ powerPreference: 'high-performance' });
     this._renderer.setPixelRatio(window.devicePixelRatio);
   }
 

--- a/viewer/visual-tests/test-fixtures/utilities/fitCameraToBoundingBox.ts
+++ b/viewer/visual-tests/test-fixtures/utilities/fitCameraToBoundingBox.ts
@@ -2,23 +2,24 @@
  * Copyright 2022 Cognite AS
  */
 
-import * as THREE from 'three';
+import type { Box3, Camera } from 'three';
+import { Sphere, Vector3 } from 'three';
 
 export function fitCameraToBoundingBox(
-  camera: THREE.Camera,
-  box: THREE.Box3,
+  camera: Camera,
+  box: Box3,
   radiusFactor: number = 2
-): { position: THREE.Vector3; target: THREE.Vector3 } {
-  const center = new THREE.Vector3().lerpVectors(box.min, box.max, 0.5);
-  const radius = 0.5 * new THREE.Vector3().subVectors(box.max, box.min).length();
-  const boundingSphere = new THREE.Sphere(center, radius);
+): { position: Vector3; target: Vector3 } {
+  const center = new Vector3().lerpVectors(box.min, box.max, 0.5);
+  const radius = 0.5 * new Vector3().subVectors(box.max, box.min).length();
+  const boundingSphere = new Sphere(center, radius);
 
   const target = boundingSphere.center;
   const distance = boundingSphere.radius * radiusFactor;
-  const direction = new THREE.Vector3(0, 0, -1);
+  const direction = new Vector3(0, 0, -1);
   direction.applyQuaternion(camera.quaternion);
 
-  const position = new THREE.Vector3();
+  const position = new Vector3();
   position.copy(direction).multiplyScalar(-distance).add(target);
 
   camera.position.copy(position);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Removes all cases of `import * as THREE ...` in favor of named imports.