### PR TITLE
chore(viewer): use vite preview server for visual tests

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -46,7 +46,7 @@
     "test": "pnpm run test:wasm && pnpm run test:ts",
     "test:ts": "pnpm run build:wasm-test && vitest run --reporter=verbose",
     "test:wasm": "pnpm -r run --if-present run-wasm-pack test --headless --chrome ./wasm",
-    "test:visual:server": "pnpm run build:wasm && vite dev --config ./visual-tests/visual-tests.vite.config.ts",
+    "test:visual:server": "pnpm run build:wasm && pnpm vite build --config ./visual-tests/visual-tests.vite.config.ts && pnpm vite preview --config ./visual-tests/visual-tests.vite.config.ts --port 8080",
     "test:visual": "playwright test --config=visual-tests/playwright.config.ts",
     "test:visual:update": "playwright test --config=visual-tests/playwright.config.ts --update-snapshots",
     "typecheck:lib": "tsc --project tsconfig.lib.json --noEmit",

--- a/viewer/visual-tests/visual-tests.vite.config.ts
+++ b/viewer/visual-tests/visual-tests.vite.config.ts
@@ -29,7 +29,7 @@ function readCdfEnv(): string {
   }
 }
 
-export default defineConfig(_ => {
+export default defineConfig(({ command }) => {
   const open = setTestFixture(process.env.testFixture);
   const cdfEnv = readCdfEnv();
 
@@ -55,11 +55,9 @@ export default defineConfig(_ => {
     },
 
     build: {
+      assetsInlineLimit: Infinity,
       outDir: path.resolve(__dirname, 'dist'),
-      sourcemap: 'inline',
-      rollupOptions: {
-        input: path.resolve(__dirname, './VisualTest.browser.ts')
-      }
+      sourcemap: command === 'serve' ? 'inline' : false
     },
 
     worker: {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Use the vite preview server to host visual tests instead of the vite dev server. This is a lot more performant since the browser will not need to download (and transpile) each individual module, but rather just use a static build.
