### PR TITLE
feat(viewer): allow setting minPointSize for Overlay3DCollection

### DIFF
--- a/viewer/packages/3d-overlays/src/Overlay3DCollection.ts
+++ b/viewer/packages/3d-overlays/src/Overlay3DCollection.ts
@@ -29,6 +29,10 @@ export type Overlay3DCollectionOptions = {
    */
   maxPointSize?: number;
   /**
+   * The minimum display size of each icon in pixels
+   */
+  minPointSize?: number;
+  /**
    * The default color to apply to overlay icons without a color on their own
    */
   defaultOverlayColor?: Color;
@@ -82,7 +86,7 @@ export class Overlay3DCollection<MetadataType = DefaultOverlay3DContentType>
       {
         spriteTexture: this._sharedTextures.color,
         maskTexture: this._sharedTextures.mask,
-        minPixelSize: this.MinPixelSize,
+        minPixelSize: options?.minPointSize ?? this.MinPixelSize,
         maxPixelSize: options?.maxPointSize ?? this.MaxPixelSize,
         radius: this._iconRadius
       },

--- a/viewer/reveal.api.md
+++ b/viewer/reveal.api.md
@@ -1809,6 +1809,7 @@ export type Overlay3DCollectionOptions = {
     overlayTexture?: Texture;
     overlayTextureMask?: Texture;
     maxPointSize?: number;
+    minPointSize?: number;
     defaultOverlayColor?: Color;
 };
 


### PR DESCRIPTION
#### Type of change
![Feat](https://img.shields.io/badge/Type-Feat-green)  <!-- new feature for the user, not a new feature for build script -->

## Description :pencil:
Allow setting min size for `Overlay3DCollection`
