### PR TITLE
chore(viewer): add maxWait for consuming sector geometry

### DIFF
--- a/viewer/packages/cad-geometry-loaders/src/CadManager.ts
+++ b/viewer/packages/cad-geometry-loaders/src/CadManager.ts
@@ -122,12 +122,16 @@ export class CadManager {
       this.updateTreeIndexToSectorsMap(cadModel, sector);
     };
 
-    const debouncedConsumeSectors = batchedDebounce((sectors: ConsumedSector[]) => {
-      for (const sector of sectors) {
-        consumeNextSector(sector);
-      }
-      this._cadModelUpdateHandler.reportNewSectorsLoaded(sectors.length);
-    }, this._sectorBufferTime);
+    const debouncedConsumeSectors = batchedDebounce(
+      (sectors: ConsumedSector[]) => {
+        for (const sector of sectors) {
+          consumeNextSector(sector);
+        }
+        this._cadModelUpdateHandler.reportNewSectorsLoaded(sectors.length);
+      },
+      this._sectorBufferTime,
+      { maxWait: 1000 }
+    );
 
     this._unsubscribeConsumedSectors = this._cadModelUpdateHandler.on('onNewConsumedSector', debouncedConsumeSectors);
     this._unsubscribeLoadingState = this._cadModelUpdateHandler.on('onLoadingStateChanged', loadingState => {


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Chore](https://img.shields.io/badge/Type-Chore-lightgrey) <!-- updating grunt tasks etc; no production code change -->

Fixes: https://github.com/cognitedata/reveal/issues/5714

## Issue description:
"When there are a lot of sectors to load and we have a full cache the debouncedConsumeSectors seem to never "debounce" until after all sectors are loaded. This in some cases causes the entire model to pop in after a few seconds instead of "streaming" in new sectors as they are loaded, and it gives an impression of higher loading times (since there is no visible progress until everything is loaded). The problem is bigger on slower machines.

`maxWait` property on the debounce will allow visible loading, and make the model usable while it loads."


