### PR TITLE
fix: point-cloud & cad model stopped loading when switching multiple models

### DIFF
--- a/viewer/packages/pointclouds/src/potree-three-loader/loading/EptBinaryLoader.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/loading/EptBinaryLoader.ts
@@ -86,7 +86,7 @@ export class EptBinaryLoader implements ILoader {
 
   async parse(node: PointCloudEptGeometryNode, data: ArrayBuffer): Promise<ParsedEptData | Error> {
     const autoTerminatingWorker = await EptBinaryLoader.WORKER_POOL.getWorker();
-    const eptDecoderWorker = Comlink.wrap<EptBinaryDecoderWorker>(autoTerminatingWorker.worker);
+    const eptDecoderWorker = autoTerminatingWorker.getComlinkProxy<EptBinaryDecoderWorker>();
     const eptData: EptInputData = {
       buffer: data,
       schema: node.ept.schema,
@@ -99,18 +99,22 @@ export class EptBinaryLoader implements ILoader {
       .filter(objAndBox => objAndBox[1].intersectsBox(node.boundingBox))
       .map(objAndBox => objAndBox[0]);
 
-    const result = await eptDecoderWorker(
-      Comlink.transfer(eptData, [eptData.buffer]),
-      relevantObjects,
-      node.boundingBox.min.toArray(),
-      {
-        min: node.boundingBox.min.toArray(),
-        max: node.boundingBox.max.toArray()
-      }
-    );
-
-    EptBinaryLoader.WORKER_POOL.releaseWorker(autoTerminatingWorker);
-    return result;
+    try {
+      const result = await eptDecoderWorker(
+        Comlink.transfer(eptData, [eptData.buffer]),
+        relevantObjects,
+        node.boundingBox.min.toArray(),
+        {
+          min: node.boundingBox.min.toArray(),
+          max: node.boundingBox.max.toArray()
+        }
+      );
+      return result;
+    } catch (err) {
+      return err as Error;
+    } finally {
+      EptBinaryLoader.WORKER_POOL.releaseWorker(autoTerminatingWorker);
+    }
   }
 }
 

--- a/viewer/packages/pointclouds/src/potree-three-loader/utils/WorkerPool.test.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/utils/WorkerPool.test.ts
@@ -1,0 +1,122 @@
+/*!
+ * Copyright 2026 Cognite AS
+ */
+
+import { vi } from 'vitest';
+import * as Comlink from 'comlink';
+import { AutoTerminatingWorker, WorkerPool } from './WorkerPool';
+
+class MockWorker extends EventTarget implements Worker {
+  private readonly _port1: MessagePort;
+  private readonly _port2: MessagePort;
+
+  onerror: ((this: AbstractWorker, ev: Event) => void) | null = null;
+  onmessage: ((this: Worker, ev: MessageEvent) => void) | null = null;
+  onmessageerror: ((this: Worker, ev: MessageEvent) => void) | null = null;
+
+  constructor() {
+    super();
+    const { port1, port2 } = new MessageChannel();
+    this._port1 = port1;
+    this._port2 = port2;
+
+    Comlink.expose((x: number) => x * 2, this._port2);
+
+    this._port1.addEventListener('message', (event: MessageEvent) => {
+      this.dispatchEvent(new MessageEvent('message', { data: event.data }));
+    });
+    this._port1.start();
+  }
+
+  postMessage(message: unknown, transfer: Transferable[]): void;
+  postMessage(message: unknown, options?: StructuredSerializeOptions): void;
+  postMessage(message: unknown, transferOrOptions?: Transferable[] | StructuredSerializeOptions): void {
+    const transfer = Array.isArray(transferOrOptions) ? transferOrOptions : [];
+    this._port1.postMessage(message, transfer);
+  }
+
+  terminate(): void {
+    this._port1.close();
+    this._port2.close();
+  }
+}
+
+describe(AutoTerminatingWorker.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('getComlinkProxy returns the same proxy instance on repeated calls', () => {
+    const worker = new MockWorker();
+    const autoWorker = new AutoTerminatingWorker(worker, 7000);
+
+    const proxy1 = autoWorker.getComlinkProxy<(x: number) => number>();
+    const proxy2 = autoWorker.getComlinkProxy<(x: number) => number>();
+
+    expect(proxy1).toBe(proxy2);
+  });
+
+  test('cached proxy responds correctly across multiple sequential calls', async () => {
+    const worker = new MockWorker();
+    const autoWorker = new AutoTerminatingWorker(worker, 7000);
+
+    const proxy = autoWorker.getComlinkProxy<(x: number) => number>();
+    const result1 = await proxy(5);
+    const result2 = await proxy(10);
+    const result3 = await proxy(7);
+
+    expect(result1).toBe(10);
+    expect(result2).toBe(20);
+    expect(result3).toBe(14);
+  });
+
+  test('markIdle terminates worker and cleans up proxy after idle timeout', () => {
+    vi.useFakeTimers();
+    const worker = new MockWorker();
+    const terminateSpy = vi.spyOn(worker, 'terminate');
+    const autoWorker = new AutoTerminatingWorker(worker, 7000);
+
+    autoWorker.getComlinkProxy<(x: number) => number>();
+    autoWorker.markIdle();
+
+    expect(autoWorker.isTerminated).toBe(false);
+
+    vi.advanceTimersByTime(7000);
+
+    expect(autoWorker.isTerminated).toBe(true);
+    expect(terminateSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe(WorkerPool.name, () => {
+  test('reused worker returns the same proxy and it remains functional', async () => {
+    const pool = new WorkerPool<MockWorker>(1, MockWorker);
+
+    const worker1 = await pool.getWorker();
+    const proxy1 = worker1.getComlinkProxy<(x: number) => number>();
+    expect(await proxy1(3)).toBe(6);
+    pool.releaseWorker(worker1);
+
+    const worker2 = await pool.getWorker();
+    expect(worker2).toBe(worker1);
+
+    const proxy2 = worker2.getComlinkProxy<(x: number) => number>();
+    expect(proxy2).toBe(proxy1);
+
+    expect(await proxy2(4)).toBe(8);
+    pool.releaseWorker(worker2);
+  });
+
+  test('worker proxy stays functional after multiple pool acquire-release cycles', async () => {
+    const pool = new WorkerPool<MockWorker>(1, MockWorker);
+
+    for (let i = 1; i <= 5; i++) {
+      const worker = await pool.getWorker();
+      const proxy = worker.getComlinkProxy<(x: number) => number>();
+      const result = await proxy(i);
+      expect(result).toBe(i * 2);
+      pool.releaseWorker(worker);
+    }
+  });
+});

--- a/viewer/packages/pointclouds/src/potree-three-loader/utils/WorkerPool.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/utils/WorkerPool.ts
@@ -19,8 +19,11 @@ export class AutoTerminatingWorker {
   }
 
   public getComlinkProxy<T>(): Comlink.Remote<T> {
+    if (this.terminated || !this._wrappedWorker) {
+      throw new Error('Cannot get Comlink proxy for a terminated worker');
+    }
     if (!this._comlinkProxy) {
-      this._comlinkProxy = Comlink.wrap<unknown>(this._wrappedWorker!);
+      this._comlinkProxy = Comlink.wrap<unknown>(this._wrappedWorker);
     }
     return this._comlinkProxy as Comlink.Remote<T>;
   }

--- a/viewer/packages/pointclouds/src/potree-three-loader/utils/WorkerPool.ts
+++ b/viewer/packages/pointclouds/src/potree-three-loader/utils/WorkerPool.ts
@@ -1,9 +1,11 @@
 import { AsyncBlockingQueue } from './async-blocking-queue';
+import * as Comlink from 'comlink';
 
 export class AutoTerminatingWorker {
   private timeoutId: number | undefined = undefined;
   private terminated: boolean = false;
   private _wrappedWorker: Worker | undefined;
+  private _comlinkProxy: Comlink.Remote<unknown> | undefined;
 
   constructor(
     wrappedWorker: Worker,
@@ -16,6 +18,13 @@ export class AutoTerminatingWorker {
     return this._wrappedWorker!;
   }
 
+  public getComlinkProxy<T>(): Comlink.Remote<T> {
+    if (!this._comlinkProxy) {
+      this._comlinkProxy = Comlink.wrap<unknown>(this._wrappedWorker!);
+    }
+    return this._comlinkProxy as Comlink.Remote<T>;
+  }
+
   get isTerminated(): boolean {
     return this.terminated;
   }
@@ -23,6 +32,10 @@ export class AutoTerminatingWorker {
   markIdle(): void {
     this.timeoutId = window.setTimeout(() => {
       this.terminated = true;
+      if (this._comlinkProxy) {
+        this._comlinkProxy[Comlink.releaseProxy]();
+        this._comlinkProxy = undefined;
+      }
       this._wrappedWorker!.terminate();
       this._wrappedWorker = undefined;
     }, this.maxIdle);


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-7215

## Description :pencil:
Point cloud data and Cad data stopped loading when switching between models (removing old models and adding new ones). Only 360 image collections were unaffected because they don't use the worker pool.

The Vite migration replaced the custom `setupTransferableMethodsOnMain` worker RPC with `Comlink`. `Comlink.wrap()` installs a permanent message event listener on the worker. Since workers are pooled and reused, each reuse added another listener to the same worker. After some reuses, a single worker had `N` accumulated Comlink listeners.
When the worker asked a response, all `N` listeners received it. The stale listeners from earlier proxies attempted to process messages meant for the current proxy, causing internal Comlink state corruption (`TypeError: Cannot read properties of undefined`). The current proxy's promise never resolved, so `releaseWorker()` in the finally block never executed and the worker was **permanently** stuck.

With a pool of 8 workers, once all 8 were stuck, every subsequent `getWorker()` call blocked forever, no point cloud or CAD model data could load.

This PR fixes the issue

## How has this been tested? :mag:

In `examples` and in `fusion` (both `unified-3d` and `3d-management`)


## Test instructions :information_source:

- run `pnpm install && pnpm build` in `viewer` and then run `yarn && yarn start` in `examples`
- Load [example](https://localhost:3549/?project=3d-test&env=greenfield-3d&modelId=6733832742816610&revisionId= 8936381564697305) (which already contains a point-cloud model)
- Now add new new model using using Models GUI. with modelId - `1304266634014089`, revisionId - `271145091694327`
- Both point cloud model should be visible

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
