### PR TITLE
[SEC-5370] Use Cognite Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":disablePeerDependencies"],
+  "extends": ["local>cognitedata/renovate-config-public", ":disablePeerDependencies"],
   "timezone": "Europe/Oslo",
   "labels": ["dependencies"],
   "ignorePaths": [


### PR DESCRIPTION
Use Cognite defaults for Renovate. Cognite defaults include better protection for supply chain attacks, including a cooldown/minReleaseAge period for dependencies.

Tracked under [SEC-5370](https://cognitedata.atlassian.net/browse/SEC-5370).

[SEC-5370]: https://cognitedata.atlassian.net/browse/SEC-5370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ