### PR TITLE
fix: use station name as label in CDM-based 360-images

### DIFF
--- a/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.test.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.test.ts
@@ -7,8 +7,9 @@ import type { CogniteClient } from '@cognite/sdk';
 import { It, Mock } from 'moq.ts';
 import { Cdf360CdmBatchCollectionLoader } from './Cdf360CdmBatchCollectionLoader';
 import type { DataModelsSdk } from '../../../../DataModelsSdk';
+import { CdfImage360CollectionDmQuery } from './get360CdmCollectionsQuery';
 
-type DmsSdkQueryResult = Awaited<ReturnType<DataModelsSdk['queryNodesAndEdges']>>;
+type QueryResult = Awaited<ReturnType<typeof DataModelsSdk.prototype.queryNodesAndEdges<CdfImage360CollectionDmQuery>>>;
 
 describe(Cdf360CdmBatchCollectionLoader.name, () => {
   test('should batch multiple collection requests into a single DMS query', async () => {
@@ -161,7 +162,22 @@ describe(Cdf360CdmBatchCollectionLoader.name, () => {
     expect(filesRetrieveMock).not.toHaveBeenCalled();
   });
 
-  function createMockSdk(dmsResponse: DmsSdkQueryResult, dmsError?: Error) {
+  test('uses station name as label', async () => {
+    const collectionIds = ['collection_1'];
+    const dmsResponse = createMockDmsResponse(collectionIds);
+    const { cogniteSdkMock, dmsSdkMock } = createMockSdk(dmsResponse);
+
+    const batchLoader = new Cdf360CdmBatchCollectionLoader(dmsSdkMock.object(), cogniteSdkMock.object());
+
+    const results = await batchLoader.getCollectionDescriptors({
+      externalId: 'collection_1',
+      space: 'test_space'
+    });
+
+    expect(results[0].label).toEqual(dmsResponse.stations[0].properties.cdf_cdm['Cognite360ImageStation/v1'].name);
+  });
+
+  function createMockSdk(dmsResponse: QueryResult, dmsError?: Error) {
     const cogniteSdkMock = new Mock<CogniteClient>()
       .setup(instance => instance.getBaseUrl())
       .returns('https://example.com')
@@ -178,14 +194,14 @@ describe(Cdf360CdmBatchCollectionLoader.name, () => {
         });
     } else {
       dmsSdkMock
-        .setup(instance => instance.queryNodesAndEdges(It.IsAny(), It.IsAny()))
-        .returns(Promise.resolve(dmsResponse));
+        .setup(instance => instance.queryNodesAndEdges<CdfImage360CollectionDmQuery>(It.IsAny(), It.IsAny()))
+        .returnsAsync(dmsResponse);
     }
 
     return { cogniteSdkMock, dmsSdkMock };
   }
 
-  function createMockDmsResponse(collectionIds: string[]): DmsSdkQueryResult {
+  function createMockDmsResponse(collectionIds: string[]): QueryResult {
     const collections = collectionIds.map(id => ({
       instanceType: 'node' as const,
       version: 1,
@@ -240,7 +256,23 @@ describe(Cdf360CdmBatchCollectionLoader.name, () => {
     return {
       image_collections: collections,
       images,
-      stations: []
-    };
+      stations: [
+        {
+          externalId: `station_${collectionIds[0]}`,
+          space: 'test_space',
+          createdTime: 0,
+          lastUpdatedTime: 0,
+          version: 1,
+          instanceType: 'node',
+          properties: {
+            cdf_cdm: {
+              'Cognite360ImageStation/v1': {
+                name: 'station-name'
+              }
+            }
+          }
+        }
+      ]
+    } as const;
   }
 });

--- a/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.test.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.test.ts
@@ -7,7 +7,7 @@ import type { CogniteClient } from '@cognite/sdk';
 import { It, Mock } from 'moq.ts';
 import { Cdf360CdmBatchCollectionLoader } from './Cdf360CdmBatchCollectionLoader';
 import type { DataModelsSdk } from '../../../../DataModelsSdk';
-import { CdfImage360CollectionDmQuery } from './get360CdmCollectionsQuery';
+import type { CdfImage360CollectionDmQuery } from './get360CdmCollectionsQuery';
 
 type QueryResult = Awaited<ReturnType<typeof DataModelsSdk.prototype.queryNodesAndEdges<CdfImage360CollectionDmQuery>>>;
 

--- a/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.test.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.test.ts
@@ -148,8 +148,8 @@ describe(Cdf360CdmBatchCollectionLoader.name, () => {
       .returns(filesApiMock.object());
 
     const dmsSdkMock = new Mock<DataModelsSdk>()
-      .setup(instance => instance.queryNodesAndEdges(It.IsAny(), It.IsAny()))
-      .returns(Promise.resolve(dmsResponse));
+      .setup(instance => instance.queryNodesAndEdges<CdfImage360CollectionDmQuery>(It.IsAny(), It.IsAny()))
+      .returnsAsync(dmsResponse);
 
     const batchLoader = new Cdf360CdmBatchCollectionLoader(dmsSdkMock.object(), cogniteSdkMock.object());
 

--- a/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.ts
+++ b/viewer/packages/data-providers/src/image-360-data-providers/descriptor-providers/datamodels/cdm/Cdf360CdmBatchCollectionLoader.ts
@@ -25,6 +25,7 @@ import { getDmsPaginationCursor } from '../../../../utilities/dmsPaginationUtils
 type QueryResult = Awaited<ReturnType<typeof DataModelsSdk.prototype.queryNodesAndEdges<CdfImage360CollectionDmQuery>>>;
 
 type ImageInstanceResult = QueryResult['images'][number];
+type ImageStationResult = QueryResult['stations'][number];
 type ImageResultProperties = ImageInstanceResult['properties']['cdf_cdm']['Cognite360Image/v1'];
 
 // Collection types - batch query uses 'image_collections' (plural)
@@ -33,7 +34,7 @@ type CollectionInstanceResult = QueryResult['image_collections'][number];
 type BatchQueryResult = {
   image_collections: CollectionInstanceResult[];
   images: ImageInstanceResult[];
-  stations: DMInstanceRef[];
+  stations: ImageStationResult[];
   nextCursor?: Record<string, string>;
 };
 
@@ -145,8 +146,22 @@ export class Cdf360CdmBatchCollectionLoader extends BatchLoader<
     }
 
     const imagesByCollection = new Map<DMInstanceKey, ImageInstanceResult[]>();
+    const stationById = new Map<DMInstanceKey, ImageStationResult>();
+    const stationByImage = new Map<DMInstanceKey, ImageStationResult>();
+
+    result.stations.forEach(station => {
+      stationById.set(dmInstanceRefToKey(station), station);
+    });
 
     result.images.forEach(image => {
+      const stationId = image.properties?.cdf_cdm?.['Cognite360Image/v1']?.station360;
+      if (stationId !== undefined && isDmIdentifier(stationId)) {
+        const station = stationById.get(dmInstanceRefToKey(stationId));
+        if (station !== undefined) {
+          stationByImage.set(dmInstanceRefToKey(image), station);
+        }
+      }
+
       const collectionRef = image.properties?.cdf_cdm?.['Cognite360Image/v1']?.collection360;
       if (!isDmIdentifier(collectionRef)) {
         return;
@@ -174,15 +189,16 @@ export class Cdf360CdmBatchCollectionLoader extends BatchLoader<
 
       // Create file descriptors directly from images using instance IDs
       // This eliminates the need for /files/byids API calls (~100+ requests for large collections)
-      const imagesWithFiles = collectionImages.map(image => ({
+      const imagesWithFilesAndStation = collectionImages.map(image => ({
         image,
-        fileDescriptors: this.createFileDescriptorsFromImage(image)
+        fileDescriptors: this.createFileDescriptorsFromImage(image),
+        station: stationByImage.get(dmInstanceRefToKey(image))
       }));
 
       const historicalSets = this.createHistoricalImageSets(
         collectionId,
         collectionLabel ?? collectionId,
-        imagesWithFiles
+        imagesWithFilesAndStation
       );
 
       grouped.set(collectionKey, historicalSets);
@@ -219,10 +235,14 @@ export class Cdf360CdmBatchCollectionLoader extends BatchLoader<
   private createHistoricalImageSets(
     collectionId: string,
     collectionLabel: string,
-    imagesWithFiles: Array<{ image: ImageInstanceResult; fileDescriptors: Image360FileDescriptor[] }>
+    imagesWithFilesAndStation: Array<{
+      image: ImageInstanceResult;
+      fileDescriptors: Image360FileDescriptor[];
+      station?: ImageStationResult;
+    }>
   ): Historical360ImageSet<DMDataSourceType>[] {
     // Filter out images that don't have all 6 face files
-    const imagesGroupedWithFileDescriptors = imagesWithFiles.filter(
+    const imagesGroupedWithFileDescriptors = imagesWithFilesAndStation.filter(
       ({ fileDescriptors }) => fileDescriptors.length === 6
     );
 
@@ -249,13 +269,20 @@ export class Cdf360CdmBatchCollectionLoader extends BatchLoader<
   private getHistorical360ImageSet(
     collectionId: string,
     collectionLabel: string,
-    imageFileDescriptors: { image: ImageInstanceResult; fileDescriptors: Image360FileDescriptor[] }[]
+    imageFileDescriptors: {
+      image: ImageInstanceResult;
+      fileDescriptors: Image360FileDescriptor[];
+      station?: ImageStationResult;
+    }[]
   ): Historical360ImageSet<DMDataSourceType> {
     const mainImagePropsArray = imageFileDescriptors.map(
       descriptor => descriptor.image.properties.cdf_cdm['Cognite360Image/v1']
     );
 
     const id = imageFileDescriptors[0].image;
+
+    const stationName = imageFileDescriptors[0].station?.properties.cdf_cdm['Cognite360ImageStation/v1'].name;
+
     return {
       collectionId,
       collectionLabel,
@@ -267,7 +294,7 @@ export class Cdf360CdmBatchCollectionLoader extends BatchLoader<
           p.fileDescriptors
         )
       ),
-      label: '',
+      label: typeof stationName === 'string' ? stationName : '',
       transform: this.getRevisionTransform(mainImagePropsArray[0])
     };
   }


### PR DESCRIPTION
#### Type of change
<!-- Please delete options that are not relevant. -->
![Bug](https://img.shields.io/badge/Type-Bug-red) <!-- bug fix for the user, not a fix to a build script -->

#### Jira ticket :blue_book:
<!--(mention JIRA ticket/s)-->

https://cognitedata.atlassian.net/browse/BND3D-7179

## Description :pencil:
<!---
- Describe your changes in detail.
- Why is this change required?
- What problem does it solve?
- List any related PRs
-->

Attaches station name to the image label. 

## How has this been tested? :mag:

<!---
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Also list any relevant details for your test configuration.
-->


## Test instructions :information_source:

<!---
- Describe steps to try/test the suggested changes
-->

- Open Unified-3D in a DM-project
- Open any scene/360-image
- Enter any image
- Open Details-panel
- Observe that station name is in the title of the 360-details

## Checklist :ballot_box_with_check:

<!---
- Here is a checklist that should completed before merging this given feature.
- Any shortcomings from the items below should be explained and detailed within the contents of this PR.
-->

- [x] I am happy with this implementation.
- [x] I have performed a self-review of my own code.
- [x] I have added unit and visuals tests to prove that my feature works to the best of my ability.
- [x] I have added documentation to new and changed elements; both public and internally shared ones
- [x] I have refactored the code for testability, readability and extendibility to the best of my ability.
- [x] I have listed the JIRA tasks covering remaining work or tech debt related to this PR in the description.
