### PR TITLE
chore(viewer): get rid of ES decorators

### DIFF
--- a/viewer/packages/rendering/src/pointcloud-rendering/PointCloudMaterial.ts
+++ b/viewer/packages/rendering/src/pointcloud-rendering/PointCloudMaterial.ts
@@ -260,12 +260,71 @@ export class PointCloudMaterial extends RawShaderMaterial {
     }
   }
 
-  @requiresShaderUpdate() accessor weighted: boolean = false;
-  @requiresShaderUpdate() accessor hqDepthPass: boolean = false;
-  @requiresShaderUpdate() accessor pointColorType: PointColorType = PointColorType.Rgb;
-  @requiresShaderUpdate() accessor pointSizeType: PointSizeType = PointSizeType.Adaptive;
-  @requiresShaderUpdate() accessor useEDL: boolean = false;
-  @requiresShaderUpdate() accessor shape: PointShape = PointShape.Circle;
+  private _weighted: boolean = false;
+  get weighted(): boolean {
+    return this._weighted;
+  }
+  set weighted(value: boolean) {
+    if (value !== this._weighted) {
+      this._weighted = value;
+      this.updateShaderSource();
+    }
+  }
+
+  private _hqDepthPass: boolean = false;
+  get hqDepthPass(): boolean {
+    return this._hqDepthPass;
+  }
+  set hqDepthPass(value: boolean) {
+    if (value !== this._hqDepthPass) {
+      this._hqDepthPass = value;
+      this.updateShaderSource();
+    }
+  }
+
+  private _pointColorType: PointColorType = PointColorType.Rgb;
+  get pointColorType(): PointColorType {
+    return this._pointColorType;
+  }
+  set pointColorType(value: PointColorType) {
+    if (value !== this._pointColorType) {
+      this._pointColorType = value;
+      this.updateShaderSource();
+    }
+  }
+
+  private _pointSizeType: PointSizeType = PointSizeType.Adaptive;
+  get pointSizeType(): PointSizeType {
+    return this._pointSizeType;
+  }
+  set pointSizeType(value: PointSizeType) {
+    if (value !== this._pointSizeType) {
+      this._pointSizeType = value;
+      this.updateShaderSource();
+    }
+  }
+
+  private _useEDL: boolean = false;
+  get useEDL(): boolean {
+    return this._useEDL;
+  }
+  set useEDL(value: boolean) {
+    if (value !== this._useEDL) {
+      this._useEDL = value;
+      this.updateShaderSource();
+    }
+  }
+
+  private _shape: PointShape = PointShape.Circle;
+  get shape(): PointShape {
+    return this._shape;
+  }
+  set shape(value: PointShape) {
+    if (value !== this._shape) {
+      this._shape = value;
+      this.updateShaderSource();
+    }
+  }
 
   attributes = {
     position: { type: 'fv', value: [] as const },
@@ -475,25 +534,4 @@ function makeUniform<T>(type: string, value: T): IUniform<T> {
 
 function getValid<T>(a: T | undefined, b: T): T {
   return a === undefined ? b : a;
-}
-
-function requiresShaderUpdate() {
-  return (_target: any, context: { name: string | symbol }) => ({
-    get(this: PointCloudMaterial & Record<string, any>) {
-      const fieldName = `_${context.name.toString()}`;
-      return this[fieldName];
-    },
-    set(this: PointCloudMaterial & Record<string, any>, value: any) {
-      const fieldName = `_${context.name.toString()}`;
-      if (value !== this[fieldName]) {
-        this[fieldName] = value;
-        this.updateShaderSource();
-      }
-    },
-    init(this: PointCloudMaterial & Record<string, any>, value: any) {
-      const fieldName = `_${context.name.toString()}`;
-      this[fieldName] = value;
-      return value;
-    }
-  });
 }

--- a/viewer/packages/rendering/src/pointcloud-rendering/PointCloudMaterial.ts
+++ b/viewer/packages/rendering/src/pointcloud-rendering/PointCloudMaterial.ts
@@ -134,20 +134,131 @@ export class PointCloudMaterial extends RawShaderMaterial {
     vnStart: makeUniform('f', 0.0)
   };
 
-  @uniform('fov') accessor fov!: number;
-  @uniform('heightMax') accessor heightMax!: number;
-  @uniform('heightMin') accessor heightMin!: number;
-  @uniform('intensityBrightness') accessor intensityBrightness!: number;
-  @uniform('intensityContrast') accessor intensityContrast!: number;
-  @uniform('intensityGamma') accessor intensityGamma!: number;
-  @uniform('intensityRange') accessor intensityRange!: [number, number];
-  @uniform('maxSize') accessor maxSize!: number;
-  @uniform('minSize') accessor minSize!: number;
-  @uniform('octreeSize') accessor octreeSize!: number;
-  @uniform('screenHeight') accessor screenHeight!: number;
-  @uniform('screenWidth') accessor screenWidth!: number;
-  @uniform('size') accessor size!: number;
-  @uniform('spacing') accessor spacing!: number;
+  get fov(): number {
+    return this.getUniform('fov');
+  }
+  set fov(value: number) {
+    if (value !== this.getUniform('fov')) {
+      this.setUniform('fov', value);
+    }
+  }
+
+  get heightMax(): number {
+    return this.getUniform('heightMax');
+  }
+  set heightMax(value: number) {
+    if (value !== this.getUniform('heightMax')) {
+      this.setUniform('heightMax', value);
+    }
+  }
+
+  get heightMin(): number {
+    return this.getUniform('heightMin');
+  }
+  set heightMin(value: number) {
+    if (value !== this.getUniform('heightMin')) {
+      this.setUniform('heightMin', value);
+    }
+  }
+
+  get intensityBrightness(): number {
+    return this.getUniform('intensityBrightness');
+  }
+  set intensityBrightness(value: number) {
+    if (value !== this.getUniform('intensityBrightness')) {
+      this.setUniform('intensityBrightness', value);
+    }
+  }
+
+  get intensityContrast(): number {
+    return this.getUniform('intensityContrast');
+  }
+  set intensityContrast(value: number) {
+    if (value !== this.getUniform('intensityContrast')) {
+      this.setUniform('intensityContrast', value);
+    }
+  }
+
+  get intensityGamma(): number {
+    return this.getUniform('intensityGamma');
+  }
+  set intensityGamma(value: number) {
+    if (value !== this.getUniform('intensityGamma')) {
+      this.setUniform('intensityGamma', value);
+    }
+  }
+
+  get intensityRange(): [number, number] {
+    return this.getUniform('intensityRange');
+  }
+  set intensityRange(value: [number, number]) {
+    if (value !== this.getUniform('intensityRange')) {
+      this.setUniform('intensityRange', value);
+    }
+  }
+
+  get maxSize(): number {
+    return this.getUniform('maxSize');
+  }
+  set maxSize(value: number) {
+    if (value !== this.getUniform('maxSize')) {
+      this.setUniform('maxSize', value);
+    }
+  }
+
+  get minSize(): number {
+    return this.getUniform('minSize');
+  }
+  set minSize(value: number) {
+    if (value !== this.getUniform('minSize')) {
+      this.setUniform('minSize', value);
+    }
+  }
+
+  get octreeSize(): number {
+    return this.getUniform('octreeSize');
+  }
+  set octreeSize(value: number) {
+    if (value !== this.getUniform('octreeSize')) {
+      this.setUniform('octreeSize', value);
+    }
+  }
+
+  get screenHeight(): number {
+    return this.getUniform('screenHeight');
+  }
+  set screenHeight(value: number) {
+    if (value !== this.getUniform('screenHeight')) {
+      this.setUniform('screenHeight', value);
+    }
+  }
+
+  get screenWidth(): number {
+    return this.getUniform('screenWidth');
+  }
+  set screenWidth(value: number) {
+    if (value !== this.getUniform('screenWidth')) {
+      this.setUniform('screenWidth', value);
+    }
+  }
+
+  get size(): number {
+    return this.getUniform('size');
+  }
+  set size(value: number) {
+    if (value !== this.getUniform('size')) {
+      this.setUniform('size', value);
+    }
+  }
+
+  get spacing(): number {
+    return this.getUniform('spacing');
+  }
+  set spacing(value: number) {
+    if (value !== this.getUniform('spacing')) {
+      this.setUniform('spacing', value);
+    }
+  }
 
   @requiresShaderUpdate() accessor weighted: boolean = false;
   @requiresShaderUpdate() accessor hqDepthPass: boolean = false;
@@ -364,20 +475,6 @@ function makeUniform<T>(type: string, value: T): IUniform<T> {
 
 function getValid<T>(a: T | undefined, b: T): T {
   return a === undefined ? b : a;
-}
-
-function uniform<K extends keyof IPointCloudMaterialUniforms>(uniformName: K) {
-  type UniformType = IPointCloudMaterialUniforms[K]['value'];
-  return (_target: any, _context: any) => ({
-    get(this: PointCloudMaterial) {
-      return this.getUniform(uniformName);
-    },
-    set(this: PointCloudMaterial, value: UniformType) {
-      if (value !== this.getUniform(uniformName)) {
-        this.setUniform(uniformName, value);
-      }
-    }
-  });
 }
 
 function requiresShaderUpdate() {

--- a/viewer/visual-tests/visual-tests.vite.config.ts
+++ b/viewer/visual-tests/visual-tests.vite.config.ts
@@ -7,7 +7,6 @@ import glsl from 'vite-plugin-glsl';
 import wasm from 'vite-plugin-wasm';
 import fs from 'fs';
 import path from 'path';
-import { tsAccessorDecoratorPlugin } from '../vite.config';
 
 function setTestFixture(testFixture: string | undefined): string | boolean {
   if (testFixture === undefined) {
@@ -37,7 +36,7 @@ export default defineConfig(_ => {
   return {
     root: __dirname,
 
-    plugins: [tsAccessorDecoratorPlugin(), glsl()],
+    plugins: [glsl()],
 
     define: {
       CDF_ENV: cdfEnv

--- a/viewer/vite.config.ts
+++ b/viewer/vite.config.ts
@@ -7,8 +7,6 @@ import glsl from 'vite-plugin-glsl';
 import wasm from 'vite-plugin-wasm';
 import pkg from './package.json' with { type: 'json' };
 import dts from 'unplugin-dts/vite';
-import type { Plugin } from 'vite';
-import typescript from 'typescript';
 import path from 'path';
 
 export default defineConfig(({ command }) => {
@@ -23,8 +21,7 @@ export default defineConfig(({ command }) => {
             '@reveal/*': ['./packages/*']
           }
         }
-      }),
-      tsAccessorDecoratorPlugin()
+      })
     ],
 
     worker: {
@@ -90,37 +87,4 @@ export default defineConfig(({ command }) => {
 
 function getDependencyMatchers(deps: Record<string, string>) {
   return Object.keys(deps).map(dep => new RegExp(`^${dep}(?:/.+)?$`));
-}
-
-// This plugin compiles TypeScript files containing accessor decorators using the TypeScript compiler,
-// as Vite's default handling does not support this syntax.
-// It only runs on the PointCloudMaterial.ts file to minimize overhead, as this is the only file in the project using accessor decorators.
-// Once https://github.com/oxc-project/oxc/issues/9170 is resolved and merged upstream to vite, this plugin can be removed.
-export function tsAccessorDecoratorPlugin(): Plugin {
-  return {
-    name: 'vitest-ts-accessor-decorator',
-    enforce: 'pre',
-    transform: {
-      filter: {
-        id: /^.*[/\\]PointCloudMaterial\.ts$/
-      },
-      handler(code, id) {
-        const cleanId = id.split('?')[0];
-        if (!cleanId.endsWith('.ts') && !cleanId.endsWith('.tsx')) return;
-        if (!/\baccessor\b/.test(code)) return;
-
-        const result = typescript.transpileModule(code, {
-          fileName: cleanId,
-          compilerOptions: {
-            target: typescript.ScriptTarget.ES2019,
-            module: typescript.ModuleKind.ESNext,
-            useDefineForClassFields: false,
-            esModuleInterop: true
-          }
-        });
-
-        return result.outputText;
-      }
-    }
-  };
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Replaces decorator usages with simple getters/setters. This removes some necessary hacks (such as a custom plugin) and while more verbose, simplifies the implementation. This also unblocks typescript 7 as it will not have a stable programmable API for a while (source: https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/).