### PR TITLE
fix: camera behavior lagging in point cloud picking for many point cloud in viewer

### DIFF
--- a/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
+++ b/viewer/packages/camera-manager/src/Flexible/FlexibleControls.ts
@@ -433,6 +433,10 @@ export class FlexibleControls {
       // Pan left, right, up or down
       if (!translator) {
         translator = new FlexibleControlsTranslator(this);
+        // Store the translator immediately before awaiting so concurrent drag events
+        // find a non-null translator and fall through to the simple-pan fallback
+        // instead of each triggering their own intersectPointClouds GPU readback.
+        this._mouseDragInfo.update(position, translator);
         await translator.initialize(position);
       }
       if (!this._mouseDragInfo) {

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.test.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.test.ts
@@ -77,6 +77,7 @@ describe(PointCloudPickingHandler.name, () => {
       pointIndex: 0,
       object: node.octree,
       position: new Vector3(1, 2, 3),
+      pointCloud: node.octree,
       objectId
     });
 
@@ -102,6 +103,7 @@ describe(PointCloudPickingHandler.name, () => {
       pointIndex: 0,
       object: node.octree,
       position: new Vector3(1, 2, 3),
+      pointCloud: node.octree,
       objectId
     });
 
@@ -112,46 +114,80 @@ describe(PointCloudPickingHandler.name, () => {
     expect(result[0].volumeMetadata).toEqual({ volumeInstanceRef, assetRef: undefined });
   });
 
-  test('intersectPointClouds returns intersections sorted by distance to camera (closest first)', async () => {
+  test('intersectPointClouds calls pick() once with all visible octrees regardless of node count', async () => {
+    const node1 = createPointCloudNode();
+    const node2 = createPointCloudNode();
+    const node3 = createPointCloudNode();
+    const pickSpy = vi.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue(null);
+
+    await handler.intersectPointClouds([node1, node2, node3], createMockIntersectInput());
+
+    expect(pickSpy).toHaveBeenCalledOnce();
+    const [, , octreesArg] = pickSpy.mock.calls[0];
+    expect(octreesArg).toEqual([node1.octree, node2.octree, node3.octree]);
+  });
+
+  test('intersectPointClouds returns nearest intersection from batched pick across multiple point clouds', async () => {
     const node1 = createPointCloudNode();
     const node2 = createPointCloudNode();
     const input = createMockIntersectInput();
-    // Camera is at origin; node1 octree is at distance 5, node2 octree is at distance 1
-    vi.spyOn(PointCloudOctreePicker.prototype, 'pick')
-      .mockResolvedValueOnce({ pointIndex: 0, object: node1.octree, position: new Vector3(5, 0, 0), objectId: 0 })
-      .mockResolvedValueOnce({
-        pointIndex: 0,
-        object: node2.octree,
-        position: new Vector3(1, 0, 0),
-        objectId: 0
-      });
+
+    // Simulate picker returning the nearest hit (node2 at distance 1) from a single batched call
+    vi.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue({
+      pointIndex: 0,
+      object: node2.octree,
+      position: new Vector3(1, 0, 0),
+      pointCloud: node2.octree,
+      objectId: 0
+    });
 
     const result = await handler.intersectPointClouds([node1, node2], input);
 
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(1);
+    expect(result[0].pointCloudNode).toBe(node2);
     expect(result[0].point).toEqual(new Vector3(1, 0, 0));
-    expect(result[1].point).toEqual(new Vector3(5, 0, 0));
   });
 
-  test('intersectPointClouds filters out intersections clipped by clipping planes', async () => {
-    const node1 = createPointCloudNode();
-    const node2 = createPointCloudNode();
+  test('intersectPointClouds filters out intersection clipped by clipping planes', async () => {
+    const node = createPointCloudNode();
     // Clipping plane: normal (-1,0,0) + constant 5 → clips all points with x > 5
     const clippingPlane = new Plane(new Vector3(-1, 0, 0), 5);
     const input: IntersectInput = {
       ...createMockIntersectInput(),
       clippingPlanes: [clippingPlane]
     };
-    vi.spyOn(PointCloudOctreePicker.prototype, 'pick')
-      .mockResolvedValueOnce({ pointIndex: 0, object: node1.octree, position: new Vector3(1, 0, 0), objectId: 0 })
-      .mockResolvedValueOnce({
-        pointIndex: 0,
-        object: node2.octree,
-        position: new Vector3(10, 0, 0),
-        objectId: 0
-      });
 
-    const result = await handler.intersectPointClouds([node1, node2], input);
+    vi.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue({
+      pointIndex: 0,
+      object: node.octree,
+      position: new Vector3(10, 0, 0), // clipped
+      pointCloud: node.octree,
+      objectId: 0
+    });
+
+    const result = await handler.intersectPointClouds([node], input);
+
+    expect(result).toEqual([]);
+  });
+
+  test('intersectPointClouds returns result when intersection is not clipped', async () => {
+    const node = createPointCloudNode();
+    // Clipping plane: normal (-1,0,0) + constant 5 → clips all points with x > 5
+    const clippingPlane = new Plane(new Vector3(-1, 0, 0), 5);
+    const input: IntersectInput = {
+      ...createMockIntersectInput(),
+      clippingPlanes: [clippingPlane]
+    };
+
+    vi.spyOn(PointCloudOctreePicker.prototype, 'pick').mockResolvedValue({
+      pointIndex: 0,
+      object: node.octree,
+      position: new Vector3(1, 0, 0), // not clipped
+      pointCloud: node.octree,
+      objectId: 0
+    });
+
+    const result = await handler.intersectPointClouds([node], input);
 
     expect(result).toHaveLength(1);
     expect(result[0].point).toEqual(new Vector3(1, 0, 0));

--- a/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
+++ b/viewer/packages/pointclouds/src/PointCloudPickingHandler.ts
@@ -43,67 +43,78 @@ export class PointCloudPickingHandler {
 
     const release = await this._mutex.acquire();
     try {
-      const intersections: { node: PointCloudNode<DataSourceType>; pick: PickPoint }[] = [];
-
       // Get PointCloudNodes which are visible.
       const visibleNodes = nodes.filter(node => node.visible);
-
-      for (const node of visibleNodes) {
-        const pick = await this._picker.pick(camera, this._raycaster.ray, [node.octree], {
-          pickWindowSize: PointCloudPickingHandler.PickingWindowSize
-        });
-        if (pick !== null) {
-          intersections.push({ node, pick });
-        }
+      if (visibleNodes.length === 0) {
+        return [];
       }
 
-      return intersections
-        .filter(({ pick }) => isPointVisibleByPlanes(input.clippingPlanes, pick.position))
-        .sort((a, b) => a.pick.position.distanceTo(camera.position) - b.pick.position.distanceTo(camera.position))
-        .map(({ node: pointCloudNode, pick: x }) => {
-          const pointCloudObject = pointCloudNode.getStylableObjectMetadata(x.objectId);
+      // Pass all visible octrees to a single pick() call. PointCloudOctreePickerHelper.render()
+      // renders all octrees in one GPU pass using per-node index offsets, then does a single
+      // async GPU readback — reducing cost from N × readback to 1 × readback regardless of
+      // how many point clouds are in the scene.
+      const allOctrees = visibleNodes.map(n => n.octree);
+      const pick = await this._picker.pick(camera, this._raycaster.ray, allOctrees, {
+        pickWindowSize: PointCloudPickingHandler.PickingWindowSize
+      });
 
-          const baseObject = {
-            distance: x.position.distanceTo(camera.position),
-            point: x.position,
-            pointIndex: x.pointIndex,
-            pointCloudNode,
-            object: x.object
-          };
+      if (pick === null || !isPointVisibleByPlanes(input.clippingPlanes, pick.position)) {
+        return [];
+      }
 
-          if (pointCloudObject !== undefined) {
-            if (isClassicPointCloudVolume(pointCloudObject)) {
-              const result: IntersectPointCloudNodeResult<ClassicDataSourceType> = {
-                ...baseObject,
-                pointCloudNode: pointCloudNode as PointCloudNode<ClassicDataSourceType>,
-                volumeMetadata: {
-                  annotationId: pointCloudObject.annotationId,
-                  assetRef: pointCloudObject.assetRef,
-                  instanceRef: pointCloudObject.instanceRef
-                }
-              };
+      const pointCloudNode = visibleNodes.find(n => n.octree === pick.pointCloud);
+      if (pointCloudNode === undefined) {
+        return [];
+      }
 
-              return result;
-            } else if (isDMPointCloudVolume(pointCloudObject)) {
-              const result: IntersectPointCloudNodeResult<DMDataSourceType> = {
-                ...baseObject,
-                pointCloudNode: pointCloudNode as PointCloudNode<DMDataSourceType>,
-                volumeMetadata: {
-                  volumeInstanceRef: pointCloudObject.volumeInstanceRef,
-                  assetRef: pointCloudObject.assetRef
-                }
-              };
-
-              return result;
-            } else {
-              throw new Error('Unknown point cloud object type');
-            }
-          }
-
-          return baseObject;
-        });
+      return [mapPickResult(pointCloudNode, pick, camera)];
     } finally {
       release();
     }
   }
+}
+
+function mapPickResult(
+  pointCloudNode: PointCloudNode<DataSourceType>,
+  x: PickPoint,
+  camera: IntersectInput['camera']
+): IntersectPointCloudNodeResult<DataSourceType> {
+  const pointCloudObject = pointCloudNode.getStylableObjectMetadata(x.objectId);
+
+  const baseObject = {
+    distance: x.position.distanceTo(camera.position),
+    point: x.position,
+    pointIndex: x.pointIndex,
+    pointCloudNode,
+    object: x.object
+  };
+
+  if (pointCloudObject !== undefined) {
+    if (isClassicPointCloudVolume(pointCloudObject)) {
+      const result: IntersectPointCloudNodeResult<ClassicDataSourceType> = {
+        ...baseObject,
+        pointCloudNode: pointCloudNode as PointCloudNode<ClassicDataSourceType>,
+        volumeMetadata: {
+          annotationId: pointCloudObject.annotationId,
+          assetRef: pointCloudObject.assetRef,
+          instanceRef: pointCloudObject.instanceRef
+        }
+      };
+      return result;
+    } else if (isDMPointCloudVolume(pointCloudObject)) {
+      const result: IntersectPointCloudNodeResult<DMDataSourceType> = {
+        ...baseObject,
+        pointCloudNode: pointCloudNode as PointCloudNode<DMDataSourceType>,
+        volumeMetadata: {
+          volumeInstanceRef: pointCloudObject.volumeInstanceRef,
+          assetRef: pointCloudObject.assetRef
+        }
+      };
+      return result;
+    } else {
+      throw new Error('Unknown point cloud object type');
+    }
+  }
+
+  return baseObject;
 }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-7243

## Description :pencil:
User report that camera behaves erratically when many point cloud model are in the Reveal viewer for dragging and zooming with lesser configuration machine.

I found that scenes with multiple point clouds, `intersectPointClouds` called `PointCloudOctreePicker.pick()` once per cloud in a sequential for...await loop, N point clouds meant N GPU renders + N async CPU-GPU sync points.

In this PR, I have improved the picking by passing all visible `octrees` to a single `pick()` call instead of one per node. This reduces picking to N GPU readbacks to 1.

## How has this been tested? :mag:

In Nippon project in unified-3d


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->


## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
